### PR TITLE
Add basic semantic PHP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ graph TD
 
 1. **Parsing**: We use `tree-sitter` to intelligently parse your code into meaningful blocks (functions, classes, interfaces). JSDoc comments and docstrings are automatically included with their associated code.
 
-**Supported Languages**: TypeScript, JavaScript, Python, Rust, Go, Java, C#, Ruby, Bash, C, C++, JSON, TOML, YAML
+**Supported Languages**: TypeScript, JavaScript, Python, Rust, Go, Java, C#, Ruby, PHP, Bash, C, C++, JSON, TOML, YAML
 2. **Chunking**: Large blocks are split with overlapping windows to preserve context across chunk boundaries.
 3. **Embedding**: These blocks are converted into vector representations using your configured AI provider.
 4. **Storage**: Embeddings are stored in SQLite (deduplicated by content hash) and vectors in `usearch` with F16 quantization for 50% memory savings. A branch catalog tracks which chunks exist on each branch.

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-language",
+ "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
@@ -860,6 +861,16 @@ name = "tree-sitter-language"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-python"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,6 +27,7 @@ tree-sitter-c = "0.23"
 tree-sitter-cpp = "0.23"
 tree-sitter-toml-ng = "0.7"
 tree-sitter-yaml = "0.7"
+tree-sitter-php = "0.23"
 tree-sitter-language = "0.1"
 rusqlite = { version = "0.31", features = ["bundled"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -41,6 +41,7 @@ pub fn parse_file_internal(file_path: &str, content: &str) -> Result<Vec<CodeChu
         Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
         Language::Toml => tree_sitter_toml_ng::LANGUAGE.into(),
         Language::Yaml => tree_sitter_yaml::LANGUAGE.into(),
+        Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
         _ => return Ok(chunk_by_lines(content, &language)),
     };
 
@@ -219,6 +220,9 @@ fn is_comment_node(node_type: &str, language: &Language) -> bool {
         Language::Yaml => {
             matches!(node_type, "comment")
         }
+        Language::Php => {
+            matches!(node_type, "comment")
+        }
         _ => false,
     }
 }
@@ -322,6 +326,17 @@ fn is_semantic_node(node_type: &str, language: &Language) -> bool {
         }
         Language::Yaml => {
             matches!(node_type, "block_mapping_pair" | "block_sequence")
+        }
+        Language::Php => {
+            matches!(
+                node_type,
+                "function_definition"
+                    | "method_declaration"
+                    | "class_declaration"
+                    | "interface_declaration"
+                    | "trait_declaration"
+                    | "enum_declaration"
+            )
         }
         _ => false,
     }

--- a/native/src/types.rs
+++ b/native/src/types.rs
@@ -30,6 +30,7 @@ pub enum Language {
     Yaml,
     Bash,
     Markdown,
+    Php,
     Unknown,
 }
 
@@ -53,6 +54,7 @@ impl Language {
             "yaml" | "yml" => Language::Yaml,
             "sh" | "bash" | "zsh" => Language::Bash,
             "md" | "mdx" => Language::Markdown,
+            "php" | "inc" => Language::Php,
             _ => Language::Unknown,
         }
     }
@@ -76,6 +78,7 @@ impl Language {
             Language::Yaml => "yaml",
             Language::Bash => "bash",
             Language::Markdown => "markdown",
+            Language::Php => "php",
             Language::Unknown => "unknown",
         }
     }
@@ -99,6 +102,7 @@ impl Language {
             "yaml" | "yml" => Language::Yaml,
             "bash" | "sh" | "zsh" => Language::Bash,
             "markdown" | "md" => Language::Markdown,
+            "php" => Language::Php,
             _ => Language::Unknown,
         }
     }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,7 +3,7 @@ export const DEFAULT_INCLUDE = [
   "**/*.{py,pyi}",
   "**/*.{go,rs,java,kt,scala}",
   "**/*.{c,cpp,cc,h,hpp}",
-  "**/*.{rb,php,swift}",
+  "**/*.{rb,php,inc,swift}",
   "**/*.{vue,svelte,astro}",
   "**/*.{sql,graphql,proto}",
   "**/*.{yaml,yml,toml}",

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -71,6 +71,61 @@ const add = (a, b) => a + b;
 
       expect(chunks).toBeInstanceOf(Array);
     });
+
+    it("should parse PHP files", () => {
+      const content = `
+<?php
+
+function greet($name) {
+    return "Hello, " . $name;
+}
+
+class User {
+    private $name;
+
+    public function __construct($name) {
+        $this->name = $name;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+}
+
+interface Logger {
+    public function log($message);
+}
+`;
+      const chunks = parseFile("test.php", content);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(3);
+      expect(chunks.some((c) => c.content.includes("function greet"))).toBe(true);
+      expect(chunks.some((c) => c.content.includes("class User"))).toBe(true);
+      expect(chunks.some((c) => c.content.includes("interface Logger"))).toBe(true);
+    });
+
+    it("should parse PHP .inc files", () => {
+      const content = `
+<?php
+
+function helper($value) {
+    return $value * 2;
+}
+
+trait Timestampable {
+    private $createdAt;
+
+    public function setCreatedAt($time) {
+        $this->createdAt = $time;
+    }
+}
+`;
+      const chunks = parseFile("config.inc", content);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+      expect(chunks.some((c) => c.content.includes("function helper"))).toBe(true);
+      expect(chunks.some((c) => c.content.includes("trait Timestampable"))).toBe(true);
+    });
   });
 
   describe("parseFiles", () => {


### PR DESCRIPTION
## Summary

Added basic semantic PHP parsing.

## Changes

- Modified types.rs to add .php and .inc files
- Added PHP nodes to is_semantic_node and is_comment_node in parser.rs
- Added .inc to the list of general filetypes gotten in src/config/constants.ts
- Wrote some PHP parse tests in tests/native.test.ts
- Updated documentation to reflect the new PHP support

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [ ] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [ ] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #34 
