### PR TITLE
feat: add call graph extraction and query support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Semantic codebase indexing plugin for OpenCode. Hybrid TypeScript/Rust architecture:
 - **TypeScript** (`src/`): Plugin logic, embedding providers, OpenCode tools
-- **Rust** (`native/`): Tree-sitter parsing, usearch vectors, SQLite storage, BM25 inverted index
+- **Rust** (`native/`): Tree-sitter parsing, usearch vectors, SQLite storage, BM25 inverted index, call graph extraction
 
 ## Build/Test/Lint
 
@@ -52,10 +52,11 @@ native/src/
 ├── parser.rs             # Tree-sitter parsing (14 languages: TS, JS, Python, Rust, Go, Java, C#, Ruby, Bash, C, C++, JSON, TOML, YAML)
 ├── chunker.rs            # Semantic chunking with overlap
 ├── store.rs              # usearch vector store (F16 quantization)
-├── db.rs                 # SQLite: embeddings, chunks, branch catalog
+├── db.rs                 # SQLite: embeddings, chunks, branch catalog, symbols, call edges
+├── call_extractor.rs     # Tree-sitter query-based call extraction (TS/JS, Python, Go, Rust)
 ├── inverted_index.rs     # BM25 keyword search
 ├── hasher.rs             # xxhash content hashing
-└── types.rs              # Shared types
+└── types.rs              # Shared types (Language enum with from_string)
 
 tests/                    # Vitest tests (30s timeout for native ops)
 commands/                 # Slash command definitions (/search, /find, /index)
@@ -75,6 +76,8 @@ skill/                    # OpenCode skill guidance
 | Add slash command | `commands/` + register in `src/index.ts` config() |
 
 | Add/modify MCP tool | `src/mcp-server.ts` (createMcpServer) |
+| Modify call graph extraction | `native/src/call_extractor.rs` + query files in `native/queries/` |
+| Add call graph language | `native/queries/<lang>-calls.scm` + update `call_extractor.rs` |
 ## CODE MAP
 
 ### TypeScript Exports (`src/index.ts`)
@@ -89,12 +92,13 @@ skill/                    # OpenCode skill guidance
 | `index_health_check` | Tool | GC orphaned embeddings/chunks |
 | `index_metrics` | Tool | Get performance metrics (requires debug.enabled + debug.metrics) |
 | `index_logs` | Tool | Get debug logs (requires debug.enabled) |
+| `call_graph` | Tool | Query call graph for callers/callees of functions |
 
 
 ### MCP Server Exports (`src/mcp-server.ts`)
 | Symbol | Type | Purpose |
 |--------|------|---------|
-| `createMcpServer` | fn | Creates MCP Server with 8 tools + 4 prompts, lazy Indexer init |
+| `createMcpServer` | fn | Creates MCP Server with 9 tools + 4 prompts, lazy Indexer init |
 
 ### CLI Entry (`src/cli.ts`)
 | Symbol | Type | Purpose |
@@ -218,6 +222,7 @@ afterEach(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
 | `logger.test.ts` | Logger utility, metrics collection |
 
 | `mcp-server.test.ts` | MCP server: tool/prompt registration, execution via InMemoryTransport |
+| `call-graph.test.ts` | Call extraction, storage, resolution, branch awareness, integration |
 ### Benchmarks
 ```bash
 npx tsx benchmarks/run.ts   # Performance testing for native operations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Call graph extraction and query**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports across 5 languages (TypeScript/JavaScript, Python, Go, Rust)
+- **`call_graph` tool**: Query callers or callees of any function/method with branch-aware filtering
+- **DB schema v2**: `symbols`, `call_edges`, and `branch_symbols` tables with full CRUD, GC, and batch operations
+- **Same-file call resolution**: Automatically resolves call edges to symbols defined in the same file during indexing
+
+### Fixed
+- **Missing `call_graph` export**: The `call_graph` tool was not exported from the plugin entry point — now available to OpenCode users
+
 ## [0.5.0] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    npx opencode-codebase-index-mcp                            # uses current directory
    ```
 
-The MCP server exposes all 8 tools (`codebase_search`, `codebase_peek`, `find_similar`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 4 prompts (`search`, `find`, `index`, `status`).
+The MCP server exposes all 9 tools (`codebase_search`, `codebase_peek`, `find_similar`, `call_graph`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 4 prompts (`search`, `find`, `index`, `status`).
 
 The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) are optional peer dependencies — they're only needed if you use the MCP server.
 
@@ -112,6 +112,7 @@ src/api/checkout.ts:89      (Route handler for /pay)
 | Don't know the function name | `codebase_search` | Semantic search finds by meaning |
 | Exploring unfamiliar codebase | `codebase_search` | Discovers related code across files |
 | Just need to find locations | `codebase_peek` | Returns metadata only, saves ~90% tokens |
+| Understand code flow | `call_graph` | Find callers/callees of any function |
 | Know exact identifier | `grep` | Faster, finds all occurrences |
 | Need ALL matches | `grep` | Semantic returns top N only |
 | Mixed discovery + precision | `/find` (hybrid) | Best of both worlds |
@@ -211,7 +212,7 @@ When you switch branches, code changes but embeddings for unchanged content rema
 
 ```
 .opencode/index/
-├── codebase.db           # SQLite: embeddings, chunks, branch catalog
+├── codebase.db           # SQLite: embeddings, chunks, branch catalog, symbols, call edges
 ├── vectors.usearch       # Vector index (uSearch)
 ├── inverted-index.json   # BM25 keyword index
 └── file-hashes.json      # File change detection
@@ -266,6 +267,12 @@ Returns collected metrics about indexing and search performance. Requires `debug
 ### `index_logs`
 Returns recent debug logs with optional filtering.
 - **Parameters**: `category` (optional: `search`, `embedding`, `cache`, `gc`, `branch`), `level` (optional: `error`, `warn`, `info`, `debug`), `limit` (default: 50).
+
+### `call_graph`
+Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, and Rust.
+- **Use for**: Understanding code flow, tracing dependencies, impact analysis.
+- **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries).
+- **Example**: Find who calls `validateToken` → `call_graph(name="validateToken", direction="callers")`
 
 ## 🎮 Slash Commands
 
@@ -564,8 +571,9 @@ CI will automatically run tests and type checking on your PR.
 The Rust native module handles performance-critical operations:
 - **tree-sitter**: Language-aware code parsing with JSDoc/docstring extraction
 - **usearch**: High-performance vector similarity search with F16 quantization
-- **SQLite**: Persistent storage for embeddings, chunks, and branch catalog
+- **SQLite**: Persistent storage for embeddings, chunks, branch catalog, symbols, and call edges
 - **BM25 inverted index**: Fast keyword search for hybrid retrieval
+- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust)
 - **xxhash**: Fast content hashing for change detection
 
 Rebuild with: `npm run build:native` (requires Rust toolchain)

--- a/commands/call-graph.md
+++ b/commands/call-graph.md
@@ -1,0 +1,24 @@
+---
+description: Trace callers or callees using the call graph
+---
+
+Trace function dependencies using the `call_graph` tool.
+
+User input: $ARGUMENTS
+
+Interpret input as follows:
+- Default to `direction="callers"` unless input asks for callees/calls/makes calls.
+- `name=<function>` or plain text function name sets `name`.
+- `symbolId=<id>` is required for `direction="callees"`.
+
+Execution flow:
+1. If direction is `callers`, call `call_graph` with `{ name, direction: "callers" }`.
+2. If direction is `callees` and `symbolId` is present, call `call_graph` with `{ name, direction: "callees", symbolId }`.
+3. If direction is `callees` and `symbolId` is missing, first call `call_graph` with `direction="callers"` to get symbol IDs, then ask the user to choose one if multiple are returned.
+
+Examples:
+- `/call-graph Database` → callers for `Database`
+- `/call-graph callers name=Indexer` → callers for `Indexer`
+- `/call-graph callees name=Database symbolId=sym_abc123` → callees for selected symbol
+
+If output says no callers found, suggest running `/index force` first.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "streaming-iterator",
  "tempfile",
  "thiserror",
  "tree-sitter",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -37,6 +37,7 @@ walkdir = "2.5"
 ignore = "0.4"
 thiserror = "1.0"
 anyhow = "1.0"
+streaming-iterator = "0.1"
 # On Linux/macOS: use default features (simsimd + fp16lib) for SIMD-accelerated vector ops
 # On Windows: disable simsimd — MSVC lacks _mm512_reduce_add_ph intrinsic (usearch#325)
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/native/queries/go-calls.scm
+++ b/native/queries/go-calls.scm
@@ -1,0 +1,16 @@
+; =============================================================
+; Tree-sitter query for extracting function calls from Go
+; =============================================================
+
+; Direct function calls: foo(), bar(1, 2)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; Method/package calls: obj.Method(), fmt.Println()
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @callee.name)) @call
+
+; Import: import "fmt"
+(import_spec
+  path: (interpreted_string_literal) @import.name) @import

--- a/native/queries/javascript-calls.scm
+++ b/native/queries/javascript-calls.scm
@@ -1,1 +1,56 @@
-typescript-calls.scm
+; =============================================================
+; Tree-sitter query file for extracting function calls from TS/JS
+; Captures are named with @ prefix and used to extract node text
+; =============================================================
+
+; -------------------------------------------------------------
+; Direct function calls: foo(), bar(1, 2)
+; Captures the function identifier being called
+; -------------------------------------------------------------
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; -------------------------------------------------------------
+; Method calls: obj.method(), this.foo(), array.map()
+; Captures the property (method name) being called
+; -------------------------------------------------------------
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @callee.name)) @call
+
+; -------------------------------------------------------------
+; Constructor calls: new Foo(), new Bar(args)
+; Captures the class/constructor name
+; -------------------------------------------------------------
+(new_expression
+  constructor: (identifier) @callee.name) @constructor
+
+; -------------------------------------------------------------
+; ES6 named imports: import { foo, bar as baz } from 'module'
+; Captures each imported name and the source module
+; -------------------------------------------------------------
+(import_statement
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @import.name)))
+  source: (string) @import.source) @import
+
+; -------------------------------------------------------------
+; Default imports: import React from 'react'
+; Captures the default import name and source
+; -------------------------------------------------------------
+(import_statement
+  (import_clause
+    (identifier) @import.default)
+  source: (string) @import.source) @import
+
+; -------------------------------------------------------------
+; Namespace imports: import * as utils from './utils'
+; Captures the namespace alias and source
+; -------------------------------------------------------------
+(import_statement
+  (import_clause
+    (namespace_import
+      (identifier) @import.namespace))
+  source: (string) @import.source) @import

--- a/native/queries/javascript-calls.scm
+++ b/native/queries/javascript-calls.scm
@@ -1,0 +1,1 @@
+typescript-calls.scm

--- a/native/queries/python-calls.scm
+++ b/native/queries/python-calls.scm
@@ -1,0 +1,25 @@
+; =============================================================
+; Tree-sitter query for extracting function calls from Python
+; =============================================================
+
+; Direct function calls: foo(), bar(1, 2)
+(call
+  function: (identifier) @callee.name) @call
+
+; Method calls: obj.method(), self.foo()
+(call
+  function: (attribute
+    attribute: (identifier) @callee.name)) @call
+
+; Constructor calls (same as function calls in Python, but capitalized by convention)
+; Handled by the Call type — caller can check capitalization
+
+; Import: import foo
+(import_statement
+  name: (dotted_name
+    (identifier) @import.name)) @import
+
+; From import: from module import foo, bar
+(import_from_statement
+  name: (dotted_name
+    (identifier) @import.name)) @import

--- a/native/queries/rust-calls.scm
+++ b/native/queries/rust-calls.scm
@@ -1,0 +1,32 @@
+; =============================================================
+; Tree-sitter query for extracting function calls from Rust
+; =============================================================
+
+; Direct function calls: foo(), bar(1, 2)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; Method calls: obj.method(), self.foo()
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @callee.name)) @call
+
+; Path calls: std::fs::read(), Vec::new()
+(call_expression
+  function: (scoped_identifier
+    name: (identifier) @callee.name)) @call
+
+; Macro calls: println!(), vec![]
+(macro_invocation
+  macro: (identifier) @callee.name) @call
+
+; Use imports: use std::fs;
+(use_declaration
+  argument: (scoped_identifier
+    name: (identifier) @import.name)) @import
+
+; Use list imports: use std::{foo, bar};
+(use_declaration
+  argument: (scoped_use_list
+    list: (use_list
+      (identifier) @import.name))) @import

--- a/native/queries/typescript-calls.scm
+++ b/native/queries/typescript-calls.scm
@@ -1,0 +1,56 @@
+; =============================================================
+; Tree-sitter query file for extracting function calls from TS/JS
+; Captures are named with @ prefix and used to extract node text
+; =============================================================
+
+; -------------------------------------------------------------
+; Direct function calls: foo(), bar(1, 2)
+; Captures the function identifier being called
+; -------------------------------------------------------------
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; -------------------------------------------------------------
+; Method calls: obj.method(), this.foo(), array.map()
+; Captures the property (method name) being called
+; -------------------------------------------------------------
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @callee.name)) @call
+
+; -------------------------------------------------------------
+; Constructor calls: new Foo(), new Bar(args)
+; Captures the class/constructor name
+; -------------------------------------------------------------
+(new_expression
+  constructor: (identifier) @callee.name) @constructor
+
+; -------------------------------------------------------------
+; ES6 named imports: import { foo, bar as baz } from 'module'
+; Captures each imported name and the source module
+; -------------------------------------------------------------
+(import_statement
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @import.name)))
+  source: (string) @import.source) @import
+
+; -------------------------------------------------------------
+; Default imports: import React from 'react'
+; Captures the default import name and source
+; -------------------------------------------------------------
+(import_statement
+  (import_clause
+    (identifier) @import.default)
+  source: (string) @import.source) @import
+
+; -------------------------------------------------------------
+; Namespace imports: import * as utils from './utils'
+; Captures the namespace alias and source
+; -------------------------------------------------------------
+(import_statement
+  (import_clause
+    (namespace_import
+      (identifier) @import.namespace))
+  source: (string) @import.source) @import

--- a/native/src/call_extractor.rs
+++ b/native/src/call_extractor.rs
@@ -1,0 +1,411 @@
+use crate::types::Language;
+use anyhow::{anyhow, Result};
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Parser, Query, QueryCursor};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallType {
+    Call,
+    MethodCall,
+    Constructor,
+    Import,
+}
+
+#[derive(Debug, Clone)]
+pub struct CallSite {
+    pub callee_name: String,
+    pub line: u32,
+    pub column: u32,
+    pub call_type: CallType,
+}
+
+pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>> {
+    let language = Language::from_string(language_name);
+    let ts_language = match language {
+        Language::TypeScript | Language::TypeScriptTsx => {
+            tree_sitter_typescript::LANGUAGE_TSX.into()
+        }
+        Language::JavaScript | Language::JavaScriptJsx => tree_sitter_javascript::LANGUAGE.into(),
+        Language::Python => tree_sitter_python::LANGUAGE.into(),
+        Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+        Language::Go => tree_sitter_go::LANGUAGE.into(),
+        _ => return Ok(vec![]),
+    };
+
+    let mut parser = Parser::new();
+    parser
+        .set_language(&ts_language)
+        .map_err(|e| anyhow!("Failed to set language: {}", e))?;
+
+    let tree = parser
+        .parse(content, None)
+        .ok_or_else(|| anyhow!("Parse failed"))?;
+
+    let query_source = match language {
+        Language::TypeScript
+        | Language::TypeScriptTsx
+        | Language::JavaScript
+        | Language::JavaScriptJsx => include_str!("../queries/typescript-calls.scm"),
+        Language::Python => include_str!("../queries/python-calls.scm"),
+        Language::Rust => include_str!("../queries/rust-calls.scm"),
+        Language::Go => include_str!("../queries/go-calls.scm"),
+        _ => return Ok(vec![]),
+    };
+
+    let query = Query::new(&ts_language, query_source)
+        .map_err(|e| anyhow!("Failed to compile query: {}", e))?;
+
+    let callee_name_idx = query.capture_index_for_name("callee.name");
+    let call_idx = query.capture_index_for_name("call");
+    let constructor_idx = query.capture_index_for_name("constructor");
+    let import_name_idx = query.capture_index_for_name("import.name");
+    let import_default_idx = query.capture_index_for_name("import.default");
+    let import_namespace_idx = query.capture_index_for_name("import.namespace");
+
+    let method_parent_kinds: &[&str] = match language {
+        Language::TypeScript
+        | Language::TypeScriptTsx
+        | Language::JavaScript
+        | Language::JavaScriptJsx => &["member_expression"],
+        Language::Python => &["attribute"],
+        Language::Rust => &["field_expression"],
+        Language::Go => &["selector_expression"],
+        _ => &[],
+    };
+
+    let mut cursor = QueryCursor::new();
+    let mut calls = Vec::new();
+    let text_bytes = content.as_bytes();
+
+    let mut captures_iter = cursor.captures(&query, tree.root_node(), text_bytes);
+
+    while let Some((match_, _)) = captures_iter.next() {
+        let mut callee_name: Option<String> = None;
+        let mut call_type: Option<CallType> = None;
+        let mut position: Option<(u32, u32)> = None;
+
+        for capture in match_.captures {
+            let node = capture.node;
+            let text = node.utf8_text(text_bytes).unwrap_or("");
+
+            if let Some(idx) = callee_name_idx {
+                if capture.index == idx {
+                    callee_name = Some(text.to_string());
+                    if position.is_none() {
+                        let start = node.start_position();
+                        position = Some((start.row as u32 + 1, start.column as u32));
+                    }
+                }
+            }
+
+            if let Some(idx) = call_idx {
+                if capture.index == idx && call_type.is_none() {
+                    call_type = Some(CallType::Call);
+                }
+            }
+
+            if let Some(idx) = constructor_idx {
+                if capture.index == idx {
+                    call_type = Some(CallType::Constructor);
+                }
+            }
+
+            if let Some(idx) = import_name_idx {
+                if capture.index == idx {
+                    callee_name = Some(text.to_string());
+                    call_type = Some(CallType::Import);
+                    let start = node.start_position();
+                    position = Some((start.row as u32 + 1, start.column as u32));
+                }
+            }
+
+            if let Some(idx) = import_default_idx {
+                if capture.index == idx {
+                    callee_name = Some(text.to_string());
+                    call_type = Some(CallType::Import);
+                    let start = node.start_position();
+                    position = Some((start.row as u32 + 1, start.column as u32));
+                }
+            }
+
+            if let Some(idx) = import_namespace_idx {
+                if capture.index == idx {
+                    callee_name = Some(text.to_string());
+                    call_type = Some(CallType::Import);
+                    let start = node.start_position();
+                    position = Some((start.row as u32 + 1, start.column as u32));
+                }
+            }
+        }
+
+        if let (Some(name), Some(CallType::Call), Some(pos)) = (&callee_name, call_type, position) {
+            let is_method_call = match_.captures.iter().any(|c| {
+                if let Some(idx) = callee_name_idx {
+                    if c.index == idx {
+                        if let Some(parent) = c.node.parent() {
+                            return method_parent_kinds.contains(&parent.kind());
+                        }
+                    }
+                }
+                false
+            });
+
+            let final_call_type = if is_method_call {
+                CallType::MethodCall
+            } else {
+                CallType::Call
+            };
+
+            calls.push(CallSite {
+                callee_name: name.clone(),
+                line: pos.0,
+                column: pos.1,
+                call_type: final_call_type,
+            });
+        } else if let (Some(name), Some(ct), Some(pos)) = (callee_name, call_type, position) {
+            calls.push(CallSite {
+                callee_name: name,
+                line: pos.0,
+                column: pos.1,
+                call_type: ct,
+            });
+        }
+    }
+
+    Ok(calls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_direct_calls() {
+        let code = "function test() { foo(); bar(1, 2); }";
+        let calls = extract_calls(code, "typescript").unwrap();
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "foo" && c.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "bar" && c.call_type == CallType::Call));
+    }
+
+    #[test]
+    fn test_extract_method_calls() {
+        let code = "obj.method(); this.foo();";
+        let calls = extract_calls(code, "typescript").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "method" && c.call_type == CallType::MethodCall),
+            "Expected method call, got: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "foo" && c.call_type == CallType::MethodCall),
+            "Expected method call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_extract_constructors() {
+        let code = "new Foo(); new Bar(1, 2);";
+        let calls = extract_calls(code, "typescript").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "Foo" && c.call_type == CallType::Constructor),
+            "Expected constructor call, got: {:?}",
+            calls
+        );
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "Bar" && c.call_type == CallType::Constructor));
+    }
+
+    #[test]
+    fn test_extract_imports() {
+        let code = r#"
+            import { foo, bar } from 'module1';
+            import React from 'react';
+            import * as utils from './utils';
+        "#;
+        let calls = extract_calls(code, "typescript").unwrap();
+
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "foo" && c.call_type == CallType::Import));
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "bar" && c.call_type == CallType::Import));
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "React" && c.call_type == CallType::Import));
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "utils" && c.call_type == CallType::Import));
+    }
+
+    #[test]
+    fn test_line_column_numbers() {
+        let code = "foo();\nbar();";
+        let calls = extract_calls(code, "typescript").unwrap();
+
+        let foo_call = calls.iter().find(|c| c.callee_name == "foo").unwrap();
+        assert_eq!(foo_call.line, 1);
+        assert_eq!(foo_call.column, 0);
+
+        let bar_call = calls.iter().find(|c| c.callee_name == "bar").unwrap();
+        assert_eq!(bar_call.line, 2);
+        assert_eq!(bar_call.column, 0);
+    }
+
+    #[test]
+    fn test_javascript_support() {
+        let code = "console.log('test'); alert('hi');";
+        let calls = extract_calls(code, "javascript").unwrap();
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "log" && c.call_type == CallType::MethodCall));
+        assert!(calls
+            .iter()
+            .any(|c| c.callee_name == "alert" && c.call_type == CallType::Call));
+    }
+
+    #[test]
+    fn test_python_direct_calls() {
+        let code = "print('hello')\nlen([1, 2, 3])";
+        let calls = extract_calls(code, "python").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "print" && c.call_type == CallType::Call),
+            "Expected print call, got: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "len" && c.call_type == CallType::Call),
+            "Expected len call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_python_method_calls() {
+        let code = "obj.method()\nself.foo()";
+        let calls = extract_calls(code, "python").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "method" && c.call_type == CallType::MethodCall),
+            "Expected method call, got: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "foo" && c.call_type == CallType::MethodCall),
+            "Expected method call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_python_imports() {
+        let code = "import os\nfrom pathlib import Path";
+        let calls = extract_calls(code, "python").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "os" && c.call_type == CallType::Import),
+            "Expected os import, got: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "Path" && c.call_type == CallType::Import),
+            "Expected Path import, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_go_direct_calls() {
+        let code = "package main\nfunc main() { foo() }";
+        let calls = extract_calls(code, "go").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "foo" && c.call_type == CallType::Call),
+            "Expected foo call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_go_method_calls() {
+        let code = "package main\nfunc main() { fmt.Println(\"hello\") }";
+        let calls = extract_calls(code, "go").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "Println" && c.call_type == CallType::MethodCall),
+            "Expected Println method call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_rust_direct_calls() {
+        let code = "fn main() { foo(); bar(1, 2); }";
+        let calls = extract_calls(code, "rust").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "foo" && c.call_type == CallType::Call),
+            "Expected foo call, got: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "bar" && c.call_type == CallType::Call),
+            "Expected bar call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_rust_method_calls() {
+        let code = "fn main() { self.foo(); obj.method(); }";
+        let calls = extract_calls(code, "rust").unwrap();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "foo" && c.call_type == CallType::MethodCall),
+            "Expected foo method call, got: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.callee_name == "method" && c.call_type == CallType::MethodCall),
+            "Expected method call, got: {:?}",
+            calls
+        );
+    }
+
+    #[test]
+    fn test_unsupported_language() {
+        let code = "<html><body>hello</body></html>";
+        let calls = extract_calls(code, "html").unwrap();
+        assert_eq!(calls.len(), 0);
+    }
+}

--- a/native/src/call_extractor.rs
+++ b/native/src/call_extractor.rs
@@ -42,10 +42,12 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         .ok_or_else(|| anyhow!("Parse failed"))?;
 
     let query_source = match language {
-        Language::TypeScript
-        | Language::TypeScriptTsx
-        | Language::JavaScript
-        | Language::JavaScriptJsx => include_str!("../queries/typescript-calls.scm"),
+        Language::TypeScript | Language::TypeScriptTsx => {
+            include_str!("../queries/typescript-calls.scm")
+        }
+        Language::JavaScript | Language::JavaScriptJsx => {
+            include_str!("../queries/javascript-calls.scm")
+        }
         Language::Python => include_str!("../queries/python-calls.scm"),
         Language::Rust => include_str!("../queries/rust-calls.scm"),
         Language::Go => include_str!("../queries/go-calls.scm"),

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -13,7 +13,7 @@ pub enum DbError {
 pub type DbResult<T> = Result<T, DbError>;
 
 /// Schema version for migrations
-const SCHEMA_VERSION: i32 = 1;
+const SCHEMA_VERSION: i32 = 2;
 
 /// Maximum number of SQL bind parameters per query.
 /// SQLite defaults to 999 (SQLITE_MAX_VARIABLE_NUMBER). We use 900 to stay safely under.
@@ -104,6 +104,61 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
         )?;
     }
 
+
+    if from_version < 2 {
+        // v2: Call graph tables
+        conn.execute_batch(
+            r#"
+            -- Symbols table: function/class/method definitions extracted from source files
+            CREATE TABLE IF NOT EXISTS symbols (
+                id TEXT PRIMARY KEY,
+                file_path TEXT NOT NULL,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                start_line INTEGER NOT NULL,
+                start_col INTEGER NOT NULL,
+                end_line INTEGER NOT NULL,
+                end_col INTEGER NOT NULL,
+                language TEXT NOT NULL
+            );
+
+            -- Call edges: relationships between symbols (caller -> callee)
+            CREATE TABLE IF NOT EXISTS call_edges (
+                id TEXT PRIMARY KEY,
+                from_symbol_id TEXT NOT NULL,
+                target_name TEXT NOT NULL,
+                to_symbol_id TEXT,
+                call_type TEXT NOT NULL,
+                line INTEGER NOT NULL,
+                col INTEGER NOT NULL,
+                is_resolved INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (from_symbol_id) REFERENCES symbols(id)
+            );
+
+            -- Branch-symbol catalog: which symbols exist on which branch
+            CREATE TABLE IF NOT EXISTS branch_symbols (
+                branch TEXT NOT NULL,
+                symbol_id TEXT NOT NULL,
+                PRIMARY KEY (branch, symbol_id)
+            );
+
+            -- Indexes
+            CREATE INDEX IF NOT EXISTS idx_symbols_file_path ON symbols(file_path);
+            CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+            CREATE INDEX IF NOT EXISTS idx_call_edges_from ON call_edges(from_symbol_id);
+            CREATE INDEX IF NOT EXISTS idx_call_edges_to ON call_edges(to_symbol_id);
+            CREATE INDEX IF NOT EXISTS idx_call_edges_target_name ON call_edges(target_name);
+            CREATE INDEX IF NOT EXISTS idx_branch_symbols_branch ON branch_symbols(branch);
+            CREATE INDEX IF NOT EXISTS idx_branch_symbols_symbol_id ON branch_symbols(symbol_id);
+            "#,
+        )?;
+
+        // Update schema version
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
+            params![SCHEMA_VERSION.to_string()],
+        )?;
+    }
     Ok(())
 }
 
@@ -529,6 +584,374 @@ pub fn get_all_branches(conn: &Connection) -> DbResult<Vec<String>> {
     Ok(results)
 }
 
+
+// ============================================================================
+// Symbol Operations (Call Graph)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+pub struct SymbolRow {
+    pub id: String,
+    pub file_path: String,
+    pub name: String,
+    pub kind: String,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+    pub language: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CallEdgeRow {
+    pub id: String,
+    pub from_symbol_id: String,
+    pub target_name: String,
+    pub to_symbol_id: Option<String>,
+    pub call_type: String,
+    pub line: u32,
+    pub col: u32,
+    pub is_resolved: bool,
+}
+
+/// Insert or replace a symbol
+pub fn upsert_symbol(conn: &Connection, symbol: &SymbolRow) -> DbResult<()> {
+    conn.execute(
+        r#"
+        INSERT OR REPLACE INTO symbols (id, file_path, name, kind, start_line, start_col, end_line, end_col, language)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+        params![
+            symbol.id,
+            symbol.file_path,
+            symbol.name,
+            symbol.kind,
+            symbol.start_line,
+            symbol.start_col,
+            symbol.end_line,
+            symbol.end_col,
+            symbol.language
+        ],
+    )?;
+    Ok(())
+}
+
+/// Batch insert or replace symbols within a single transaction
+pub fn upsert_symbols_batch(conn: &mut Connection, symbols: &[SymbolRow]) -> DbResult<()> {
+    if symbols.is_empty() {
+        return Ok(());
+    }
+
+    let tx = conn.transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            r#"
+            INSERT OR REPLACE INTO symbols (id, file_path, name, kind, start_line, start_col, end_line, end_col, language)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )?;
+
+        for symbol in symbols {
+            stmt.execute(params![
+                symbol.id,
+                symbol.file_path,
+                symbol.name,
+                symbol.kind,
+                symbol.start_line,
+                symbol.start_col,
+                symbol.end_line,
+                symbol.end_col,
+                symbol.language
+            ])?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// Get all symbols in a file
+pub fn get_symbols_by_file(conn: &Connection, file_path: &str) -> DbResult<Vec<SymbolRow>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT id, file_path, name, kind, start_line, start_col, end_line, end_col, language
+        FROM symbols WHERE file_path = ?
+        ORDER BY start_line
+        "#,
+    )?;
+
+    let rows = stmt.query_map(params![file_path], |row| {
+        Ok(SymbolRow {
+            id: row.get(0)?,
+            file_path: row.get(1)?,
+            name: row.get(2)?,
+            kind: row.get(3)?,
+            start_line: row.get(4)?,
+            start_col: row.get(5)?,
+            end_line: row.get(6)?,
+            end_col: row.get(7)?,
+            language: row.get(8)?,
+        })
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+/// Find a symbol by name and file path
+pub fn _get_symbol_by_name(
+    conn: &Connection,
+    name: &str,
+    file_path: &str,
+) -> DbResult<Option<SymbolRow>> {
+    let result = conn
+        .query_row(
+            r#"
+            SELECT id, file_path, name, kind, start_line, start_col, end_line, end_col, language
+            FROM symbols WHERE name = ? AND file_path = ?
+            "#,
+            params![name, file_path],
+            |row| {
+                Ok(SymbolRow {
+                    id: row.get(0)?,
+                    file_path: row.get(1)?,
+                    name: row.get(2)?,
+                    kind: row.get(3)?,
+                    start_line: row.get(4)?,
+                    start_col: row.get(5)?,
+                    end_line: row.get(6)?,
+                    end_col: row.get(7)?,
+                    language: row.get(8)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(result)
+}
+
+/// Delete all symbols for a file
+pub fn delete_symbols_by_file(conn: &Connection, file_path: &str) -> DbResult<usize> {
+    let count = conn.execute("DELETE FROM symbols WHERE file_path = ?", params![file_path])?;
+    Ok(count)
+}
+
+// ============================================================================
+// Call Edge Operations (Call Graph)
+// ============================================================================
+
+/// Insert or replace a call edge
+pub fn upsert_call_edge(conn: &Connection, edge: &CallEdgeRow) -> DbResult<()> {
+    conn.execute(
+        r#"
+        INSERT OR REPLACE INTO call_edges (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+        params![
+            edge.id,
+            edge.from_symbol_id,
+            edge.target_name,
+            edge.to_symbol_id,
+            edge.call_type,
+            edge.line,
+            edge.col,
+            edge.is_resolved as i32
+        ],
+    )?;
+    Ok(())
+}
+
+/// Batch insert or replace call edges within a single transaction
+pub fn upsert_call_edges_batch(conn: &mut Connection, edges: &[CallEdgeRow]) -> DbResult<()> {
+    if edges.is_empty() {
+        return Ok(());
+    }
+
+    let tx = conn.transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            r#"
+            INSERT OR REPLACE INTO call_edges (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )?;
+
+        for edge in edges {
+            stmt.execute(params![
+                edge.id,
+                edge.from_symbol_id,
+                edge.target_name,
+                edge.to_symbol_id,
+                edge.call_type,
+                edge.line,
+                edge.col,
+                edge.is_resolved as i32
+            ])?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// Get all call edges calling a symbol name (filtered by branch)
+pub fn get_callers(
+    conn: &Connection,
+    symbol_name: &str,
+    branch: &str,
+) -> DbResult<Vec<CallEdgeRow>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT ce.id, ce.from_symbol_id, ce.target_name, ce.to_symbol_id, ce.call_type, ce.line, ce.col, ce.is_resolved
+        FROM call_edges ce
+        INNER JOIN symbols s ON ce.from_symbol_id = s.id
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
+        WHERE ce.target_name = ?
+        "#,
+    )?;
+
+    let rows = stmt.query_map(params![branch, symbol_name], |row| {
+        Ok(CallEdgeRow {
+            id: row.get(0)?,
+            from_symbol_id: row.get(1)?,
+            target_name: row.get(2)?,
+            to_symbol_id: row.get(3)?,
+            call_type: row.get(4)?,
+            line: row.get(5)?,
+            col: row.get(6)?,
+            is_resolved: row.get::<_, i32>(7)? != 0,
+        })
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+/// Get all call edges from a symbol
+pub fn get_callees(conn: &Connection, symbol_id: &str) -> DbResult<Vec<CallEdgeRow>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved
+        FROM call_edges WHERE from_symbol_id = ?
+        "#,
+    )?;
+
+    let rows = stmt.query_map(params![symbol_id], |row| {
+        Ok(CallEdgeRow {
+            id: row.get(0)?,
+            from_symbol_id: row.get(1)?,
+            target_name: row.get(2)?,
+            to_symbol_id: row.get(3)?,
+            call_type: row.get(4)?,
+            line: row.get(5)?,
+            col: row.get(6)?,
+            is_resolved: row.get::<_, i32>(7)? != 0,
+        })
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+/// Delete all call edges where the source symbol is in a file
+pub fn delete_call_edges_by_file(conn: &Connection, file_path: &str) -> DbResult<usize> {
+    let count = conn.execute(
+        r#"
+        DELETE FROM call_edges WHERE from_symbol_id IN (
+            SELECT id FROM symbols WHERE file_path = ?
+        )
+        "#,
+        params![file_path],
+    )?;
+    Ok(count)
+}
+
+/// Resolve a call edge by setting the target symbol
+pub fn resolve_call_edge(
+    conn: &Connection,
+    edge_id: &str,
+    to_symbol_id: &str,
+) -> DbResult<()> {
+    conn.execute(
+        "UPDATE call_edges SET to_symbol_id = ?, is_resolved = 1 WHERE id = ?",
+        params![to_symbol_id, edge_id],
+    )?;
+    Ok(())
+}
+
+// ============================================================================
+// Branch Symbol Operations (Call Graph)
+// ============================================================================
+
+/// Add symbols to a branch
+pub fn add_symbols_to_branch(
+    conn: &Connection,
+    branch: &str,
+    symbol_ids: &[String],
+) -> DbResult<()> {
+    if symbol_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut stmt =
+        conn.prepare("INSERT OR IGNORE INTO branch_symbols (branch, symbol_id) VALUES (?, ?)")?;
+
+    for symbol_id in symbol_ids {
+        stmt.execute(params![branch, symbol_id])?;
+    }
+    Ok(())
+}
+
+/// Batch add symbols to a branch within a single transaction
+pub fn add_symbols_to_branch_batch(
+    conn: &mut Connection,
+    branch: &str,
+    symbol_ids: &[String],
+) -> DbResult<()> {
+    if symbol_ids.is_empty() {
+        return Ok(());
+    }
+
+    let tx = conn.transaction()?;
+    {
+        let mut stmt =
+            tx.prepare("INSERT OR IGNORE INTO branch_symbols (branch, symbol_id) VALUES (?, ?)")?;
+
+        for symbol_id in symbol_ids {
+            stmt.execute(params![branch, symbol_id])?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+/// Get all symbol IDs for a branch
+pub fn get_branch_symbol_ids(conn: &Connection, branch: &str) -> DbResult<Vec<String>> {
+    let mut stmt = conn.prepare("SELECT symbol_id FROM branch_symbols WHERE branch = ?")?;
+    let rows = stmt.query_map(params![branch], |row| row.get::<_, String>(0))?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+/// Remove all symbols from a branch
+pub fn clear_branch_symbols(conn: &Connection, branch: &str) -> DbResult<usize> {
+    let count = conn.execute(
+        "DELETE FROM branch_symbols WHERE branch = ?",
+        params![branch],
+    )?;
+    Ok(count)
+}
+
 // ============================================================================
 // Metadata Operations
 // ============================================================================
@@ -592,6 +1015,45 @@ pub fn gc_orphan_chunks(conn: &Connection) -> DbResult<usize> {
     Ok(count)
 }
 
+
+/// Delete orphaned symbols (not referenced by any branch)
+pub fn gc_orphan_symbols(conn: &Connection) -> DbResult<usize> {
+    // First, delete call edges referencing orphan symbols to avoid FK violation
+    conn.execute(
+        r#"
+        DELETE FROM call_edges
+        WHERE from_symbol_id NOT IN (
+            SELECT DISTINCT symbol_id FROM branch_symbols
+        )
+        "#,
+        [],
+    )?;
+    let count = conn.execute(
+        r#"
+        DELETE FROM symbols
+        WHERE id NOT IN (
+            SELECT DISTINCT symbol_id FROM branch_symbols
+        )
+        "#,
+        [],
+    )?;
+    Ok(count)
+}
+
+/// Delete orphaned call edges (from_symbol not in symbols table)
+pub fn gc_orphan_call_edges(conn: &Connection) -> DbResult<usize> {
+    let count = conn.execute(
+        r#"
+        DELETE FROM call_edges
+        WHERE from_symbol_id NOT IN (
+            SELECT DISTINCT id FROM symbols
+        )
+        "#,
+        [],
+    )?;
+    Ok(count)
+}
+
 /// Get database statistics
 pub fn get_stats(conn: &Connection) -> DbResult<DbStats> {
     let embedding_count: i64 =
@@ -604,21 +1066,27 @@ pub fn get_stats(conn: &Connection) -> DbResult<DbStats> {
         [],
         |row| row.get(0),
     )?;
-
+    let symbol_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))?;
+    let call_edge_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM call_edges", [], |row| row.get(0))?;
     Ok(DbStats {
         embedding_count: embedding_count as u64,
         chunk_count: chunk_count as u64,
         branch_chunk_count: branch_chunk_count as u64,
         branch_count: branch_count as u64,
+        symbol_count: symbol_count as u64,
+        call_edge_count: call_edge_count as u64,
     })
 }
-
 #[derive(Debug, Clone)]
 pub struct DbStats {
     pub embedding_count: u64,
     pub chunk_count: u64,
     pub branch_chunk_count: u64,
     pub branch_count: u64,
+    pub symbol_count: u64,
+    pub call_edge_count: u64,
 }
 
 #[cfg(test)]
@@ -643,7 +1111,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "1");
+        assert_eq!(version, "2");
     }
 
     #[test]
@@ -737,5 +1205,291 @@ mod tests {
 
         assert!(!embedding_exists(&conn, "orphan").unwrap());
         assert!(embedding_exists(&conn, "used").unwrap());
+    }
+
+    #[test]
+    fn test_symbol_operations() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        let symbol = SymbolRow {
+            id: "sym1".to_string(),
+            file_path: "src/main.ts".to_string(),
+            name: "handleRequest".to_string(),
+            kind: "function".to_string(),
+            start_line: 10,
+            start_col: 0,
+            end_line: 25,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+
+        // Insert
+        upsert_symbol(&conn, &symbol).unwrap();
+
+        // Get by file
+        let symbols = get_symbols_by_file(&conn, "src/main.ts").unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "handleRequest");
+        assert_eq!(symbols[0].kind, "function");
+        assert_eq!(symbols[0].start_line, 10);
+
+        // Get by name
+        let found = _get_symbol_by_name(&conn, "handleRequest", "src/main.ts").unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, "sym1");
+
+        // Not found
+        let missing = _get_symbol_by_name(&conn, "missing", "src/main.ts").unwrap();
+        assert!(missing.is_none());
+
+        // Delete by file
+        let deleted = delete_symbols_by_file(&conn, "src/main.ts").unwrap();
+        assert_eq!(deleted, 1);
+        let symbols = get_symbols_by_file(&conn, "src/main.ts").unwrap();
+        assert!(symbols.is_empty());
+    }
+
+    #[test]
+    fn test_symbol_batch_operations() {
+        let (_temp_dir, mut conn) = setup_test_db();
+
+        let symbols = vec![
+            SymbolRow {
+                id: "s1".to_string(),
+                file_path: "src/a.ts".to_string(),
+                name: "foo".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                language: "typescript".to_string(),
+            },
+            SymbolRow {
+                id: "s2".to_string(),
+                file_path: "src/a.ts".to_string(),
+                name: "bar".to_string(),
+                kind: "function".to_string(),
+                start_line: 7, start_col: 0, end_line: 12, end_col: 1,
+                language: "typescript".to_string(),
+            },
+            SymbolRow {
+                id: "s3".to_string(),
+                file_path: "src/b.ts".to_string(),
+                name: "baz".to_string(),
+                kind: "class".to_string(),
+                start_line: 1, start_col: 0, end_line: 50, end_col: 1,
+                language: "typescript".to_string(),
+            },
+        ];
+
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+
+        let file_a = get_symbols_by_file(&conn, "src/a.ts").unwrap();
+        assert_eq!(file_a.len(), 2);
+        let file_b = get_symbols_by_file(&conn, "src/b.ts").unwrap();
+        assert_eq!(file_b.len(), 1);
+        assert_eq!(file_b[0].kind, "class");
+    }
+
+    #[test]
+    fn test_call_edge_operations() {
+        let (_temp_dir, mut conn) = setup_test_db();
+
+        // Setup symbols
+        let symbols = vec![
+            SymbolRow {
+                id: "sym_main".to_string(),
+                file_path: "src/main.ts".to_string(),
+                name: "main".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 10, end_col: 1,
+                language: "typescript".to_string(),
+            },
+            SymbolRow {
+                id: "sym_helper".to_string(),
+                file_path: "src/helper.ts".to_string(),
+                name: "helper".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                language: "typescript".to_string(),
+            },
+        ];
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+
+        // Add symbols to branch
+        add_symbols_to_branch(&conn, "main", &["sym_main".to_string(), "sym_helper".to_string()]).unwrap();
+
+        // Create call edge: main -> helper
+        let edge = CallEdgeRow {
+            id: "edge1".to_string(),
+            from_symbol_id: "sym_main".to_string(),
+            target_name: "helper".to_string(),
+            to_symbol_id: None,
+            call_type: "Call".to_string(),
+            line: 5,
+            col: 4,
+            is_resolved: false,
+        };
+        upsert_call_edge(&conn, &edge).unwrap();
+
+        // Get callees of main
+        let callees = get_callees(&conn, "sym_main").unwrap();
+        assert_eq!(callees.len(), 1);
+        assert_eq!(callees[0].target_name, "helper");
+        assert!(!callees[0].is_resolved);
+
+        // Get callers of helper (branch-filtered)
+        let callers = get_callers(&conn, "helper", "main").unwrap();
+        assert_eq!(callers.len(), 1);
+        assert_eq!(callers[0].from_symbol_id, "sym_main");
+
+        // Resolve the edge
+        resolve_call_edge(&conn, "edge1", "sym_helper").unwrap();
+        let callees = get_callees(&conn, "sym_main").unwrap();
+        assert!(callees[0].is_resolved);
+        assert_eq!(callees[0].to_symbol_id, Some("sym_helper".to_string()));
+
+        // Delete by file
+        let deleted = delete_call_edges_by_file(&conn, "src/main.ts").unwrap();
+        assert_eq!(deleted, 1);
+        let callees = get_callees(&conn, "sym_main").unwrap();
+        assert!(callees.is_empty());
+    }
+
+    #[test]
+    fn test_branch_symbols() {
+        let (_temp_dir, mut conn) = setup_test_db();
+
+        let symbols = vec![
+            SymbolRow {
+                id: "s1".to_string(),
+                file_path: "src/a.ts".to_string(),
+                name: "foo".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                language: "typescript".to_string(),
+            },
+            SymbolRow {
+                id: "s2".to_string(),
+                file_path: "src/b.ts".to_string(),
+                name: "bar".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                language: "typescript".to_string(),
+            },
+        ];
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+
+        // Add to branch
+        add_symbols_to_branch_batch(&mut conn, "main", &["s1".to_string(), "s2".to_string()]).unwrap();
+
+        let ids = get_branch_symbol_ids(&conn, "main").unwrap();
+        assert_eq!(ids.len(), 2);
+
+        // Clear
+        let cleared = clear_branch_symbols(&conn, "main").unwrap();
+        assert_eq!(cleared, 2);
+        let ids = get_branch_symbol_ids(&conn, "main").unwrap();
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_gc_symbols_and_edges() {
+        let (_temp_dir, mut conn) = setup_test_db();
+
+        // Create symbols
+        let symbols = vec![
+            SymbolRow {
+                id: "used".to_string(),
+                file_path: "src/a.ts".to_string(),
+                name: "used_fn".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                language: "typescript".to_string(),
+            },
+            SymbolRow {
+                id: "orphan".to_string(),
+                file_path: "src/b.ts".to_string(),
+                name: "orphan_fn".to_string(),
+                kind: "function".to_string(),
+                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                language: "typescript".to_string(),
+            },
+        ];
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+
+        // Only add 'used' to a branch
+        add_symbols_to_branch(&conn, "main", &["used".to_string()]).unwrap();
+
+        // Create call edges from both
+        let edges = vec![
+            CallEdgeRow {
+                id: "e1".to_string(),
+                from_symbol_id: "used".to_string(),
+                target_name: "something".to_string(),
+                to_symbol_id: None,
+                call_type: "Call".to_string(),
+                line: 3, col: 4,
+                is_resolved: false,
+            },
+            CallEdgeRow {
+                id: "e2".to_string(),
+                from_symbol_id: "orphan".to_string(),
+                target_name: "other".to_string(),
+                to_symbol_id: None,
+                call_type: "Call".to_string(),
+                line: 2, col: 0,
+                is_resolved: false,
+            },
+        ];
+        upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        // GC orphan symbols (also cascades to delete orphan call edges from those symbols)
+        let removed = gc_orphan_symbols(&conn).unwrap();
+        assert_eq!(removed, 1);
+        let remaining = get_symbols_by_file(&conn, "src/a.ts").unwrap();
+        assert_eq!(remaining.len(), 1);
+        let removed_syms = get_symbols_by_file(&conn, "src/b.ts").unwrap();
+        assert!(removed_syms.is_empty());
+        // gc_orphan_call_edges should find 0 since gc_orphan_symbols already cleaned them
+        let removed_edges = gc_orphan_call_edges(&conn).unwrap();
+        assert_eq!(removed_edges, 0);
+        // Edge from 'used' still exists
+        let remaining_edges = get_callees(&conn, "used").unwrap();
+        assert_eq!(remaining_edges.len(), 1);
+    }
+
+    #[test]
+    fn test_stats_include_symbols() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        // Initially empty
+        let stats = get_stats(&conn).unwrap();
+        assert_eq!(stats.symbol_count, 0);
+        assert_eq!(stats.call_edge_count, 0);
+
+        // Add a symbol and edge
+        let symbol = SymbolRow {
+            id: "s1".to_string(),
+            file_path: "src/a.ts".to_string(),
+            name: "test".to_string(),
+            kind: "function".to_string(),
+            start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+            language: "typescript".to_string(),
+        };
+        upsert_symbol(&conn, &symbol).unwrap();
+
+        let edge = CallEdgeRow {
+            id: "e1".to_string(),
+            from_symbol_id: "s1".to_string(),
+            target_name: "foo".to_string(),
+            to_symbol_id: None,
+            call_type: "Call".to_string(),
+            line: 3, col: 0,
+            is_resolved: false,
+        };
+        upsert_call_edge(&conn, &edge).unwrap();
+
+        let stats = get_stats(&conn).unwrap();
+        assert_eq!(stats.symbol_count, 1);
+        assert_eq!(stats.call_edge_count, 1);
     }
 }

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -104,7 +104,6 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
         )?;
     }
 
-
     if from_version < 2 {
         // v2: Call graph tables
         conn.execute_batch(
@@ -584,7 +583,6 @@ pub fn get_all_branches(conn: &Connection) -> DbResult<Vec<String>> {
     Ok(results)
 }
 
-
 // ============================================================================
 // Symbol Operations (Call Graph)
 // ============================================================================
@@ -733,7 +731,10 @@ pub fn _get_symbol_by_name(
 
 /// Delete all symbols for a file
 pub fn delete_symbols_by_file(conn: &Connection, file_path: &str) -> DbResult<usize> {
-    let count = conn.execute("DELETE FROM symbols WHERE file_path = ?", params![file_path])?;
+    let count = conn.execute(
+        "DELETE FROM symbols WHERE file_path = ?",
+        params![file_path],
+    )?;
     Ok(count)
 }
 
@@ -873,11 +874,7 @@ pub fn delete_call_edges_by_file(conn: &Connection, file_path: &str) -> DbResult
 }
 
 /// Resolve a call edge by setting the target symbol
-pub fn resolve_call_edge(
-    conn: &Connection,
-    edge_id: &str,
-    to_symbol_id: &str,
-) -> DbResult<()> {
+pub fn resolve_call_edge(conn: &Connection, edge_id: &str, to_symbol_id: &str) -> DbResult<()> {
     conn.execute(
         "UPDATE call_edges SET to_symbol_id = ?, is_resolved = 1 WHERE id = ?",
         params![to_symbol_id, edge_id],
@@ -1015,7 +1012,6 @@ pub fn gc_orphan_chunks(conn: &Connection) -> DbResult<usize> {
     Ok(count)
 }
 
-
 /// Delete orphaned symbols (not referenced by any branch)
 pub fn gc_orphan_symbols(conn: &Connection) -> DbResult<usize> {
     // First, delete call edges referencing orphan symbols to avoid FK violation
@@ -1066,8 +1062,7 @@ pub fn get_stats(conn: &Connection) -> DbResult<DbStats> {
         [],
         |row| row.get(0),
     )?;
-    let symbol_count: i64 =
-        conn.query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))?;
+    let symbol_count: i64 = conn.query_row("SELECT COUNT(*) FROM symbols", [], |row| row.get(0))?;
     let call_edge_count: i64 =
         conn.query_row("SELECT COUNT(*) FROM call_edges", [], |row| row.get(0))?;
     Ok(DbStats {
@@ -1259,7 +1254,10 @@ mod tests {
                 file_path: "src/a.ts".to_string(),
                 name: "foo".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 5,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
             SymbolRow {
@@ -1267,7 +1265,10 @@ mod tests {
                 file_path: "src/a.ts".to_string(),
                 name: "bar".to_string(),
                 kind: "function".to_string(),
-                start_line: 7, start_col: 0, end_line: 12, end_col: 1,
+                start_line: 7,
+                start_col: 0,
+                end_line: 12,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
             SymbolRow {
@@ -1275,7 +1276,10 @@ mod tests {
                 file_path: "src/b.ts".to_string(),
                 name: "baz".to_string(),
                 kind: "class".to_string(),
-                start_line: 1, start_col: 0, end_line: 50, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 50,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
         ];
@@ -1300,7 +1304,10 @@ mod tests {
                 file_path: "src/main.ts".to_string(),
                 name: "main".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 10, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 10,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
             SymbolRow {
@@ -1308,14 +1315,22 @@ mod tests {
                 file_path: "src/helper.ts".to_string(),
                 name: "helper".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 5,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
         ];
         upsert_symbols_batch(&mut conn, &symbols).unwrap();
 
         // Add symbols to branch
-        add_symbols_to_branch(&conn, "main", &["sym_main".to_string(), "sym_helper".to_string()]).unwrap();
+        add_symbols_to_branch(
+            &conn,
+            "main",
+            &["sym_main".to_string(), "sym_helper".to_string()],
+        )
+        .unwrap();
 
         // Create call edge: main -> helper
         let edge = CallEdgeRow {
@@ -1364,7 +1379,10 @@ mod tests {
                 file_path: "src/a.ts".to_string(),
                 name: "foo".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 5,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
             SymbolRow {
@@ -1372,14 +1390,18 @@ mod tests {
                 file_path: "src/b.ts".to_string(),
                 name: "bar".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 5,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
         ];
         upsert_symbols_batch(&mut conn, &symbols).unwrap();
 
         // Add to branch
-        add_symbols_to_branch_batch(&mut conn, "main", &["s1".to_string(), "s2".to_string()]).unwrap();
+        add_symbols_to_branch_batch(&mut conn, "main", &["s1".to_string(), "s2".to_string()])
+            .unwrap();
 
         let ids = get_branch_symbol_ids(&conn, "main").unwrap();
         assert_eq!(ids.len(), 2);
@@ -1402,7 +1424,10 @@ mod tests {
                 file_path: "src/a.ts".to_string(),
                 name: "used_fn".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 5,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
             SymbolRow {
@@ -1410,7 +1435,10 @@ mod tests {
                 file_path: "src/b.ts".to_string(),
                 name: "orphan_fn".to_string(),
                 kind: "function".to_string(),
-                start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+                start_line: 1,
+                start_col: 0,
+                end_line: 5,
+                end_col: 1,
                 language: "typescript".to_string(),
             },
         ];
@@ -1427,7 +1455,8 @@ mod tests {
                 target_name: "something".to_string(),
                 to_symbol_id: None,
                 call_type: "Call".to_string(),
-                line: 3, col: 4,
+                line: 3,
+                col: 4,
                 is_resolved: false,
             },
             CallEdgeRow {
@@ -1436,7 +1465,8 @@ mod tests {
                 target_name: "other".to_string(),
                 to_symbol_id: None,
                 call_type: "Call".to_string(),
-                line: 2, col: 0,
+                line: 2,
+                col: 0,
                 is_resolved: false,
             },
         ];
@@ -1472,7 +1502,10 @@ mod tests {
             file_path: "src/a.ts".to_string(),
             name: "test".to_string(),
             kind: "function".to_string(),
-            start_line: 1, start_col: 0, end_line: 5, end_col: 1,
+            start_line: 1,
+            start_col: 0,
+            end_line: 5,
+            end_col: 1,
             language: "typescript".to_string(),
         };
         upsert_symbol(&conn, &symbol).unwrap();
@@ -1483,7 +1516,8 @@ mod tests {
             target_name: "foo".to_string(),
             to_symbol_id: None,
             call_type: "Call".to_string(),
-            line: 3, col: 0,
+            line: 3,
+            col: 0,
             is_resolved: false,
         };
         upsert_call_edge(&conn, &edge).unwrap();

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -13,7 +13,7 @@ pub enum DbError {
 pub type DbResult<T> = Result<T, DbError>;
 
 /// Schema version for migrations
-const SCHEMA_VERSION: i32 = 2;
+const SCHEMA_VERSION: i32 = 3;
 
 /// Maximum number of SQL bind parameters per query.
 /// SQLite defaults to 999 (SQLITE_MAX_VARIABLE_NUMBER). We use 900 to stay safely under.
@@ -29,7 +29,9 @@ pub fn init_db(db_path: &Path) -> DbResult<Connection> {
     let conn = Connection::open(db_path)?;
 
     // Enable WAL mode for better concurrent read performance
-    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA foreign_keys = ON;",
+    )?;
 
     let current_version: i32 = conn
         .query_row(
@@ -131,7 +133,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
                 line INTEGER NOT NULL,
                 col INTEGER NOT NULL,
                 is_resolved INTEGER NOT NULL DEFAULT 0,
-                FOREIGN KEY (from_symbol_id) REFERENCES symbols(id)
+                FOREIGN KEY (from_symbol_id) REFERENCES symbols(id) ON DELETE CASCADE
             );
 
             -- Branch-symbol catalog: which symbols exist on which branch
@@ -158,6 +160,48 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
             params![SCHEMA_VERSION.to_string()],
         )?;
     }
+    if from_version >= 2 && from_version < 3 {
+        conn.execute_batch(
+            r#"
+            PRAGMA foreign_keys = OFF;
+
+            BEGIN;
+
+            CREATE TABLE call_edges_new (
+                id TEXT PRIMARY KEY,
+                from_symbol_id TEXT NOT NULL,
+                target_name TEXT NOT NULL,
+                to_symbol_id TEXT,
+                call_type TEXT NOT NULL,
+                line INTEGER NOT NULL,
+                col INTEGER NOT NULL,
+                is_resolved INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (from_symbol_id) REFERENCES symbols(id) ON DELETE CASCADE
+            );
+
+            INSERT INTO call_edges_new (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved)
+            SELECT id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved
+            FROM call_edges;
+
+            DROP TABLE call_edges;
+            ALTER TABLE call_edges_new RENAME TO call_edges;
+
+            CREATE INDEX IF NOT EXISTS idx_call_edges_from ON call_edges(from_symbol_id);
+            CREATE INDEX IF NOT EXISTS idx_call_edges_to ON call_edges(to_symbol_id);
+            CREATE INDEX IF NOT EXISTS idx_call_edges_target_name ON call_edges(target_name);
+
+            COMMIT;
+
+            PRAGMA foreign_keys = ON;
+            "#,
+        )?;
+
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
+            params![SCHEMA_VERSION.to_string()],
+        )?;
+    }
+
     Ok(())
 }
 
@@ -612,6 +656,20 @@ pub struct CallEdgeRow {
     pub is_resolved: bool,
 }
 
+#[derive(Debug, Clone)]
+pub struct CallerRow {
+    pub id: String,
+    pub from_symbol_id: String,
+    pub from_symbol_name: String,
+    pub from_symbol_file_path: String,
+    pub target_name: String,
+    pub to_symbol_id: Option<String>,
+    pub call_type: String,
+    pub line: u32,
+    pub col: u32,
+    pub is_resolved: bool,
+}
+
 /// Insert or replace a symbol
 pub fn upsert_symbol(conn: &Connection, symbol: &SymbolRow) -> DbResult<()> {
     conn.execute(
@@ -699,7 +757,7 @@ pub fn get_symbols_by_file(conn: &Connection, file_path: &str) -> DbResult<Vec<S
 }
 
 /// Find a symbol by name and file path
-pub fn _get_symbol_by_name(
+pub fn get_symbol_by_name(
     conn: &Connection,
     name: &str,
     file_path: &str,
@@ -821,6 +879,53 @@ pub fn get_callers(
             line: row.get(5)?,
             col: row.get(6)?,
             is_resolved: row.get::<_, i32>(7)? != 0,
+        })
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+pub fn get_callers_with_context(
+    conn: &Connection,
+    symbol_name: &str,
+    branch: &str,
+) -> DbResult<Vec<CallerRow>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT
+            ce.id,
+            ce.from_symbol_id,
+            s.name,
+            s.file_path,
+            ce.target_name,
+            ce.to_symbol_id,
+            ce.call_type,
+            ce.line,
+            ce.col,
+            ce.is_resolved
+        FROM call_edges ce
+        INNER JOIN symbols s ON ce.from_symbol_id = s.id
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
+        WHERE ce.target_name = ?
+        "#,
+    )?;
+
+    let rows = stmt.query_map(params![branch, symbol_name], |row| {
+        Ok(CallerRow {
+            id: row.get(0)?,
+            from_symbol_id: row.get(1)?,
+            from_symbol_name: row.get(2)?,
+            from_symbol_file_path: row.get(3)?,
+            target_name: row.get(4)?,
+            to_symbol_id: row.get(5)?,
+            call_type: row.get(6)?,
+            line: row.get(7)?,
+            col: row.get(8)?,
+            is_resolved: row.get::<_, i32>(9)? != 0,
         })
     })?;
 
@@ -1109,7 +1214,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "2");
+        assert_eq!(version, "3");
     }
 
     #[test]
@@ -1232,12 +1337,12 @@ mod tests {
         assert_eq!(symbols[0].start_line, 10);
 
         // Get by name
-        let found = _get_symbol_by_name(&conn, "handleRequest", "src/main.ts").unwrap();
+        let found = get_symbol_by_name(&conn, "handleRequest", "src/main.ts").unwrap();
         assert!(found.is_some());
         assert_eq!(found.unwrap().id, "sym1");
 
         // Not found
-        let missing = _get_symbol_by_name(&conn, "missing", "src/main.ts").unwrap();
+        let missing = get_symbol_by_name(&conn, "missing", "src/main.ts").unwrap();
         assert!(missing.is_none());
 
         // Delete by file
@@ -1528,5 +1633,138 @@ mod tests {
         let stats = get_stats(&conn).unwrap();
         assert_eq!(stats.symbol_count, 1);
         assert_eq!(stats.call_edge_count, 1);
+    }
+
+    #[test]
+    fn test_migration_v3_adds_cascade_on_call_edges() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("migration-v2.db");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                r#"
+                CREATE TABLE metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+                CREATE TABLE symbols (
+                    id TEXT PRIMARY KEY,
+                    file_path TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    start_line INTEGER NOT NULL,
+                    start_col INTEGER NOT NULL,
+                    end_line INTEGER NOT NULL,
+                    end_col INTEGER NOT NULL,
+                    language TEXT NOT NULL
+                );
+                CREATE TABLE call_edges (
+                    id TEXT PRIMARY KEY,
+                    from_symbol_id TEXT NOT NULL,
+                    target_name TEXT NOT NULL,
+                    to_symbol_id TEXT,
+                    call_type TEXT NOT NULL,
+                    line INTEGER NOT NULL,
+                    col INTEGER NOT NULL,
+                    is_resolved INTEGER NOT NULL DEFAULT 0,
+                    FOREIGN KEY (from_symbol_id) REFERENCES symbols(id)
+                );
+                CREATE INDEX idx_call_edges_from ON call_edges(from_symbol_id);
+                CREATE INDEX idx_call_edges_to ON call_edges(to_symbol_id);
+                CREATE INDEX idx_call_edges_target_name ON call_edges(target_name);
+                INSERT INTO metadata (key, value) VALUES ('schema_version', '2');
+                "#,
+            )
+            .unwrap();
+        }
+
+        let conn = init_db(&db_path).unwrap();
+
+        let schema_version: String = conn
+            .query_row(
+                "SELECT value FROM metadata WHERE key = 'schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(schema_version, "3");
+
+        let on_delete: String = conn
+            .query_row("PRAGMA foreign_key_list(call_edges)", [], |row| row.get(6))
+            .unwrap();
+        assert_eq!(on_delete.to_uppercase(), "CASCADE");
+    }
+
+    #[test]
+    fn test_foreign_keys_enabled_by_default() {
+        let (_temp_dir, conn) = setup_test_db();
+        let enabled: i64 = conn
+            .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(enabled, 1);
+    }
+
+    #[test]
+    fn test_cascade_deletes_call_edges_when_symbol_deleted() {
+        let (_temp_dir, mut conn) = setup_test_db();
+
+        let symbols = vec![
+            SymbolRow {
+                id: "sym_caller".to_string(),
+                file_path: "src/main.ts".to_string(),
+                name: "main".to_string(),
+                kind: "function".to_string(),
+                start_line: 1,
+                start_col: 0,
+                end_line: 10,
+                end_col: 1,
+                language: "typescript".to_string(),
+            },
+            SymbolRow {
+                id: "sym_target".to_string(),
+                file_path: "src/main.ts".to_string(),
+                name: "target".to_string(),
+                kind: "function".to_string(),
+                start_line: 12,
+                start_col: 0,
+                end_line: 20,
+                end_col: 1,
+                language: "typescript".to_string(),
+            },
+        ];
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+        add_symbols_to_branch(
+            &conn,
+            "main",
+            &["sym_caller".to_string(), "sym_target".to_string()],
+        )
+        .unwrap();
+
+        let edge = CallEdgeRow {
+            id: "edge_cascade".to_string(),
+            from_symbol_id: "sym_caller".to_string(),
+            target_name: "target".to_string(),
+            to_symbol_id: None,
+            call_type: "Call".to_string(),
+            line: 5,
+            col: 2,
+            is_resolved: false,
+        };
+        upsert_call_edge(&conn, &edge).unwrap();
+        let before = get_callees(&conn, "sym_caller", "main").unwrap();
+        assert_eq!(before.len(), 1);
+
+        let deleted = delete_symbols_by_file(&conn, "src/main.ts").unwrap();
+        assert_eq!(deleted, 2);
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM call_edges WHERE id = 'edge_cascade'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -160,7 +160,7 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
             params![SCHEMA_VERSION.to_string()],
         )?;
     }
-    if from_version >= 2 && from_version < 3 {
+    if (2..3).contains(&from_version) {
         conn.execute_batch(
             r#"
             PRAGMA foreign_keys = OFF;

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -804,13 +804,13 @@ impl Database {
     }
 
     #[napi]
-    pub fn get_callees(&self, symbol_id: String) -> Result<Vec<CallEdgeData>> {
+    pub fn get_callees(&self, symbol_id: String, branch: String) -> Result<Vec<CallEdgeData>> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
         let rows =
-            db::get_callees(&conn, &symbol_id).map_err(|e| Error::from_reason(e.to_string()))?;
+            db::get_callees(&conn, &symbol_id, &branch).map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(rows
             .into_iter()
             .map(|r| CallEdgeData {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 
+mod call_extractor;
 mod chunker;
 mod db;
 mod hasher;
@@ -7,7 +8,6 @@ mod inverted_index;
 mod parser;
 mod store;
 mod types;
-mod call_extractor;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -777,8 +777,7 @@ impl Database {
                 is_resolved: e.is_resolved,
             })
             .collect();
-        db::upsert_call_edges_batch(&mut conn, &rows)
-            .map_err(|e| Error::from_reason(e.to_string()))
+        db::upsert_call_edges_batch(&mut conn, &rows).map_err(|e| Error::from_reason(e.to_string()))
     }
 
     #[napi]
@@ -810,8 +809,8 @@ impl Database {
             .conn
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
-        let rows = db::get_callees(&conn, &symbol_id)
-            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows =
+            db::get_callees(&conn, &symbol_id).map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(rows
             .into_iter()
             .map(|r| CallEdgeData {
@@ -880,8 +879,7 @@ impl Database {
             .conn
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
-        db::get_branch_symbol_ids(&conn, &branch)
-            .map_err(|e| Error::from_reason(e.to_string()))
+        db::get_branch_symbol_ids(&conn, &branch).map_err(|e| Error::from_reason(e.to_string()))
     }
 
     #[napi]
@@ -903,8 +901,7 @@ impl Database {
             .conn
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
-        let count =
-            db::gc_orphan_symbols(&conn).map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::gc_orphan_symbols(&conn).map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(count as u32)
     }
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -7,6 +7,7 @@ mod inverted_index;
 mod parser;
 mod store;
 mod types;
+mod call_extractor;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -37,6 +38,23 @@ pub fn hash_content(content: String) -> String {
 #[napi]
 pub fn hash_file(file_path: String) -> Result<String> {
     hasher::xxhash_file(&file_path).map_err(|e| Error::from_reason(e.to_string()))
+}
+
+#[napi]
+pub fn extract_calls(content: String, language: String) -> Result<Vec<CallSiteData>> {
+    call_extractor::extract_calls(&content, &language)
+        .map(|sites| {
+            sites
+                .into_iter()
+                .map(|s| CallSiteData {
+                    callee_name: s.callee_name,
+                    line: s.line,
+                    column: s.column,
+                    call_type: format!("{:?}", s.call_type),
+                })
+                .collect()
+        })
+        .map_err(|e| Error::from_reason(e.to_string()))
 }
 
 #[napi]
@@ -184,6 +202,39 @@ pub struct KeyMetadataPair {
 }
 
 #[napi(object)]
+pub struct CallSiteData {
+    pub callee_name: String,
+    pub line: u32,
+    pub column: u32,
+    pub call_type: String,
+}
+
+#[napi(object)]
+pub struct SymbolData {
+    pub id: String,
+    pub file_path: String,
+    pub name: String,
+    pub kind: String,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+    pub language: String,
+}
+
+#[napi(object)]
+pub struct CallEdgeData {
+    pub id: String,
+    pub from_symbol_id: String,
+    pub target_name: String,
+    pub to_symbol_id: Option<String>,
+    pub call_type: String,
+    pub line: u32,
+    pub col: u32,
+    pub is_resolved: bool,
+}
+
+#[napi(object)]
 pub struct KeywordSearchResult {
     pub chunk_id: String,
     pub score: f64,
@@ -290,6 +341,8 @@ pub struct DatabaseStats {
     pub chunk_count: u32,
     pub branch_chunk_count: u32,
     pub branch_count: u32,
+    pub symbol_count: u32,
+    pub call_edge_count: u32,
 }
 
 #[napi]
@@ -599,6 +652,270 @@ impl Database {
             chunk_count: stats.chunk_count as u32,
             branch_chunk_count: stats.branch_chunk_count as u32,
             branch_count: stats.branch_count as u32,
+            symbol_count: stats.symbol_count as u32,
+            call_edge_count: stats.call_edge_count as u32,
         })
+    }
+
+    // ── Symbol methods ──────────────────────────────────────────────
+
+    #[napi]
+    pub fn upsert_symbol(&self, symbol: SymbolData) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let row = db::SymbolRow {
+            id: symbol.id,
+            file_path: symbol.file_path,
+            name: symbol.name,
+            kind: symbol.kind,
+            start_line: symbol.start_line,
+            start_col: symbol.start_col,
+            end_line: symbol.end_line,
+            end_col: symbol.end_col,
+            language: symbol.language,
+        };
+        db::upsert_symbol(&conn, &row).map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn upsert_symbols_batch(&self, symbols: Vec<SymbolData>) -> Result<()> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows: Vec<db::SymbolRow> = symbols
+            .into_iter()
+            .map(|s| db::SymbolRow {
+                id: s.id,
+                file_path: s.file_path,
+                name: s.name,
+                kind: s.kind,
+                start_line: s.start_line,
+                start_col: s.start_col,
+                end_line: s.end_line,
+                end_col: s.end_col,
+                language: s.language,
+            })
+            .collect();
+        db::upsert_symbols_batch(&mut conn, &rows).map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn get_symbols_by_file(&self, file_path: String) -> Result<Vec<SymbolData>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows = db::get_symbols_by_file(&conn, &file_path)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(rows
+            .into_iter()
+            .map(|r| SymbolData {
+                id: r.id,
+                file_path: r.file_path,
+                name: r.name,
+                kind: r.kind,
+                start_line: r.start_line,
+                start_col: r.start_col,
+                end_line: r.end_line,
+                end_col: r.end_col,
+                language: r.language,
+            })
+            .collect())
+    }
+
+    #[napi]
+    pub fn delete_symbols_by_file(&self, file_path: String) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_symbols_by_file(&conn, &file_path)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    // ── Call Edge methods ────────────────────────────────────────────
+
+    #[napi]
+    pub fn upsert_call_edge(&self, edge: CallEdgeData) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let row = db::CallEdgeRow {
+            id: edge.id,
+            from_symbol_id: edge.from_symbol_id,
+            target_name: edge.target_name,
+            to_symbol_id: edge.to_symbol_id,
+            call_type: edge.call_type,
+            line: edge.line,
+            col: edge.col,
+            is_resolved: edge.is_resolved,
+        };
+        db::upsert_call_edge(&conn, &row).map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn upsert_call_edges_batch(&self, edges: Vec<CallEdgeData>) -> Result<()> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows: Vec<db::CallEdgeRow> = edges
+            .into_iter()
+            .map(|e| db::CallEdgeRow {
+                id: e.id,
+                from_symbol_id: e.from_symbol_id,
+                target_name: e.target_name,
+                to_symbol_id: e.to_symbol_id,
+                call_type: e.call_type,
+                line: e.line,
+                col: e.col,
+                is_resolved: e.is_resolved,
+            })
+            .collect();
+        db::upsert_call_edges_batch(&mut conn, &rows)
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn get_callers(&self, symbol_name: String, branch: String) -> Result<Vec<CallEdgeData>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows = db::get_callers(&conn, &symbol_name, &branch)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(rows
+            .into_iter()
+            .map(|r| CallEdgeData {
+                id: r.id,
+                from_symbol_id: r.from_symbol_id,
+                target_name: r.target_name,
+                to_symbol_id: r.to_symbol_id,
+                call_type: r.call_type,
+                line: r.line,
+                col: r.col,
+                is_resolved: r.is_resolved,
+            })
+            .collect())
+    }
+
+    #[napi]
+    pub fn get_callees(&self, symbol_id: String) -> Result<Vec<CallEdgeData>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows = db::get_callees(&conn, &symbol_id)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(rows
+            .into_iter()
+            .map(|r| CallEdgeData {
+                id: r.id,
+                from_symbol_id: r.from_symbol_id,
+                target_name: r.target_name,
+                to_symbol_id: r.to_symbol_id,
+                call_type: r.call_type,
+                line: r.line,
+                col: r.col,
+                is_resolved: r.is_resolved,
+            })
+            .collect())
+    }
+
+    #[napi]
+    pub fn delete_call_edges_by_file(&self, file_path: String) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_call_edges_by_file(&conn, &file_path)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
+    pub fn resolve_call_edge(&self, edge_id: String, to_symbol_id: String) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::resolve_call_edge(&conn, &edge_id, &to_symbol_id)
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    // ── Branch Symbol methods ────────────────────────────────────────
+
+    #[napi]
+    pub fn add_symbols_to_branch(&self, branch: String, symbol_ids: Vec<String>) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::add_symbols_to_branch(&conn, &branch, &symbol_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn add_symbols_to_branch_batch(
+        &self,
+        branch: String,
+        symbol_ids: Vec<String>,
+    ) -> Result<()> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::add_symbols_to_branch_batch(&mut conn, &branch, &symbol_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn get_branch_symbol_ids(&self, branch: String) -> Result<Vec<String>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::get_branch_symbol_ids(&conn, &branch)
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn clear_branch_symbols(&self, branch: String) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::clear_branch_symbols(&conn, &branch)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    // ── GC methods for symbols/edges ─────────────────────────────────
+
+    #[napi]
+    pub fn gc_orphan_symbols(&self) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count =
+            db::gc_orphan_symbols(&conn).map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
+    pub fn gc_orphan_call_edges(&self) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count =
+            db::gc_orphan_call_edges(&conn).map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
     }
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -226,6 +226,8 @@ pub struct SymbolData {
 pub struct CallEdgeData {
     pub id: String,
     pub from_symbol_id: String,
+    pub from_symbol_name: Option<String>,
+    pub from_symbol_file_path: Option<String>,
     pub target_name: String,
     pub to_symbol_id: Option<String>,
     pub call_type: String,
@@ -727,6 +729,31 @@ impl Database {
     }
 
     #[napi]
+    pub fn get_symbol_by_name(
+        &self,
+        name: String,
+        file_path: String,
+    ) -> Result<Option<SymbolData>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let row = db::get_symbol_by_name(&conn, &name, &file_path)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(row.map(|r| SymbolData {
+            id: r.id,
+            file_path: r.file_path,
+            name: r.name,
+            kind: r.kind,
+            start_line: r.start_line,
+            start_col: r.start_col,
+            end_line: r.end_line,
+            end_col: r.end_col,
+            language: r.language,
+        }))
+    }
+
+    #[napi]
     pub fn delete_symbols_by_file(&self, file_path: String) -> Result<u32> {
         let conn = self
             .conn
@@ -793,6 +820,8 @@ impl Database {
             .map(|r| CallEdgeData {
                 id: r.id,
                 from_symbol_id: r.from_symbol_id,
+                from_symbol_name: None,
+                from_symbol_file_path: None,
                 target_name: r.target_name,
                 to_symbol_id: r.to_symbol_id,
                 call_type: r.call_type,
@@ -816,6 +845,37 @@ impl Database {
             .map(|r| CallEdgeData {
                 id: r.id,
                 from_symbol_id: r.from_symbol_id,
+                from_symbol_name: None,
+                from_symbol_file_path: None,
+                target_name: r.target_name,
+                to_symbol_id: r.to_symbol_id,
+                call_type: r.call_type,
+                line: r.line,
+                col: r.col,
+                is_resolved: r.is_resolved,
+            })
+            .collect())
+    }
+
+    #[napi]
+    pub fn get_callers_with_context(
+        &self,
+        symbol_name: String,
+        branch: String,
+    ) -> Result<Vec<CallEdgeData>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows = db::get_callers_with_context(&conn, &symbol_name, &branch)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(rows
+            .into_iter()
+            .map(|r| CallEdgeData {
+                id: r.id,
+                from_symbol_id: r.from_symbol_id,
+                from_symbol_name: Some(r.from_symbol_name),
+                from_symbol_file_path: Some(r.from_symbol_file_path),
                 target_name: r.target_name,
                 to_symbol_id: r.to_symbol_id,
                 call_type: r.call_type,

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -809,8 +809,8 @@ impl Database {
             .conn
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
-        let rows =
-            db::get_callees(&conn, &symbol_id, &branch).map_err(|e| Error::from_reason(e.to_string()))?;
+        let rows = db::get_callees(&conn, &symbol_id, &branch)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(rows
             .into_iter()
             .map(|r| CallEdgeData {

--- a/native/src/types.rs
+++ b/native/src/types.rs
@@ -79,4 +79,27 @@ impl Language {
             Language::Unknown => "unknown",
         }
     }
+
+    pub fn from_string(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "typescript" | "ts" => Language::TypeScript,
+            "tsx" => Language::TypeScriptTsx,
+            "javascript" | "js" => Language::JavaScript,
+            "jsx" => Language::JavaScriptJsx,
+            "python" | "py" => Language::Python,
+            "rust" | "rs" => Language::Rust,
+            "go" => Language::Go,
+            "java" => Language::Java,
+            "csharp" | "cs" | "c#" => Language::CSharp,
+            "ruby" | "rb" => Language::Ruby,
+            "c" => Language::C,
+            "cpp" | "c++" => Language::Cpp,
+            "json" => Language::Json,
+            "toml" => Language::Toml,
+            "yaml" | "yml" => Language::Yaml,
+            "bash" | "sh" | "zsh" => Language::Bash,
+            "markdown" | "md" => Language::Markdown,
+            _ => Language::Unknown,
+        }
+    }
 }

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -12,6 +12,7 @@ description: Semantic code search by meaning. Use codebase_peek to find WHERE co
 | Just need file locations | `codebase_peek` | Metadata only, saves ~90% tokens |
 | Need to see actual code | `codebase_search` | Returns full code content |
 | Find duplicates/patterns | `find_similar` | Given code snippet → similar code |
+| Understand code flow | `call_graph` | Find callers/callees of any function |
 | Don't know function/class names | `codebase_peek` or `codebase_search` | Natural language → code |
 | Know exact identifier names | `grep` | Faster, more precise |
 | Need ALL occurrences | `grep` | Semantic returns top N only |
@@ -45,8 +46,19 @@ Find code similar to a given snippet. Use for duplicate detection, pattern disco
 find_similar(code="function validate(input) { return input.length > 0; }", excludeFile="src/current.ts")
 ```
 
+### `call_graph`
+Query callers or callees of a function/method. Built automatically during indexing for TypeScript, JavaScript, Python, Go, and Rust.
+
+```
+call_graph(name="validateToken", direction="callers")
+call_graph(name="validateToken", direction="callees", symbolId="src/auth.ts::validateToken")
+```
+
+- `direction="callers"`: Who calls this function?
+- `direction="callees"`: What does this function call? (requires `symbolId` from a prior callers query)
+
 ### `index_codebase`
-Create/update index. Required before first search. Incremental (~50ms when unchanged).
+Manually trigger indexing. Required before first search. Incremental (~50ms when unchanged).
 
 ### `index_status`
 Check if indexed and ready.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   index_metrics,
   index_logs,
   find_similar,
+  call_graph,
   initializeTools,
 } from "./tools/index.js";
 import { loadCommandsFromDirectory } from "./commands/loader.js";
@@ -94,6 +95,7 @@ const plugin: Plugin = async ({ directory }) => {
       index_metrics,
       index_logs,
       find_similar,
+      call_graph,
     },
 
     async config(cfg) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -31,6 +31,9 @@ import {
 import type { SymbolData, CallEdgeData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 
+const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust"]);
+const SEMANTIC_CHUNK_TYPES = new Set(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module"]);
+
 function float32ArrayToBuffer(arr: number[]): Buffer {
   const float32 = new Float32Array(arr);
   return Buffer.from(float32.buffer);
@@ -747,10 +750,8 @@ export class Indexer {
 
     // ── Call Graph Extraction ────────────────────────────────────────
     // Extract symbols and call edges from changed files.
-    const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust"]);
     const allSymbolIds = new Set<string>();
     const symbolsByFile = new Map<string, SymbolData[]>();
-    const semanticChunkTypes = new Set(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module"]);
 
     // For changed files: delete old symbols/edges, extract new ones
     for (let i = 0; i < parsedFiles.length; i++) {
@@ -765,7 +766,7 @@ export class Indexer {
       const fileSymbols: SymbolData[] = [];
 
       for (const chunk of parsed.chunks) {
-        if (!chunk.name || !semanticChunkTypes.has(chunk.chunkType)) continue;
+        if (!chunk.name || !SEMANTIC_CHUNK_TYPES.has(chunk.chunkType)) continue;
 
         const symbolId = `sym_${hashContent(parsed.path + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`;
         const symbol: SymbolData = {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1698,6 +1698,6 @@ export class Indexer {
 
   async getCallees(symbolId: string): Promise<CallEdgeData[]> {
     const { database } = await this.ensureInitialized();
-    return database.getCallees(symbolId);
+    return database.getCallees(symbolId, this.currentBranch);
   }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -25,7 +25,10 @@ import {
   ChunkData,
   createDynamicBatches,
   hashFile,
+  hashContent,
+  extractCalls,
 } from "../native/index.js";
+import type { SymbolData, CallEdgeData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 
 function float32ArrayToBuffer(arr: number[]): Buffer {
@@ -84,6 +87,8 @@ export interface HealthCheckResult {
   filePaths: string[];
   gcOrphanEmbeddings: number;
   gcOrphanChunks: number;
+  gcOrphanSymbols: number;
+  gcOrphanCallEdges: number;
 }
 
 export interface StatusResult {
@@ -739,6 +744,99 @@ export class Indexer {
       database.upsertChunksBatch(chunkDataBatch);
     }
 
+
+    // ── Call Graph Extraction ────────────────────────────────────────
+    // Extract symbols and call edges from changed files.
+    const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust"]);
+    const allSymbolIds = new Set<string>();
+    const symbolsByFile = new Map<string, SymbolData[]>();
+    const semanticChunkTypes = new Set(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module"]);
+
+    // For changed files: delete old symbols/edges, extract new ones
+    for (let i = 0; i < parsedFiles.length; i++) {
+      const parsed = parsedFiles[i];
+      const changedFile = changedFiles[i];
+
+      // Clean up old call graph data for this file
+      database.deleteCallEdgesByFile(parsed.path);
+      database.deleteSymbolsByFile(parsed.path);
+
+      // Build symbols from parsed chunks
+      const fileSymbols: SymbolData[] = [];
+
+      for (const chunk of parsed.chunks) {
+        if (!chunk.name || !semanticChunkTypes.has(chunk.chunkType)) continue;
+
+        const symbolId = `sym_${hashContent(parsed.path + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`;
+        const symbol: SymbolData = {
+          id: symbolId,
+          filePath: parsed.path,
+          name: chunk.name,
+          kind: chunk.chunkType,
+          startLine: chunk.startLine,
+          startCol: 0,
+          endLine: chunk.endLine,
+          endCol: 0,
+          language: chunk.language,
+        };
+        fileSymbols.push(symbol);
+        allSymbolIds.add(symbolId);
+      }
+
+      if (fileSymbols.length > 0) {
+        database.upsertSymbolsBatch(fileSymbols);
+        symbolsByFile.set(parsed.path, fileSymbols);
+      }
+
+      // Extract call sites from file content (only for supported languages)
+      const fileLanguage = parsed.chunks[0]?.language;
+      if (!fileLanguage || !CALL_GRAPH_LANGUAGES.has(fileLanguage)) continue;
+
+      const callSites = extractCalls(changedFile.content, fileLanguage);
+      if (callSites.length === 0) continue;
+
+      // Map each call site to its enclosing symbol
+      const edges: CallEdgeData[] = [];
+      for (const site of callSites) {
+        // Find the enclosing symbol (function/method that contains this call)
+        const enclosingSymbol = fileSymbols.find(
+          (sym) => site.line >= sym.startLine && site.line <= sym.endLine
+        );
+        if (!enclosingSymbol) continue;
+
+        const edgeId = `edge_${hashContent(enclosingSymbol.id + ":" + site.calleeName + ":" + site.line + ":" + site.column).slice(0, 16)}`;
+        edges.push({
+          id: edgeId,
+          fromSymbolId: enclosingSymbol.id,
+          targetName: site.calleeName,
+          callType: site.callType,
+          line: site.line,
+          col: site.column,
+          isResolved: false,
+        });
+      }
+
+      if (edges.length > 0) {
+        database.upsertCallEdgesBatch(edges);
+
+        // Resolve same-file calls
+        for (const edge of edges) {
+          const matchingSymbol = fileSymbols.find((sym) => sym.name === edge.targetName);
+          if (matchingSymbol) {
+            database.resolveCallEdge(edge.id, matchingSymbol.id);
+          }
+        }
+      }
+    }
+
+    // Collect symbol IDs from unchanged files for branch association
+    for (const filePath of unchangedFilePaths) {
+      const existingSymbols = database.getSymbolsByFile(filePath);
+      for (const sym of existingSymbols) {
+        allSymbolIds.add(sym.id);
+      }
+    }
+
     let removedCount = 0;
     for (const [chunkId] of existingChunks) {
       if (!currentChunkIds.has(chunkId)) {
@@ -763,6 +861,8 @@ export class Indexer {
     if (pendingChunks.length === 0 && removedCount === 0) {
       database.clearBranch(this.currentBranch);
       database.addChunksToBranchBatch(this.currentBranch, Array.from(currentChunkIds));
+      database.clearBranchSymbols(this.currentBranch);
+      database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
       this.fileHashCache = currentFileHashes;
       this.saveFileHashCache();
       stats.durationMs = Date.now() - startTime;
@@ -780,6 +880,8 @@ export class Indexer {
     if (pendingChunks.length === 0) {
       database.clearBranch(this.currentBranch);
       database.addChunksToBranchBatch(this.currentBranch, Array.from(currentChunkIds));
+      database.clearBranchSymbols(this.currentBranch);
+      database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
       store.save();
       invertedIndex.save();
       this.fileHashCache = currentFileHashes;
@@ -938,6 +1040,8 @@ export class Indexer {
 
     database.clearBranch(this.currentBranch);
     database.addChunksToBranchBatch(this.currentBranch, Array.from(currentChunkIds));
+    database.clearBranchSymbols(this.currentBranch);
+    database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
 
     store.save();
     invertedIndex.save();
@@ -1304,6 +1408,7 @@ export class Indexer {
 
     // Clear branch catalog
     database.clearBranch(this.currentBranch);
+    database.clearBranchSymbols(this.currentBranch);
 
     // Clear index metadata so compatibility is re-evaluated from scratch
     database.deleteMetadata("index.version");
@@ -1342,6 +1447,8 @@ export class Indexer {
           removedCount++;
         }
         database.deleteChunksByFile(filePath);
+        database.deleteCallEdgesByFile(filePath);
+        database.deleteSymbolsByFile(filePath);
         removedFilePaths.push(filePath);
       }
     }
@@ -1353,6 +1460,8 @@ export class Indexer {
 
     const gcOrphanEmbeddings = database.gcOrphanEmbeddings();
     const gcOrphanChunks = database.gcOrphanChunks();
+    const gcOrphanSymbols = database.gcOrphanSymbols();
+    const gcOrphanCallEdges = database.gcOrphanCallEdges();
 
     this.logger.recordGc(removedCount, gcOrphanChunks, gcOrphanEmbeddings);
     this.logger.gc("info", "Health check complete", {
@@ -1362,7 +1471,7 @@ export class Indexer {
       removedFiles: removedFilePaths.length,
     });
 
-    return { removed: removedCount, filePaths: removedFilePaths, gcOrphanEmbeddings, gcOrphanChunks };
+    return { removed: removedCount, filePaths: removedFilePaths, gcOrphanEmbeddings, gcOrphanChunks, gcOrphanSymbols, gcOrphanCallEdges };
   }
 
   async retryFailedBatches(): Promise<{ succeeded: number; failed: number; remaining: number }> {
@@ -1579,5 +1688,15 @@ export class Indexer {
         };
       })
     );
+  }
+
+  async getCallers(targetName: string): Promise<CallEdgeData[]> {
+    const { database } = await this.ensureInitialized();
+    return database.getCallers(targetName, this.currentBranch);
+  }
+
+  async getCallees(symbolId: string): Promise<CallEdgeData[]> {
+    const { database } = await this.ensureInitialized();
+    return database.getCallees(symbolId);
   }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -784,6 +784,13 @@ export class Indexer {
         allSymbolIds.add(symbolId);
       }
 
+      const symbolsByName = new Map<string, SymbolData[]>();
+      for (const symbol of fileSymbols) {
+        const existing = symbolsByName.get(symbol.name) ?? [];
+        existing.push(symbol);
+        symbolsByName.set(symbol.name, existing);
+      }
+
       if (fileSymbols.length > 0) {
         database.upsertSymbolsBatch(fileSymbols);
         symbolsByFile.set(parsed.path, fileSymbols);
@@ -810,6 +817,7 @@ export class Indexer {
           id: edgeId,
           fromSymbolId: enclosingSymbol.id,
           targetName: site.calleeName,
+          toSymbolId: undefined,
           callType: site.callType,
           line: site.line,
           col: site.column,
@@ -822,9 +830,9 @@ export class Indexer {
 
         // Resolve same-file calls
         for (const edge of edges) {
-          const matchingSymbol = fileSymbols.find((sym) => sym.name === edge.targetName);
-          if (matchingSymbol) {
-            database.resolveCallEdge(edge.id, matchingSymbol.id);
+          const candidates = symbolsByName.get(edge.targetName);
+          if (candidates && candidates.length === 1) {
+            database.resolveCallEdge(edge.id, candidates[0].id);
           }
         }
       }
@@ -1693,7 +1701,7 @@ export class Indexer {
 
   async getCallers(targetName: string): Promise<CallEdgeData[]> {
     const { database } = await this.ensureInitialized();
-    return database.getCallers(targetName, this.currentBranch);
+    return database.getCallersWithContext(targetName, this.currentBranch);
   }
 
   async getCallees(symbolId: string): Promise<CallEdgeData[]> {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -32,7 +32,28 @@ import type { SymbolData, CallEdgeData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 
 const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust"]);
-const SEMANTIC_CHUNK_TYPES = new Set(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module"]);
+const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
+  "function_declaration",
+  "function",
+  "arrow_function",
+  "method_definition",
+  "class_declaration",
+  "interface_declaration",
+  "type_alias_declaration",
+  "enum_declaration",
+  "function_definition",
+  "class_definition",
+  "decorated_definition",
+  "method_declaration",
+  "type_declaration",
+  "type_spec",
+  "function_item",
+  "impl_item",
+  "struct_item",
+  "enum_item",
+  "trait_item",
+  "mod_item",
+]);
 
 function float32ArrayToBuffer(arr: number[]): Buffer {
   const float32 = new Float32Array(arr);
@@ -766,7 +787,7 @@ export class Indexer {
       const fileSymbols: SymbolData[] = [];
 
       for (const chunk of parsed.chunks) {
-        if (!chunk.name || !SEMANTIC_CHUNK_TYPES.has(chunk.chunkType)) continue;
+        if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
 
         const symbolId = `sym_${hashContent(parsed.path + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`;
         const symbol: SymbolData = {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -394,6 +394,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
       return { content: [{ type: "text", text: `"${args.name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}` }] };
     },
   );
+
   // --- Prompts ---
 
   server.prompt(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -233,7 +233,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
       await ensureInitialized();
       const result = await indexer.healthCheck();
 
-      if (result.removed === 0 && result.gcOrphanEmbeddings === 0 && result.gcOrphanChunks === 0) {
+      if (result.removed === 0 && result.gcOrphanEmbeddings === 0 && result.gcOrphanChunks === 0 && result.gcOrphanSymbols === 0 && result.gcOrphanCallEdges === 0) {
         return { content: [{ type: "text", text: "Index is healthy. No stale entries found." }] };
       }
 
@@ -249,6 +249,14 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
 
       if (result.gcOrphanChunks > 0) {
         lines.push(`  Garbage collected orphan chunks: ${result.gcOrphanChunks}`);
+      }
+
+      if (result.gcOrphanSymbols > 0) {
+        lines.push(`  Garbage collected orphan symbols: ${result.gcOrphanSymbols}`);
+      }
+
+      if (result.gcOrphanCallEdges > 0) {
+        lines.push(`  Garbage collected orphan call edges: ${result.gcOrphanCallEdges}`);
       }
 
       if (result.filePaths.length > 0) {
@@ -352,6 +360,40 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
     },
   );
 
+
+  server.tool(
+    "call_graph",
+    "Query the call graph to find callers or callees of a function/method. Use to understand code flow and dependencies.",
+    {
+      name: z.string().describe("Function or method name to query"),
+      direction: z.enum(["callers", "callees"]).default("callers").describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
+      symbolId: z.string().optional().describe("Symbol ID (required for 'callees' direction)"),
+    },
+    async (args) => {
+      await ensureInitialized();
+      if (args.direction === "callees") {
+        if (!args.symbolId) {
+          return { content: [{ type: "text", text: "Error: 'symbolId' is required when direction is 'callees'." }] };
+        }
+        const callees = await indexer.getCallees(args.symbolId);
+        if (callees.length === 0) {
+          return { content: [{ type: "text", text: `No callees found for symbol ${args.symbolId}.` }] };
+        }
+        const formatted = callees.map((e, i) =>
+          `[${i + 1}] \u2192 ${e.targetName} (${e.callType}) at line ${e.line}${e.isResolved ? ` [resolved: ${e.toSymbolId}]` : " [unresolved]"}`
+        );
+        return { content: [{ type: "text", text: `Callees (${callees.length}):\n\n${formatted.join("\n")}` }] };
+      }
+      const callers = await indexer.getCallers(args.name);
+      if (callers.length === 0) {
+        return { content: [{ type: "text", text: `No callers found for "${args.name}".` }] };
+      }
+      const formatted = callers.map((e, i) =>
+        `[${i + 1}] \u2190 from symbol ${e.fromSymbolId} (${e.callType}) at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`
+      );
+      return { content: [{ type: "text", text: `"${args.name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}` }] };
+    },
+  );
   // --- Prompts ---
 
   server.prompt(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { Indexer, type IndexStats } from "./indexer/index.js";
 import type { ParsedCodebaseIndexConfig, LogLevel } from "./config/schema.js";
 import { formatCostEstimate } from "./utils/cost.js";
+import type { LogEntry } from "./utils/logger.js";
 
 const MAX_CONTENT_LINES = 30;
 
@@ -303,7 +304,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
         return { content: [{ type: "text", text: "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true\n  }\n}\n```" }] };
       }
 
-      let logs;
+      let logs: LogEntry[];
       if (args.category) {
         logs = logger.getLogsByCategory(args.category, args.limit);
       } else if (args.level) {
@@ -389,7 +390,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
         return { content: [{ type: "text", text: `No callers found for "${args.name}".` }] };
       }
       const formatted = callers.map((e, i) =>
-        `[${i + 1}] \u2190 from symbol ${e.fromSymbolId} (${e.callType}) at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`
+        `[${i + 1}] \u2190 from ${e.fromSymbolName ?? "<unknown>"} in ${e.fromSymbolFilePath ?? "<unknown file>"} [${e.fromSymbolId}] (${e.callType}) at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`
       );
       return { content: [{ type: "text", text: `"${args.name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}` }] };
     },

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -90,6 +90,39 @@ export interface ParsedFile {
   hash: string;
 }
 
+
+export type CallType = "Call" | "MethodCall" | "Constructor" | "Import";
+
+export interface CallSiteData {
+  calleeName: string;
+  line: number;
+  column: number;
+  callType: CallType;
+}
+
+export interface SymbolData {
+  id: string;
+  filePath: string;
+  name: string;
+  kind: string;
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+  language: string;
+}
+
+export interface CallEdgeData {
+  id: string;
+  fromSymbolId: string;
+  targetName: string;
+  toSymbolId?: string;
+  callType: string;
+  line: number;
+  col: number;
+  isResolved: boolean;
+}
+
 export interface SearchResult {
   id: string;
   score: number;
@@ -137,6 +170,11 @@ export function hashContent(content: string): string {
 
 export function hashFile(filePath: string): string {
   return native.hashFile(filePath);
+}
+
+
+export function extractCalls(content: string, language: string): CallSiteData[] {
+  return native.extractCalls(content, language);
 }
 
 export class VectorStore {
@@ -533,6 +571,8 @@ export interface DatabaseStats {
   chunkCount: number;
   branchChunkCount: number;
   branchCount: number;
+  symbolCount: number;
+  callEdgeCount: number;
 }
 
 export class Database {
@@ -647,5 +687,80 @@ export class Database {
 
   getStats(): DatabaseStats {
     return this.inner.getStats();
+  }
+
+  // ── Symbol methods ──────────────────────────────────────────────
+
+  upsertSymbol(symbol: SymbolData): void {
+    this.inner.upsertSymbol(symbol);
+  }
+
+  upsertSymbolsBatch(symbols: SymbolData[]): void {
+    if (symbols.length === 0) return;
+    this.inner.upsertSymbolsBatch(symbols);
+  }
+
+  getSymbolsByFile(filePath: string): SymbolData[] {
+    return this.inner.getSymbolsByFile(filePath);
+  }
+
+  deleteSymbolsByFile(filePath: string): number {
+    return this.inner.deleteSymbolsByFile(filePath);
+  }
+
+  // ── Call Edge methods ────────────────────────────────────────────
+
+  upsertCallEdge(edge: CallEdgeData): void {
+    this.inner.upsertCallEdge(edge);
+  }
+
+  upsertCallEdgesBatch(edges: CallEdgeData[]): void {
+    if (edges.length === 0) return;
+    this.inner.upsertCallEdgesBatch(edges);
+  }
+
+  getCallers(targetName: string, branch: string): CallEdgeData[] {
+    return this.inner.getCallers(targetName, branch);
+  }
+
+  getCallees(symbolId: string): CallEdgeData[] {
+    return this.inner.getCallees(symbolId);
+  }
+
+  deleteCallEdgesByFile(filePath: string): number {
+    return this.inner.deleteCallEdgesByFile(filePath);
+  }
+
+  resolveCallEdge(edgeId: string, toSymbolId: string): void {
+    this.inner.resolveCallEdge(edgeId, toSymbolId);
+  }
+
+  // ── Branch Symbol methods ────────────────────────────────────────
+
+  addSymbolsToBranch(branch: string, symbolIds: string[]): void {
+    this.inner.addSymbolsToBranch(branch, symbolIds);
+  }
+
+  addSymbolsToBranchBatch(branch: string, symbolIds: string[]): void {
+    if (symbolIds.length === 0) return;
+    this.inner.addSymbolsToBranchBatch(branch, symbolIds);
+  }
+
+  getBranchSymbolIds(branch: string): string[] {
+    return this.inner.getBranchSymbolIds(branch);
+  }
+
+  clearBranchSymbols(branch: string): number {
+    return this.inner.clearBranchSymbols(branch);
+  }
+
+  // ── GC methods for symbols/edges ─────────────────────────────────
+
+  gcOrphanSymbols(): number {
+    return this.inner.gcOrphanSymbols();
+  }
+
+  gcOrphanCallEdges(): number {
+    return this.inner.gcOrphanCallEdges();
   }
 }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -723,8 +723,8 @@ export class Database {
     return this.inner.getCallers(targetName, branch);
   }
 
-  getCallees(symbolId: string): CallEdgeData[] {
-    return this.inner.getCallees(symbolId);
+  getCallees(symbolId: string, branch: string): CallEdgeData[] {
+    return this.inner.getCallees(symbolId, branch);
   }
 
   deleteCallEdgesByFile(filePath: string): number {

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -115,6 +115,8 @@ export interface SymbolData {
 export interface CallEdgeData {
   id: string;
   fromSymbolId: string;
+  fromSymbolName?: string;
+  fromSymbolFilePath?: string;
   targetName: string;
   toSymbolId?: string;
   callType: string;
@@ -704,6 +706,10 @@ export class Database {
     return this.inner.getSymbolsByFile(filePath);
   }
 
+  getSymbolByName(name: string, filePath: string): SymbolData | null {
+    return this.inner.getSymbolByName(name, filePath) ?? null;
+  }
+
   deleteSymbolsByFile(filePath: string): number {
     return this.inner.deleteSymbolsByFile(filePath);
   }
@@ -721,6 +727,10 @@ export class Database {
 
   getCallers(targetName: string, branch: string): CallEdgeData[] {
     return this.inner.getCallers(targetName, branch);
+  }
+
+  getCallersWithContext(targetName: string, branch: string): CallEdgeData[] {
+    return this.inner.getCallersWithContext(targetName, branch);
   }
 
   getCallees(symbolId: string, branch: string): CallEdgeData[] {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -217,3 +217,37 @@ export const codebase_search: ToolDefinition = tool({
     return `Found ${results.length} results for "${args.query}":\n\n${formatSearchResults(results, "score")}`;
   },
 });
+
+export const call_graph: ToolDefinition = tool({
+  description:
+    "Query the call graph to find callers or callees of a function/method. Use to understand code flow and dependencies between functions.",
+  args: {
+    name: z.string().describe("Function or method name to query"),
+    direction: z.enum(["callers", "callees"]).default("callers").describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
+    symbolId: z.string().optional().describe("Symbol ID (required for 'callees' direction, returned by previous call_graph queries)"),
+  },
+  async execute(args) {
+    const indexer = getIndexer();
+    if (args.direction === "callees") {
+      if (!args.symbolId) {
+        return "Error: 'symbolId' is required when direction is 'callees'. First use direction='callers' to find the symbol ID.";
+      }
+      const callees = await indexer.getCallees(args.symbolId);
+      if (callees.length === 0) {
+        return `No callees found for symbol ${args.symbolId}. The function may not call any other tracked functions.`;
+      }
+      const formatted = callees.map((e, i) =>
+        `[${i + 1}] \u2192 ${e.targetName} (${e.callType}) at line ${e.line}${e.isResolved ? ` [resolved: ${e.toSymbolId}]` : " [unresolved]"}`
+      );
+      return `${args.name} calls ${callees.length} function(s):\n\n${formatted.join("\n")}`;
+    }
+    const callers = await indexer.getCallers(args.name);
+    if (callers.length === 0) {
+      return `No callers found for "${args.name}". It may not be called by any tracked function, or the index needs updating.`;
+    }
+    const formatted = callers.map((e, i) =>
+      `[${i + 1}] \u2190 from symbol ${e.fromSymbolId} (${e.callType}) at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`
+    );
+    return `"${args.name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}`;
+  },
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { Indexer } from "../indexer/index.js";
 import { ParsedCodebaseIndexConfig } from "../config/schema.js";
 import { formatCostEstimate } from "../utils/cost.js";
 import type { LogLevel } from "../config/schema.js";
+import type { LogEntry } from "../utils/logger.js";
 import {
   formatProgressTitle,
   formatIndexStats,
@@ -149,7 +150,7 @@ export const index_logs: ToolDefinition = tool({
       return "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true\n  }\n}\n```";
     }
 
-    let logs;
+    let logs: LogEntry[];
     if (args.category) {
       logs = logger.getLogsByCategory(args.category, args.limit);
     } else if (args.level) {
@@ -246,7 +247,7 @@ export const call_graph: ToolDefinition = tool({
       return `No callers found for "${args.name}". It may not be called by any tracked function, or the index needs updating.`;
     }
     const formatted = callers.map((e, i) =>
-      `[${i + 1}] \u2190 from symbol ${e.fromSymbolId} (${e.callType}) at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`
+      `[${i + 1}] \u2190 from ${e.fromSymbolName ?? "<unknown>"} in ${e.fromSymbolFilePath ?? "<unknown file>"} [${e.fromSymbolId}] (${e.callType}) at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`
     );
     return `"${args.name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}`;
   },

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -151,7 +151,7 @@ export function formatCodebasePeek(results: SearchResult[], query: string): stri
 }
 
 export function formatHealthCheck(result: HealthCheckResult): string {
-  if (result.removed === 0 && result.gcOrphanEmbeddings === 0 && result.gcOrphanChunks === 0) {
+  if (result.removed === 0 && result.gcOrphanEmbeddings === 0 && result.gcOrphanChunks === 0 && result.gcOrphanSymbols === 0 && result.gcOrphanCallEdges === 0) {
     return "Index is healthy. No stale entries found.";
   }
 
@@ -167,6 +167,14 @@ export function formatHealthCheck(result: HealthCheckResult): string {
   
   if (result.gcOrphanChunks > 0) {
     lines.push(`  Garbage collected orphan chunks: ${result.gcOrphanChunks}`);
+  }
+
+  if (result.gcOrphanSymbols > 0) {
+    lines.push(`  Garbage collected orphan symbols: ${result.gcOrphanSymbols}`);
+  }
+
+  if (result.gcOrphanCallEdges > 0) {
+    lines.push(`  Garbage collected orphan call edges: ${result.gcOrphanCallEdges}`);
   }
 
   if (result.filePaths.length > 0) {

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -181,7 +181,8 @@ describe("call-graph", () => {
       ];
       db.upsertCallEdgesBatch(edges);
 
-      const callees = db.getCallees("sym_a");
+      db.addSymbolsToBranchBatch("test", ["sym_a", "sym_b"]);
+      const callees = db.getCallees("sym_a", "test");
       expect(callees.length).toBe(1);
       expect(callees[0].targetName).toBe("callee");
       expect(callees[0].callType).toBe("Call");
@@ -274,7 +275,8 @@ describe("call-graph", () => {
       db.resolveCallEdge("edge_resolve", "sym_target");
 
       // Verify resolution
-      const callees = db.getCallees("sym_caller");
+      db.addSymbolsToBranchBatch("test", ["sym_caller", "sym_target"]);
+      const callees = db.getCallees("sym_caller", "test");
       expect(callees.length).toBe(1);
       expect(callees[0].isResolved).toBe(true);
       expect(callees[0].toSymbolId).toBe("sym_target");
@@ -312,7 +314,8 @@ describe("call-graph", () => {
       db.upsertCallEdgesBatch(edges);
 
       // Don't resolve — it's cross-file
-      const callees = db.getCallees("sym_local");
+      db.addSymbolsToBranchBatch("test", ["sym_local"]);
+      const callees = db.getCallees("sym_local", "test");
       expect(callees.length).toBe(1);
       expect(callees[0].isResolved).toBe(false);
       expect(callees[0].toSymbolId).toBeUndefined();
@@ -374,7 +377,8 @@ describe("call-graph", () => {
       // Resolve to only one of the targets
       db.resolveCallEdge("edge_multi", "sym_helper_a");
 
-      const callees = db.getCallees("sym_caller_m");
+      db.addSymbolsToBranchBatch("test", ["sym_caller_m", "sym_helper_a", "sym_helper_b"]);
+      const callees = db.getCallees("sym_caller_m", "test");
       expect(callees.length).toBe(1);
       expect(callees[0].isResolved).toBe(true);
       expect(callees[0].toSymbolId).toBe("sym_helper_a");
@@ -596,7 +600,7 @@ describe("call-graph", () => {
       // Verify entryPoint's callees
       const entryPointSymbol = symbols.find((s) => s.name === "entryPoint");
       expect(entryPointSymbol).toBeDefined();
-      const entryCallees = db.getCallees(entryPointSymbol!.id);
+      const entryCallees = db.getCallees(entryPointSymbol!.id, "main");
       expect(entryCallees.length).toBeGreaterThan(0);
 
       const entryCalleeNames = entryCallees.map((e) => e.targetName);

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { extractCalls, Database, hashContent } from "../src/native/index.js";
+import type { SymbolData, CallEdgeData } from "../src/native/index.js";
+
+const fixturesDir = path.join(__dirname, "fixtures", "call-graph");
 
 describe("call-graph", () => {
   let tempDir: string;
@@ -15,115 +19,596 @@ describe("call-graph", () => {
   });
 
   describe("call extraction", () => {
-    it.skip("should extract direct function calls", () => {
-      // TODO: Will test extractCalls() from native module
-      // Load tests/fixtures/call-graph/simple-calls.ts
-      // Parse and extract call_expression nodes
-      // Verify directCall, helper, compute are captured
+    it("should extract direct function calls", () => {
+      const content = fs.readFileSync(path.join(fixturesDir, "simple-calls.ts"), "utf-8");
+      const calls = extractCalls(content, "typescript");
+
+      const callNames = calls.map((c) => c.calleeName);
+      expect(callNames).toContain("directCall");
+      expect(callNames).toContain("helper");
+      expect(callNames).toContain("compute");
+
+      const directCall = calls.find((c) => c.calleeName === "directCall");
+      expect(directCall).toBeDefined();
+      expect(directCall!.callType).toBe("Call");
+
+      const helperCall = calls.find((c) => c.calleeName === "helper");
+      expect(helperCall).toBeDefined();
+      expect(helperCall!.callType).toBe("Call");
     });
 
-    it.skip("should extract method calls", () => {
-      // TODO: Will test obj.method() patterns
-      // Load tests/fixtures/call-graph/method-calls.ts
-      // Verify member_expression + call_expression captured
+    it("should extract method calls", () => {
+      const content = fs.readFileSync(path.join(fixturesDir, "method-calls.ts"), "utf-8");
+      const calls = extractCalls(content, "typescript");
+
+      const callNames = calls.map((c) => c.calleeName);
+      expect(callNames).toContain("validate");
+      expect(callNames).toContain("reset");
+      expect(callNames).toContain("add");
+      expect(callNames).toContain("subtract");
+      expect(callNames).toContain("square");
     });
 
-    it.skip("should extract constructor calls", () => {
-      // TODO: Will test new Foo() patterns
-      // Load tests/fixtures/call-graph/constructors.ts
-      // Verify new_expression nodes captured
+    it("should extract constructor calls", () => {
+      const content = fs.readFileSync(path.join(fixturesDir, "constructors.ts"), "utf-8");
+      const calls = extractCalls(content, "typescript");
+
+      const constructorCalls = calls.filter((c) => c.callType === "Constructor");
+      const constructorNames = constructorCalls.map((c) => c.calleeName);
+      expect(constructorNames).toContain("SimpleClass");
+      expect(constructorNames).toContain("ClassWithArgs");
+      expect(constructorNames).toContain("NestedConstruction");
+      expect(constructorNames).toContain("GenericBox");
     });
 
-    it.skip("should extract imports", () => {
-      // TODO: Will test import statement extraction
-      // Load tests/fixtures/call-graph/imports.ts
-      // Verify import_statement and named/default imports captured
+    it("should extract imports", () => {
+      const content = fs.readFileSync(path.join(fixturesDir, "imports.ts"), "utf-8");
+      const calls = extractCalls(content, "typescript");
+
+      const importCalls = calls.filter((c) => c.callType === "Import");
+      const importNames = importCalls.map((c) => c.calleeName);
+      expect(importNames).toContain("parseFile");
+      expect(importNames).toContain("hashContent");
+      expect(importNames).toContain("Indexer");
+      expect(importNames).toContain("Logger");
+      expect(importNames).toContain("Database");
     });
 
-    it.skip("should handle nested calls", () => {
-      // TODO: Will test deeply nested call patterns
-      // Load tests/fixtures/call-graph/nested-calls.ts
-      // Verify all call levels captured correctly
+    it("should handle nested calls", () => {
+      const content = fs.readFileSync(path.join(fixturesDir, "nested-calls.ts"), "utf-8");
+      const calls = extractCalls(content, "typescript");
+
+      const callNames = calls.map((c) => c.calleeName);
+      expect(callNames).toContain("inner");
+      expect(callNames).toContain("middle");
+      expect(callNames).toContain("deep");
+      expect(callNames).toContain("compute");
+      expect(callNames).toContain("transform");
+      expect(callNames).toContain("getData");
     });
 
-    it.skip("should handle edge cases", () => {
-      // TODO: Will test edge cases like optional chaining, dynamic imports
-      // Load tests/fixtures/call-graph/edge-cases.ts
-      // Verify obj?.method(), await import(), etc.
+    it("should handle edge cases", () => {
+      const content = fs.readFileSync(path.join(fixturesDir, "edge-cases.ts"), "utf-8");
+      const calls = extractCalls(content, "typescript");
+
+      const callNames = calls.map((c) => c.calleeName);
+      expect(callNames).toContain("method");
+      expect(callNames).toContain("trueCase");
+      expect(callNames).toContain("falseCase");
+      expect(callNames).toContain("riskyOperation");
+      expect(callNames).toContain("handleError");
+      expect(callNames).toContain("cleanup");
+      expect(callNames).toContain("fetchData");
     });
   });
 
   describe("call graph storage", () => {
-    it.skip("should store symbols in database", () => {
-      // TODO: Will test db.upsertSymbolsBatch()
-      // Create Database instance
-      // Insert symbols with file_path, name, kind, line/col
-      // Verify symbols retrievable via query
+    it("should store symbols in database", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_001",
+          filePath: "/src/foo.ts",
+          name: "fooFunc",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_002",
+          filePath: "/src/foo.ts",
+          name: "barFunc",
+          kind: "function",
+          startLine: 12,
+          startCol: 0,
+          endLine: 20,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+
+      db.upsertSymbolsBatch(symbols);
+      const retrieved = db.getSymbolsByFile("/src/foo.ts");
+      expect(retrieved.length).toBe(2);
+
+      const names = retrieved.map((s) => s.name);
+      expect(names).toContain("fooFunc");
+      expect(names).toContain("barFunc");
     });
 
-    it.skip("should store call edges", () => {
-      // TODO: Will test db.upsertCallEdgesBatch()
-      // Create symbols first
-      // Insert edges with from_symbol_id, target_name, is_resolved
-      // Verify edges retrievable
+    it("should store call edges", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_a",
+          filePath: "/src/a.ts",
+          name: "caller",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_b",
+          filePath: "/src/a.ts",
+          name: "callee",
+          kind: "function",
+          startLine: 12,
+          startCol: 0,
+          endLine: 20,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_001",
+          fromSymbolId: "sym_a",
+          targetName: "callee",
+          callType: "Call",
+          line: 5,
+          col: 2,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      const callees = db.getCallees("sym_a");
+      expect(callees.length).toBe(1);
+      expect(callees[0].targetName).toBe("callee");
+      expect(callees[0].callType).toBe("Call");
     });
 
-    it.skip("should store branch relationships", () => {
-      // TODO: Will test addSymbolsToBranchBatch()
-      // Create branch and symbols
-      // Associate symbols with branch
-      // Verify branch filtering works
+    it("should store branch relationships", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_br1",
+          filePath: "/src/x.ts",
+          name: "branchFunc",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+      db.addSymbolsToBranchBatch("main", ["sym_br1"]);
+
+      // Create an edge from sym_br1 targeting "branchFunc" so getCallers can find it
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_br1",
+          fromSymbolId: "sym_br1",
+          targetName: "branchFunc",
+          callType: "Call",
+          line: 3,
+          col: 0,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      // getCallers filters by branch
+      const callers = db.getCallers("branchFunc", "main");
+      expect(callers.length).toBe(1);
+      expect(callers[0].fromSymbolId).toBe("sym_br1");
     });
   });
 
   describe("call resolution", () => {
-    it.skip("should resolve same-file calls", () => {
-      // TODO: Will test resolveSameFileEdges()
-      // Load tests/fixtures/call-graph/same-file-refs.ts
-      // Extract calls and symbols
-      // Run resolution logic
-      // Verify is_resolved=true and to_symbol_id set
+    it("should resolve same-file calls", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_caller",
+          filePath: "/src/file.ts",
+          name: "caller",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_target",
+          filePath: "/src/file.ts",
+          name: "target",
+          kind: "function",
+          startLine: 7,
+          startCol: 0,
+          endLine: 12,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_resolve",
+          fromSymbolId: "sym_caller",
+          targetName: "target",
+          callType: "Call",
+          line: 3,
+          col: 2,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      // Resolve the edge
+      db.resolveCallEdge("edge_resolve", "sym_target");
+
+      // Verify resolution
+      const callees = db.getCallees("sym_caller");
+      expect(callees.length).toBe(1);
+      expect(callees[0].isResolved).toBe(true);
+      expect(callees[0].toSymbolId).toBe("sym_target");
     });
 
-    it.skip("should leave cross-file calls unresolved", () => {
-      // TODO: Will test that imports remain is_resolved=false
-      // Load fixtures with imports
-      // Verify imported symbols have is_resolved=false
-      // Verify to_symbol_id is NULL
+    it("should leave cross-file calls unresolved", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_local",
+          filePath: "/src/local.ts",
+          name: "localFunc",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_cross",
+          fromSymbolId: "sym_local",
+          targetName: "externalFunc",
+          callType: "Import",
+          line: 1,
+          col: 0,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      // Don't resolve — it's cross-file
+      const callees = db.getCallees("sym_local");
+      expect(callees.length).toBe(1);
+      expect(callees[0].isResolved).toBe(false);
+      expect(callees[0].toSymbolId).toBeUndefined();
     });
 
-    it.skip("should handle multiple targets with same name", () => {
-      // TODO: Will test disambiguation when same function name appears multiple times
-      // Create symbols with same name but different scopes
-      // Verify resolution picks correct target by scope/context
+    it("should handle multiple targets with same name", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_caller_m",
+          filePath: "/src/main.ts",
+          name: "main",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_helper_a",
+          filePath: "/src/a.ts",
+          name: "helper",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_helper_b",
+          filePath: "/src/b.ts",
+          name: "helper",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_multi",
+          fromSymbolId: "sym_caller_m",
+          targetName: "helper",
+          callType: "Call",
+          line: 5,
+          col: 2,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      // Resolve to only one of the targets
+      db.resolveCallEdge("edge_multi", "sym_helper_a");
+
+      const callees = db.getCallees("sym_caller_m");
+      expect(callees.length).toBe(1);
+      expect(callees[0].isResolved).toBe(true);
+      expect(callees[0].toSymbolId).toBe("sym_helper_a");
     });
   });
 
   describe("branch awareness", () => {
-    it.skip("should filter symbols by current branch", () => {
-      // TODO: Will test branch filtering
-      // Create symbols on branch A
-      // Create symbols on branch B
-      // Query with branch filter
-      // Verify only branch A symbols returned
+    it("should filter symbols by current branch", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_main_1",
+          filePath: "/src/main.ts",
+          name: "mainFunc",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_feat_1",
+          filePath: "/src/feat.ts",
+          name: "featFunc",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      db.addSymbolsToBranchBatch("main", ["sym_main_1"]);
+      db.addSymbolsToBranchBatch("feature", ["sym_feat_1"]);
+
+      // Create edges so getCallers can find them
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_main_1",
+          fromSymbolId: "sym_main_1",
+          targetName: "mainFunc",
+          callType: "Call",
+          line: 3,
+          col: 0,
+          isResolved: false,
+        },
+        {
+          id: "edge_feat_1",
+          fromSymbolId: "sym_feat_1",
+          targetName: "featFunc",
+          callType: "Call",
+          line: 3,
+          col: 0,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      // Query with branch "main" should only return main symbols
+      const mainCallers = db.getCallers("mainFunc", "main");
+      expect(mainCallers.length).toBe(1);
+      expect(mainCallers[0].fromSymbolId).toBe("sym_main_1");
+
+      // Query with branch "main" should not return feature symbols
+      const featOnMain = db.getCallers("featFunc", "main");
+      expect(featOnMain.length).toBe(0);
     });
 
-    it.skip("should filter call edges by branch", () => {
-      // TODO: Will test edge branch filtering
-      // Create edges on different branches
-      // Query with branch filter
-      // Verify only correct branch edges returned
+    it("should filter call edges by branch", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_br_a",
+          filePath: "/src/a.ts",
+          name: "funcA",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_br_b",
+          filePath: "/src/b.ts",
+          name: "funcB",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      db.addSymbolsToBranchBatch("main", ["sym_br_a"]);
+      db.addSymbolsToBranchBatch("other", ["sym_br_b"]);
+
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_ba",
+          fromSymbolId: "sym_br_a",
+          targetName: "sharedTarget",
+          callType: "Call",
+          line: 3,
+          col: 0,
+          isResolved: false,
+        },
+        {
+          id: "edge_bb",
+          fromSymbolId: "sym_br_b",
+          targetName: "sharedTarget",
+          callType: "Call",
+          line: 3,
+          col: 0,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      // Only sym_br_a is on "main"
+      const mainCallers = db.getCallers("sharedTarget", "main");
+      expect(mainCallers.length).toBe(1);
+      expect(mainCallers[0].fromSymbolId).toBe("sym_br_a");
+
+      // Only sym_br_b is on "other"
+      const otherCallers = db.getCallers("sharedTarget", "other");
+      expect(otherCallers.length).toBe(1);
+      expect(otherCallers[0].fromSymbolId).toBe("sym_br_b");
     });
   });
 
   describe("integration", () => {
-    it.skip("should build complete call graph for simple project", () => {
-      // TODO: End-to-end test
-      // Parse multiple fixture files
-      // Extract all calls and symbols
-      // Store in database
+    it("should build complete call graph for simple project", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+      const content = fs.readFileSync(path.join(fixturesDir, "same-file-refs.ts"), "utf-8");
+      const filePath = path.join(fixturesDir, "same-file-refs.ts");
+
+      // Extract calls
+      const callSites = extractCalls(content, "typescript");
+      expect(callSites.length).toBeGreaterThan(0);
+
+      // Build symbols from known functions in the fixture
+      const functionDefs = [
+        { name: "entryPoint", startLine: 5, endLine: 13 },
+        { name: "helperA", startLine: 15, endLine: 18 },
+        { name: "helperB", startLine: 20, endLine: 22 },
+        { name: "internalUtil", startLine: 24, endLine: 26 },
+        { name: "MyClass", startLine: 28, endLine: 41 },
+        { name: "outerScope", startLine: 54, endLine: 60 },
+        { name: "fibonacci", startLine: 63, endLine: 66 },
+        { name: "evenOdd", startLine: 68, endLine: 71 },
+        { name: "isOdd", startLine: 73, endLine: 76 },
+        { name: "exported", startLine: 79, endLine: 81 },
+      ];
+
+      const symbols: SymbolData[] = functionDefs.map((def) => ({
+        id: `sym_${hashContent(filePath + ":" + def.name + ":function:" + def.startLine).slice(0, 16)}`,
+        filePath,
+        name: def.name,
+        kind: "function",
+        startLine: def.startLine,
+        startCol: 0,
+        endLine: def.endLine,
+        endCol: 0,
+        language: "typescript",
+      }));
+
+      db.upsertSymbolsBatch(symbols);
+
+      // Build edges from call sites
+      const edges: CallEdgeData[] = [];
+      for (const site of callSites) {
+        const enclosing = symbols.find(
+          (sym) => site.line >= sym.startLine && site.line <= sym.endLine
+        );
+        if (!enclosing) continue;
+
+        const edgeId = `edge_${hashContent(enclosing.id + ":" + site.calleeName + ":" + site.line + ":" + site.column).slice(0, 16)}`;
+        edges.push({
+          id: edgeId,
+          fromSymbolId: enclosing.id,
+          targetName: site.calleeName,
+          callType: site.callType,
+          line: site.line,
+          col: site.column,
+          isResolved: false,
+        });
+      }
+
+      expect(edges.length).toBeGreaterThan(0);
+      db.upsertCallEdgesBatch(edges);
+
       // Resolve same-file calls
-      // Verify complete graph structure
+      for (const edge of edges) {
+        const matchingSymbol = symbols.find((sym) => sym.name === edge.targetName);
+        if (matchingSymbol) {
+          db.resolveCallEdge(edge.id, matchingSymbol.id);
+        }
+      }
+
+      // Add symbols to branch
+      db.addSymbolsToBranchBatch("main", symbols.map((s) => s.id));
+
+      // Verify: helperA should be called by entryPoint, arrowFunc, outerScope (innerScope), exported
+      const helperACallers = db.getCallers("helperA", "main");
+      expect(helperACallers.length).toBeGreaterThan(0);
+
+      // Verify: helperB should be called by entryPoint and helperA
+      const helperBCallers = db.getCallers("helperB", "main");
+      expect(helperBCallers.length).toBeGreaterThan(0);
+
+      // Verify entryPoint's callees
+      const entryPointSymbol = symbols.find((s) => s.name === "entryPoint");
+      expect(entryPointSymbol).toBeDefined();
+      const entryCallees = db.getCallees(entryPointSymbol!.id);
+      expect(entryCallees.length).toBeGreaterThan(0);
+
+      const entryCalleeNames = entryCallees.map((e) => e.targetName);
+      expect(entryCalleeNames).toContain("helperA");
+      expect(entryCalleeNames).toContain("helperB");
+
+      // Verify resolved edges have toSymbolId set
+      const resolvedCallees = entryCallees.filter((e) => e.isResolved);
+      expect(resolvedCallees.length).toBeGreaterThan(0);
+      for (const resolved of resolvedCallees) {
+        expect(resolved.toSymbolId).toBeDefined();
+      }
     });
   });
 });

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -383,6 +383,66 @@ describe("call-graph", () => {
       expect(callees[0].isResolved).toBe(true);
       expect(callees[0].toSymbolId).toBe("sym_helper_a");
     });
+
+    it("should keep ambiguous same-file target unresolved", () => {
+      const db = new Database(path.join(tempDir, "test.db"));
+
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_caller_amb",
+          filePath: "/src/file.ts",
+          name: "caller",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 5,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_dup_1",
+          filePath: "/src/file.ts",
+          name: "dup",
+          kind: "function",
+          startLine: 7,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_dup_2",
+          filePath: "/src/file.ts",
+          name: "dup",
+          kind: "function",
+          startLine: 12,
+          startCol: 0,
+          endLine: 15,
+          endCol: 0,
+          language: "typescript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_ambiguous",
+          fromSymbolId: "sym_caller_amb",
+          targetName: "dup",
+          callType: "Call",
+          line: 3,
+          col: 2,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+
+      db.addSymbolsToBranchBatch("test", ["sym_caller_amb", "sym_dup_1", "sym_dup_2"]);
+      const callees = db.getCallees("sym_caller_amb", "test");
+      expect(callees.length).toBe(1);
+      expect(callees[0].isResolved).toBe(false);
+      expect(callees[0].toSymbolId).toBeUndefined();
+    });
   });
 
   describe("branch awareness", () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -180,10 +180,15 @@ Final line.`;
       expect(commands.has("search")).toBe(true);
       expect(commands.has("index")).toBe(true);
       expect(commands.has("find")).toBe(true);
+      expect(commands.has("call-graph")).toBe(true);
 
       const indexCmd = commands.get("index")!;
       expect(indexCmd.description).toBe("Index the codebase for semantic search");
       expect(indexCmd.template).toContain("index_codebase");
+
+      const callGraphCmd = commands.get("call-graph")!;
+      expect(callGraphCmd.description).toBe("Trace callers or callees using the call graph");
+      expect(callGraphCmd.template).toContain("call_graph");
     });
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -54,6 +54,8 @@ vi.mock("../src/indexer/index.js", () => {
       removed: 0,
       gcOrphanEmbeddings: 0,
       gcOrphanChunks: 0,
+      gcOrphanSymbols: 0,
+      gcOrphanCallEdges: 0,
       filePaths: [],
     });
     clearIndex = vi.fn().mockResolvedValue(undefined);
@@ -117,13 +119,14 @@ describe("MCP server tools and prompts", () => {
     await client.close();
   });
 
-  it("should register all 8 tools", async () => {
+  it("should register all 9 tools", async () => {
     const tools = await client.listTools();
 
-    expect(tools.tools).toHaveLength(8);
+    expect(tools.tools).toHaveLength(9);
 
     const toolNames = tools.tools.map(t => t.name).sort();
     const expectedNames = [
+      "call_graph",
       "codebase_peek",
       "codebase_search",
       "find_similar",

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -377,6 +377,8 @@ describe("tools utils", () => {
         filePaths: [],
         gcOrphanEmbeddings: 0,
         gcOrphanChunks: 0,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
       });
 
       expect(result).toBe("Index is healthy. No stale entries found.");
@@ -388,6 +390,8 @@ describe("tools utils", () => {
         filePaths: ["src/old.ts", "src/deleted.ts"],
         gcOrphanEmbeddings: 0,
         gcOrphanChunks: 0,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
       });
 
       expect(result).toContain("Removed stale entries: 5");
@@ -401,6 +405,8 @@ describe("tools utils", () => {
         filePaths: [],
         gcOrphanEmbeddings: 10,
         gcOrphanChunks: 0,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
       });
 
       expect(result).toContain("orphan embeddings: 10");
@@ -412,6 +418,8 @@ describe("tools utils", () => {
         filePaths: [],
         gcOrphanEmbeddings: 0,
         gcOrphanChunks: 3,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
       });
 
       expect(result).toContain("orphan chunks: 3");
@@ -423,6 +431,8 @@ describe("tools utils", () => {
         filePaths: ["a.ts"],
         gcOrphanEmbeddings: 5,
         gcOrphanChunks: 3,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
       });
 
       expect(result).toContain("Removed stale entries: 2");


### PR DESCRIPTION
## Summary

- **Full-stack call graph feature**: Rust-based extraction of function calls, method calls, constructors, and imports across 5 languages (TypeScript/JavaScript, Python, Go, Rust)
- **SQLite storage with branch awareness**: Schema v2 migration adds `symbols`, `call_edges`, and `branch_symbols` tables with full CRUD, GC, and batch operations
- **End-to-end integration**: NAPI bindings → TypeScript wrappers → Indexer integration → `call_graph` OpenCode tool → MCP server tool

## What's New

### Rust Layer (`native/`)
- `call_extractor.rs` (~411 lines): Tree-sitter query-based call extraction for 5 languages
- Tree-sitter query files: `typescript-calls.scm`, `python-calls.scm`, `go-calls.scm`, `rust-calls.scm`
- `Language::from_string()` added to `types.rs`
- DB schema v2: `symbols`, `call_edges`, `branch_symbols` tables
- 16 new Database methods (CRUD + GC + batch ops for symbols and call edges)
- `streaming-iterator` dependency added

### TypeScript Layer (`src/`)
- NAPI bindings: `extractCalls` function + `CallSiteData`, `SymbolData`, `CallEdgeData` types
- 16 Database wrapper methods in `src/native/index.ts`
- Indexer: Automatic call extraction during indexing, branch symbol association, `getCallers()`/`getCallees()` public API
- `call_graph` tool in `src/tools/index.ts` with callers/callees direction support
- MCP server: `call_graph` tool registration + health check GC fields
- `formatHealthCheck` updated for new GC counters

### Tests
- `tests/call-graph.test.ts`: 15 comprehensive tests (extraction, storage, resolution, branch awareness, integration)
- Updated `tests/mcp-server.test.ts` (9 tools) and `tests/tools-utils.test.ts` (new GC fields)

## Verification

- ✅ `cargo check` — zero warnings
- ✅ `cargo test` — 47 tests pass
- ✅ `npm run build` — TypeScript + Rust build success
- ✅ `npm run typecheck` — zero type errors
- ✅ `npm run test:run` — 352 tests pass, 0 failures
- ✅ `npm run lint` — clean