### PR TITLE
fix: remove empty args schema from status prompt causing validation error

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -408,7 +408,6 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
   server.prompt(
     "status",
     "Check if the codebase is indexed and ready",
-    {},
     () => ({
       messages: [{
         role: "user",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -281,6 +281,18 @@ describe("MCP server tools and prompts", () => {
     expect(msgContent.text).toContain("index_status");
   });
 
+  it("should get status prompt without arguments (issue #13)", async () => {
+    const prompt = await client.getPrompt({
+      name: "status",
+    });
+
+    expect(prompt.messages).toBeDefined();
+    expect(prompt.messages).toHaveLength(1);
+    expect(prompt.messages[0].role).toBe("user");
+    const msgContent = prompt.messages[0].content as { type: string; text?: string };
+    expect(msgContent.text).toContain("index_status");
+  });
+
   it("should execute index_metrics tool", async () => {
     const result = await client.callTool({
       name: "index_metrics",


### PR DESCRIPTION
## Summary

- Fixes the `Invalid arguments for prompt status` error when MCP clients call the `status` prompt without arguments (#13)
- The `status` prompt passed an empty `{}` as `argsSchema`, which the SDK interpreted as a required Zod object schema. When clients sent `prompts/get` without an `arguments` field (`undefined`), validation failed.
- Removed the empty `{}` so the SDK correctly treats the prompt as having no arguments.
- Added a regression test that calls `getPrompt` without arguments.

Closes #13