### PR TITLE
fix: throttle GitHub Models eval quality requests

### DIFF
--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -91,6 +91,18 @@ jobs:
 
       - name: Create eval quality config from secrets
         run: |
+          if [ "${{ steps.eval-provider.outputs.provider_source }}" = "github-models" ]; then
+            EMBED_CONCURRENCY=1
+            EMBED_REQUEST_INTERVAL_MS=5000
+            EMBED_RETRIES=5
+            EMBED_RETRY_DELAY_MS=15000
+          else
+            EMBED_CONCURRENCY=3
+            EMBED_REQUEST_INTERVAL_MS=1000
+            EMBED_RETRIES=3
+            EMBED_RETRY_DELAY_MS=1000
+          fi
+
           cat > .github/eval-quality-config.json <<EOF
           {
             "embeddingProvider": "custom",
@@ -99,14 +111,18 @@ jobs:
               "apiKey": "${{ steps.eval-provider.outputs.api_key }}",
               "model": "${{ steps.eval-provider.outputs.model }}",
               "dimensions": ${{ steps.eval-provider.outputs.dimensions }},
-              "timeoutMs": 30000
+              "timeoutMs": 30000,
+              "concurrency": $EMBED_CONCURRENCY,
+              "requestIntervalMs": $EMBED_REQUEST_INTERVAL_MS
             },
             "indexing": {
               "autoIndex": false,
               "watchFiles": false,
               "respectGitignore": true,
               "semanticOnly": false,
-              "requireProjectMarker": false
+              "requireProjectMarker": false,
+              "retries": $EMBED_RETRIES,
+              "retryDelayMs": $EMBED_RETRY_DELAY_MS
             },
             "search": {
               "maxResults": 10,


### PR DESCRIPTION
## Summary

Throttle the Eval Quality Gate's GitHub Models fallback path so the workflow stays under the embedding API rate limit instead of failing before budget evaluation.

## Changes

- detect when the eval workflow is using the GitHub Models fallback path
- generate a slower CI embedding config for that path with serialized requests and longer retry delays
- preserve the previous custom-provider behavior for explicit provider override secrets

## Testing

How were these changes tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

N/A