### PR TITLE
fix: improve first-run indexing diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,31 @@
 3. **Index your codebase**
    Run `/index` or ask the agent to index your codebase. This only needs to be done once — subsequent updates are incremental.
 
+   **Recommended check:** run `/status` after the first index so you can confirm the detected provider/model before you start searching.
+
 4. **Start Searching**
    Ask:
    > "Find the function that handles credit card validation errors"
+
+### Provider selection notes
+
+- **Default auto-detect order:** Ollama → GitHub Copilot → OpenAI → Google
+- **Ollama** is the preferred zero-cost local option and works especially well for large repos:
+
+  ```bash
+  ollama pull nomic-embed-text
+  ```
+
+  ```json
+  {
+    "embeddingProvider": "ollama"
+  }
+  ```
+
+- **GitHub Copilot** is a good default if OpenCode already has Copilot auth and you prefer hosted embeddings.
+- **OpenAI** is a good hosted option when you want predictable API behavior and standard cloud setup.
+- **Google** is available if you prefer Gemini-hosted embeddings.
+- If `/status` reports provider or compatibility problems, follow that guidance before using `/index force`.
 
 ## 🌐 MCP Server (Cursor, Claude Code, Windsurf, etc.)
 
@@ -315,6 +337,7 @@ Manually trigger indexing.
 
 ### `index_status`
 Checks if the index is ready and healthy.
+- **Recommended workflow**: run this after `/index` to confirm the detected provider/model and whether the index is ready to search.
 
 ### `index_health_check`
 Maintenance tool to remove stale entries from deleted files and orphaned embeddings/chunks from the database.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -117,6 +117,12 @@ ollama pull nomic-embed-text
 ### Verify Provider Detection
 Run `/status` in OpenCode to see which provider is detected.
 
+Auto-detect tries providers in this order:
+1. Ollama
+2. GitHub Copilot
+3. OpenAI
+4. Google (Gemini)
+
 ---
 
 ## Rate Limiting Errors
@@ -154,6 +160,8 @@ OpenAI has generous limits, but if you hit them:
 ### For Google
 Similar to OpenAI. Check your quota at [Google Cloud Console](https://console.cloud.google.com/).
 
+If you see provider/model errors, verify that your configured Google credentials have access to the Gemini embeddings API.
+
 ### For Large Codebases (1k+ files)
 Use Ollama locally - no rate limits:
 ```bash
@@ -185,6 +193,8 @@ Ask the agent:
 > "Force reindex the codebase"
 
 Or run `/index force`.
+
+Only use force reindex for a full rebuild. If `/status` reports failed embedding batches, fix the provider/auth issue first and rerun `/index` normally.
 
 ### Reset Everything
 Delete the entire index directory:

--- a/commands/index.md
+++ b/commands/index.md
@@ -21,3 +21,7 @@ Examples:
 IMPORTANT: You MUST pass the parsed arguments to `index_codebase`. Do not ignore them.
 
 Show final statistics including files processed, chunks indexed, tokens used, and duration.
+
+If indexing completes but the codebase still is not ready, tell the user to run `/status` next.
+- If `/status` reports failed embedding batches, fix the provider/auth issue and rerun `/index` normally.
+- Use `/index force` only for a full rebuild or when `/status` reports provider/model incompatibility.

--- a/commands/status.md
+++ b/commands/status.md
@@ -9,7 +9,11 @@ This shows:
 - Number of indexed chunks
 - Embedding provider and model being used
 - Current git branch
+- Failed embedding batches or compatibility warnings that explain why search is not ready
 
 No arguments needed - just run `index_status`.
 
-If not indexed, suggest running `/index` to create the index.
+If not indexed:
+- suggest running `/index` when no index exists yet
+- if status reports failed embedding batches, tell the user to fix the provider/auth issue and rerun `/index` normally
+- if status reports provider/model incompatibility, tell the user to run `/index force` for a full rebuild

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -102,6 +102,13 @@ export const EMBEDDING_MODELS = {
 export const DEFAULT_PROVIDER_MODELS = {
   "github-copilot": "text-embedding-3-small",
   "openai": "text-embedding-3-small",
-  "google": "text-embedding-005",
+  "google": "gemini-embedding-001",
   "ollama": "nomic-embed-text",
 } as const
+
+export const AUTO_DETECT_PROVIDER_ORDER = [
+  "github-copilot",
+  "openai",
+  "google",
+  "ollama",
+] as const;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -107,8 +107,8 @@ export const DEFAULT_PROVIDER_MODELS = {
 } as const
 
 export const AUTO_DETECT_PROVIDER_ORDER = [
+  "ollama",
   "github-copilot",
   "openai",
   "google",
-  "ollama",
 ] as const;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,6 +1,6 @@
 // Config schema without zod dependency to avoid version conflicts with OpenCode SDK
 
-import { DEFAULT_INCLUDE, DEFAULT_EXCLUDE, EMBEDDING_MODELS, DEFAULT_PROVIDER_MODELS } from "./constants.js";
+import { AUTO_DETECT_PROVIDER_ORDER, DEFAULT_INCLUDE, DEFAULT_EXCLUDE, EMBEDDING_MODELS, DEFAULT_PROVIDER_MODELS } from "./constants.js";
 import { substituteEnvString } from "./env-substitution.js";
 
 export type IndexScope = "project" | "global";
@@ -425,6 +425,10 @@ export function getDefaultModelForProvider(provider: EmbeddingProvider): Embeddi
 export type EmbeddingProvider = keyof typeof EMBEDDING_MODELS;
 
 export const availableProviders: EmbeddingProvider[] = Object.keys(EMBEDDING_MODELS) as EmbeddingProvider[]
+
+export const autoDetectProviders: EmbeddingProvider[] = AUTO_DETECT_PROVIDER_ORDER.filter(
+  (provider): provider is EmbeddingProvider => provider in EMBEDDING_MODELS,
+);
 
 export type ProviderModels = {
   [P in keyof typeof EMBEDDING_MODELS]: keyof (typeof EMBEDDING_MODELS)[P]

--- a/src/embeddings/detector.ts
+++ b/src/embeddings/detector.ts
@@ -1,4 +1,4 @@
-import { type EmbeddingProvider, type CustomProviderConfig, type BaseModelInfo, getDefaultModelForProvider, isValidModel, availableProviders, EmbeddingModelName, EMBEDDING_MODELS } from "../config";
+import { type EmbeddingProvider, type CustomProviderConfig, type BaseModelInfo, getDefaultModelForProvider, isValidModel, autoDetectProviders, EmbeddingModelName, EMBEDDING_MODELS } from "../config";
 import { existsSync, readFileSync } from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -91,7 +91,7 @@ export async function detectEmbeddingProvider<P extends EmbeddingProvider>(
 }
 
 export async function tryDetectProvider(): Promise<ConfiguredProviderInfo> {
-  for (const provider of availableProviders) {
+  for (const provider of autoDetectProviders) {
     const credentials = await getProviderCredentials(provider);
     if (credentials) {
       return {
@@ -103,7 +103,7 @@ export async function tryDetectProvider(): Promise<ConfiguredProviderInfo> {
   }
 
   throw new Error(
-    `No embedding-capable provider found. Please authenticate with OpenCode using one of: ${availableProviders.join(", ")}.`
+    `No embedding-capable provider found. Please authenticate with OpenCode using one of: ${autoDetectProviders.join(", ")}.`
   );
 }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -128,6 +128,8 @@ export interface StatusResult {
   currentBranch: string;
   baseBranch: string;
   compatibility: IndexCompatibility | null;
+  failedBatchesCount: number;
+  failedBatchesPath?: string;
 }
 
 export interface IndexProgress {
@@ -2962,6 +2964,7 @@ export class Indexer {
 
   async getStatus(): Promise<StatusResult> {
     const { store, configuredProviderInfo } = await this.ensureInitialized();
+    const failedBatchesCount = this.getFailedBatchesCount();
 
     return {
       indexed: store.count() > 0,
@@ -2972,6 +2975,8 @@ export class Indexer {
       currentBranch: this.currentBranch,
       baseBranch: this.baseBranch,
       compatibility: this.indexCompatibility,
+      failedBatchesCount,
+      failedBatchesPath: failedBatchesCount > 0 ? this.failedBatchesPath : undefined,
     };
   }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1529,22 +1529,37 @@ export class Indexer {
   private saveFailedBatches(batches: FailedBatch[]): void {
     if (batches.length === 0) {
       if (existsSync(this.failedBatchesPath)) {
-        fsPromises.unlink(this.failedBatchesPath).catch(() => { });
+        try {
+          unlinkSync(this.failedBatchesPath);
+        } catch {
+          // Ignore cleanup failures; stale diagnostics are best-effort only.
+        }
       }
       return;
     }
     writeFileSync(this.failedBatchesPath, JSON.stringify(batches, null, 2));
   }
 
-  private addFailedBatch(batch: PendingChunk[], error: string): void {
-    const existing = this.loadFailedBatches();
-    existing.push({
-      chunks: batch,
-      error,
-      attemptCount: 1,
-      lastAttempt: new Date().toISOString(),
-    });
-    this.saveFailedBatches(existing);
+  private collectRetryableFailedChunks(
+    currentFileHashes: Map<string, string>,
+    unchangedFilePaths: Set<string>
+  ): PendingChunk[] {
+    const retryableById = new Map<string, PendingChunk>();
+
+    for (const batch of this.loadFailedBatches()) {
+      for (const chunk of batch.chunks) {
+        const filePath = chunk.metadata.filePath;
+        if (!currentFileHashes.has(filePath)) {
+          continue;
+        }
+        if (!unchangedFilePaths.has(filePath)) {
+          continue;
+        }
+        retryableById.set(chunk.id, chunk);
+      }
+    }
+
+    return Array.from(retryableById.values());
   }
 
   private getProviderRateLimits(provider: string): {
@@ -2089,6 +2104,7 @@ export class Indexer {
       skippedFiles: [],
       parseFailures: [],
     };
+    const failedBatchesForCurrentRun: FailedBatch[] = [];
 
     onProgress?.({
       phase: "scanning",
@@ -2247,6 +2263,18 @@ export class Indexer {
       }
     }
 
+    const retryableFailedChunks = this.collectRetryableFailedChunks(currentFileHashes, unchangedFilePaths);
+    if (retryableFailedChunks.length > 0) {
+      const pendingChunkIds = new Set(pendingChunks.map((chunk) => chunk.id));
+      for (const chunk of retryableFailedChunks) {
+        if (!pendingChunkIds.has(chunk.id)) {
+          pendingChunks.push(chunk);
+          pendingChunkIds.add(chunk.id);
+          currentChunkIds.add(chunk.id);
+        }
+      }
+    }
+
     if (chunkDataBatch.length > 0) {
       database.upsertChunksBatch(chunkDataBatch);
     }
@@ -2378,6 +2406,7 @@ export class Indexer {
       database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
       this.fileHashCache = currentFileHashes;
       this.saveFileHashCache();
+      this.saveFailedBatches([]);
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -2399,6 +2428,7 @@ export class Indexer {
       invertedIndex.save();
       this.fileHashCache = currentFileHashes;
       this.saveFileHashCache();
+      this.saveFailedBatches([]);
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -2532,7 +2562,12 @@ export class Indexer {
           });
         } catch (error) {
           stats.failedChunks += batch.length;
-          this.addFailedBatch(batch, getErrorMessage(error));
+          failedBatchesForCurrentRun.push({
+            chunks: batch,
+            error: getErrorMessage(error),
+            attemptCount: 1,
+            lastAttempt: new Date().toISOString(),
+          });
           this.logger.recordEmbeddingError();
           this.logger.embedding("error", `Failed to embed batch after retries`, {
             batchSize: batch.length,
@@ -2543,6 +2578,7 @@ export class Indexer {
     }
 
     await queue.onIdle();
+    this.saveFailedBatches(failedBatchesForCurrentRun);
 
     onProgress?.({
       phase: "storing",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,9 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { Indexer, type IndexStats } from "./indexer/index.js";
+import { Indexer } from "./indexer/index.js";
 import type { ParsedCodebaseIndexConfig, LogLevel } from "./config/schema.js";
-import { formatDefinitionLookup } from "./tools/utils.js";
+import { formatDefinitionLookup, formatIndexStats, formatStatus } from "./tools/utils.js";
 import { formatCostEstimate } from "./utils/cost.js";
 import type { LogEntry } from "./utils/logger.js";
 
@@ -16,88 +16,6 @@ function truncateContent(content: string): string {
     lines.slice(0, MAX_CONTENT_LINES).join("\n") +
     `\n// ... (${lines.length - MAX_CONTENT_LINES} more lines)`
   );
-}
-
-function formatIndexStats(stats: IndexStats, verbose: boolean = false): string {
-  const lines: string[] = [];
-
-  if (stats.indexedChunks === 0 && stats.removedChunks === 0) {
-    lines.push(`Indexed. ${stats.totalFiles} files processed, ${stats.existingChunks} code chunks already up to date.`);
-  } else if (stats.indexedChunks === 0) {
-    lines.push(`Indexed. ${stats.totalFiles} files, removed ${stats.removedChunks} stale chunks, ${stats.existingChunks} chunks remain.`);
-  } else {
-    let main = `Indexed. ${stats.totalFiles} files processed, ${stats.indexedChunks} new chunks embedded.`;
-    if (stats.existingChunks > 0) {
-      main += ` ${stats.existingChunks} unchanged chunks skipped.`;
-    }
-    lines.push(main);
-
-    if (stats.removedChunks > 0) {
-      lines.push(`Removed ${stats.removedChunks} stale chunks.`);
-    }
-
-    if (stats.failedChunks > 0) {
-      lines.push(`Failed: ${stats.failedChunks} chunks.`);
-    }
-
-    lines.push(`Tokens: ${stats.tokensUsed.toLocaleString()}, Duration: ${(stats.durationMs / 1000).toFixed(1)}s`);
-  }
-
-  if (verbose) {
-    if (stats.skippedFiles.length > 0) {
-      const tooLarge = stats.skippedFiles.filter(f => f.reason === "too_large");
-      const excluded = stats.skippedFiles.filter(f => f.reason === "excluded");
-      const gitignored = stats.skippedFiles.filter(f => f.reason === "gitignore");
-
-      lines.push("");
-      lines.push(`Skipped files: ${stats.skippedFiles.length}`);
-      if (tooLarge.length > 0) {
-        lines.push(`  Too large (${tooLarge.length}): ${tooLarge.slice(0, 5).map(f => f.path).join(", ")}${tooLarge.length > 5 ? "..." : ""}`);
-      }
-      if (excluded.length > 0) {
-        lines.push(`  Excluded (${excluded.length}): ${excluded.slice(0, 5).map(f => f.path).join(", ")}${excluded.length > 5 ? "..." : ""}`);
-      }
-      if (gitignored.length > 0) {
-        lines.push(`  Gitignored (${gitignored.length}): ${gitignored.slice(0, 5).map(f => f.path).join(", ")}${gitignored.length > 5 ? "..." : ""}`);
-      }
-    }
-
-    if (stats.parseFailures.length > 0) {
-      lines.push("");
-      lines.push(`Files with no extractable chunks (${stats.parseFailures.length}): ${stats.parseFailures.slice(0, 10).join(", ")}${stats.parseFailures.length > 10 ? "..." : ""}`);
-    }
-  }
-
-  return lines.join("\n");
-}
-
-function formatStatus(status: {
-  indexed: boolean;
-  vectorCount: number;
-  provider: string;
-  model: string;
-  indexPath: string;
-  currentBranch: string;
-  baseBranch: string;
-}): string {
-  if (!status.indexed) {
-    return "Codebase is not indexed. Run index_codebase to create an index.";
-  }
-
-  const lines = [
-    `Index status:`,
-    `  Indexed chunks: ${status.vectorCount.toLocaleString()}`,
-    `  Provider: ${status.provider}`,
-    `  Model: ${status.model}`,
-    `  Location: ${status.indexPath}`,
-  ];
-
-  if (status.currentBranch !== "default") {
-    lines.push(`  Current branch: ${status.currentBranch}`);
-    lines.push(`  Base branch: ${status.baseBranch}`);
-  }
-
-  return lines.join("\n");
 }
 
 const CHUNK_TYPE_ENUM = [

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -14,6 +14,14 @@ function truncateContent(content: string): string {
 
 export function formatIndexStats(stats: IndexStats, verbose: boolean = false): string {
   const lines: string[] = [];
+
+  if (stats.failedChunks > 0) {
+    lines.push(`INDEXING WARNING: ${stats.failedChunks} chunks failed to embed.`);
+    if (stats.failedBatchesPath) {
+      lines.push(`Inspect failed batches at: ${stats.failedBatchesPath}`);
+    }
+    lines.push("");
+  }
   
   if (stats.indexedChunks === 0 && stats.removedChunks === 0) {
     lines.push(`${stats.totalFiles} files processed, ${stats.existingChunks} code chunks already up to date.`);
@@ -67,6 +75,19 @@ export function formatIndexStats(stats: IndexStats, verbose: boolean = false): s
 
 export function formatStatus(status: StatusResult): string {
   if (!status.indexed) {
+    if (status.failedBatchesCount > 0) {
+      const lines = [
+        "Codebase is not indexed. The last indexing run left failed embedding batches.",
+        "Run index_codebase again after fixing the provider/model configuration.",
+      ];
+
+      if (status.failedBatchesPath) {
+        lines.push(`Failed batches: ${status.failedBatchesPath}`);
+      }
+
+      return lines.join("\n");
+    }
+
     return "Codebase is not indexed. Run index_codebase to create an index.";
   }
 
@@ -80,6 +101,14 @@ export function formatStatus(status: StatusResult): string {
   if (status.currentBranch !== "default") {
     lines.push(`Current branch: ${status.currentBranch}`);
     lines.push(`Base branch: ${status.baseBranch}`);
+  }
+
+  if (status.failedBatchesCount > 0) {
+    lines.push("");
+    lines.push(`INDEXING WARNING: ${status.failedBatchesCount} failed embedding batch${status.failedBatchesCount === 1 ? " remains" : "es remain"}.`);
+    if (status.failedBatchesPath) {
+      lines.push(`Failed batches: ${status.failedBatchesPath}`);
+    }
   }
 
   if (status.compatibility && !status.compatibility.compatible) {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -78,7 +78,7 @@ export function formatStatus(status: StatusResult): string {
     if (status.failedBatchesCount > 0) {
       const lines = [
         "Codebase is not indexed. The last indexing run left failed embedding batches.",
-        "Fix the provider/model configuration, then rerun index_codebase. If nothing changed, use force=true to retry the saved failed batches.",
+        "Fix the provider/model configuration, then rerun index_codebase normally to retry the saved failed batches. Use force=true only for a full rebuild or compatibility reset.",
       ];
 
       if (status.failedBatchesPath) {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -78,7 +78,7 @@ export function formatStatus(status: StatusResult): string {
     if (status.failedBatchesCount > 0) {
       const lines = [
         "Codebase is not indexed. The last indexing run left failed embedding batches.",
-        "Run index_codebase again after fixing the provider/model configuration.",
+        "Fix the provider/model configuration, then rerun index_codebase. If nothing changed, use force=true to retry the saved failed batches.",
       ];
 
       if (status.failedBatchesPath) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -939,8 +939,11 @@ describe("config schema", () => {
       expect(defaultProviders.sort()).toEqual(providers.sort());
     });
 
-    it("should prefer GitHub Copilot before Google for auto-detection", () => {
-      expect(AUTO_DETECT_PROVIDER_ORDER[0]).toBe("github-copilot");
+    it("should prefer Ollama before cloud providers for auto-detection", () => {
+      expect(AUTO_DETECT_PROVIDER_ORDER[0]).toBe("ollama");
+      expect(AUTO_DETECT_PROVIDER_ORDER.indexOf("github-copilot")).toBeGreaterThan(
+        AUTO_DETECT_PROVIDER_ORDER.indexOf("ollama"),
+      );
       expect(AUTO_DETECT_PROVIDER_ORDER.indexOf("google")).toBeGreaterThan(
         AUTO_DETECT_PROVIDER_ORDER.indexOf("github-copilot"),
       );

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/config/schema.js";
 import {
   EMBEDDING_MODELS,
+  AUTO_DETECT_PROVIDER_ORDER,
   DEFAULT_PROVIDER_MODELS,
 } from "../src/config/constants.js";
 
@@ -836,8 +837,8 @@ describe("config schema", () => {
     it("should return correct model for google", () => {
       const model = getDefaultModelForProvider("google");
       expect(model.provider).toBe("google");
-      expect(model.model).toBe("text-embedding-005");
-      expect(model.dimensions).toBe(768);
+      expect(model.model).toBe("gemini-embedding-001");
+      expect(model.dimensions).toBe(1536);
     });
 
     it("should return correct model for ollama", () => {
@@ -936,6 +937,13 @@ describe("config schema", () => {
       const providers = Object.keys(EMBEDDING_MODELS);
       const defaultProviders = Object.keys(DEFAULT_PROVIDER_MODELS);
       expect(defaultProviders.sort()).toEqual(providers.sort());
+    });
+
+    it("should prefer GitHub Copilot before Google for auto-detection", () => {
+      expect(AUTO_DETECT_PROVIDER_ORDER[0]).toBe("github-copilot");
+      expect(AUTO_DETECT_PROVIDER_ORDER.indexOf("google")).toBeGreaterThan(
+        AUTO_DETECT_PROVIDER_ORDER.indexOf("github-copilot"),
+      );
     });
   });
 });

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1,0 +1,147 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
+import { formatStatus } from "../src/tools/utils.js";
+
+describe("indexer failed batch recovery", () => {
+  let tempDir: string;
+  let sourceFile: string;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let failEmbeddings = false;
+
+  beforeEach(() => {
+    failEmbeddings = false;
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = Array.isArray(body.input) ? body.input : [];
+
+      if (failEmbeddings) {
+        return new Response(JSON.stringify({ error: "rate limited" }), { status: 429 });
+      }
+
+      const data = texts.map((text) => {
+        let seed = 0;
+        for (const ch of text) {
+          seed = (seed * 31 + ch.charCodeAt(0)) % 1000;
+        }
+        const embedding = Array.from({ length: 8 }, (_, idx) => ((seed + idx * 17) % 997) / 997);
+        return { embedding };
+      });
+
+      return new Response(
+        JSON.stringify({
+          data,
+          usage: { total_tokens: Math.max(1, texts.length * 8) },
+        }),
+        { status: 200 }
+      );
+    });
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "failed-batches-indexer-"));
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    sourceFile = path.join(tempDir, "src", "index.ts");
+    fs.writeFileSync(
+      sourceFile,
+      [
+        "export function alpha() {",
+        "  return 'alpha';",
+        "}",
+        "",
+        "export function beta() {",
+        "  return alpha();",
+        "}",
+      ].join("\n"),
+      "utf-8"
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function createIndexer(): Indexer {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    });
+
+    return new Indexer(tempDir, config);
+  }
+
+  it("retries saved failed batches on a later successful rerun without force", async () => {
+    const indexer = createIndexer();
+
+    failEmbeddings = true;
+    const failedStats = await indexer.index();
+    expect(failedStats.failedChunks).toBeGreaterThan(0);
+
+    const failedStatus = await indexer.getStatus();
+    expect(failedStatus.indexed).toBe(false);
+    expect(failedStatus.failedBatchesCount).toBeGreaterThan(0);
+
+    failEmbeddings = false;
+    const recoveredStats = await indexer.index();
+    expect(recoveredStats.failedChunks).toBe(0);
+    expect(recoveredStats.indexedChunks).toBeGreaterThan(0);
+
+    const recoveredStatus = await indexer.getStatus();
+    expect(recoveredStatus.indexed).toBe(true);
+    expect(recoveredStatus.failedBatchesCount).toBe(0);
+    expect(recoveredStatus.failedBatchesPath).toBeUndefined();
+  });
+
+  it("clears stale failed batch warnings after a clean no-op run", async () => {
+    const indexer = createIndexer();
+
+    failEmbeddings = true;
+    await indexer.index();
+
+    failEmbeddings = false;
+    await indexer.index();
+
+    const recoveredStatus = await indexer.getStatus();
+    expect(recoveredStatus.failedBatchesCount).toBe(0);
+
+    const noopStats = await indexer.index();
+    expect(noopStats.failedChunks).toBe(0);
+
+    const noopStatus = await indexer.getStatus();
+    expect(noopStatus.indexed).toBe(true);
+    expect(noopStatus.failedBatchesCount).toBe(0);
+    expect(noopStatus.failedBatchesPath).toBeUndefined();
+  });
+
+  it("mentions force reruns in not-indexed failed batch guidance", () => {
+    const message = formatStatus({
+      indexed: false,
+      vectorCount: 0,
+      provider: "google",
+      model: "gemini-embedding-001",
+      indexPath: "/tmp/index",
+      currentBranch: "default",
+      baseBranch: "default",
+      compatibility: null,
+      failedBatchesCount: 2,
+      failedBatchesPath: "/tmp/index/failed-batches.json",
+    });
+
+    expect(message).toContain("force=true");
+    expect(message).toContain("retry the saved failed batches");
+  });
+});

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -127,7 +127,7 @@ describe("indexer failed batch recovery", () => {
     expect(noopStatus.failedBatchesPath).toBeUndefined();
   });
 
-  it("mentions force reruns in not-indexed failed batch guidance", () => {
+  it("recommends a normal rerun before force rebuilds in failed batch guidance", () => {
     const message = formatStatus({
       indexed: false,
       vectorCount: 0,
@@ -141,7 +141,8 @@ describe("indexer failed batch recovery", () => {
       failedBatchesPath: "/tmp/index/failed-batches.json",
     });
 
-    expect(message).toContain("force=true");
+    expect(message).toContain("rerun index_codebase normally");
     expect(message).toContain("retry the saved failed batches");
+    expect(message).toContain("Use force=true only for a full rebuild or compatibility reset");
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -4,6 +4,33 @@ import { parseConfig } from "../src/config/schema.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
+let mockIndexResult = {
+  totalFiles: 10,
+  totalChunks: 50,
+  indexedChunks: 50,
+  failedChunks: 0,
+  failedBatchesPath: undefined as string | undefined,
+  tokensUsed: 1000,
+  durationMs: 500,
+  existingChunks: 0,
+  removedChunks: 0,
+  skippedFiles: [],
+  parseFailures: [],
+};
+
+let mockStatusResult = {
+  indexed: true,
+  vectorCount: 50,
+  provider: "openai",
+  model: "text-embedding-3-small",
+  indexPath: "/tmp/index",
+  currentBranch: "main",
+  baseBranch: "main",
+  compatibility: { compatible: true },
+  failedBatchesCount: 0,
+  failedBatchesPath: undefined as string | undefined,
+};
+
 vi.mock("../src/indexer/index.js", () => {
   class MockIndexer {
     initialize = vi.fn().mockResolvedValue(undefined);
@@ -29,27 +56,8 @@ vi.mock("../src/indexer/index.js", () => {
         score: 0.88,
       },
     ]);
-    index = vi.fn().mockResolvedValue({
-      totalFiles: 10,
-      totalChunks: 50,
-      indexedChunks: 50,
-      failedChunks: 0,
-      tokensUsed: 1000,
-      durationMs: 500,
-      existingChunks: 0,
-      removedChunks: 0,
-      skippedFiles: [],
-      parseFailures: [],
-    });
-    getStatus = vi.fn().mockResolvedValue({
-      indexed: true,
-      vectorCount: 50,
-      provider: "openai",
-      model: "text-embedding-3-small",
-      indexPath: "/tmp/index",
-      currentBranch: "main",
-      baseBranch: "main",
-    });
+    index = vi.fn().mockImplementation(async () => mockIndexResult);
+    getStatus = vi.fn().mockImplementation(async () => mockStatusResult);
     healthCheck = vi.fn().mockResolvedValue({
       removed: 0,
       gcOrphanEmbeddings: 0,
@@ -104,6 +112,32 @@ describe("MCP server tools and prompts", () => {
   let server: ReturnType<typeof createMcpServer>;
 
   beforeEach(async () => {
+    mockIndexResult = {
+      totalFiles: 10,
+      totalChunks: 50,
+      indexedChunks: 50,
+      failedChunks: 0,
+      failedBatchesPath: undefined,
+      tokensUsed: 1000,
+      durationMs: 500,
+      existingChunks: 0,
+      removedChunks: 0,
+      skippedFiles: [],
+      parseFailures: [],
+    };
+    mockStatusResult = {
+      indexed: true,
+      vectorCount: 50,
+      provider: "openai",
+      model: "text-embedding-3-small",
+      indexPath: "/tmp/index",
+      currentBranch: "main",
+      baseBranch: "main",
+      compatibility: { compatible: true },
+      failedBatchesCount: 0,
+      failedBatchesPath: undefined,
+    };
+
     const config = parseConfig({});
     server = createMcpServer("/tmp/test-project", config);
     client = new Client({ name: "test-client", version: "1.0.0" });
@@ -189,8 +223,58 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content).toHaveLength(1);
     expect(content[0].type).toBe("text");
-    expect(content[0].text).toContain("Index status");
+    expect(content[0].text).toContain("Indexed chunks");
     expect(content[0].text).toContain("50");
+    expect(content[0].text).toContain("Compatibility: Index is compatible");
+  });
+
+  it("should surface failed batch diagnostics in index_codebase output", async () => {
+    mockIndexResult = {
+      totalFiles: 10,
+      totalChunks: 50,
+      indexedChunks: 5,
+      failedChunks: 2,
+      failedBatchesPath: "/tmp/index/failed-batches.json",
+      tokensUsed: 1000,
+      durationMs: 500,
+      existingChunks: 0,
+      removedChunks: 0,
+      skippedFiles: [],
+      parseFailures: [],
+    };
+
+    const result = await client.callTool({
+      name: "index_codebase",
+      arguments: {},
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("INDEXING WARNING");
+    expect(content[0].text).toContain("failed-batches.json");
+  });
+
+  it("should surface failed batch diagnostics in index_status output", async () => {
+    mockStatusResult = {
+      indexed: false,
+      vectorCount: 0,
+      provider: "google",
+      model: "gemini-embedding-001",
+      indexPath: "/tmp/index",
+      currentBranch: "default",
+      baseBranch: "default",
+      compatibility: null,
+      failedBatchesCount: 2,
+      failedBatchesPath: "/tmp/index/failed-batches.json",
+    };
+
+    const result = await client.callTool({
+      name: "index_status",
+      arguments: {},
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("failed embedding batches");
+    expect(content[0].text).toContain("failed-batches.json");
   });
 
   it("should execute index_codebase with estimateOnly", async () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -24,6 +24,7 @@ function createBaseStats(overrides: Partial<IndexStats> = {}): IndexStats {
     removedChunks: 0,
     skippedFiles: [],
     parseFailures: [],
+    failedBatchesPath: undefined,
     ...overrides,
   };
 }
@@ -80,6 +81,21 @@ describe("tools utils", () => {
       const result = formatIndexStats(stats);
 
       expect(result).toContain("Failed: 2 chunks");
+    });
+
+    it("should highlight failed batch path when chunks fail", () => {
+      const stats = createBaseStats({
+        totalFiles: 10,
+        indexedChunks: 5,
+        failedChunks: 2,
+        failedBatchesPath: "/tmp/failed-batches.json",
+        tokensUsed: 500,
+        durationMs: 500,
+      });
+      const result = formatIndexStats(stats);
+
+      expect(result).toContain("INDEXING WARNING");
+      expect(result).toContain("/tmp/failed-batches.json");
     });
 
     it("should not include verbose details by default", () => {
@@ -148,6 +164,8 @@ describe("tools utils", () => {
         currentBranch: "default",
         baseBranch: "default",
         compatibility: null,
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
       };
       const result = formatStatus(status);
 
@@ -165,6 +183,8 @@ describe("tools utils", () => {
         currentBranch: "default",
         baseBranch: "default",
         compatibility: { compatible: true },
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
       };
       const result = formatStatus(status);
 
@@ -186,6 +206,8 @@ describe("tools utils", () => {
         currentBranch: "feature-x",
         baseBranch: "main",
         compatibility: { compatible: true },
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
       };
       const result = formatStatus(status);
 
@@ -214,6 +236,8 @@ describe("tools utils", () => {
             updatedAt: "2025-01-01",
           },
         },
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
       };
       const result = formatStatus(status);
 
@@ -233,10 +257,50 @@ describe("tools utils", () => {
         currentBranch: "default",
         baseBranch: "default",
         compatibility: null,
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
       };
       const result = formatStatus(status);
 
       expect(result).toContain("No compatibility information found");
+    });
+
+    it("should surface failed batches when index is not yet usable", () => {
+      const status: StatusResult = {
+        indexed: false,
+        vectorCount: 0,
+        provider: "google",
+        model: "gemini-embedding-001",
+        indexPath: "/tmp/index",
+        currentBranch: "default",
+        baseBranch: "default",
+        compatibility: null,
+        failedBatchesCount: 2,
+        failedBatchesPath: "/tmp/index/failed-batches.json",
+      };
+      const result = formatStatus(status);
+
+      expect(result).toContain("failed embedding batches");
+      expect(result).toContain("/tmp/index/failed-batches.json");
+    });
+
+    it("should warn when indexed data exists alongside failed batches", () => {
+      const status: StatusResult = {
+        indexed: true,
+        vectorCount: 100,
+        provider: "google",
+        model: "gemini-embedding-001",
+        indexPath: "/tmp/index",
+        currentBranch: "default",
+        baseBranch: "default",
+        compatibility: { compatible: true },
+        failedBatchesCount: 1,
+        failedBatchesPath: "/tmp/index/failed-batches.json",
+      };
+      const result = formatStatus(status);
+
+      expect(result).toContain("INDEXING WARNING");
+      expect(result).toContain("failed-batches.json");
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the confusing first-run indexing failure reported in issue #58 by making auto provider selection safer and surfacing failed embedding batches directly in tool output.

## Changes

- prefer GitHub Copilot before other built-in providers during `embeddingProvider: \"auto\"` detection
- switch the built-in Google default model to `gemini-embedding-001`, which matches the Gemini API path used by the provider
- expose failed embedding batch warnings and failed-batches path in `index_codebase` / `index_status`

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [ ] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [ ] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #58