### PR TITLE
fix: reset corrupted local SQLite indexes during health checks

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -147,7 +147,10 @@ export interface StatusResult {
   compatibility: IndexCompatibility | null;
   failedBatchesCount: number;
   failedBatchesPath?: string;
+  warning?: string;
 }
+
+const STARTUP_WARNING_METADATA_KEY = "index.startupWarning";
 
 export interface IndexProgress {
   phase: "scanning" | "parsing" | "embedding" | "storing" | "complete";
@@ -2127,7 +2130,12 @@ export class Indexer {
     }
 
     if (shouldRunGc) {
-      await this.healthCheck();
+      const result = await this.healthCheck();
+      if (result.warning) {
+        this.database.setMetadata(STARTUP_WARNING_METADATA_KEY, result.warning);
+      } else {
+        this.database.deleteMetadata(STARTUP_WARNING_METADATA_KEY);
+      }
       this.database.setMetadata("lastGcTimestamp", now.toString());
     }
   }
@@ -3342,7 +3350,7 @@ export class Indexer {
   }
 
   async getStatus(): Promise<StatusResult> {
-    const { store, configuredProviderInfo } = await this.ensureInitialized();
+    const { store, configuredProviderInfo, database } = await this.ensureInitialized();
     const failedBatchesCount = this.getFailedBatchesCount();
 
     return {
@@ -3356,6 +3364,7 @@ export class Indexer {
       compatibility: this.indexCompatibility,
       failedBatchesCount,
       failedBatchesPath: failedBatchesCount > 0 ? this.failedBatchesPath : undefined,
+      warning: database.getMetadata(STARTUP_WARNING_METADATA_KEY) ?? undefined,
     };
   }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -106,6 +106,13 @@ export interface IndexStats {
   skippedFiles: SkippedFile[];
   parseFailures: string[];
   failedBatchesPath?: string;
+  warning?: string;
+  resetCorruptedIndex?: boolean;
+}
+
+interface CorruptedIndexResetResult {
+  warning: string;
+  resetCorruptedIndex: true;
 }
 
 export interface SearchResult {
@@ -2125,11 +2132,11 @@ export class Indexer {
     }
   }
 
-  private async maybeRunOrphanGc(): Promise<void> {
-    if (!this.database) return;
+  private async maybeRunOrphanGc(): Promise<CorruptedIndexResetResult | null> {
+    if (!this.database) return null;
 
     const stats = this.database.getStats();
-    if (!stats) return;
+    if (!stats) return null;
 
     const orphanCount = stats.embeddingCount - stats.chunkCount;
     if (orphanCount > this.config.indexing.gcOrphanThreshold) {
@@ -2138,12 +2145,17 @@ export class Indexer {
         this.database.gcOrphanChunks();
       } catch (error) {
         if (await this.tryResetCorruptedIndex("running automatic orphan garbage collection", error)) {
-          return;
+          return {
+            resetCorruptedIndex: true,
+            warning: this.getCorruptedIndexWarning(path.join(this.indexPath, "codebase.db")),
+          };
         }
         throw error;
       }
       this.database.setMetadata("lastGcTimestamp", Date.now().toString());
     }
+
+    return null;
   }
 
   private getCorruptedIndexWarning(dbPath: string): string {
@@ -2910,7 +2922,25 @@ export class Indexer {
 
     // Auto-GC after indexing: check if orphan count exceeds threshold
     if (this.config.indexing.autoGc && stats.removedChunks > 0) {
-      await this.maybeRunOrphanGc();
+      const gcReset = await this.maybeRunOrphanGc();
+      if (gcReset) {
+        stats.durationMs = Date.now() - startTime;
+        stats.warning = gcReset.warning;
+        stats.resetCorruptedIndex = true;
+
+        this.logger.recordIndexingEnd();
+        this.logger.warn("Indexing ended after resetting corrupted local index during automatic GC", {
+          files: stats.totalFiles,
+          indexed: stats.indexedChunks,
+          existing: stats.existingChunks,
+          removed: stats.removedChunks,
+          failed: stats.failedChunks,
+          tokens: stats.tokensUsed,
+          durationMs: stats.durationMs,
+        });
+
+        return stats;
+      }
     }
 
     stats.durationMs = Date.now() - startTime;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -86,6 +86,14 @@ function isRateLimitError(error: unknown): boolean {
   return message.includes("429") || message.toLowerCase().includes("rate limit") || message.toLowerCase().includes("too many requests");
 }
 
+function isSqliteCorruptionError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return message.includes("database disk image is malformed")
+    || message.includes("file is not a database")
+    || message.includes("database schema is corrupt")
+    || message.includes("sqlite_corrupt");
+}
+
 export interface IndexStats {
   totalFiles: number;
   totalChunks: number;
@@ -117,6 +125,8 @@ export interface HealthCheckResult {
   gcOrphanChunks: number;
   gcOrphanSymbols: number;
   gcOrphanCallEdges: number;
+  warning?: string;
+  resetCorruptedIndex?: boolean;
 }
 
 export interface StatusResult {
@@ -2037,8 +2047,19 @@ export class Indexer {
     }
 
     const dbPath = path.join(this.indexPath, "codebase.db");
-    const dbIsNew = !existsSync(dbPath);
-    this.database = new Database(dbPath);
+    let dbIsNew = !existsSync(dbPath);
+    try {
+      this.database = new Database(dbPath);
+    } catch (error) {
+      if (!(await this.tryResetCorruptedIndex("initializing index database", error))) {
+        throw error;
+      }
+
+      this.store = new VectorStore(storePath, dimensions);
+      this.invertedIndex = new InvertedIndex(invertedIndexPath);
+      this.database = new Database(dbPath);
+      dbIsNew = true;
+    }
 
     // Recover from interrupted indexing AFTER store, invertedIndex, and database
     // are all initialized. healthCheck() calls ensureInitialized() which checks
@@ -2112,10 +2133,79 @@ export class Indexer {
 
     const orphanCount = stats.embeddingCount - stats.chunkCount;
     if (orphanCount > this.config.indexing.gcOrphanThreshold) {
-      this.database.gcOrphanEmbeddings();
-      this.database.gcOrphanChunks();
+      try {
+        this.database.gcOrphanEmbeddings();
+        this.database.gcOrphanChunks();
+      } catch (error) {
+        if (await this.tryResetCorruptedIndex("running automatic orphan garbage collection", error)) {
+          return;
+        }
+        throw error;
+      }
       this.database.setMetadata("lastGcTimestamp", Date.now().toString());
     }
+  }
+
+  private getCorruptedIndexWarning(dbPath: string): string {
+    if (this.config.scope === "global") {
+      return `Detected a corrupted shared global SQLite index at ${dbPath}. Automatic repair is disabled for global scope because it may delete other projects' index data. Remove or repair the shared index manually, then rerun index_codebase with force=true.`;
+    }
+
+    return `Detected a corrupted local SQLite index at ${dbPath} and reset the local index. Run index_codebase to rebuild search data.`;
+  }
+
+  private async tryResetCorruptedIndex(stage: string, error: unknown): Promise<boolean> {
+    if (!isSqliteCorruptionError(error)) {
+      return false;
+    }
+
+    const dbPath = path.join(this.indexPath, "codebase.db");
+    const warning = this.getCorruptedIndexWarning(dbPath);
+    const errorMessage = getErrorMessage(error);
+
+    if (this.config.scope === "global") {
+      this.logger.error("Detected corrupted shared global index database", {
+        stage,
+        dbPath,
+        error: errorMessage,
+      });
+      throw new Error(`${warning} Original SQLite error: ${errorMessage}`);
+    }
+
+    this.logger.warn("Detected corrupted local index database, resetting local index", {
+      stage,
+      dbPath,
+      error: errorMessage,
+    });
+
+    this.store = null;
+    this.invertedIndex = null;
+    this.database = null;
+    this.indexCompatibility = null;
+    this.fileHashCache.clear();
+
+    const resetPaths = [
+      path.join(this.indexPath, "codebase.db"),
+      path.join(this.indexPath, "codebase.db-shm"),
+      path.join(this.indexPath, "codebase.db-wal"),
+      path.join(this.indexPath, "vectors.usearch"),
+      path.join(this.indexPath, "inverted-index.json"),
+      path.join(this.indexPath, "file-hashes.json"),
+      path.join(this.indexPath, "failed-batches.json"),
+      path.join(this.indexPath, "indexing.lock"),
+      path.join(this.indexPath, "vectors"),
+    ];
+
+    await Promise.all(resetPaths.map(async (targetPath) => {
+      try {
+        await fsPromises.rm(targetPath, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup. The follow-up reinitialization will recreate what it needs.
+      }
+    }));
+
+    await fsPromises.mkdir(this.indexPath, { recursive: true });
+    return true;
   }
 
   private migrateFromLegacyIndex(): void {
@@ -3356,10 +3446,34 @@ export class Indexer {
       invertedIndex.save();
     }
 
-    const gcOrphanEmbeddings = database.gcOrphanEmbeddings();
-    const gcOrphanChunks = database.gcOrphanChunks();
-    const gcOrphanSymbols = database.gcOrphanSymbols();
-    const gcOrphanCallEdges = database.gcOrphanCallEdges();
+    let gcOrphanEmbeddings: number;
+    let gcOrphanChunks: number;
+    let gcOrphanSymbols: number;
+    let gcOrphanCallEdges: number;
+
+    try {
+      gcOrphanEmbeddings = database.gcOrphanEmbeddings();
+      gcOrphanChunks = database.gcOrphanChunks();
+      gcOrphanSymbols = database.gcOrphanSymbols();
+      gcOrphanCallEdges = database.gcOrphanCallEdges();
+    } catch (error) {
+      if (!(await this.tryResetCorruptedIndex("running index health check", error))) {
+        throw error;
+      }
+
+      await this.ensureInitialized();
+
+      return {
+        removed: 0,
+        filePaths: [],
+        gcOrphanEmbeddings: 0,
+        gcOrphanChunks: 0,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
+        resetCorruptedIndex: true,
+        warning: this.getCorruptedIndexWarning(path.join(this.indexPath, "codebase.db")),
+      };
+    }
 
     this.logger.recordGc(removedCount, gcOrphanChunks, gcOrphanEmbeddings);
     this.logger.gc("info", "Health check complete", {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 import { Indexer } from "./indexer/index.js";
 import type { ParsedCodebaseIndexConfig, LogLevel } from "./config/schema.js";
-import { formatDefinitionLookup, formatIndexStats, formatStatus } from "./tools/utils.js";
+import { formatDefinitionLookup, formatHealthCheck, formatIndexStats, formatStatus } from "./tools/utils.js";
 import { formatCostEstimate } from "./utils/cost.js";
 import type { LogEntry } from "./utils/logger.js";
 
@@ -152,38 +152,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
     async () => {
       await ensureInitialized();
       const result = await indexer.healthCheck();
-
-      if (result.removed === 0 && result.gcOrphanEmbeddings === 0 && result.gcOrphanChunks === 0 && result.gcOrphanSymbols === 0 && result.gcOrphanCallEdges === 0) {
-        return { content: [{ type: "text", text: "Index is healthy. No stale entries found." }] };
-      }
-
-      const lines = [`Health check complete:`];
-
-      if (result.removed > 0) {
-        lines.push(`  Removed stale entries: ${result.removed}`);
-      }
-
-      if (result.gcOrphanEmbeddings > 0) {
-        lines.push(`  Garbage collected orphan embeddings: ${result.gcOrphanEmbeddings}`);
-      }
-
-      if (result.gcOrphanChunks > 0) {
-        lines.push(`  Garbage collected orphan chunks: ${result.gcOrphanChunks}`);
-      }
-
-      if (result.gcOrphanSymbols > 0) {
-        lines.push(`  Garbage collected orphan symbols: ${result.gcOrphanSymbols}`);
-      }
-
-      if (result.gcOrphanCallEdges > 0) {
-        lines.push(`  Garbage collected orphan call edges: ${result.gcOrphanCallEdges}`);
-      }
-
-      if (result.filePaths.length > 0) {
-        lines.push(`  Cleaned paths: ${result.filePaths.join(", ")}`);
-      }
-
-      return { content: [{ type: "text", text: lines.join("\n") }] };
+      return { content: [{ type: "text", text: formatHealthCheck(result) }] };
     },
   );
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -79,6 +79,10 @@ export function formatIndexStats(stats: IndexStats, verbose: boolean = false): s
 
 export function formatStatus(status: StatusResult): string {
   if (!status.indexed) {
+    if (status.warning) {
+      return status.warning;
+    }
+
     if (status.failedBatchesCount > 0) {
       const lines = [
         "Codebase is not indexed. The last indexing run left failed embedding batches.",

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -13,6 +13,10 @@ function truncateContent(content: string): string {
 }
 
 export function formatIndexStats(stats: IndexStats, verbose: boolean = false): string {
+  if (stats.resetCorruptedIndex) {
+    return stats.warning ?? "Detected a corrupted local index and reset it during indexing. Run index_codebase again to rebuild search data.";
+  }
+
   const lines: string[] = [];
 
   if (stats.failedChunks > 0) {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -179,6 +179,10 @@ export function formatCodebasePeek(results: SearchResult[]): string {
 }
 
 export function formatHealthCheck(result: HealthCheckResult): string {
+  if (result.resetCorruptedIndex) {
+    return result.warning ?? "Detected a corrupted local index and reset it. Run index_codebase to rebuild search data.";
+  }
+
   if (result.removed === 0 && result.gcOrphanEmbeddings === 0 && result.gcOrphanChunks === 0 && result.gcOrphanSymbols === 0 && result.gcOrphanCallEdges === 0) {
     return "Index is healthy. No stale entries found.";
   }

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -220,6 +220,47 @@ describe("indexer clearIndex force rebuild", () => {
     expect(rebuiltStats.indexedChunks).toBeGreaterThan(0);
   });
 
+  it("resets a corrupted local sqlite index during health check and reports rebuild guidance", async () => {
+    embeddingDimensions = 8;
+    const indexer = createIndexer(tempDir, 8);
+    const stats = await indexer.index();
+    expect(stats.indexedChunks).toBeGreaterThan(0);
+
+    const database = (indexer as unknown as { database: Database }).database;
+    vi.spyOn(database, "gcOrphanEmbeddings").mockReturnValue(0);
+    vi.spyOn(database, "gcOrphanChunks").mockImplementation(() => {
+      throw new Error("SQLite error: database disk image is malformed");
+    });
+
+    const result = await indexer.healthCheck();
+    expect(result.resetCorruptedIndex).toBe(true);
+    expect(result.warning).toContain("reset the local index");
+
+    const status = await indexer.getStatus();
+    expect(status.indexed).toBe(false);
+    expect(status.vectorCount).toBe(0);
+  });
+
+  it("refuses to auto-reset a corrupted shared global sqlite index", async () => {
+    vi.stubEnv("HOME", tempHome);
+
+    const projectA = path.join(tempDir, "project-a");
+    const projectAFile = path.join(projectA, "src", "a.ts");
+    fs.mkdirSync(path.dirname(projectAFile), { recursive: true });
+    fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
+
+    const indexer = createIndexer(projectA, 8, "global");
+    await indexer.index();
+
+    const database = (indexer as unknown as { database: Database }).database;
+    vi.spyOn(database, "gcOrphanEmbeddings").mockReturnValue(0);
+    vi.spyOn(database, "gcOrphanChunks").mockImplementation(() => {
+      throw new Error("SQLite error: database disk image is malformed");
+    });
+
+    await expect(indexer.healthCheck()).rejects.toThrow("Automatic repair is disabled for global scope");
+  });
+
   it("preserves shared knowledge-base rows still referenced by another global project", async () => {
     vi.stubEnv("HOME", tempHome);
 

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -261,6 +261,64 @@ describe("indexer clearIndex force rebuild", () => {
     await expect(indexer.healthCheck()).rejects.toThrow("Automatic repair is disabled for global scope");
   });
 
+  it("surfaces rebuild guidance when automatic orphan GC resets a corrupted local index", async () => {
+    embeddingDimensions = 8;
+    const indexer = new Indexer(tempDir, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-8d",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+        autoGc: true,
+        gcOrphanThreshold: 0,
+      },
+    }));
+
+    const initialStats = await indexer.index();
+    expect(initialStats.indexedChunks).toBeGreaterThan(0);
+
+    const database = (indexer as unknown as { database: Database }).database;
+    vi.spyOn(database, "getStats").mockReturnValue({
+      embeddingCount: 2,
+      chunkCount: 1,
+      branchChunkCount: 1,
+      branchCount: 1,
+      symbolCount: 0,
+      callEdgeCount: 0,
+    });
+    const realGcOrphanEmbeddings = database.gcOrphanEmbeddings.bind(database);
+    vi.spyOn(database, "gcOrphanEmbeddings").mockImplementation(() => realGcOrphanEmbeddings());
+    vi.spyOn(database, "gcOrphanChunks").mockImplementation(() => {
+      throw new Error("SQLite error: database disk image is malformed");
+    });
+
+    const maybeRunOrphanGc = vi.spyOn(indexer as unknown as { maybeRunOrphanGc: () => Promise<unknown> }, "maybeRunOrphanGc");
+
+    fs.writeFileSync(sourceFile, [
+      "export function alpha() {",
+      "  return 'alpha-updated';",
+      "}",
+      "",
+      "export function gamma() {",
+      "  return alpha();",
+      "}",
+    ].join("\n"), "utf-8");
+
+    const result = await indexer.index();
+    expect(maybeRunOrphanGc).toHaveBeenCalled();
+    expect(result.resetCorruptedIndex).toBe(true);
+    expect(result.warning).toContain("reset the local index");
+
+    const status = await indexer.getStatus();
+    expect(status.indexed).toBe(false);
+    expect(status.vectorCount).toBe(0);
+  });
+
   it("preserves shared knowledge-base rows still referenced by another global project", async () => {
     vi.stubEnv("HOME", tempHome);
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -31,6 +31,24 @@ let mockStatusResult = {
   failedBatchesPath: undefined as string | undefined,
 };
 
+let mockHealthCheckResult = {
+  removed: 0,
+  gcOrphanEmbeddings: 0,
+  gcOrphanChunks: 0,
+  gcOrphanSymbols: 0,
+  gcOrphanCallEdges: 0,
+  filePaths: [],
+} as {
+  removed: number;
+  gcOrphanEmbeddings: number;
+  gcOrphanChunks: number;
+  gcOrphanSymbols: number;
+  gcOrphanCallEdges: number;
+  filePaths: string[];
+  resetCorruptedIndex?: boolean;
+  warning?: string;
+};
+
 vi.mock("../src/indexer/index.js", () => {
   class MockIndexer {
     initialize = vi.fn().mockResolvedValue(undefined);
@@ -58,14 +76,7 @@ vi.mock("../src/indexer/index.js", () => {
     ]);
     index = vi.fn().mockImplementation(async () => mockIndexResult);
     getStatus = vi.fn().mockImplementation(async () => mockStatusResult);
-    healthCheck = vi.fn().mockResolvedValue({
-      removed: 0,
-      gcOrphanEmbeddings: 0,
-      gcOrphanChunks: 0,
-      gcOrphanSymbols: 0,
-      gcOrphanCallEdges: 0,
-      filePaths: [],
-    });
+    healthCheck = vi.fn().mockImplementation(async () => mockHealthCheckResult);
     clearIndex = vi.fn().mockResolvedValue(undefined);
     estimateCost = vi.fn().mockResolvedValue({
       filesCount: 10,
@@ -136,6 +147,14 @@ describe("MCP server tools and prompts", () => {
       compatibility: { compatible: true },
       failedBatchesCount: 0,
       failedBatchesPath: undefined,
+    };
+    mockHealthCheckResult = {
+      removed: 0,
+      gcOrphanEmbeddings: 0,
+      gcOrphanChunks: 0,
+      gcOrphanSymbols: 0,
+      gcOrphanCallEdges: 0,
+      filePaths: [],
     };
 
     const config = parseConfig({});
@@ -301,6 +320,28 @@ describe("MCP server tools and prompts", () => {
     expect(content).toHaveLength(1);
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("healthy");
+  });
+
+  it("should surface corruption reset guidance in index_health_check output", async () => {
+    mockHealthCheckResult = {
+      removed: 0,
+      gcOrphanEmbeddings: 0,
+      gcOrphanChunks: 0,
+      gcOrphanSymbols: 0,
+      gcOrphanCallEdges: 0,
+      filePaths: [],
+      resetCorruptedIndex: true,
+      warning: "Detected a corrupted local SQLite index and reset the local index. Run index_codebase to rebuild search data.",
+    };
+
+    const result = await client.callTool({
+      name: "index_health_check",
+      arguments: {},
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("corrupted local SQLite index");
+    expect(content[0].text).not.toContain("healthy");
   });
 
   it("should execute find_similar tool", async () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -299,6 +299,27 @@ describe("tools utils", () => {
       expect(result).toContain("/tmp/index/failed-batches.json");
     });
 
+    it("should surface startup reset guidance before generic not-indexed messaging", () => {
+      const status: StatusResult = {
+        indexed: false,
+        vectorCount: 0,
+        provider: "google",
+        model: "gemini-embedding-001",
+        indexPath: "/tmp/index",
+        currentBranch: "default",
+        baseBranch: "default",
+        compatibility: null,
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
+        warning: "Detected a corrupted local SQLite index at /tmp/index/codebase.db and reset the local index. Run index_codebase to rebuild search data.",
+      };
+      const result = formatStatus(status);
+
+      expect(result).toContain("corrupted local SQLite index");
+      expect(result).toContain("Run index_codebase to rebuild search data");
+      expect(result).not.toContain("Codebase is not indexed");
+    });
+
     it("should warn when indexed data exists alongside failed batches", () => {
       const status: StatusResult = {
         indexed: true,

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -435,6 +435,22 @@ describe("tools utils", () => {
   });
 
   describe("formatHealthCheck", () => {
+    it("should show corruption reset warning when health check reset the local index", () => {
+      const result = formatHealthCheck({
+        removed: 0,
+        filePaths: [],
+        gcOrphanEmbeddings: 0,
+        gcOrphanChunks: 0,
+        gcOrphanSymbols: 0,
+        gcOrphanCallEdges: 0,
+        resetCorruptedIndex: true,
+        warning: "Detected a corrupted local SQLite index and reset the local index.",
+      });
+
+      expect(result).toContain("corrupted local SQLite index");
+      expect(result).toContain("reset the local index");
+    });
+
     it("should return healthy message when nothing to clean", () => {
       const result = formatHealthCheck({
         removed: 0,

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -98,6 +98,21 @@ describe("tools utils", () => {
       expect(result).toContain("/tmp/failed-batches.json");
     });
 
+    it("should surface corrupted index reset guidance instead of a success summary", () => {
+      const stats = createBaseStats({
+        totalFiles: 10,
+        indexedChunks: 5,
+        removedChunks: 2,
+        resetCorruptedIndex: true,
+        warning: "Detected a corrupted local SQLite index and reset the local index. Run index_codebase to rebuild search data.",
+      });
+      const result = formatIndexStats(stats);
+
+      expect(result).toContain("corrupted local SQLite index");
+      expect(result).toContain("Run index_codebase to rebuild search data");
+      expect(result).not.toContain("5 new chunks embedded");
+    });
+
     it("should not include verbose details by default", () => {
       const stats = createBaseStats({
         totalFiles: 10,


### PR DESCRIPTION
## Summary

Reset corrupted project-local SQLite index state during health checks and orphan GC so rebuildable cache data no longer crashes the tool with malformed database errors.

## Changes

- detect SQLite corruption errors during index startup and health-check GC
- auto-reset corrupted project-local index artifacts and return rebuild guidance instead of crashing
- keep shared global indexes fail-safe by requiring manual repair rather than deleting other projects' cached data
- add regression tests for corruption recovery paths and health-check warning formatting

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [ ] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Notes:
- `npm run build` hit native build timeout in this session while waiting on Cargo build locks.
- `npm run test:run` still fails in the existing latency budget assertions in `tests/retrieval-benchmark.test.ts`, which appear unrelated to this SQLite corruption fix.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Related to #63
