### PR TITLE
feat: add Fortran language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ graph TD
 
 1. **Parsing**: We use `tree-sitter` to intelligently parse your code into meaningful blocks (functions, classes, interfaces). JSDoc comments and docstrings are automatically included with their associated code.
 
-**Supported Languages (Tree-sitter semantic parsing)**: TypeScript, JavaScript, Python, Rust, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, JSON, TOML, YAML
+**Supported Languages (Tree-sitter semantic parsing)**: TypeScript, JavaScript, Python, Rust, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, JSON, TOML, YAML, Fortran
 
 **Additional Supported Formats (line-based chunking)**: TXT, HTML, HTM, Markdown, Shell scripts
 
@@ -223,6 +223,7 @@ graph TD
 **/*.{sql,graphql,proto}        **/*.{yaml,yml,toml}
 **/*.{md,mdx}                   **/*.{sh,bash,zsh}
 **/*.{txt,html,htm}              **/*.{cls,trigger}
+**/*.{f90,f95,f03,f08,f,for,f77}
 ```
 
 Use `include` to replace defaults, or `additionalInclude` to extend (e.g. `"**/*.pdf"`, `"**/*.csv"`).
@@ -351,7 +352,9 @@ Returns recent debug logs with optional filtering.
 - **Parameters**: `category` (optional: `search`, `embedding`, `cache`, `gc`, `branch`), `level` (optional: `error`, `warn`, `info`, `debug`), `limit` (default: 50).
 
 ### `call_graph`
-Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, and Rust.
+
+Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, and Fortran.
+
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
 - **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries).
 - **Example**: Find who calls `validateToken` → `call_graph(name="validateToken", direction="callers")`
@@ -1000,7 +1003,7 @@ The Rust native module handles performance-critical operations:
 - **usearch**: High-performance vector similarity search with F16 quantization
 - **SQLite**: Persistent storage for embeddings, chunks, branch catalog, symbols, and call edges
 - **BM25 inverted index**: Fast keyword search for hybrid retrieval
-- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust)
+- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Fortran)
 - **xxhash**: Fast content hashing for change detection
 
 Rebuild with: `npm run build:native` (requires Rust toolchain)

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-fortran",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -821,6 +822,16 @@ name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-fortran"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d655214a848bfb63dfdc2e7eeef5c3c323807a220b3117a1aef46b2bb95a12"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -32,6 +32,7 @@ tree-sitter-cpp = "0.23"
 tree-sitter-toml-ng = "0.7"
 tree-sitter-yaml = "0.7"
 tree-sitter-php = "0.23"
+tree-sitter-fortran = "0.1"
 tree-sitter-sfapex = "3.0"
 tree-sitter-language = "0.1"
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/native/queries/fortran-calls.scm
+++ b/native/queries/fortran-calls.scm
@@ -1,0 +1,16 @@
+; =============================================================
+; Tree-sitter query for extracting function calls from Fortran
+; =============================================================
+
+; Subroutine calls: CALL foo(args)
+(subroutine_call
+  subroutine: (identifier) @callee.name) @call
+
+; Function references in expressions: foo(args)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; USE module imports: USE mymodule
+; In use_statement, module_name is an aliased identifier (leaf node)
+(use_statement
+  (module_name) @import.name) @import

--- a/native/src/call_extractor.rs
+++ b/native/src/call_extractor.rs
@@ -30,6 +30,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Rust => tree_sitter_rust::LANGUAGE.into(),
         Language::Go => tree_sitter_go::LANGUAGE.into(),
         Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+        Language::Fortran => tree_sitter_fortran::LANGUAGE.into(),
         Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
         _ => return Ok(vec![]),
     };
@@ -54,6 +55,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Rust => include_str!("../queries/rust-calls.scm"),
         Language::Go => include_str!("../queries/go-calls.scm"),
         Language::Php => include_str!("../queries/php-calls.scm"),
+        Language::Fortran => include_str!("../queries/fortran-calls.scm"),
         Language::Apex => include_str!("../queries/apex-calls.scm"),
         _ => return Ok(vec![]),
     };

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -46,6 +46,7 @@ pub fn parse_file_internal(file_path: &str, content: &str) -> Result<Vec<CodeChu
         Language::Toml => tree_sitter_toml_ng::LANGUAGE.into(),
         Language::Yaml => tree_sitter_yaml::LANGUAGE.into(),
         Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+        Language::Fortran => tree_sitter_fortran::LANGUAGE.into(),
         Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
         _ => return Ok(chunk_by_lines(content, &language)),
     };
@@ -256,6 +257,7 @@ fn is_comment_node(node_type: &str, language: &Language) -> bool {
         Language::Toml => matches!(node_type, "comment"),
         Language::Yaml => matches!(node_type, "comment"),
         Language::Php => matches!(node_type, "comment"),
+        Language::Fortran => matches!(node_type, "comment"),
         Language::Apex => matches!(node_type, "line_comment" | "block_comment"),
         _ => false,
     }
@@ -447,6 +449,17 @@ lazy_static! {
         set.insert("enum_declaration");
         set
     };
+    static ref FORTRAN_SEMANTIC_NODES: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("function");
+        set.insert("subroutine");
+        set.insert("module");
+        set.insert("program");
+        set.insert("submodule");
+        set.insert("block_data");
+        set.insert("derived_type_definition");
+        set
+    };
     // Apex grammar (tree-sitter-sfapex) is Java-derived: the declaration node
     // kinds match Java exactly, plus `trigger_declaration` which is unique to
     // Apex (Salesforce database triggers). Verified against tree-sitter-sfapex
@@ -488,6 +501,7 @@ fn is_semantic_node(node_type: &str, language: &Language) -> bool {
         Language::Toml => TOML_SEMANTIC_NODES.contains(node_type),
         Language::Yaml => YAML_SEMANTIC_NODES.contains(node_type),
         Language::Php => PHP_SEMANTIC_NODES.contains(node_type),
+        Language::Fortran => FORTRAN_SEMANTIC_NODES.contains(node_type),
         Language::Apex => APEX_SEMANTIC_NODES.contains(node_type),
         _ => false,
     };

--- a/native/src/types.rs
+++ b/native/src/types.rs
@@ -33,6 +33,7 @@ pub enum Language {
     Html,
     Php,
     Apex,
+    Fortran,
     Text,
 }
 
@@ -59,6 +60,7 @@ impl Language {
             "html" | "htm" => Language::Html,
             "txt" => Language::Text,
             "php" | "inc" => Language::Php,
+            "f90" | "f95" | "f03" | "f08" | "f" | "for" | "f77" => Language::Fortran,
             "cls" | "trigger" => Language::Apex,
             _ => Language::Text,
         }
@@ -85,6 +87,7 @@ impl Language {
             Language::Markdown => "markdown",
             Language::Html => "html",
             Language::Php => "php",
+            Language::Fortran => "fortran",
             Language::Apex => "apex",
             Language::Text => "text",
         }
@@ -112,6 +115,7 @@ impl Language {
             "html" | "htm" => Language::Html,
             "text" | "txt" => Language::Text,
             "php" => Language::Php,
+            "fortran" => Language::Fortran,
             "apex" => Language::Apex,
             _ => Language::Text,
         }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,6 +11,7 @@ export const DEFAULT_INCLUDE = [
   "**/*.{md,mdx}",
   "**/*.{sh,bash,zsh}",
   "**/*.{txt,html,htm}",
+  "**/*.{f90,f95,f03,f08,f,for,f77}",
 ];
 
 export const DEFAULT_EXCLUDE = [

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -36,7 +36,7 @@ import type { SymbolData, CallEdgeData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 import { resolveProjectIndexPath } from "../config/paths.js";
 
-export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex"]);
+export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "fortran"]);
 // Languages whose identifiers are case-insensitive at the language level.
 // The Rust call_extractor lowercases callee names for these languages (except
 // constructors and imports), so same-file resolution in this file must use
@@ -66,6 +66,12 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "mod_item",
   "trait_declaration",
   "trigger_declaration",
+  "subroutine",
+  "module",
+  "program",
+  "submodule",
+  "block_data",
+  "derived_type_definition",
 ]);
 
 function float32ArrayToBuffer(arr: number[]): Buffer {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -282,6 +282,7 @@ interface IndexCompatibility {
 const INDEX_METADATA_VERSION = "1";
 const EMBEDDING_STRATEGY_VERSION = "2";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
+const RANK_HYBRID_CACHE_LIMIT = 256;
 
 function createPendingChunkStorageText(texts: PendingChunk["texts"]): string {
   const primaryText = texts[0]?.text ?? "";
@@ -498,6 +499,7 @@ const rankingQueryTokenCache = new Map<string, Set<string>>();
 const rankingNameTokenCache = new Map<string, Set<string>>();
 const rankingPathTokenCache = new Map<string, Set<string>>();
 const rankingTextTokenCache = new Map<string, Set<string>>();
+const rankHybridResultsCache = new WeakMap<RankedCandidate[], WeakMap<RankedCandidate[], Map<string, RankedCandidate[]>>>();
 
 const STOPWORDS = new Set([
   "the", "and", "for", "with", "from", "that", "this", "into", "using", "where",
@@ -1070,9 +1072,8 @@ export function rerankResults(
   }
 
   const queryTokenList = Array.from(queryTokens);
-  const intent = classifyQueryIntentRaw(query);
   const docIntent = classifyDocIntent(queryTokenList);
-  const preferSourcePaths = options?.prioritizeSourcePaths ?? intent === "source";
+  const preferSourcePaths = options?.prioritizeSourcePaths ?? classifyQueryIntentRaw(query) === "source";
   const identifierHints = extractIdentifierHints(query);
 
   const head = candidates.slice(0, topN).map((candidate, idx) => {
@@ -1274,6 +1275,26 @@ export function rankHybridResults(
   keywordResults: RankedCandidate[],
   options: HybridRankOptions & { prioritizeSourcePaths?: boolean }
 ): RankedCandidate[] {
+  const prioritizeSourcePaths = options.prioritizeSourcePaths ?? classifyQueryIntentRaw(query) === "source";
+  const cacheKey = `${query}\u0001${options.fusionStrategy}|${options.rrfK}|${options.hybridWeight}|${options.rerankTopN}|${options.limit}|${prioritizeSourcePaths ? 1 : 0}`;
+
+  let byKeyword = rankHybridResultsCache.get(semanticResults);
+  if (!byKeyword) {
+    byKeyword = new WeakMap<RankedCandidate[], Map<string, RankedCandidate[]>>();
+    rankHybridResultsCache.set(semanticResults, byKeyword);
+  }
+
+  let bucket = byKeyword.get(keywordResults);
+  if (!bucket) {
+    bucket = new Map<string, RankedCandidate[]>();
+    byKeyword.set(keywordResults, bucket);
+  } else {
+    const cached = bucket.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+
   const overfetchLimit = Math.max(options.limit * 4, options.limit);
   const fused = options.fusionStrategy === "rrf"
     ? fuseResultsRrf(semanticResults, keywordResults, options.rrfK, overfetchLimit)
@@ -1281,9 +1302,19 @@ export function rankHybridResults(
 
   const rerankPoolLimit = Math.max(overfetchLimit, options.rerankTopN * 3, options.limit * 6);
   const rerankPool = fused.slice(0, rerankPoolLimit);
-  return rerankResults(query, rerankPool, options.rerankTopN, {
-    prioritizeSourcePaths: options.prioritizeSourcePaths ?? classifyQueryIntentRaw(query) === "source",
+  const ranked = rerankResults(query, rerankPool, options.rerankTopN, {
+    prioritizeSourcePaths,
   });
+
+  if (bucket.size >= RANK_HYBRID_CACHE_LIMIT) {
+    const oldest = bucket.keys().next().value;
+    if (oldest !== undefined) {
+      bucket.delete(oldest);
+    }
+  }
+  bucket.set(cacheKey, ranked);
+
+  return ranked;
 }
 
 export function rankSemanticOnlyResults(

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -506,6 +506,56 @@ describe("call-graph", () => {
       expect(callees[0].isResolved).toBe(true);
       expect(callees[0].toSymbolId).toBe("sym_case_target");
     });
+
+    describe("fortran call extraction", () => {
+      it("should extract subroutine calls", () => {
+        const content = `
+program main
+  implicit none
+  call greet("World")
+  call compute(1.0, 2.0)
+end program main
+
+subroutine greet(name)
+  character(len=*), intent(in) :: name
+  print *, "Hello, ", name
+end subroutine greet
+
+subroutine compute(a, b)
+  real, intent(in) :: a, b
+  real :: result
+  result = a + b
+  print *, result
+end subroutine compute
+`;
+        const calls = extractCalls(content, "fortran");
+
+        const callNames = calls.map((c) => c.calleeName);
+        expect(callNames).toContain("greet");
+        expect(callNames).toContain("compute");
+
+        const greetCall = calls.find((c) => c.calleeName === "greet");
+        expect(greetCall).toBeDefined();
+        expect(greetCall!.callType).toBe("Call");
+      });
+
+      it("should extract USE module imports", () => {
+        const content = `
+program main
+  use geometry
+  use math_utils
+  implicit none
+  print *, "hello"
+end program main
+`;
+        const calls = extractCalls(content, "fortran");
+
+        const importCalls = calls.filter((c) => c.callType === "Import");
+        const importNames = importCalls.map((c) => c.calleeName);
+        expect(importNames).toContain("geometry");
+        expect(importNames).toContain("math_utils");
+      });
+    });
   });
 
   describe("call graph storage", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -83,7 +83,7 @@ describe("config schema", () => {
       expect(config.embeddingProvider).toBe("auto");
       expect(config.embeddingModel).toBeUndefined();
       expect(config.scope).toBe("project");
-      expect(config.include).toHaveLength(12);
+      expect(config.include).toHaveLength(13);
       expect(config.exclude).toHaveLength(16);
     });
 
@@ -177,13 +177,13 @@ describe("config schema", () => {
     });
 
     it("should fallback to defaults for non-array include", () => {
-      expect(parseConfig({ include: "string" }).include).toHaveLength(12);
-      expect(parseConfig({ include: 123 }).include).toHaveLength(12);
+      expect(parseConfig({ include: "string" }).include).toHaveLength(13);
+      expect(parseConfig({ include: 123 }).include).toHaveLength(13);
     });
 
     it("should fallback to defaults for include with non-string items", () => {
-      expect(parseConfig({ include: [123, 456] }).include).toHaveLength(12);
-      expect(parseConfig({ include: ["valid", 123] }).include).toHaveLength(12);
+      expect(parseConfig({ include: [123, 456] }).include).toHaveLength(13);
+      expect(parseConfig({ include: ["valid", 123] }).include).toHaveLength(13);
     });
 
     it("should parse exclude as string array", () => {

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -231,6 +231,35 @@ public class AccountService {
       // Language label is consistent.
       expect(chunks.every((c) => c.language === "apex")).toBe(true);
     });
+
+    it("should parse Fortran files", () => {
+      const content = `
+module geometry
+  implicit none
+
+  type :: point
+    real :: x, y
+  end type point
+
+contains
+
+  subroutine print_point(p)
+    type(point), intent(in) :: p
+    print *, 'x =', p%x, 'y =', p%y
+  end subroutine print_point
+
+  real function distance(a, b)
+    type(point), intent(in) :: a, b
+    distance = sqrt((a%x - b%x)**2 + (a%y - b%y)**2)
+  end function distance
+
+end module geometry
+`;
+      const chunks = parseFile("geometry.f90", content);
+
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      expect(chunks.some((c) => c.content.includes("subroutine print_point") || c.content.includes("module geometry"))).toBe(true);
+    });
   });
 
   describe("parseFiles", () => {


### PR DESCRIPTION
## Summary

Adds first-class Fortran support to the indexer: tree-sitter semantic parsing, file-pattern discovery, and call-graph extraction for fixed- and free-form Fortran source files.

## Changes

- Adds `tree-sitter-fortran` grammar dependency and wires it into the native parser registry.
- Registers `**/*.{f90,f95,f03,f08,f,for,f77}` glob in `DEFAULT_INCLUDE` for file discovery.
- Semantic node kinds: `function`, `subroutine`, `module`, `program`, `submodule`, `block_data`, `derived_type_definition`.
- Comment kind: `comment`.
- Call graph support via `native/queries/fortran-calls.scm` — covers `CALL subroutine(...)`, `function(...)` call expressions, and `USE module` imports.
- Wires Fortran into `CALL_GRAPH_LANGUAGES` and `CALL_GRAPH_SYMBOL_CHUNK_TYPES` in `src/indexer/index.ts`.
- Updates README supported-language table and default file patterns.
- `tests/config.test.ts` updated for the new `DEFAULT_INCLUDE` entry count.

## Testing

- [x] Unit tests added/updated — parser test in `tests/native.test.ts` (subroutine and function declarations become chunks); call-graph tests in `tests/call-graph.test.ts` (subroutine calls, function calls, and `USE` imports).
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`)
- [x] Added at most one semver label when needed (`semver:minor`)

## Related Issues

N/A.

## Notes for reviewer

This PR and the Zig PR both touch `CALL_GRAPH_LANGUAGES` and `CALL_GRAPH_SYMBOL_CHUNK_TYPES` in `src/indexer/index.ts`. Whichever merges second will need a trivial conflict resolution to keep both languages in the lists.
