### PR TITLE
fix: reset shared index state on force rebuild

### DIFF
--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -620,6 +620,31 @@ pub fn clear_branch(conn: &Connection, branch: &str) -> DbResult<usize> {
     Ok(count)
 }
 
+/// Remove branch catalog entries for specific chunk IDs.
+pub fn delete_branch_chunks_by_chunk_ids(
+    conn: &Connection,
+    chunk_ids: &[String],
+) -> DbResult<usize> {
+    if chunk_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total = 0;
+    for chunk in chunk_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "DELETE FROM branch_chunks WHERE chunk_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(chunk.iter());
+        total += conn.execute(&sql, params)?;
+    }
+
+    Ok(total)
+}
+
 /// Get all chunk IDs for a branch
 pub fn get_branch_chunk_ids(conn: &Connection, branch: &str) -> DbResult<Vec<String>> {
     let mut stmt = conn.prepare("SELECT chunk_id FROM branch_chunks WHERE branch = ?")?;
@@ -1112,6 +1137,31 @@ pub fn delete_call_edges_by_file(conn: &Connection, file_path: &str) -> DbResult
     Ok(count)
 }
 
+/// Clear resolved call targets that point at symbols being deleted.
+pub fn clear_call_edge_targets_for_symbols(
+    conn: &Connection,
+    symbol_ids: &[String],
+) -> DbResult<usize> {
+    if symbol_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total = 0;
+    for chunk in symbol_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "UPDATE call_edges SET to_symbol_id = NULL, is_resolved = 0 WHERE to_symbol_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(chunk.iter());
+        total += conn.execute(&sql, params)?;
+    }
+
+    Ok(total)
+}
+
 /// Resolve a call edge by setting the target symbol
 pub fn resolve_call_edge(conn: &Connection, edge_id: &str, to_symbol_id: &str) -> DbResult<()> {
     conn.execute(
@@ -1186,6 +1236,31 @@ pub fn clear_branch_symbols(conn: &Connection, branch: &str) -> DbResult<usize> 
         params![branch],
     )?;
     Ok(count)
+}
+
+/// Remove branch-symbol catalog entries for specific symbol IDs.
+pub fn delete_branch_symbols_by_symbol_ids(
+    conn: &Connection,
+    symbol_ids: &[String],
+) -> DbResult<usize> {
+    if symbol_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total = 0;
+    for chunk in symbol_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "DELETE FROM branch_symbols WHERE symbol_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(chunk.iter());
+        total += conn.execute(&sql, params)?;
+    }
+
+    Ok(total)
 }
 
 /// Remove all indexed data so a force rebuild starts from an empty database.

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -1188,6 +1188,17 @@ pub fn clear_branch_symbols(conn: &Connection, branch: &str) -> DbResult<usize> 
     Ok(count)
 }
 
+/// Remove all indexed data so a force rebuild starts from an empty database.
+pub fn clear_all_indexed_data(conn: &Connection) -> DbResult<()> {
+    conn.execute("DELETE FROM branch_symbols", [])?;
+    conn.execute("DELETE FROM branch_chunks", [])?;
+    conn.execute("DELETE FROM call_edges", [])?;
+    conn.execute("DELETE FROM symbols", [])?;
+    conn.execute("DELETE FROM chunks", [])?;
+    conn.execute("DELETE FROM embeddings", [])?;
+    Ok(())
+}
+
 // ============================================================================
 // Metadata Operations
 // ============================================================================
@@ -1736,6 +1747,61 @@ mod tests {
         // Edge from 'used' still exists
         let remaining_edges = get_callees(&conn, "used", "main").unwrap();
         assert_eq!(remaining_edges.len(), 1);
+    }
+
+    #[test]
+    fn test_clear_all_indexed_data() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        upsert_embedding(&conn, "hash", &[1, 2, 3, 4], "chunk text", "model").unwrap();
+        upsert_chunk(
+            &conn,
+            "chunk1",
+            "hash",
+            "src/main.ts",
+            1,
+            3,
+            Some("function"),
+            Some("main"),
+            "typescript",
+        )
+        .unwrap();
+        add_chunks_to_branch(&conn, "main", &["chunk1".to_string()]).unwrap();
+
+        let symbol = SymbolRow {
+            id: "sym1".to_string(),
+            file_path: "src/main.ts".to_string(),
+            name: "main".to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 3,
+            end_col: 0,
+            language: "typescript".to_string(),
+        };
+        upsert_symbol(&conn, &symbol).unwrap();
+        add_symbols_to_branch(&conn, "main", &["sym1".to_string()]).unwrap();
+
+        let edge = CallEdgeRow {
+            id: "edge1".to_string(),
+            from_symbol_id: "sym1".to_string(),
+            target_name: "target".to_string(),
+            to_symbol_id: None,
+            call_type: "Call".to_string(),
+            line: 2,
+            col: 0,
+            is_resolved: false,
+        };
+        upsert_call_edge(&conn, &edge).unwrap();
+
+        clear_all_indexed_data(&conn).unwrap();
+
+        assert!(!embedding_exists(&conn, "hash").unwrap());
+        assert!(get_chunk(&conn, "chunk1").unwrap().is_none());
+        assert!(get_branch_chunk_ids(&conn, "main").unwrap().is_empty());
+        assert!(get_symbols_by_file(&conn, "src/main.ts").unwrap().is_empty());
+        assert!(get_branch_symbol_ids(&conn, "main").unwrap().is_empty());
+        assert!(get_callees(&conn, "sym1", "main").unwrap().is_empty());
     }
 
     #[test]

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -1799,7 +1799,9 @@ mod tests {
         assert!(!embedding_exists(&conn, "hash").unwrap());
         assert!(get_chunk(&conn, "chunk1").unwrap().is_none());
         assert!(get_branch_chunk_ids(&conn, "main").unwrap().is_empty());
-        assert!(get_symbols_by_file(&conn, "src/main.ts").unwrap().is_empty());
+        assert!(get_symbols_by_file(&conn, "src/main.ts")
+            .unwrap()
+            .is_empty());
         assert!(get_branch_symbol_ids(&conn, "main").unwrap().is_empty());
         assert!(get_callees(&conn, "sym1", "main").unwrap().is_empty());
     }

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -620,6 +620,32 @@ pub fn clear_branch(conn: &Connection, branch: &str) -> DbResult<usize> {
     Ok(count)
 }
 
+/// Return chunk IDs that are still referenced by any branch.
+pub fn get_referenced_chunk_ids(conn: &Connection, chunk_ids: &[String]) -> DbResult<Vec<String>> {
+    if chunk_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::new();
+    for chunk in chunk_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT DISTINCT chunk_id FROM branch_chunks WHERE chunk_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(chunk.iter());
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params, |row| row.get::<_, String>(0))?;
+        for row in rows {
+            results.push(row?);
+        }
+    }
+
+    Ok(results)
+}
+
 /// Remove branch catalog entries for specific chunk IDs.
 pub fn delete_branch_chunks_by_chunk_ids(
     conn: &Connection,
@@ -639,6 +665,34 @@ pub fn delete_branch_chunks_by_chunk_ids(
             placeholders
         );
         let params = rusqlite::params_from_iter(chunk.iter());
+        total += conn.execute(&sql, params)?;
+    }
+
+    Ok(total)
+}
+
+/// Remove branch catalog entries for specific chunk IDs on a specific branch.
+pub fn delete_branch_chunks_for_branch(
+    conn: &Connection,
+    branch: &str,
+    chunk_ids: &[String],
+) -> DbResult<usize> {
+    if chunk_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total = 0;
+    for chunk in chunk_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "DELETE FROM branch_chunks WHERE branch = ? AND chunk_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(
+            std::iter::once(branch).chain(chunk.iter().map(|s| s.as_str())),
+        );
         total += conn.execute(&sql, params)?;
     }
 
@@ -1238,6 +1292,35 @@ pub fn clear_branch_symbols(conn: &Connection, branch: &str) -> DbResult<usize> 
     Ok(count)
 }
 
+/// Return symbol IDs that are still referenced by any branch.
+pub fn get_referenced_symbol_ids(
+    conn: &Connection,
+    symbol_ids: &[String],
+) -> DbResult<Vec<String>> {
+    if symbol_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::new();
+    for chunk in symbol_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT DISTINCT symbol_id FROM branch_symbols WHERE symbol_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(chunk.iter());
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params, |row| row.get::<_, String>(0))?;
+        for row in rows {
+            results.push(row?);
+        }
+    }
+
+    Ok(results)
+}
+
 /// Remove branch-symbol catalog entries for specific symbol IDs.
 pub fn delete_branch_symbols_by_symbol_ids(
     conn: &Connection,
@@ -1257,6 +1340,34 @@ pub fn delete_branch_symbols_by_symbol_ids(
             placeholders
         );
         let params = rusqlite::params_from_iter(chunk.iter());
+        total += conn.execute(&sql, params)?;
+    }
+
+    Ok(total)
+}
+
+/// Remove branch-symbol catalog entries for specific symbol IDs on a specific branch.
+pub fn delete_branch_symbols_for_branch(
+    conn: &Connection,
+    branch: &str,
+    symbol_ids: &[String],
+) -> DbResult<usize> {
+    if symbol_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut total = 0;
+    for chunk in symbol_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "DELETE FROM branch_symbols WHERE branch = ? AND symbol_id IN ({})",
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(
+            std::iter::once(branch).chain(chunk.iter().map(|s| s.as_str())),
+        );
         total += conn.execute(&sql, params)?;
     }
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -605,6 +605,17 @@ impl Database {
     }
 
     #[napi]
+    pub fn delete_branch_chunks_by_chunk_ids(&self, chunk_ids: Vec<String>) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_branch_chunks_by_chunk_ids(&conn, &chunk_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
     pub fn get_branch_chunk_ids(&self, branch: String) -> Result<Vec<String>> {
         let conn = self
             .conn
@@ -680,6 +691,17 @@ impl Database {
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
         db::clear_all_indexed_data(&conn).map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn clear_call_edge_targets_for_symbols(&self, symbol_ids: Vec<String>) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::clear_call_edge_targets_for_symbols(&conn, &symbol_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
     }
 
     #[napi]
@@ -1058,6 +1080,17 @@ impl Database {
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
         let count = db::clear_branch_symbols(&conn, &branch)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
+    pub fn delete_branch_symbols_by_symbol_ids(&self, symbol_ids: Vec<String>) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_branch_symbols_by_symbol_ids(&conn, &symbol_ids)
             .map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(count as u32)
     }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -674,6 +674,15 @@ impl Database {
     }
 
     #[napi]
+    pub fn clear_all_indexed_data(&self) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::clear_all_indexed_data(&conn).map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
     pub fn gc_orphan_embeddings(&self) -> Result<u32> {
         let conn = self
             .conn

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -616,6 +616,21 @@ impl Database {
     }
 
     #[napi]
+    pub fn delete_branch_chunks_for_branch(
+        &self,
+        branch: String,
+        chunk_ids: Vec<String>,
+    ) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_branch_chunks_for_branch(&conn, &branch, &chunk_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
     pub fn get_branch_chunk_ids(&self, branch: String) -> Result<Vec<String>> {
         let conn = self
             .conn
@@ -636,6 +651,16 @@ impl Database {
             added: delta.added,
             removed: delta.removed,
         })
+    }
+
+    #[napi]
+    pub fn get_referenced_chunk_ids(&self, chunk_ids: Vec<String>) -> Result<Vec<String>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::get_referenced_chunk_ids(&conn, &chunk_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))
     }
 
     #[napi]
@@ -1085,12 +1110,37 @@ impl Database {
     }
 
     #[napi]
+    pub fn get_referenced_symbol_ids(&self, symbol_ids: Vec<String>) -> Result<Vec<String>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        db::get_referenced_symbol_ids(&conn, &symbol_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
     pub fn delete_branch_symbols_by_symbol_ids(&self, symbol_ids: Vec<String>) -> Result<u32> {
         let conn = self
             .conn
             .lock()
             .map_err(|e| Error::from_reason(e.to_string()))?;
         let count = db::delete_branch_symbols_by_symbol_ids(&conn, &symbol_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
+    pub fn delete_branch_symbols_for_branch(
+        &self,
+        branch: String,
+        symbol_ids: Vec<String>,
+    ) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_branch_symbols_for_branch(&conn, &branch, &symbol_ids)
             .map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(count as u32)
     }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1513,9 +1513,18 @@ export class Indexer {
     return this.currentBranch || "default";
   }
 
+  private getLegacyMigrationMetadataKey(): string {
+    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
+    return `index.globalBranchMigration.${projectHash}`;
+  }
+
   private getBranchCatalogKeys(): string[] {
     const primary = this.getBranchCatalogKey();
     if (this.config.scope !== "global") {
+      return [primary];
+    }
+
+    if (this.database?.getMetadata(this.getLegacyMigrationMetadataKey()) === "done") {
       return [primary];
     }
 
@@ -1573,6 +1582,15 @@ export class Indexer {
   private clearScopedFailedBatches(roots: string[]): void {
     const { retained: retainedBatches } = this.partitionFailedBatches(roots);
     this.saveFailedBatches(retainedBatches);
+  }
+
+  private hasForeignScopedFileHashData(roots: string[]): boolean {
+    return Array.from(this.fileHashCache.keys()).some((filePath) => !this.isFileInCurrentScope(filePath, roots));
+  }
+
+  private hasForeignScopedFailedBatches(roots: string[]): boolean {
+    const { retained } = this.partitionFailedBatches(roots);
+    return retained.length > 0;
   }
 
   private saveScopedFailedBatches(batches: FailedBatch[], roots: string[]): void {
@@ -2147,6 +2165,9 @@ export class Indexer {
     this.database.setMetadata("index.embeddingProvider", provider.provider);
     this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
     this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
+    if (this.config.scope === "global") {
+      this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
+    }
     this.database.setMetadata("index.updatedAt", now);
 
     if (!existingCreatedAt) {
@@ -2582,6 +2603,8 @@ export class Indexer {
         this.saveFileHashCache();
         this.saveFailedBatches([]);
       }
+      this.saveIndexMetadata(configuredProviderInfo);
+      this.indexCompatibility = { compatible: true };
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -2609,6 +2632,8 @@ export class Indexer {
         this.saveFileHashCache();
         this.saveFailedBatches([]);
       }
+      this.saveIndexMetadata(configuredProviderInfo);
+      this.indexCompatibility = { compatible: true };
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -2979,7 +3004,8 @@ export class Indexer {
     }
 
     const prefilterStartTime = performance.now();
-    const shouldPrefilterByBranch = branchChunkIds !== null && branchChunkIds.size > 0;
+    const shouldPrefilterByBranch = branchChunkIds !== null && (this.config.scope === "global" || branchChunkIds.size > 0);
+    const allowBranchPrefilterFallback = this.config.scope !== "global";
     const prefilteredSemantic = shouldPrefilterByBranch && branchChunkIds
       ? semanticResults.filter((r) => branchChunkIds.has(r.id))
       : semanticResults;
@@ -2987,27 +3013,27 @@ export class Indexer {
       ? keywordResults.filter((r) => branchChunkIds.has(r.id))
       : keywordResults;
 
-    const semanticCandidates = (shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0)
+    const semanticCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0)
       ? semanticResults
       : prefilteredSemantic;
-    const keywordCandidates = (shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0)
+    const keywordCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0)
       ? keywordResults
       : prefilteredKeyword;
     const prefilterMs = performance.now() - prefilterStartTime;
 
-    if (branchChunkIds && branchChunkIds.size === 0) {
+    if (this.config.scope !== "global" && branchChunkIds && branchChunkIds.size === 0) {
       this.logger.search("warn", "Branch prefilter skipped because branch catalog is empty", {
         branch: this.currentBranch,
       });
     }
 
-    if (shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0) {
+    if (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0) {
       this.logger.search("warn", "Branch prefilter produced no semantic overlap, using unfiltered semantic candidates", {
         branch: this.currentBranch,
       });
     }
 
-    if (shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0) {
+    if (allowBranchPrefilterFallback && shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0) {
       this.logger.search("warn", "Branch prefilter produced no keyword overlap, using unfiltered keyword candidates", {
         branch: this.currentBranch,
       });
@@ -3212,10 +3238,14 @@ export class Indexer {
     if (this.config.scope === "global") {
       store.load();
       invertedIndex.load();
+      this.loadFileHashCache();
       const roots = this.getScopedRoots();
       const compatibility = this.checkCompatibility();
       const allMetadata = store.getAllMetadata();
-      const hasForeignData = allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots));
+      const hasForeignData =
+        allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots)) ||
+        this.hasForeignScopedFileHashData(roots) ||
+        this.hasForeignScopedFailedBatches(roots);
 
       if (!compatibility.compatible && hasForeignData) {
         throw new Error(
@@ -3241,6 +3271,7 @@ export class Indexer {
         database.deleteMetadata("index.embeddingProvider");
         database.deleteMetadata("index.embeddingModel");
         database.deleteMetadata("index.embeddingDimensions");
+        database.deleteMetadata(this.getLegacyMigrationMetadataKey());
         database.deleteMetadata("index.createdAt");
         database.deleteMetadata("index.updatedAt");
 
@@ -3248,7 +3279,6 @@ export class Indexer {
         return;
       }
 
-      this.loadFileHashCache();
       this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
       this.clearScopedFileHashCache(roots);
       this.clearScopedFailedBatches(roots);
@@ -3275,6 +3305,7 @@ export class Indexer {
     database.deleteMetadata("index.embeddingProvider");
     database.deleteMetadata("index.embeddingModel");
     database.deleteMetadata("index.embeddingDimensions");
+    database.deleteMetadata(this.getLegacyMigrationMetadataKey());
     database.deleteMetadata("index.createdAt");
     database.deleteMetadata("index.updatedAt");
 
@@ -3490,22 +3521,23 @@ export class Indexer {
     }
 
     const prefilterStartTime = performance.now();
-    const shouldPrefilterByBranch = branchChunkIds !== null && branchChunkIds.size > 0;
+    const shouldPrefilterByBranch = branchChunkIds !== null && (this.config.scope === "global" || branchChunkIds.size > 0);
+    const allowBranchPrefilterFallback = this.config.scope !== "global";
     const prefilteredSemantic = shouldPrefilterByBranch && branchChunkIds
       ? semanticResults.filter((r) => branchChunkIds.has(r.id))
       : semanticResults;
-    const semanticCandidates = (shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0)
+    const semanticCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0)
       ? semanticResults
       : prefilteredSemantic;
     const prefilterMs = performance.now() - prefilterStartTime;
 
-    if (branchChunkIds && branchChunkIds.size === 0) {
+    if (this.config.scope !== "global" && branchChunkIds && branchChunkIds.size === 0) {
       this.logger.search("warn", "Branch prefilter skipped because branch catalog is empty", {
         branch: this.currentBranch,
       });
     }
 
-    if (shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0) {
+    if (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0) {
       this.logger.search("warn", "Branch prefilter produced no semantic overlap, using unfiltered semantic candidates", {
         branch: this.currentBranch,
       });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1594,7 +1594,9 @@ export class Indexer {
       ...scopedEntries.map(({ metadata }) => metadata.filePath),
     ]);
 
-    database.deleteBranchChunksForBranch(this.getBranchCatalogKey(), removedChunkIds);
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      database.deleteBranchChunksForBranch(branchKey, removedChunkIds);
+    }
     const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIds));
     const removableChunkIds = removedChunkIds.filter((chunkId) => !sharedChunkIds.has(chunkId));
 
@@ -1610,7 +1612,9 @@ export class Indexer {
       }
     }
 
-    database.deleteBranchSymbolsForBranch(this.getBranchCatalogKey(), symbolIds);
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      database.deleteBranchSymbolsForBranch(branchKey, symbolIds);
+    }
     const sharedSymbolIds = new Set(database.getReferencedSymbolIds(symbolIds));
     const removableSymbolIds = symbolIds.filter((symbolId) => !sharedSymbolIds.has(symbolId));
 
@@ -2114,7 +2118,7 @@ export class Indexer {
     if (chunkDataBatch.length > 0) {
       this.database.upsertChunksBatch(chunkDataBatch);
     }
-    this.database.addChunksToBranchBatch(this.currentBranch || "default", chunkIds);
+    this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
   }
 
   private loadIndexMetadata(): IndexMetadata | null {
@@ -3237,7 +3241,6 @@ export class Indexer {
         database.deleteMetadata("index.embeddingProvider");
         database.deleteMetadata("index.embeddingModel");
         database.deleteMetadata("index.embeddingDimensions");
-        database.deleteMetadata("index.globalBranchKeyVersion");
         database.deleteMetadata("index.createdAt");
         database.deleteMetadata("index.updatedAt");
 
@@ -3272,7 +3275,6 @@ export class Indexer {
     database.deleteMetadata("index.embeddingProvider");
     database.deleteMetadata("index.embeddingModel");
     database.deleteMetadata("index.embeddingDimensions");
-    database.deleteMetadata("index.globalBranchKeyVersion");
     database.deleteMetadata("index.createdAt");
     database.deleteMetadata("index.updatedAt");
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -204,7 +204,6 @@ interface IndexCompatibility {
 
 const INDEX_METADATA_VERSION = "1";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
-const GLOBAL_BRANCH_KEY_VERSION = "2";
 
 function isPathWithinRoot(filePath: string, rootPath: string): boolean {
   const normalizedFilePath = path.resolve(filePath);
@@ -1520,11 +1519,6 @@ export class Indexer {
       return [primary];
     }
 
-    const version = this.database?.getMetadata("index.globalBranchKeyVersion");
-    if (version === GLOBAL_BRANCH_KEY_VERSION) {
-      return [primary];
-    }
-
     const legacy = this.getLegacyBranchCatalogKey();
     return primary === legacy ? [primary] : [primary, legacy];
   }
@@ -1600,13 +1594,14 @@ export class Indexer {
       ...scopedEntries.map(({ metadata }) => metadata.filePath),
     ]);
 
-    for (const chunkId of removedChunkIds) {
+    database.deleteBranchChunksForBranch(this.getBranchCatalogKey(), removedChunkIds);
+    const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIds));
+    const removableChunkIds = removedChunkIds.filter((chunkId) => !sharedChunkIds.has(chunkId));
+
+    for (const chunkId of removableChunkIds) {
       store.remove(chunkId);
       invertedIndex.removeChunk(chunkId);
     }
-
-    database.deleteBranchChunksForBranch(this.getBranchCatalogKey(), removedChunkIds);
-    const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIds));
 
     const symbolIds: string[] = [];
     for (const filePath of filePaths) {
@@ -1615,9 +1610,11 @@ export class Indexer {
       }
     }
 
-    database.clearCallEdgeTargetsForSymbols(symbolIds);
     database.deleteBranchSymbolsForBranch(this.getBranchCatalogKey(), symbolIds);
     const sharedSymbolIds = new Set(database.getReferencedSymbolIds(symbolIds));
+    const removableSymbolIds = symbolIds.filter((symbolId) => !sharedSymbolIds.has(symbolId));
+
+    database.clearCallEdgeTargetsForSymbols(removableSymbolIds);
 
     for (const filePath of filePaths) {
       const fileChunkIds = database.getChunksByFile(filePath).map((chunk) => chunk.chunkId);
@@ -2146,9 +2143,6 @@ export class Indexer {
     this.database.setMetadata("index.embeddingProvider", provider.provider);
     this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
     this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
-    if (this.config.scope === "global") {
-      this.database.setMetadata("index.globalBranchKeyVersion", GLOBAL_BRANCH_KEY_VERSION);
-    }
     this.database.setMetadata("index.updatedAt", now);
 
     if (!existingCreatedAt) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1606,17 +1606,24 @@ export class Indexer {
   ): { removedChunkIds: string[]; hasForeignData: boolean } {
     const allMetadata = store.getAllMetadata();
     const scopedEntries = allMetadata.filter(({ metadata }) => this.isFileInCurrentScope(metadata.filePath, roots));
-    const removedChunkIds = scopedEntries.map(({ key }) => key);
     const filePaths = new Set<string>([
       ...Array.from(this.fileHashCache.keys()).filter((filePath) => this.isFileInCurrentScope(filePath, roots)),
       ...scopedEntries.map(({ metadata }) => metadata.filePath),
     ]);
 
-    for (const branchKey of this.getBranchCatalogKeys()) {
-      database.deleteBranchChunksForBranch(branchKey, removedChunkIds);
+    const removedChunkIds = new Set<string>(scopedEntries.map(({ key }) => key));
+    for (const filePath of filePaths) {
+      for (const chunk of database.getChunksByFile(filePath)) {
+        removedChunkIds.add(chunk.chunkId);
+      }
     }
-    const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIds));
-    const removableChunkIds = removedChunkIds.filter((chunkId) => !sharedChunkIds.has(chunkId));
+    const removedChunkIdList = Array.from(removedChunkIds);
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      database.deleteBranchChunksForBranch(branchKey, removedChunkIdList);
+    }
+    const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIdList));
+    const removableChunkIds = removedChunkIdList.filter((chunkId) => !sharedChunkIds.has(chunkId));
 
     for (const chunkId of removableChunkIds) {
       store.remove(chunkId);
@@ -1661,7 +1668,7 @@ export class Indexer {
     invertedIndex.save();
 
     return {
-      removedChunkIds,
+      removedChunkIds: removedChunkIdList,
       hasForeignData: allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots)),
     };
   }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -205,6 +205,12 @@ interface IndexCompatibility {
 const INDEX_METADATA_VERSION = "1";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
 
+function isPathWithinRoot(filePath: string, rootPath: string): boolean {
+  const normalizedFilePath = path.resolve(filePath);
+  const normalizedRoot = path.resolve(rootPath);
+  return normalizedFilePath === normalizedRoot || normalizedFilePath.startsWith(`${normalizedRoot}${path.sep}`);
+}
+
 const rankingQueryTokenCache = new Map<string, Set<string>>();
 const rankingNameTokenCache = new Map<string, Set<string>>();
 const rankingPathTokenCache = new Map<string, Set<string>>();
@@ -1483,6 +1489,134 @@ export class Indexer {
     renameSync(tempPath, targetPath);
   }
 
+  private getScopedRoots(): string[] {
+    const roots = new Set<string>([path.resolve(this.projectRoot)]);
+
+    for (const kbRoot of this.config.knowledgeBases) {
+      roots.add(path.resolve(this.projectRoot, kbRoot));
+    }
+
+    return Array.from(roots);
+  }
+
+  private getBranchCatalogKey(): string {
+    const branchName = this.currentBranch || "default";
+    if (this.config.scope !== "global") {
+      return branchName;
+    }
+
+    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
+    return `${projectHash}:${branchName}`;
+  }
+
+  private isFileInCurrentScope(filePath: string, roots: string[]): boolean {
+    return roots.some((root) => isPathWithinRoot(filePath, root));
+  }
+
+  private clearScopedFileHashCache(roots: string[]): void {
+    for (const filePath of Array.from(this.fileHashCache.keys())) {
+      if (this.isFileInCurrentScope(filePath, roots)) {
+        this.fileHashCache.delete(filePath);
+      }
+    }
+    this.saveFileHashCache();
+  }
+
+  private replaceScopedFileHashCache(currentFileHashes: Map<string, string>, roots: string[]): void {
+    for (const filePath of Array.from(this.fileHashCache.keys())) {
+      if (this.isFileInCurrentScope(filePath, roots)) {
+        this.fileHashCache.delete(filePath);
+      }
+    }
+
+    for (const [filePath, hash] of currentFileHashes) {
+      this.fileHashCache.set(filePath, hash);
+    }
+
+    this.saveFileHashCache();
+  }
+
+  private partitionFailedBatches(roots: string[]): { scoped: FailedBatch[]; retained: FailedBatch[] } {
+    const scoped: FailedBatch[] = [];
+    const retained: FailedBatch[] = [];
+
+    for (const batch of this.loadFailedBatches()) {
+      const scopedChunks = batch.chunks.filter((chunk) => this.isFileInCurrentScope(chunk.metadata.filePath, roots));
+      const retainedChunks = batch.chunks.filter((chunk) => !this.isFileInCurrentScope(chunk.metadata.filePath, roots));
+
+      if (scopedChunks.length > 0) {
+        scoped.push({ ...batch, chunks: scopedChunks });
+      }
+
+      if (retainedChunks.length > 0) {
+        retained.push({ ...batch, chunks: retainedChunks });
+      }
+    }
+
+    return { scoped, retained };
+  }
+
+  private clearScopedFailedBatches(roots: string[]): void {
+    const { retained: retainedBatches } = this.partitionFailedBatches(roots);
+    this.saveFailedBatches(retainedBatches);
+  }
+
+  private saveScopedFailedBatches(batches: FailedBatch[], roots: string[]): void {
+    const { retained } = this.partitionFailedBatches(roots);
+    this.saveFailedBatches([...retained, ...batches]);
+  }
+
+  private clearSharedIndexProjectData(
+    store: VectorStore,
+    invertedIndex: InvertedIndex,
+    database: Database,
+    roots: string[]
+  ): { removedChunkIds: string[]; hasForeignData: boolean } {
+    const allMetadata = store.getAllMetadata();
+    const scopedEntries = allMetadata.filter(({ metadata }) => this.isFileInCurrentScope(metadata.filePath, roots));
+    const removedChunkIds = scopedEntries.map(({ key }) => key);
+    const filePaths = new Set<string>([
+      ...Array.from(this.fileHashCache.keys()).filter((filePath) => this.isFileInCurrentScope(filePath, roots)),
+      ...scopedEntries.map(({ metadata }) => metadata.filePath),
+    ]);
+
+    for (const chunkId of removedChunkIds) {
+      store.remove(chunkId);
+      invertedIndex.removeChunk(chunkId);
+    }
+
+    database.deleteBranchChunksByChunkIds(removedChunkIds);
+
+    const symbolIds: string[] = [];
+    for (const filePath of filePaths) {
+      for (const symbol of database.getSymbolsByFile(filePath)) {
+        symbolIds.push(symbol.id);
+      }
+    }
+
+    database.clearCallEdgeTargetsForSymbols(symbolIds);
+    database.deleteBranchSymbolsBySymbolIds(symbolIds);
+
+    for (const filePath of filePaths) {
+      database.deleteCallEdgesByFile(filePath);
+      database.deleteSymbolsByFile(filePath);
+      database.deleteChunksByFile(filePath);
+    }
+
+    database.gcOrphanCallEdges();
+    database.gcOrphanSymbols();
+    database.gcOrphanEmbeddings();
+    database.gcOrphanChunks();
+
+    store.save();
+    invertedIndex.save();
+
+    return {
+      removedChunkIds,
+      hasForeignData: allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots)),
+    };
+  }
+
   private checkForInterruptedIndexing(): boolean {
     return existsSync(this.indexingLockPath);
   }
@@ -2079,6 +2213,8 @@ export class Indexer {
 
   async index(onProgress?: ProgressCallback): Promise<IndexStats> {
     const { store, provider, invertedIndex, database, configuredProviderInfo } = await this.ensureInitialized();
+    const scopedRoots = this.config.scope === "global" ? this.getScopedRoots() : null;
+    const branchCatalogKey = this.getBranchCatalogKey();
 
     if (!this.indexCompatibility?.compatible) {
       throw new Error(
@@ -2177,6 +2313,9 @@ export class Indexer {
     const existingChunks = new Map<string, string>();
     const existingChunksByFile = new Map<string, Set<string>>();
     for (const { key, metadata } of store.getAllMetadata()) {
+      if (scopedRoots && !this.isFileInCurrentScope(metadata.filePath, scopedRoots)) {
+        continue;
+      }
       existingChunks.set(key, metadata.hash);
       const fileChunks = existingChunksByFile.get(metadata.filePath) || new Set();
       fileChunks.add(key);
@@ -2400,13 +2539,18 @@ export class Indexer {
     });
 
     if (pendingChunks.length === 0 && removedCount === 0) {
-      database.clearBranch(this.currentBranch);
-      database.addChunksToBranchBatch(this.currentBranch, Array.from(currentChunkIds));
-      database.clearBranchSymbols(this.currentBranch);
-      database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
-      this.fileHashCache = currentFileHashes;
-      this.saveFileHashCache();
-      this.saveFailedBatches([]);
+      database.clearBranch(branchCatalogKey);
+      database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
+      database.clearBranchSymbols(branchCatalogKey);
+      database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+      if (scopedRoots) {
+        this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+        this.clearScopedFailedBatches(scopedRoots);
+      } else {
+        this.fileHashCache = currentFileHashes;
+        this.saveFileHashCache();
+        this.saveFailedBatches([]);
+      }
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -2420,15 +2564,20 @@ export class Indexer {
     }
 
     if (pendingChunks.length === 0) {
-      database.clearBranch(this.currentBranch);
-      database.addChunksToBranchBatch(this.currentBranch, Array.from(currentChunkIds));
-      database.clearBranchSymbols(this.currentBranch);
-      database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
+      database.clearBranch(branchCatalogKey);
+      database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
+      database.clearBranchSymbols(branchCatalogKey);
+      database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
       store.save();
       invertedIndex.save();
-      this.fileHashCache = currentFileHashes;
-      this.saveFileHashCache();
-      this.saveFailedBatches([]);
+      if (scopedRoots) {
+        this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+        this.clearScopedFailedBatches(scopedRoots);
+      } else {
+        this.fileHashCache = currentFileHashes;
+        this.saveFileHashCache();
+        this.saveFailedBatches([]);
+      }
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -2578,7 +2727,11 @@ export class Indexer {
     }
 
     await queue.onIdle();
-    this.saveFailedBatches(failedBatchesForCurrentRun);
+    if (scopedRoots) {
+      this.saveScopedFailedBatches(failedBatchesForCurrentRun, scopedRoots);
+    } else {
+      this.saveFailedBatches(failedBatchesForCurrentRun);
+    }
 
     onProgress?.({
       phase: "storing",
@@ -2588,15 +2741,19 @@ export class Indexer {
       totalChunks: pendingChunks.length,
     });
 
-    database.clearBranch(this.currentBranch);
-    database.addChunksToBranchBatch(this.currentBranch, Array.from(currentChunkIds));
-    database.clearBranchSymbols(this.currentBranch);
-    database.addSymbolsToBranchBatch(this.currentBranch, Array.from(allSymbolIds));
+    database.clearBranch(branchCatalogKey);
+    database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
+    database.clearBranchSymbols(branchCatalogKey);
+    database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
 
     store.save();
     invertedIndex.save();
-    this.fileHashCache = currentFileHashes;
-    this.saveFileHashCache();
+    if (scopedRoots) {
+      this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+    } else {
+      this.fileHashCache = currentFileHashes;
+      this.saveFileHashCache();
+    }
 
     // Auto-GC after indexing: check if orphan count exceeds threshold
     if (this.config.indexing.autoGc && stats.removedChunks > 0) {
@@ -2784,8 +2941,8 @@ export class Indexer {
     const keywordMs = performance.now() - keywordStartTime;
 
     let branchChunkIds: Set<string> | null = null;
-    if (filterByBranch && this.currentBranch !== "default") {
-      branchChunkIds = new Set(database.getBranchChunkIds(this.currentBranch));
+    if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
+      branchChunkIds = new Set(database.getBranchChunkIds(this.getBranchCatalogKey()));
     }
 
     const prefilterStartTime = performance.now();
@@ -3019,6 +3176,53 @@ export class Indexer {
   async clearIndex(): Promise<void> {
     const { store, invertedIndex, database } = await this.ensureInitialized();
 
+    if (this.config.scope === "global") {
+      store.load();
+      invertedIndex.load();
+      const roots = this.getScopedRoots();
+      const compatibility = this.checkCompatibility();
+      const allMetadata = store.getAllMetadata();
+      const hasForeignData = allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots));
+
+      if (!compatibility.compatible && hasForeignData) {
+        throw new Error(
+          `Global index compatibility reset is unsafe because the shared index contains files from other projects. ` +
+          `The current global index cannot be force-rebuilt for ${this.projectRoot} without deleting other repositories' indexed data. ` +
+          `Use scope="project" for isolated rebuilds, or manually delete the shared global index if you intend to rebuild all projects.`
+        );
+      }
+
+      if (!hasForeignData) {
+        store.clear();
+        store.save();
+        invertedIndex.clear();
+        invertedIndex.save();
+
+        this.fileHashCache.clear();
+        this.saveFileHashCache();
+
+        database.clearAllIndexedData();
+        this.saveFailedBatches([]);
+
+        database.deleteMetadata("index.version");
+        database.deleteMetadata("index.embeddingProvider");
+        database.deleteMetadata("index.embeddingModel");
+        database.deleteMetadata("index.embeddingDimensions");
+        database.deleteMetadata("index.createdAt");
+        database.deleteMetadata("index.updatedAt");
+
+        this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo!);
+        return;
+      }
+
+      this.loadFileHashCache();
+      this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
+      this.clearScopedFileHashCache(roots);
+      this.clearScopedFailedBatches(roots);
+      this.indexCompatibility = compatibility;
+      return;
+    }
+
     store.clear();
     store.save();
     invertedIndex.clear();
@@ -3028,8 +3232,8 @@ export class Indexer {
     this.fileHashCache.clear();
     this.saveFileHashCache();
 
-     // Clear persisted index data across all branches so force rebuilds
-     // cannot reuse stale chunks, symbols, or embeddings from a prior provider.
+    // Clear persisted index data across all branches so force rebuilds
+    // cannot reuse stale chunks, symbols, or embeddings from a prior provider.
     database.clearAllIndexedData();
     this.saveFailedBatches([]);
 
@@ -3100,7 +3304,11 @@ export class Indexer {
   async retryFailedBatches(): Promise<{ succeeded: number; failed: number; remaining: number }> {
     const { store, provider, invertedIndex } = await this.ensureInitialized();
 
-    const failedBatches = this.loadFailedBatches();
+    const roots = this.config.scope === "global" ? this.getScopedRoots() : null;
+    const { scoped: scopedFailedBatches, retained: retainedFailedBatches } = roots
+      ? this.partitionFailedBatches(roots)
+      : { scoped: this.loadFailedBatches(), retained: [] as FailedBatch[] };
+    const failedBatches = scopedFailedBatches;
     if (failedBatches.length === 0) {
       return { succeeded: 0, failed: 0, remaining: 0 };
     }
@@ -3151,7 +3359,11 @@ export class Indexer {
       }
     }
 
-    this.saveFailedBatches(stillFailing);
+    if (roots) {
+      this.saveFailedBatches([...retainedFailedBatches, ...stillFailing]);
+    } else {
+      this.saveFailedBatches(stillFailing);
+    }
 
     if (succeeded > 0) {
       store.save();
@@ -3162,6 +3374,9 @@ export class Indexer {
   }
 
   getFailedBatchesCount(): number {
+    if (this.config.scope === "global") {
+      return this.partitionFailedBatches(this.getScopedRoots()).scoped.length;
+    }
     return this.loadFailedBatches().length;
   }
 
@@ -3235,8 +3450,8 @@ export class Indexer {
     const vectorMs = performance.now() - vectorStartTime;
 
     let branchChunkIds: Set<string> | null = null;
-    if (filterByBranch && this.currentBranch !== "default") {
-      branchChunkIds = new Set(database.getBranchChunkIds(this.currentBranch));
+    if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
+      branchChunkIds = new Set(database.getBranchChunkIds(this.getBranchCatalogKey()));
     }
 
     const prefilterStartTime = performance.now();
@@ -3344,11 +3559,11 @@ export class Indexer {
 
   async getCallers(targetName: string): Promise<CallEdgeData[]> {
     const { database } = await this.ensureInitialized();
-    return database.getCallersWithContext(targetName, this.currentBranch);
+    return database.getCallersWithContext(targetName, this.getBranchCatalogKey());
   }
 
   async getCallees(symbolId: string): Promise<CallEdgeData[]> {
     const { database } = await this.ensureInitialized();
-    return database.getCallees(symbolId, this.currentBranch);
+    return database.getCallees(symbolId, this.getBranchCatalogKey());
   }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3028,9 +3028,10 @@ export class Indexer {
     this.fileHashCache.clear();
     this.saveFileHashCache();
 
-    // Clear branch catalog
-    database.clearBranch(this.currentBranch);
-    database.clearBranchSymbols(this.currentBranch);
+     // Clear persisted index data across all branches so force rebuilds
+     // cannot reuse stale chunks, symbols, or embeddings from a prior provider.
+    database.clearAllIndexedData();
+    this.saveFailedBatches([]);
 
     // Clear index metadata so compatibility is re-evaluated from scratch
     database.deleteMetadata("index.version");

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -204,6 +204,7 @@ interface IndexCompatibility {
 
 const INDEX_METADATA_VERSION = "1";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
+const GLOBAL_BRANCH_KEY_VERSION = "2";
 
 function isPathWithinRoot(filePath: string, rootPath: string): boolean {
   const normalizedFilePath = path.resolve(filePath);
@@ -1509,6 +1510,25 @@ export class Indexer {
     return `${projectHash}:${branchName}`;
   }
 
+  private getLegacyBranchCatalogKey(): string {
+    return this.currentBranch || "default";
+  }
+
+  private getBranchCatalogKeys(): string[] {
+    const primary = this.getBranchCatalogKey();
+    if (this.config.scope !== "global") {
+      return [primary];
+    }
+
+    const version = this.database?.getMetadata("index.globalBranchKeyVersion");
+    if (version === GLOBAL_BRANCH_KEY_VERSION) {
+      return [primary];
+    }
+
+    const legacy = this.getLegacyBranchCatalogKey();
+    return primary === legacy ? [primary] : [primary, legacy];
+  }
+
   private isFileInCurrentScope(filePath: string, roots: string[]): boolean {
     return roots.some((root) => isPathWithinRoot(filePath, root));
   }
@@ -1585,7 +1605,8 @@ export class Indexer {
       invertedIndex.removeChunk(chunkId);
     }
 
-    database.deleteBranchChunksByChunkIds(removedChunkIds);
+    database.deleteBranchChunksForBranch(this.getBranchCatalogKey(), removedChunkIds);
+    const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIds));
 
     const symbolIds: string[] = [];
     for (const filePath of filePaths) {
@@ -1595,12 +1616,21 @@ export class Indexer {
     }
 
     database.clearCallEdgeTargetsForSymbols(symbolIds);
-    database.deleteBranchSymbolsBySymbolIds(symbolIds);
+    database.deleteBranchSymbolsForBranch(this.getBranchCatalogKey(), symbolIds);
+    const sharedSymbolIds = new Set(database.getReferencedSymbolIds(symbolIds));
 
     for (const filePath of filePaths) {
-      database.deleteCallEdgesByFile(filePath);
-      database.deleteSymbolsByFile(filePath);
-      database.deleteChunksByFile(filePath);
+      const fileChunkIds = database.getChunksByFile(filePath).map((chunk) => chunk.chunkId);
+      const fileSymbols = database.getSymbolsByFile(filePath);
+
+      if (fileChunkIds.every((chunkId) => !sharedChunkIds.has(chunkId))) {
+        database.deleteChunksByFile(filePath);
+      }
+
+      if (fileSymbols.every((symbol) => !sharedSymbolIds.has(symbol.id))) {
+        database.deleteCallEdgesByFile(filePath);
+        database.deleteSymbolsByFile(filePath);
+      }
     }
 
     database.gcOrphanCallEdges();
@@ -2116,6 +2146,9 @@ export class Indexer {
     this.database.setMetadata("index.embeddingProvider", provider.provider);
     this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
     this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
+    if (this.config.scope === "global") {
+      this.database.setMetadata("index.globalBranchKeyVersion", GLOBAL_BRANCH_KEY_VERSION);
+    }
     this.database.setMetadata("index.updatedAt", now);
 
     if (!existingCreatedAt) {
@@ -2942,7 +2975,9 @@ export class Indexer {
 
     let branchChunkIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
-      branchChunkIds = new Set(database.getBranchChunkIds(this.getBranchCatalogKey()));
+      branchChunkIds = new Set(
+        this.getBranchCatalogKeys().flatMap((branchKey) => database.getBranchChunkIds(branchKey))
+      );
     }
 
     const prefilterStartTime = performance.now();
@@ -3208,6 +3243,7 @@ export class Indexer {
         database.deleteMetadata("index.embeddingProvider");
         database.deleteMetadata("index.embeddingModel");
         database.deleteMetadata("index.embeddingDimensions");
+        database.deleteMetadata("index.globalBranchKeyVersion");
         database.deleteMetadata("index.createdAt");
         database.deleteMetadata("index.updatedAt");
 
@@ -3242,6 +3278,7 @@ export class Indexer {
     database.deleteMetadata("index.embeddingProvider");
     database.deleteMetadata("index.embeddingModel");
     database.deleteMetadata("index.embeddingDimensions");
+    database.deleteMetadata("index.globalBranchKeyVersion");
     database.deleteMetadata("index.createdAt");
     database.deleteMetadata("index.updatedAt");
 
@@ -3451,7 +3488,9 @@ export class Indexer {
 
     let branchChunkIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
-      branchChunkIds = new Set(database.getBranchChunkIds(this.getBranchCatalogKey()));
+      branchChunkIds = new Set(
+        this.getBranchCatalogKeys().flatMap((branchKey) => database.getBranchChunkIds(branchKey))
+      );
     }
 
     const prefilterStartTime = performance.now();
@@ -3559,11 +3598,35 @@ export class Indexer {
 
   async getCallers(targetName: string): Promise<CallEdgeData[]> {
     const { database } = await this.ensureInitialized();
-    return database.getCallersWithContext(targetName, this.getBranchCatalogKey());
+    const seen = new Set<string>();
+    const results: CallEdgeData[] = [];
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      for (const edge of database.getCallersWithContext(targetName, branchKey)) {
+        if (!seen.has(edge.id)) {
+          seen.add(edge.id);
+          results.push(edge);
+        }
+      }
+    }
+
+    return results;
   }
 
   async getCallees(symbolId: string): Promise<CallEdgeData[]> {
     const { database } = await this.ensureInitialized();
-    return database.getCallees(symbolId, this.getBranchCatalogKey());
+    const seen = new Set<string>();
+    const results: CallEdgeData[] = [];
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      for (const edge of database.getCallees(symbolId, branchKey)) {
+        if (!seen.has(edge.id)) {
+          seen.add(edge.id);
+          results.push(edge);
+        }
+      }
+    }
+
+    return results;
   }
 }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -696,6 +696,11 @@ export class Database {
     return this.inner.clearBranch(branch);
   }
 
+  deleteBranchChunksByChunkIds(chunkIds: string[]): number {
+    if (chunkIds.length === 0) return 0;
+    return this.inner.deleteBranchChunksByChunkIds(chunkIds);
+  }
+
   getBranchChunkIds(branch: string): string[] {
     return this.inner.getBranchChunkIds(branch);
   }
@@ -726,6 +731,11 @@ export class Database {
 
   clearAllIndexedData(): void {
     this.inner.clearAllIndexedData();
+  }
+
+  clearCallEdgeTargetsForSymbols(symbolIds: string[]): number {
+    if (symbolIds.length === 0) return 0;
+    return this.inner.clearCallEdgeTargetsForSymbols(symbolIds);
   }
 
   gcOrphanEmbeddings(): number {
@@ -819,6 +829,11 @@ export class Database {
 
   clearBranchSymbols(branch: string): number {
     return this.inner.clearBranchSymbols(branch);
+  }
+
+  deleteBranchSymbolsBySymbolIds(symbolIds: string[]): number {
+    if (symbolIds.length === 0) return 0;
+    return this.inner.deleteBranchSymbolsBySymbolIds(symbolIds);
   }
 
   // ── GC methods for symbols/edges ─────────────────────────────────

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -724,6 +724,10 @@ export class Database {
     return this.inner.deleteMetadata(key);
   }
 
+  clearAllIndexedData(): void {
+    this.inner.clearAllIndexedData();
+  }
+
   gcOrphanEmbeddings(): number {
     return this.inner.gcOrphanEmbeddings();
   }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -701,12 +701,22 @@ export class Database {
     return this.inner.deleteBranchChunksByChunkIds(chunkIds);
   }
 
+  deleteBranchChunksForBranch(branch: string, chunkIds: string[]): number {
+    if (chunkIds.length === 0) return 0;
+    return this.inner.deleteBranchChunksForBranch(branch, chunkIds);
+  }
+
   getBranchChunkIds(branch: string): string[] {
     return this.inner.getBranchChunkIds(branch);
   }
 
   getBranchDelta(branch: string, baseBranch: string): BranchDelta {
     return this.inner.getBranchDelta(branch, baseBranch);
+  }
+
+  getReferencedChunkIds(chunkIds: string[]): string[] {
+    if (chunkIds.length === 0) return [];
+    return this.inner.getReferencedChunkIds(chunkIds);
   }
 
   chunkExistsOnBranch(branch: string, chunkId: string): boolean {
@@ -831,9 +841,19 @@ export class Database {
     return this.inner.clearBranchSymbols(branch);
   }
 
+  getReferencedSymbolIds(symbolIds: string[]): string[] {
+    if (symbolIds.length === 0) return [];
+    return this.inner.getReferencedSymbolIds(symbolIds);
+  }
+
   deleteBranchSymbolsBySymbolIds(symbolIds: string[]): number {
     if (symbolIds.length === 0) return 0;
     return this.inner.deleteBranchSymbolsBySymbolIds(symbolIds);
+  }
+
+  deleteBranchSymbolsForBranch(branch: string, symbolIds: string[]): number {
+    if (symbolIds.length === 0) return 0;
+    return this.inner.deleteBranchSymbolsForBranch(branch, symbolIds);
   }
 
   // ── GC methods for symbols/edges ─────────────────────────────────

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -297,6 +297,36 @@ describe("indexer clearIndex force rebuild", () => {
     expect(searchResults.some((result) => result.filePath === projectBFile)).toBe(true);
   });
 
+  it("clears both legacy and namespaced branch rows for the current repo during global force reset", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+
+    const indexerA = createIndexer(projectA, 8, "global");
+    await indexerA.index();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    const projectAChunk = db.getChunksByFile(projectAFile)[0];
+    const namespacedBranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+
+    db.addChunksToBranchBatch("default", [projectAChunk.chunkId]);
+
+    await indexerA.clearIndex();
+
+    expect(db.chunkExistsOnBranch(namespacedBranch, projectAChunk.chunkId)).toBe(false);
+    expect(db.chunkExistsOnBranch("default", projectAChunk.chunkId)).toBe(false);
+
+    const rebuiltStats = await createIndexer(projectA, 8, "global").index();
+    expect(rebuiltStats.failedChunks).toBe(0);
+
+    const searchResults = await createIndexer(projectA, 8, "global").search("alpha", 5);
+    expect(searchResults.filter((result) => result.filePath === projectAFile)).toHaveLength(1);
+  });
+
   it("preserves resolved call edges for shared symbols kept by another global project", async () => {
     vi.stubEnv("HOME", tempHome);
 

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -286,15 +286,55 @@ describe("indexer clearIndex force rebuild", () => {
     const db = new Database(dbPath);
     const projectBChunk = db.getChunksByFile(projectBFile)[0];
     const projectAKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
-    const currentBranchKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
     const projectBKey = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
 
     db.clearBranch(projectBKey);
     db.addChunksToBranchBatch("default", [projectBChunk.chunkId]);
+    db.deleteMetadata(`index.globalBranchMigration.${hashContent(path.resolve(projectB)).slice(0, 16)}`);
     db.clearBranch(projectAKey);
 
     const searchResults = await createIndexer(projectB, 8, "global").search("beta", 5);
     expect(searchResults.some((result) => result.filePath === projectBFile)).toBe(true);
+  });
+
+  it("stops reading legacy global branch rows for a repo after that repo is reindexed", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
+
+    await createIndexer(projectA, 8, "global").index();
+    await createIndexer(projectB, 8, "global").index();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    const projectAChunk = db.getChunksByFile(projectAFile)[0];
+    const projectBChunk = db.getChunksByFile(projectBFile)[0];
+    const projectAKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+    const projectBKey = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+
+    db.clearBranch(projectAKey);
+    db.addChunksToBranchBatch("default", [projectAChunk.chunkId]);
+    db.deleteMetadata(`index.globalBranchMigration.${hashContent(path.resolve(projectA)).slice(0, 16)}`);
+
+    const legacyVisibleResults = await createIndexer(projectA, 8, "global").search("alpha", 5);
+    expect(legacyVisibleResults.some((result) => result.filePath === projectAFile)).toBe(true);
+
+    await createIndexer(projectA, 8, "global").index();
+
+    db.clearBranch(projectAKey);
+    db.addChunksToBranchBatch("default", [projectBChunk.chunkId]);
+
+    const isolatedResults = await createIndexer(projectA, 8, "global").search("beta", 5);
+    expect(isolatedResults.some((result) => result.filePath === projectBFile)).toBe(false);
+    expect(db.getMetadata(`index.globalBranchMigration.${hashContent(path.resolve(projectA)).slice(0, 16)}`)).toBe("done");
+    expect(db.getBranchChunkIds(projectBKey).length).toBeGreaterThan(0);
   });
 
   it("clears both legacy and namespaced branch rows for the current repo during global force reset", async () => {
@@ -325,6 +365,67 @@ describe("indexer clearIndex force rebuild", () => {
 
     const searchResults = await createIndexer(projectA, 8, "global").search("alpha", 5);
     expect(searchResults.filter((result) => result.filePath === projectAFile)).toHaveLength(1);
+  });
+
+  it("preserves foreign failed-batch and file-hash state during global clear when no vectors exist yet", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
+
+    const projectAIndexer = createIndexer(projectA, 8, "global");
+
+    await projectAIndexer.index();
+    const fileHashCachePath = path.join(tempHome, ".opencode", "global-index", "file-hashes.json");
+    fs.writeFileSync(
+      fileHashCachePath,
+      JSON.stringify({ [projectAFile]: "project-a-hash", [projectBFile]: "foreign-hash" }, null, 2),
+      "utf-8"
+    );
+
+    const failedBatchesPath = path.join(tempHome, ".opencode", "global-index", "failed-batches.json");
+    fs.writeFileSync(
+      failedBatchesPath,
+      JSON.stringify([
+      {
+        chunks: [
+          {
+            id: "pending-beta",
+            text: "beta pending",
+            content: "export function beta() { return 'b'; }",
+            contentHash: "pending-hash",
+            metadata: {
+              filePath: projectBFile,
+              startLine: 1,
+              endLine: 1,
+              language: "typescript",
+              chunkType: "function",
+              hash: "pending-hash",
+              name: "beta",
+            },
+          },
+        ],
+        error: "simulated failure",
+        attemptCount: 1,
+        lastAttempt: new Date().toISOString(),
+      },
+      ], null, 2),
+      "utf-8"
+    );
+
+    await projectAIndexer.clearIndex();
+
+    const fileHashCache = JSON.parse(fs.readFileSync(fileHashCachePath, "utf-8")) as Record<string, string>;
+    expect(fileHashCache[projectBFile]).toBe("foreign-hash");
+
+    const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{ chunks: Array<{ metadata: { filePath: string } }> }>;
+    expect(failedBatches.some((batch) => batch.chunks.some((chunk) => chunk.metadata.filePath === projectBFile))).toBe(true);
   });
 
   it("preserves resolved call edges for shared symbols kept by another global project", async () => {

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseConfig } from "../src/config/schema.js";
 import { Indexer } from "../src/indexer/index.js";
 import { Database } from "../src/native/index.js";
+import { hashContent } from "../src/native/index.js";
 
 describe("indexer clearIndex force rebuild", () => {
   let tempDir: string;
@@ -217,5 +218,74 @@ describe("indexer clearIndex force rebuild", () => {
     const rebuiltStats = await rebuiltIndexer.index();
     expect(rebuiltStats.failedChunks).toBe(0);
     expect(rebuiltStats.indexedChunks).toBeGreaterThan(0);
+  });
+
+  it("preserves shared knowledge-base rows still referenced by another global project", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const kbDir = path.join(tempDir, "shared-kb");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+    const kbFile = path.join(kbDir, "docs", "shared.ts");
+
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.mkdirSync(path.dirname(kbFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
+    fs.writeFileSync(kbFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+
+    const createKbIndexer = (projectRoot: string) => new Indexer(projectRoot, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-8d",
+        dimensions: 8,
+      },
+      scope: "global",
+      knowledgeBases: [kbDir],
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    }));
+
+    await createKbIndexer(projectA).index();
+    await createKbIndexer(projectB).index();
+    await createKbIndexer(projectA).clearIndex();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    expect(db.getChunksByFile(projectAFile)).toHaveLength(0);
+    expect(db.getChunksByFile(projectBFile).length).toBeGreaterThan(0);
+    expect(db.getChunksByFile(kbFile).length).toBeGreaterThan(0);
+  });
+
+  it("keeps legacy global branch catalogs readable until the project is reindexed", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+
+    const legacyIndexer = createIndexer(projectA, 8, "global");
+    await legacyIndexer.index();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    const currentChunk = db.getChunksByFile(projectAFile)[0];
+    const currentBranchKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+
+    db.clearBranch(currentBranchKey);
+    db.addChunksToBranchBatch("default", [currentChunk.chunkId]);
+    db.deleteMetadata("index.globalBranchKeyVersion");
+
+    const migratedIndexer = createIndexer(projectA, 8, "global");
+    const searchResults = await migratedIndexer.search("alpha", 5);
+    expect(searchResults.some((result) => result.filePath === projectAFile)).toBe(true);
   });
 });

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -1,0 +1,122 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
+import { Database } from "../src/native/index.js";
+
+describe("indexer clearIndex force rebuild", () => {
+  let tempDir: string;
+  let sourceFile: string;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let embeddingDimensions = 8;
+
+  beforeEach(() => {
+    embeddingDimensions = 8;
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = Array.isArray(body.input) ? body.input : [];
+
+      const data = texts.map((text) => {
+        let seed = 0;
+        for (const ch of text) {
+          seed = (seed * 31 + ch.charCodeAt(0)) % 1000;
+        }
+        const embedding = Array.from(
+          { length: embeddingDimensions },
+          (_, idx) => ((seed + idx * 17) % 997) / 997
+        );
+        return { embedding };
+      });
+
+      return new Response(
+        JSON.stringify({
+          data,
+          usage: { total_tokens: Math.max(1, texts.length * embeddingDimensions) },
+        }),
+        { status: 200 }
+      );
+    });
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clear-index-indexer-"));
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    sourceFile = path.join(tempDir, "src", "index.ts");
+    fs.writeFileSync(
+      sourceFile,
+      [
+        "export function alpha() {",
+        "  return 'alpha';",
+        "}",
+        "",
+        "export function beta() {",
+        "  return alpha();",
+        "}",
+      ].join("\n"),
+      "utf-8"
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function createIndexer(dimensions: number): Indexer {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: `mock-${dimensions}d`,
+        dimensions,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    });
+
+    return new Indexer(tempDir, config);
+  }
+
+  it("clears persisted embeddings before a force rebuild with new dimensions", async () => {
+    embeddingDimensions = 8;
+    const originalIndexer = createIndexer(8);
+    const originalStats = await originalIndexer.index();
+    expect(originalStats.failedChunks).toBe(0);
+    expect(originalStats.indexedChunks).toBeGreaterThan(0);
+
+    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+    const seededDb = new Database(dbPath);
+    expect(seededDb.getStats().embeddingCount).toBeGreaterThan(0);
+
+    embeddingDimensions = 4;
+    const rebuiltIndexer = createIndexer(4);
+    await rebuiltIndexer.clearIndex();
+
+    const clearedDb = new Database(dbPath);
+    expect(clearedDb.getStats().embeddingCount).toBe(0);
+    expect(clearedDb.getStats().chunkCount).toBe(0);
+    expect(clearedDb.getStats().branchChunkCount).toBe(0);
+
+    const rebuiltStats = await rebuiltIndexer.index();
+    expect(rebuiltStats.failedChunks).toBe(0);
+    expect(rebuiltStats.indexedChunks).toBeGreaterThan(0);
+
+    const rebuiltDb = new Database(dbPath);
+    const rebuiltBranch = rebuiltDb.getAllBranches()[0];
+    expect(rebuiltBranch).toBeTruthy();
+    const rebuiltChunkId = rebuiltDb.getBranchChunkIds(rebuiltBranch!)[0];
+    expect(rebuiltChunkId).toBeTruthy();
+    const rebuiltChunk = rebuiltDb.getChunk(rebuiltChunkId!);
+    expect(rebuiltChunk).not.toBeNull();
+    const embeddingBuffer = rebuiltDb.getEmbedding(rebuiltChunk!.contentHash);
+    expect(embeddingBuffer).not.toBeNull();
+    const floatCount = embeddingBuffer!.byteLength / Float32Array.BYTES_PER_ELEMENT;
+    expect(floatCount).toBe(4);
+  });
+});

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -262,30 +262,128 @@ describe("indexer clearIndex force rebuild", () => {
     expect(db.getChunksByFile(projectAFile)).toHaveLength(0);
     expect(db.getChunksByFile(projectBFile).length).toBeGreaterThan(0);
     expect(db.getChunksByFile(kbFile).length).toBeGreaterThan(0);
+
+    const searchResults = await createKbIndexer(projectB).search("sharedDoc", 5);
+    expect(searchResults.some((result) => result.filePath === kbFile)).toBe(true);
   });
 
-  it("keeps legacy global branch catalogs readable until the project is reindexed", async () => {
+  it("keeps legacy global branch catalogs readable across repos until each project is reindexed", async () => {
     vi.stubEnv("HOME", tempHome);
 
     const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
     const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
     fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
     fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
 
-    const legacyIndexer = createIndexer(projectA, 8, "global");
-    await legacyIndexer.index();
+    await createIndexer(projectA, 8, "global").index();
+    await createIndexer(projectB, 8, "global").index();
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = new Database(dbPath);
-    const currentChunk = db.getChunksByFile(projectAFile)[0];
+    const projectBChunk = db.getChunksByFile(projectBFile)[0];
+    const projectAKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
     const currentBranchKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+    const projectBKey = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
 
-    db.clearBranch(currentBranchKey);
-    db.addChunksToBranchBatch("default", [currentChunk.chunkId]);
-    db.deleteMetadata("index.globalBranchKeyVersion");
+    db.clearBranch(projectBKey);
+    db.addChunksToBranchBatch("default", [projectBChunk.chunkId]);
+    db.clearBranch(projectAKey);
 
-    const migratedIndexer = createIndexer(projectA, 8, "global");
-    const searchResults = await migratedIndexer.search("alpha", 5);
-    expect(searchResults.some((result) => result.filePath === projectAFile)).toBe(true);
+    const searchResults = await createIndexer(projectB, 8, "global").search("beta", 5);
+    expect(searchResults.some((result) => result.filePath === projectBFile)).toBe(true);
+  });
+
+  it("preserves resolved call edges for shared symbols kept by another global project", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const sharedDir = path.join(tempDir, "shared-kb");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+    const sharedFile = path.join(sharedDir, "shared.ts");
+
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return sharedHelper(); }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return sharedHelper(); }\n", "utf-8");
+    fs.writeFileSync(sharedFile, "export const shared = 'shared';\n", "utf-8");
+
+    const createKbIndexer = (projectRoot: string) => new Indexer(projectRoot, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-8d",
+        dimensions: 8,
+      },
+      scope: "global",
+      knowledgeBases: [sharedDir],
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    }));
+
+    await createKbIndexer(projectA).index();
+    await createKbIndexer(projectB).index();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    const projectABranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+    const projectBBranch = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+
+    const sharedSymbolId = `sym_${hashContent(`${sharedFile}:sharedHelper:function:1`).slice(0, 16)}`;
+    const betaSymbolId = `sym_${hashContent(`${projectBFile}:beta:function:1`).slice(0, 16)}`;
+    const edgeId = `edge_${hashContent(`${betaSymbolId}:sharedHelper:1:0`).slice(0, 16)}`;
+
+    db.upsertSymbolsBatch([
+      {
+        id: sharedSymbolId,
+        filePath: sharedFile,
+        name: "sharedHelper",
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 1,
+        endCol: 30,
+        language: "typescript",
+      },
+      {
+        id: betaSymbolId,
+        filePath: projectBFile,
+        name: "beta",
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 1,
+        endCol: 40,
+        language: "typescript",
+      },
+    ]);
+    db.upsertCallEdgesBatch([
+      {
+        id: edgeId,
+        fromSymbolId: betaSymbolId,
+        targetName: "sharedHelper",
+        toSymbolId: sharedSymbolId,
+        callType: "Call",
+        line: 1,
+        col: 0,
+        isResolved: true,
+      },
+    ]);
+    db.addSymbolsToBranchBatch(projectABranch, [sharedSymbolId]);
+    db.addSymbolsToBranchBatch(projectBBranch, [sharedSymbolId, betaSymbolId]);
+
+    await createKbIndexer(projectA).clearIndex();
+
+    const callers = await createKbIndexer(projectB).getCallers("sharedHelper");
+    expect(callers.some((caller) => caller.id === edgeId && caller.fromSymbolFilePath === projectBFile)).toBe(true);
   });
 });

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -428,6 +428,71 @@ describe("indexer clearIndex force rebuild", () => {
     expect(failedBatches.some((batch) => batch.chunks.some((chunk) => chunk.metadata.filePath === projectBFile))).toBe(true);
   });
 
+  it("clears current-repo branch ownership for DB-only chunks left by failed embeddings", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const sharedDir = path.join(tempDir, "shared-kb");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+    const sharedFile = path.join(sharedDir, "shared.ts");
+
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return sharedDoc(); }\n", "utf-8");
+    fs.writeFileSync(sharedFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+
+    const createKbIndexer = (projectRoot: string) => new Indexer(projectRoot, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-8d",
+        dimensions: 8,
+      },
+      scope: "global",
+      knowledgeBases: [sharedDir],
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    }));
+
+    await createKbIndexer(projectA).index();
+    await createKbIndexer(projectB).index();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    const projectABranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+    const projectBBranch = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+    const sharedChunk = db.getChunksByFile(sharedFile)[0];
+
+    db.deleteBranchChunksForBranch(projectABranch, [sharedChunk.chunkId]);
+    db.deleteBranchChunksForBranch(projectBBranch, [sharedChunk.chunkId]);
+    db.deleteChunksByFile(sharedFile);
+    db.upsertChunksBatch([
+      {
+        chunkId: sharedChunk.chunkId,
+        contentHash: sharedChunk.contentHash,
+        filePath: sharedFile,
+        startLine: sharedChunk.startLine,
+        endLine: sharedChunk.endLine,
+        nodeType: sharedChunk.nodeType,
+        name: sharedChunk.name,
+        language: sharedChunk.language,
+      },
+    ]);
+    db.addChunksToBranchBatch(projectABranch, [sharedChunk.chunkId]);
+
+    await createKbIndexer(projectA).clearIndex();
+
+    expect(db.chunkExistsOnBranch(projectABranch, sharedChunk.chunkId)).toBe(false);
+    expect(db.getChunksByFile(sharedFile)).toHaveLength(0);
+  });
+
   it("preserves resolved call edges for shared symbols kept by another global project", async () => {
     vi.stubEnv("HOME", tempHome);
 

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -13,6 +13,7 @@ describe("indexer clearIndex force rebuild", () => {
   let sourceFile: string;
   let fetchSpy: ReturnType<typeof vi.spyOn>;
   let embeddingDimensions = 8;
+  let tempHome: string;
 
   beforeEach(() => {
     embeddingDimensions = 8;
@@ -43,6 +44,7 @@ describe("indexer clearIndex force rebuild", () => {
     });
 
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clear-index-indexer-"));
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "clear-index-home-"));
     fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
     sourceFile = path.join(tempDir, "src", "index.ts");
     fs.writeFileSync(
@@ -62,10 +64,12 @@ describe("indexer clearIndex force rebuild", () => {
 
   afterEach(() => {
     fetchSpy.mockRestore();
+    vi.unstubAllEnvs();
     fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(tempHome, { recursive: true, force: true });
   });
 
-  function createIndexer(dimensions: number): Indexer {
+  function createIndexer(projectRoot: string, dimensions: number, scope: "project" | "global" = "project"): Indexer {
     const config = parseConfig({
       embeddingProvider: "custom",
       customProvider: {
@@ -73,6 +77,7 @@ describe("indexer clearIndex force rebuild", () => {
         model: `mock-${dimensions}d`,
         dimensions,
       },
+      scope,
       indexing: {
         watchFiles: false,
         retries: 0,
@@ -80,12 +85,12 @@ describe("indexer clearIndex force rebuild", () => {
       },
     });
 
-    return new Indexer(tempDir, config);
+    return new Indexer(projectRoot, config);
   }
 
   it("clears persisted embeddings before a force rebuild with new dimensions", async () => {
     embeddingDimensions = 8;
-    const originalIndexer = createIndexer(8);
+    const originalIndexer = createIndexer(tempDir, 8);
     const originalStats = await originalIndexer.index();
     expect(originalStats.failedChunks).toBe(0);
     expect(originalStats.indexedChunks).toBeGreaterThan(0);
@@ -95,7 +100,7 @@ describe("indexer clearIndex force rebuild", () => {
     expect(seededDb.getStats().embeddingCount).toBeGreaterThan(0);
 
     embeddingDimensions = 4;
-    const rebuiltIndexer = createIndexer(4);
+    const rebuiltIndexer = createIndexer(tempDir, 4);
     await rebuiltIndexer.clearIndex();
 
     const clearedDb = new Database(dbPath);
@@ -118,5 +123,99 @@ describe("indexer clearIndex force rebuild", () => {
     expect(embeddingBuffer).not.toBeNull();
     const floatCount = embeddingBuffer!.byteLength / Float32Array.BYTES_PER_ELEMENT;
     expect(floatCount).toBe(4);
+  });
+
+  it("clears only the current project from a shared global index when compatibility is unchanged", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
+
+    const indexerA = createIndexer(projectA, 8, "global");
+    const indexerB = createIndexer(projectB, 8, "global");
+
+    await indexerA.index();
+    await indexerB.index();
+
+    await indexerA.clearIndex();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    expect(db.getChunksByFile(projectAFile)).toHaveLength(0);
+    expect(db.getChunksByFile(projectBFile).length).toBeGreaterThan(0);
+
+    const remainingChunk = db.getChunksByFile(projectBFile)[0];
+    const remainingBranch = db.getAllBranches().find((branch) => branch.endsWith(":default"));
+    expect(remainingBranch).toBeTruthy();
+    expect(db.chunkExistsOnBranch(remainingBranch!, remainingChunk.chunkId)).toBe(true);
+    expect(db.getStats().embeddingCount).toBeGreaterThan(0);
+
+    const fileHashCachePath = path.join(tempHome, ".opencode", "global-index", "file-hashes.json");
+    const fileHashCache = JSON.parse(fs.readFileSync(fileHashCachePath, "utf-8")) as Record<string, string>;
+    expect(fileHashCache[projectAFile]).toBeUndefined();
+    expect(typeof fileHashCache[projectBFile]).toBe("string");
+  });
+
+  it("rejects an incompatible global force reset when the shared index contains other projects", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectB = path.join(tempDir, "project-b");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    const projectBFile = path.join(projectB, "src", "b.ts");
+
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.mkdirSync(path.dirname(projectBFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
+
+    embeddingDimensions = 8;
+    await createIndexer(projectA, 8, "global").index();
+    await createIndexer(projectB, 8, "global").index();
+
+    embeddingDimensions = 4;
+    const incompatibleIndexer = createIndexer(projectA, 4, "global");
+
+    await expect(incompatibleIndexer.clearIndex()).rejects.toThrow(
+      "Global index compatibility reset is unsafe"
+    );
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    expect(db.getChunksByFile(projectAFile).length).toBeGreaterThan(0);
+    expect(db.getChunksByFile(projectBFile).length).toBeGreaterThan(0);
+  });
+
+  it("allows an incompatible global force reset when the current project is the only indexed tenant", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+
+    embeddingDimensions = 8;
+    await createIndexer(projectA, 8, "global").index();
+
+    embeddingDimensions = 4;
+    const rebuiltIndexer = createIndexer(projectA, 4, "global");
+    await rebuiltIndexer.clearIndex();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = new Database(dbPath);
+    expect(db.getStats().embeddingCount).toBe(0);
+    expect(db.getStats().chunkCount).toBe(0);
+
+    const rebuiltStats = await rebuiltIndexer.index();
+    expect(rebuiltStats.failedChunks).toBe(0);
+    expect(rebuiltStats.indexedChunks).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Make `force=true` behave like a true shared index reset so provider/model dimension changes cannot reuse stale SQLite embeddings during the next rebuild.

## Changes

- add a native database reset path that clears shared embeddings, chunks, branch catalogs, symbols, and call edges
- update `Indexer.clearIndex()` to wipe persisted shared index state and failed-batch state before rebuilding
- add regression coverage for an in-process embedding dimension switch during a force rebuild

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #61