### PR TITLE
Index CLI command

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD041": false,
+  "MD032": false,
+  "MD031": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 **Generated:** 2025-01-16 | **Commit:** 9f94822 | **Branch:** main
 
 Semantic codebase indexing plugin for OpenCode. Hybrid TypeScript/Rust architecture:
+
 - **TypeScript** (`src/`): Plugin logic, embedding providers, OpenCode tools
 - **Rust** (`native/`): Tree-sitter parsing, usearch vectors, SQLite storage, BM25 inverted index, call graph extraction
 
@@ -21,24 +22,31 @@ npm run typecheck      # tsc --noEmit
 ```
 
 ### Single Test
+
 ```bash
 npx vitest run tests/files.test.ts
 npx vitest run -t "parseFile"
 ```
 
 ### Native Module (requires Rust)
+
 ```bash
 cd native && cargo build --release && napi build --release --platform
 ```
 
 ## File Structure
 
-```
+```text
 src/
 ├── index.ts              # Plugin entry: exports tools + slash commands
 ├── mcp-server.ts         # MCP server: wraps Indexer for Cursor/Claude Code/Windsurf
 ├── cli.ts                # CLI entry point for MCP stdio transport
 ├── config/               # Config schema (Zod) + parsing
+├── db/                   # Database backend abstraction (SQLite + pgvector)
+│   ├── backend.ts        # IDatabaseBackend + IVectorStoreBackend interfaces
+│   ├── index.ts          # Factory: createDatabaseBackend / createVectorStoreBackend
+│   ├── pg-backend.ts     # pgvector implementations
+│   └── sqlite-backend.ts # SQLite implementations (wraps Rust native)
 ├── embeddings/           # Provider detection (auto/github/openai/google/ollama)
 ├── indexer/              # Core: Indexer class, delta tracking
 ├── git/                  # Branch detection from .git/HEAD
@@ -66,23 +74,25 @@ skill/                    # OpenCode skill guidance
 ## WHERE TO LOOK
 
 | Task | Location |
-|------|----------|
+| --- | --- |
 | Add embedding provider | `src/embeddings/detector.ts` + `provider.ts` |
 | Modify indexing logic | `src/indexer/index.ts` (Indexer class) |
 | Add OpenCode tool | `src/tools/index.ts` |
 | Change parsing behavior | `native/src/parser.rs` |
 | Modify vector storage | `native/src/store.rs` |
 | Add database operation | `native/src/db.rs` + expose in `lib.rs` |
+| Add/modify database backend | `src/db/backend.ts` (interfaces) + `src/db/pg-backend.ts` or `src/db/sqlite-backend.ts` |
 | Add slash command | `commands/` + register in `src/index.ts` config() |
-
 | Add/modify MCP tool | `src/mcp-server.ts` (createMcpServer) |
 | Modify call graph extraction | `native/src/call_extractor.rs` + query files in `native/queries/` |
 | Add call graph language | `native/queries/<lang>-calls.scm` + update `call_extractor.rs` |
+
 ## CODE MAP
 
 ### TypeScript Exports (`src/index.ts`)
+
 | Symbol | Type | Purpose |
-|--------|------|---------|
+| --- | --- | --- |
 | `default` | Plugin | Main entry: returns tools + config callback |
 | `codebase_search` | Tool | Semantic search by meaning (returns full code content) |
 | `codebase_peek` | Tool | Semantic search returning metadata only (file, line, name) - saves tokens |
@@ -94,19 +104,22 @@ skill/                    # OpenCode skill guidance
 | `index_logs` | Tool | Get debug logs (requires debug.enabled) |
 | `call_graph` | Tool | Query call graph for callers/callees of functions |
 
-
 ### MCP Server Exports (`src/mcp-server.ts`)
+
 | Symbol | Type | Purpose |
-|--------|------|---------|
+| --- | --- | --- |
 | `createMcpServer` | fn | Creates MCP Server with 9 tools + 4 prompts, lazy Indexer init |
 
 ### CLI Entry (`src/cli.ts`)
+
 | Symbol | Type | Purpose |
-|--------|------|---------|
+| --- | --- | --- |
 | `main` | fn | Parses --project/--config args, starts stdio transport, handles shutdown |
+
 ### Rust NAPI Exports (`native/src/lib.rs`)
+
 | Symbol | Type | Purpose |
-|--------|------|---------|
+| --- | --- | --- |
 | `parse_file` | fn | Parse single file → CodeChunk[] |
 | `parse_files` | fn | Parallel multi-file parsing |
 | `hash_content` | fn | xxhash string |
@@ -116,9 +129,11 @@ skill/                    # OpenCode skill guidance
 | `InvertedIndex` | class | BM25 keyword search |
 
 ### Database Batch Methods
+
 The `Database` class exposes batch operations for high-performance bulk inserts:
+
 | Method | Purpose | Speedup |
-|--------|---------|---------|
+| --- | --- | --- |
 | `upsertEmbeddingsBatch` | Batch insert embeddings in single transaction | ~1.3x |
 | `upsertChunksBatch` | Batch insert chunks in single transaction | ~12x |
 | `addChunksToBranchBatch` | Batch add chunks to branch in single transaction | ~18x |
@@ -128,6 +143,7 @@ These are used by the Indexer for all bulk operations. Prefer batch methods over
 ## CONVENTIONS
 
 ### Import Rules (CRITICAL - causes runtime errors if wrong)
+
 ```typescript
 // CORRECT: .js extension required for ESM
 import { Indexer } from "./indexer/index.js";
@@ -141,13 +157,15 @@ import * as os from "os";
 ```
 
 ### Import Order
+
 1. Type-only imports (`import type { ... }`)
 2. External packages + Node.js built-ins
 3. Internal modules (with .js extension)
 
 ### Naming
+
 | Element | Convention | Example |
-|---------|------------|---------|
+| --- | --- | --- |
 | Files/Dirs | kebab-case | `codebase-index.json` |
 | Functions/Vars | camelCase | `loadJsonFile` |
 | Classes/Types | PascalCase | `Indexer`, `ChunkType` |
@@ -155,6 +173,7 @@ import * as os from "os";
 | Constants | UPPER_SNAKE_CASE | `MAX_BATCH_TOKENS` |
 
 ### Type Patterns
+
 - Explicit return types on exported functions
 - `strict: true` enabled
 - Prefix unused params with `_` (ESLint enforced)
@@ -168,6 +187,7 @@ function getErrorMessage(error: unknown): string {
 ```
 
 ### OpenCode Tool Definitions
+
 ```typescript
 import { tool, type ToolDefinition } from "@opencode-ai/plugin";
 const z = tool.schema;  // Use this, not direct zod import
@@ -187,7 +207,7 @@ export const my_tool: ToolDefinition = tool({
 ## ANTI-PATTERNS
 
 | Forbidden | Why |
-|-----------|-----|
+| --- | --- |
 | Missing `.js` in imports | Runtime ESM resolution failure |
 | Direct zod import for tools | Use `tool.schema` from plugin package |
 | `as any`, `@ts-ignore` | Strict mode violations |
@@ -201,6 +221,7 @@ export const my_tool: ToolDefinition = tool({
 - **Location**: `tests/*.test.ts`
 
 ### Temp Directory Pattern
+
 ```typescript
 let tempDir: string;
 beforeEach(() => { tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-")); });
@@ -208,8 +229,9 @@ afterEach(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
 ```
 
 ### Test Categories
+
 | File | Tests |
-|------|-------|
+| --- | --- |
 | `native.test.ts` | Rust bindings: parsing, vectors, hashing |
 | `database.test.ts` | SQLite: CRUD, branches, GC, batch operations |
 | `inverted-index.test.ts` | BM25 keyword search |
@@ -220,10 +242,11 @@ afterEach(() => { fs.rmSync(tempDir, { recursive: true, force: true }); });
 | `git.test.ts` | Git branch detection |
 | `commands.test.ts` | Slash command loader, frontmatter parsing |
 | `logger.test.ts` | Logger utility, metrics collection |
-
 | `mcp-server.test.ts` | MCP server: tool/prompt registration, execution via InMemoryTransport |
 | `call-graph.test.ts` | Call extraction, storage, resolution, branch awareness, integration |
+
 ### Benchmarks
+
 ```bash
 npx tsx benchmarks/run.ts   # Performance testing for native operations
 ```
@@ -235,13 +258,19 @@ Tests batch vs sequential performance for VectorStore and SQLite operations.
 Config loaded from `.opencode/codebase-index.json` or `~/.config/opencode/codebase-index.json`.
 
 Key options:
+
 - `embeddingProvider`: `auto` | `github-copilot` | `openai` | `google` | `ollama`
+- `database.engine`: `sqlite` (default) | `pgvector`
+- `database.pgvector.connectionString`: Full `postgres://` URI (or use host/port/user/password individually)
+- `database.pgvector.tablePrefix`: Prefix for all tables (default `ci`)
 - `indexing.watchFiles`: Auto-reindex on file changes
 - `indexing.semanticOnly`: Skip generic blocks, only index functions/classes
 - `indexing.requireProjectMarker`: Require `.git`/`package.json` etc. to enable watching (prevents hanging in home dir)
 - `search.hybridWeight`: 0.0 (semantic) to 1.0 (keyword)
 - `debug.enabled`: Enable debug logging and metrics collection
 - `debug.metrics`: Enable performance metrics (use with `index_metrics` tool)
+
+Config merging: global config is the base; project config deep-merges on top. `indexing`, `search`, `debug`, and `database.pgvector` are deep-merged key-by-key so that a project config can override a single sub-field without losing global defaults. `knowledgeBases` and `additionalInclude` arrays are union-merged from both levels.
 
 ## PR CHECKLIST
 
@@ -262,6 +291,7 @@ When creating a new release:
 7. **Create GitHub release** - `gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."`
 
 Example:
+
 ```bash
 # After updating CHANGELOG.md and package.json
 git add CHANGELOG.md package.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@ This document explains the architecture of opencode-codebase-index, including da
 
 ## High-Level Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                              OpenCode Agent                                 │
 │                                                                             │
@@ -24,7 +24,7 @@ This document explains the architecture of opencode-codebase-index, including da
 │         index_codebase, index_status, index_health_check, index_metrics,    │
 │         index_logs, add_knowledge_base, list_knowledge_bases,               │
 │         remove_knowledge_base                                               │
-│  Commands: /search, /find, /call-graph, /index, /status                     │
+│  Commands: /search, /find, /call-graph, /index, /status               │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
@@ -63,7 +63,7 @@ This document explains the architecture of opencode-codebase-index, including da
 
 ### Indexing Flow
 
-```
+```text
 Source Files → Parse → Chunk → Embed → Store
 
 1. COLLECT: File discovery (respects .gitignore)
@@ -95,7 +95,7 @@ Source Files → Parse → Chunk → Embed → Store
 
 ### Search Flow
 
-```
+```text
 Query → Embed → Search → Rank → Return
 
 1. EMBED QUERY
@@ -127,14 +127,16 @@ Query → Embed → Search → Rank → Return
 ### Indexer (`src/indexer/index.ts`)
 
 The central orchestrator. Responsibilities:
+
 - Manages full and incremental indexing
 - Coordinates parsing → embedding → storage
 - Handles rate limiting and retries
 - Tracks per-file hashes for delta detection
 
 Key methods:
+
 | Method | Purpose |
-|--------|---------|
+| --- | --- |
 | `index()` | Main entry: orchestrates full indexing flow |
 | `searchSemantic()` | Pure vector similarity search |
 | `searchHybrid()` | Combines semantic + BM25 |
@@ -145,7 +147,7 @@ Key methods:
 Abstracts different AI embedding APIs:
 
 | Provider | Implementation | Rate Limit Strategy |
-|----------|----------------|---------------------|
+| --- | --- | --- |
 | GitHub Copilot | OAuth + internal API | 1 concurrent, 4s delay |
 | OpenAI | Official API | 3 concurrent, 500ms delay |
 | Google | Gemini API | 5 concurrent, 200ms delay |
@@ -158,7 +160,7 @@ Detection order: GitHub Copilot → OpenAI → Google → Ollama
 Rust components exposed via NAPI:
 
 | Component | Crate | Purpose |
-|-----------|-------|---------|
+| --- | --- | --- |
 | Parser | tree-sitter-* | Language-aware code parsing |
 | VectorStore | usearch | HNSW vector similarity search |
 | Database | rusqlite | Persistent storage with batch ops |
@@ -168,6 +170,7 @@ Rust components exposed via NAPI:
 ### Watcher (`src/watcher/index.ts`)
 
 File system observer using chokidar:
+
 - Watches for file changes → triggers incremental index
 - Watches `.git/HEAD` → detects branch switches
 - Debounces rapid changes (500ms window)
@@ -178,7 +181,7 @@ File system observer using chokidar:
 ### Why Hybrid TypeScript + Rust?
 
 | Layer | Language | Rationale |
-|-------|----------|-----------|
+| --- | --- | --- |
 | Plugin interface | TypeScript | Native OpenCode integration, config parsing |
 | Core logic | TypeScript | Orchestration, API calls, easier iteration |
 | Hot paths | Rust | Performance: parsing, vectors, DB operations |
@@ -188,11 +191,13 @@ The 80/20 rule: TypeScript for flexibility, Rust for speed-critical operations.
 ### Why usearch for Vectors?
 
 Alternatives considered:
+
 - **FAISS**: Heavier, complex build, overkill for our scale
 - **hnswlib**: Good, but usearch is faster and has F16 support
 - **In-memory arrays**: Too slow for 10k+ vectors
 
 usearch advantages:
+
 - F16 quantization → 50% memory savings
 - Fast HNSW algorithm
 - Simple C++ core, easy Rust bindings
@@ -201,11 +206,13 @@ usearch advantages:
 ### Why SQLite for Storage?
 
 Alternatives considered:
+
 - **JSON files**: No transactions, slow for large data
 - **LevelDB/RocksDB**: Overkill, complex keys
 - **PostgreSQL**: External dependency, overkill
 
 SQLite advantages:
+
 - Single-file database
 - ACID transactions for batch inserts
 - Fast lookups by content hash
@@ -215,11 +222,13 @@ SQLite advantages:
 ### Why BM25 Hybrid Search?
 
 Pure semantic search has weaknesses:
+
 - Misses exact identifier matches
 - Can't find "the function named exactly X"
 - Embedding models have knowledge cutoffs
 
 BM25 hybrid provides:
+
 - Exact keyword matching for precision
 - Fallback when semantic misses
 - Better results for technical queries
@@ -230,11 +239,13 @@ BM25 hybrid provides:
 Problem: Redundant prompt phrases in tool responses increase token usage and may cause LLMs to exit reasoning prematurely.
 
 Solution:
+
 - **Remove summary phrases**: e.g., "Found X results", "Index status:", "Health check complete:"
 - **Return raw data**: Direct result lists without introductory text
 - **Maintain clarity**: Keep essential context for unambiguous results
 
 Benefits:
+
 - Reduced token consumption for LLM tool calls
 - Faster LLM processing (less text to parse)
 - Better integration with LLM reasoning loops
@@ -245,14 +256,15 @@ Benefits:
 Problem: Switching branches changes code but embeddings are expensive.
 
 Solution:
+
 1. **Store embeddings by content hash** (not by file)
    - Same code = same embedding, regardless of branch
    - Deduplicated storage
-   
+
 2. **Branch catalog tracks membership**
    - Lightweight: just chunk IDs per branch
    - Instant branch switch (no re-embedding)
-   
+
 3. **Filter search by current branch**
    - Query only returns relevant results
    - No stale results from other branches
@@ -260,11 +272,13 @@ Solution:
 ### Why Content-Based Deduplication?
 
 Instead of storing embeddings per-file, we hash the content:
+
 - `hash(code) → embedding_id`
 - Same utility function across files? One embedding.
 - Copy-paste code? Already embedded.
 
 Benefits:
+
 - Reduces token costs (don't re-embed duplicates)
 - Smaller index size
 - Faster incremental indexing
@@ -274,7 +288,7 @@ Benefits:
 ### Indexing Performance
 
 | Phase | Time Complexity | Actual Performance |
-|-------|-----------------|-------------------|
+| --- | --- | --- |
 | File collection | O(n files) | ~10ms for 1000 files |
 | Parsing | O(n files × file size) | ~7ms for 100 files |
 | Embedding | O(n chunks) × API latency | Bottleneck (rate limited) |
@@ -283,7 +297,7 @@ Benefits:
 ### Search Performance
 
 | Phase | Time Complexity | Actual Performance |
-|-------|-----------------|-------------------|
+| --- | --- | --- |
 | Query embedding | O(1) API call | ~800-1000ms |
 | Vector search | O(log n) HNSW | ~1ms for 10k vectors |
 | BM25 search | O(n tokens) | ~5ms for 50k tokens |
@@ -294,7 +308,7 @@ Benefits:
 ### Memory Usage
 
 | Component | Memory Profile |
-|-----------|----------------|
+| --- | --- |
 | Vector index | ~3KB per chunk (F16 quantization) |
 | SQLite | ~1KB per chunk metadata |
 | BM25 index | ~2KB per unique token |
@@ -306,7 +320,7 @@ For a typical 500-file codebase (~5000 chunks): ~30MB total
 Tool return formats are optimized to reduce token usage:
 
 | Tool | Before Optimization | After Optimization | Token Savings |
-|------|---------------------|-------------------|---------------|
+| --- | --- | --- | --- |
 | `codebase_search` | "Found X results for 'query': ..." | Raw result list | ~15-20 tokens |
 | `codebase_peek` | "Found X locations for 'query': ..." | Raw result list | ~15-20 tokens |
 | `find_similar` | "Found X similar code blocks: ..." | Raw result list | ~15-20 tokens |
@@ -321,7 +335,7 @@ Tool return formats are optimized to reduce token usage:
 ### What Gets Sent to Cloud
 
 | Data | Destination | Purpose |
-|------|-------------|---------|
+| --- | --- | --- |
 | Code chunks | Embedding provider | Vector generation |
 | Search queries | Embedding provider | Query embedding |
 
@@ -330,9 +344,11 @@ The vector index itself stays local. Only code/queries go to the embedding API.
 ### Privacy Options
 
 For maximum privacy, use Ollama:
+
 ```json
 { "embeddingProvider": "ollama" }
 ```
+
 All processing happens locally. Nothing leaves your machine.
 
 ### Credential Handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.7.0] - 2026-04-14
 
 ### Added
+
 - **Knowledge base support**: Added `add_knowledge_base`, `list_knowledge_bases`, and `remove_knowledge_base` tools to manage external document folders indexed alongside the project
 - **Reranking with SiliconFlow**: Added `BAAI/bge-reranker-v2-m3` reranking support via SiliconFlow API for improved search result quality
 - **Routing hints for local discovery**: Added dynamic routing hints so local search can steer retrieval toward more relevant code paths before semantic reranking
@@ -25,10 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Eval diversity quality gates**: Added raw and distinct top-k diversity metrics, budgets, and regression coverage for eval runs and reranker benchmarking
 
 ### Changed
+
 - **Default verbose=false**: Changed `/index` command default to `verbose=false` to reduce token consumption
 - **Dependency hardening**: Added targeted npm overrides and refreshed lockfile resolution to keep vulnerable transitive packages patched in release builds
 
 ### Fixed
+
 - **Knowledge base refresh behavior**: Adding or removing knowledge bases now rebuilds the shared in-memory indexer immediately instead of requiring a restart
 - **Watcher-triggered reindexing**: Restored automatic reindexing on file changes so watched projects and attached knowledge bases stay current during a live session
 - **Parser and call-graph stability**: Fixed recursion-limit and segmentation-fault regressions, removed unsupported parent traversal paths, and improved PHP method-call extraction reliability
@@ -38,15 +41,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.1] - 2026-03-29
 
 ### Added
+
 - **Custom provider batch caps**: Added `customProvider.maxBatchSize` / `max_batch_size` support so OpenAI-compatible embedding servers can cap inputs per `/embeddings` request
 - **Environment placeholders in config**: Added `{env:VAR_NAME}` placeholder support for string config values so secrets and endpoints can be supplied from the environment instead of committed files
 
 ### Changed
+
 - **Release documentation alignment**: Updated release metadata to publish the post-`v0.6.0` config improvements as `v0.6.1`
 
 ## [0.6.0] - 2026-03-28
 
 ### Added
+
 - **Evaluation harness**: First-class eval CLI, golden datasets, budgets, compare mode, run artifacts, and smoke/quality workflows for measuring retrieval quality over time
 - **Implementation lookup workflow**: Added a dedicated definition/implementation retrieval path across the CLI, plugin tools, MCP server, indexer, and tests for faster code lookup by intent
 - **Cross-repo benchmarking**: Added a benchmark runner with ripgrep and ast-grep baselines plus reproducible benchmarking documentation and golden datasets for external repos
@@ -55,10 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PHP language support**: Added semantic parsing, chunking, and call-graph extraction for PHP, including fixtures and tests for constructors, imports, method calls, and simple calls
 
 ### Changed
+
 - **Evaluation CI strategy**: Split the default GitHub Models quality gate from explicit external-provider budget checks and documented the active CI budget paths
 - **Documentation refresh**: Reorganized contributor and maintenance docs, expanded evaluation and benchmarking guidance, and updated README benchmark snapshots and workflow references
 
 ### Fixed
+
 - **Release Drafter permissions**: Restored draft-release updates so release automation can keep draft notes current
 - **Eval/CI correctness**: Closed CI gating gaps, normalized baseline paths, and pinned the Rust toolchain action input used by CI
 - **Benchmark auditability**: Fixed scoped ast-grep metric accounting and dataset/result mutability issues in the benchmark runner and reporting flow
@@ -68,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2] - 2026-03-21
 
 ### Added
+
 - **Call graph extraction and query**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports across 5 languages (TypeScript/JavaScript, Python, Go, Rust)
 - **`call_graph` tool**: Query callers or callees of any function/method with branch-aware filtering
 - **DB schema v2**: `symbols`, `call_edges`, and `branch_symbols` tables with full CRUD, GC, and batch operations
@@ -75,9 +84,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`/call-graph` slash command**: Added command support for call graph workflows
 
 ### Changed
+
 - **Documentation updates**: Expanded README, CHANGELOG, and skill guide to document call graph usage and behavior
 
 ### Fixed
+
 - **Missing `call_graph` export**: The `call_graph` tool was not exported from the plugin entry point — now available to OpenCode users
 - **JavaScript call extraction routing**: JavaScript now uses a dedicated query file instead of TypeScript query routing
 - **Caller output context**: Caller results now include caller symbol/file context for clearer navigation
@@ -86,19 +97,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - 2026-03-01
 
 ### Added
+
 - **Custom embedding provider**: Support for any OpenAI-compatible embedding endpoint (`custom` provider with `baseUrl`, `model`, `dimensions` config). Works with llama.cpp, vLLM, text-embeddings-inference, LiteLLM, etc.
 
 ### Fixed
+
 - **Critical: infinite recursion on stale lock file**: When a stale `indexing.lock` existed from a crashed session, `initialize()` entered infinite recursion via `recoverFromInterruptedIndexing()` → `healthCheck()` → `ensureInitialized()` → `initialize()`, causing 70GB+ memory usage and OOM. Recovery now runs after store/database initialization.
 - **Relative path storage**: Index now stores relative paths for project portability. Detects and warns about legacy absolute-path indexes.
 - **MCP status prompt**: Removed empty args schema from status prompt that caused validation errors
 
 ### Changed
+
 - **Changelog and README**: Fixed bullet formatting, added platform support table
 
 ## [0.5.0] - 2026-02-23
 
 ### Added
+
 - **MCP server**: Standalone MCP server (`opencode-codebase-index-mcp` CLI) exposing all 8 tools and 4 prompts over stdio transport, enabling integration with Cursor, Claude Code, and Windsurf
 - **Crash-safe indexing**: Lock file and atomic writes prevent index corruption from interrupted indexing sessions, with automatic recovery on next run
 - **Git worktree support**: Branch detection now works correctly in git worktrees by resolving `.git` file pointers to the actual git directory
@@ -109,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Windows support**: Native binaries now build on Windows MSVC across all 5 platform targets (macOS x86/ARM, Linux x86/ARM, Windows x86)
 
 ### Changed
+
 - **Embedding API split**: `embed()` replaced by `embedQuery()` and `embedDocument()` to support task-specific embeddings (Google)
 - **Type-safe embedding models**: `EMBEDDING_MODELS` constant as single source of truth; `EmbeddingProvider`, `EmbeddingModelName`, and related types derived at compile time
 - **Google default model**: Updated from deprecated `text-embedding-004` to `text-embedding-005`
@@ -117,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ESM compatibility**: Build config adds `createRequire` shim for ESM entry points
 
 ### Fixed
+
 - **SQLite bind parameter limit**: `get_missing_embeddings` and `get_embeddings_batch` now batch `IN (...)` queries to stay under `SQLITE_MAX_VARIABLE_NUMBER` (999) — fixes crash on large codebases (thanks @zb1749)
 - **Google embedding API endpoints**: Corrected single and batch request URLs
 - **Index compatibility on force rebuild**: `clearIndex()` now deletes stale index metadata so provider changes take effect
@@ -126,26 +143,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1] - 2025-01-19
 
 ### Added
+
 - **`requireProjectMarker` config option**: Prevents plugin from hanging when opened in non-project directories like home. When `true` (default), requires a project marker (`.git`, `package.json`, `Cargo.toml`, etc.) to enable file watching and auto-indexing.
 
 ### Fixed
+
 - Plugin no longer hangs when OpenCode is opened in home directory or other large non-project directories
 
 ## [0.4.0] - 2025-01-18
 
 ### Added
+
 - **`find_similar` tool**: Find code similar to a given snippet for duplicate detection, pattern discovery, and refactoring prep. Paste code and find semantically similar implementations elsewhere in the codebase.
 - **`codebase_peek` tool**: Token-efficient semantic search returning metadata only (file, line, name, type) without code content. Saves ~90% tokens compared to `codebase_search` for discovery workflows.
 
 ## [0.3.2] - 2025-01-18
 
 ### Fixed
+
 - Rust code formatting (cargo fmt)
 - CI publish workflow: use Node 24 + npm OIDC trusted publishing (no token required)
 
 ## [0.3.1] - 2025-01-18
 
 ### Added
+
 - **Query embedding cache**: LRU cache (100 entries, 5min TTL) avoids redundant API calls for repeated searches
 - **Query similarity matching**: Reuses cached embeddings for similar queries (Jaccard similarity ≥0.85)
 - **Batch metadata lookup**: `VectorStore.getMetadata()` and `getMetadataBatch()` for efficient chunk retrieval
@@ -153,9 +175,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Query cache stats**: Separate tracking for exact hits, similar hits, and misses
 
 ### Changed
+
 - BM25 keyword search now uses `getMetadataBatch()` - O(n) instead of O(total) for result metadata lookup
 
 ### Fixed
+
 - Remove console output from Logger (was leaking to stdout)
 - Record embedding API metrics for search queries (previously only tracked during indexing)
 - Record embedding API metrics during batch retries
@@ -163,6 +187,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2025-01-16
 
 ### Added
+
 - **Language support**: Java, C#, Ruby, Bash, C, and C++ parsing via tree-sitter
 - **CI improvements**: Rust caching, `cargo fmt --check`, `cargo clippy`, and `cargo test` in workflows
 - **/status command**: Check index health and provider info
@@ -171,23 +196,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Documentation**: ARCHITECTURE.md, TROUBLESHOOTING.md, comprehensive AGENTS.md
 
 ### Changed
+
 - Upgraded tree-sitter from 0.20 to 0.24 (new LANGUAGE constant API)
 - Optimized `embedBatch` for Google and Ollama providers with Promise.all
 - Enhanced skill documentation with filter examples
 
 ### Fixed
+
 - Node version consistency in publish workflow (Node 24 → Node 22)
 - Clippy warnings in Rust code
 
 ## [0.2.1] - 2025-01-10
 
 ### Fixed
+
 - Rate limit handling and error messages
 - TypeScript errors in delta.ts
 
 ## [0.2.0] - 2025-01-09
 
 ### Added
+
 - **Branch-aware indexing**: Embeddings stored by content hash, branch catalog tracks membership
 - **SQLite storage**: Persistent storage for embeddings, chunks, and branch catalog
 - **Slash commands**: `/search`, `/find`, `/index`, `/status` registered via config hook
@@ -195,20 +224,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provider-specific rate limiting**: Ollama has no limits, GitHub Copilot has strict limits
 
 ### Changed
+
 - Migrated from JSON file storage to SQLite database
 - Improved rate limit handling for GitHub Models API (15 req/min)
 
 ## [0.1.11] - 2025-01-07
 
 ### Added
+
 - Community standards: LICENSE, Code of Conduct, Contributing guide, Security policy, Issue templates
 
 ### Fixed
+
 - Clippy warnings and TypeScript type errors
 
 ## [0.1.10] - 2025-01-06
 
 ### Added
+
 - **F16 quantization**: 50% memory reduction for vector storage
 - **Dead-letter queue**: Failed embedding batches are tracked for retry
 - **JSDoc/docstring extraction**: Comments included with semantic nodes
@@ -217,44 +250,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **semanticOnly config**: Only index functions/classes, skip generic blocks
 
 ### Changed
+
 - Moved inverted index from TypeScript to Rust native module (performance improvement)
 
 ### Fixed
+
 - GitHub Models API for embeddings instead of Copilot API
 
 ## [0.1.9] - 2025-01-05
 
 ### Fixed
+
 - Use GitHub Models API for embeddings instead of Copilot API
 
 ## [0.1.8] - 2025-01-04
 
 ### Fixed
+
 - Only export default plugin to prevent OpenCode loader crash
 - Downgrade to zod v3 to match OpenCode SDK version
 
 ## [0.1.3] - 2025-01-02
 
 ### Changed
+
 - Use Node.js 24 for npm 11+ trusted publishing support
 - Externalize @opencode-ai/plugin to prevent runtime conflicts
 
 ### Fixed
+
 - ESM output as main entry for Bun/OpenCode compatibility
 - Native binding loading in CJS context
 
 ## [0.1.1] - 2025-01-01
 
 ### Added
+
 - CI/CD workflows for testing and publishing
 - Comprehensive README with badges, diagrams, and examples
 
 ### Fixed
+
 - NAPI configuration for OIDC trusted publishing
 
 ## [0.1.0] - 2024-12-30
 
 ### Added
+
 - **Initial release**
 - Semantic codebase indexing with tree-sitter parsing
 - Vector similarity search with usearch (HNSW algorithm)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,21 @@ Use this when you just want the shortest path to a good PR:
 
 ## Table of Contents
 
-- [Getting Started](#getting-started)
-- [Development Setup](#development-setup)
-- [Making Changes](#making-changes)
-- [Pull Request Guidelines](#pull-request-guidelines)
-- [Project Structure](#project-structure)
-- [Release Labels and Notes](#release-labels-and-notes)
+- [Contributing to opencode-codebase-index](#contributing-to-opencode-codebase-index)
+  - [Quick Contribution Checklist](#quick-contribution-checklist)
+  - [Table of Contents](#table-of-contents)
+  - [Getting Started](#getting-started)
+  - [Development Setup](#development-setup)
+    - [Prerequisites](#prerequisites)
+    - [Building](#building)
+    - [Testing](#testing)
+    - [Linting](#linting)
+  - [Making Changes](#making-changes)
+    - [Adding a new language?](#adding-a-new-language)
+  - [Pull Request Guidelines](#pull-request-guidelines)
+  - [Project Structure](#project-structure)
+  - [Release Labels and Notes](#release-labels-and-notes)
+  - [Questions?](#questions)
 
 ## Getting Started
 
@@ -100,7 +109,7 @@ cd native && cargo clippy
    ```bash
    git commit -m "feat: add my feature"
    ```
-   
+
    We follow [Conventional Commits](https://www.conventionalcommits.org/):
    - `feat:` - New feature
    - `fix:` - Bug fix
@@ -129,7 +138,7 @@ If you're contributing parser or call-graph support for a new language, use [`do
 
 ## Project Structure
 
-```
+```text
 src/                  # TypeScript source
   ├── indexer/        # Core indexing logic
   ├── embeddings/     # Embedding providers

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [📚 Knowledge Base](#-knowledge-base)
 - [🔄 Reranking](#-reranking)
 - [⚙️ Configuration](#️-configuration)
+- [🗄️ Remote Database (pgvector)](#️-remote-database-pgvector)
 - [🤝 Contributing](#-contributing)
 
 ## 👋 Choose Your Path
@@ -42,11 +43,13 @@
 ## ⚡ Quick Start
 
 1. **Install the plugin**
+
    ```bash
    npm install opencode-codebase-index
    ```
 
 2. **Add to `opencode.json`**
+
    ```json
    {
      "plugin": ["opencode-codebase-index"]
@@ -54,11 +57,13 @@
    ```
 
 3. **Index your codebase**
+
    Run `/index` or ask the agent to index your codebase. This only needs to be done once — subsequent updates are incremental.
 
    **Recommended check:** run `/status` after the first index so you can confirm the detected provider/model before you start searching.
 
 4. **Start Searching**
+
    Ask:
    > "Find the function that handles credit card validation errors"
 
@@ -87,6 +92,7 @@
 Use the same semantic search from any MCP-compatible client. Index once, search from anywhere.
 
 1. **Install dependencies**
+
    ```bash
    npm install opencode-codebase-index @modelcontextprotocol/sdk zod
    ```
@@ -94,6 +100,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
 2. **Configure your MCP client**
 
    **Cursor** (`.cursor/mcp.json`):
+
    ```json
    {
      "mcpServers": {
@@ -106,6 +113,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    ```
 
    **Claude Code** (`claude_desktop_config.json`):
+
    ```json
    {
      "mcpServers": {
@@ -118,6 +126,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    ```
 
 3. **CLI options**
+
    ```bash
    npx opencode-codebase-index-mcp --project /path/to/repo    # specify project root
    npx opencode-codebase-index-mcp --config /path/to/config   # custom config file
@@ -133,6 +142,7 @@ The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) are optional peer depe
 **Scenario**: You're new to a codebase and need to fix a bug in the payment flow.
 
 **Without Plugin (grep)**:
+
 - `grep "payment" .` → 500 results (too many)
 - `grep "card" .` → 200 results (mostly UI)
 - `grep "stripe" .` → 50 results (maybe?)
@@ -141,6 +151,7 @@ The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) are optional peer depe
 You ask: *"Where is the payment validation logic?"*
 
 Plugin returns:
+
 ```text
 src/services/billing.ts:45  (Class PaymentValidator)
 src/utils/stripe.ts:12      (Function validateCardToken)
@@ -150,7 +161,7 @@ src/api/checkout.ts:89      (Route handler for /pay)
 ## 🎯 When to Use What
 
 | Scenario | Tool | Why |
-|----------|------|-----|
+| --- | --- | --- |
 | Don't know the function name | `codebase_search` | Semantic search finds by meaning |
 | Exploring unfamiliar codebase | `codebase_search` | Discovers related code across files |
 | Just need to find locations | `codebase_peek` | Returns metadata only, saves ~90% tokens |
@@ -216,7 +227,8 @@ graph TD
 **Additional Supported Formats (line-based chunking)**: TXT, HTML, HTM, Markdown, Shell scripts
 
 **Default File Patterns**:
-```
+
+```text
 **/*.{ts,tsx,js,jsx,mjs,cjs}    **/*.{py,pyi}
 **/*.{go,rs,java,kt,scala}      **/*.{c,cpp,cc,h,hpp}
 **/*.{rb,php,inc,swift}         **/*.{vue,svelte,astro}
@@ -234,6 +246,7 @@ Use `include` to replace defaults, or `additionalInclude` to extend (e.g. `"**/*
 5. **Hybrid Search**: Combines semantic similarity (vectors) with BM25 keyword matching, fuses (`rrf` default, `weighted` fallback), applies deterministic rerank, then filters by current branch/metadata.
 
 **Performance characteristics:**
+
 - **Incremental indexing**: ~50ms check time — only re-embeds changed files
 - **Smart chunking**: Understands code structure to keep functions whole, with overlap for context
 - **Native speed**: Core logic written in Rust for maximum performance
@@ -256,7 +269,7 @@ When you switch branches, code changes but embeddings for unchanged content rema
 ### Benefits
 
 | Scenario | Without Branch Awareness | With Branch Awareness |
-|----------|-------------------------|----------------------|
+| --- | --- | --- |
 | Switch to feature branch | Re-index everything | Instant — reuse existing embeddings |
 | Return to main | Re-index everything | Instant — catalog already exists |
 | Search on branch | May return stale results | Only returns current branch's code |
@@ -270,13 +283,19 @@ When you switch branches, code changes but embeddings for unchanged content rema
 
 ### Storage Structure
 
-```
+### SQLite (default)
+
+```text
 .opencode/index/
 ├── codebase.db           # SQLite: embeddings, chunks, branch catalog, symbols, call edges
 ├── vectors.usearch       # Vector index (uSearch)
 ├── inverted-index.json   # BM25 keyword index
 └── file-hashes.json      # File change detection
 ```
+
+### pgvector
+
+All data lives in the remote PostgreSQL database; no local index files are written.
 
 ### File Exclusions
 
@@ -291,7 +310,9 @@ The following files/folders are excluded from indexing by default:
 The plugin exposes these tools to the OpenCode agent:
 
 ### `codebase_search`
+
 **The primary tool.** Searches code by describing behavior.
+
 - **Use for**: Discovery, understanding flows, finding logic when you don't know the names.
 - **Example**: `"find the middleware that sanitizes input"`
 - **Ranking path**: hybrid retrieval → fusion (`search.fusionStrategy`) → deterministic rerank (`search.rerankTopN`) → filters
@@ -299,7 +320,7 @@ The plugin exposes these tools to the OpenCode agent:
 **Writing good queries:**
 
 | ✅ Good queries (describe behavior) | ❌ Bad queries (too vague) |
-|-------------------------------------|---------------------------|
+| --- | --- |
 | "function that validates email format" | "email" |
 | "error handling for failed API calls" | "error" |
 | "middleware that checks authentication" | "auth middleware" |
@@ -307,66 +328,90 @@ The plugin exposes these tools to the OpenCode agent:
 | "where user permissions are checked" | "permissions" |
 
 ### `codebase_peek`
+
 **Token-efficient discovery.** Returns only metadata (file, line, name, type) without code content.
+
 - **Use for**: Finding WHERE code is before deciding what to read. Saves ~90% tokens vs `codebase_search`.
 - **Ranking path**: same hybrid ranking path as `codebase_search` (metadata-only output)
 - **Example output**:
-  ```
+
+  ```text
   [1] function "validatePayment" at src/billing.ts:45-67 (score: 0.92)
   [2] class "PaymentProcessor" at src/processor.ts:12-89 (score: 0.87)
-  
+
   Use Read tool to examine specific files.
   ```
+
 - **Workflow**: `codebase_peek` → find locations → `Read` specific files
 
 ### `implementation_lookup`
+
 **Definition-first lookup.** Jumps to the authoritative definition site for a symbol or natural-language definition query.
+
 - **Use for**: "Where is X defined?", symbol-definition requests, and cases where you want the implementation site rather than all usages.
 - **Behavior**: Prefers real implementation files over tests, docs, examples, and fixtures.
 - **Fallback**: If nothing authoritative is found, use `codebase_search` for broader discovery.
 
 ### `find_similar`
+
 Find code similar to a provided snippet.
+
 - **Use for**: Duplicate detection, refactor prep, pattern mining.
 - **Ranking path**: semantic retrieval only + deterministic rerank (no BM25, no RRF).
 
 ### `index_codebase`
+
 Manually trigger indexing.
+
 - **Use for**: Forcing a re-index or checking stats.
 - **Parameters**: `force` (rebuild all), `estimateOnly` (check costs), `verbose` (show skipped files and parse failures).
 
 ### `index_status`
+
 Checks if the index is ready and healthy.
+
 - **Recommended workflow**: run this after `/index` to confirm the detected provider/model and whether the index is ready to search.
 
 ### `index_health_check`
+
 Maintenance tool to remove stale entries from deleted files and orphaned embeddings/chunks from the database.
 
 ### `index_metrics`
+
 Returns collected metrics about indexing and search performance. Requires `debug.enabled` and `debug.metrics` to be `true`.
+
 - **Metrics include**: Files indexed, chunks created, cache hit rate, search timing breakdown, GC stats, embedding API call stats.
 
 ### `index_logs`
+
 Returns recent debug logs with optional filtering.
+
 - **Parameters**: `category` (optional: `search`, `embedding`, `cache`, `gc`, `branch`), `level` (optional: `error`, `warn`, `info`, `debug`), `limit` (default: 50).
 
 ### `call_graph`
+
 Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, and Rust.
+
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
 - **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries).
 - **Example**: Find who calls `validateToken` → `call_graph(name="validateToken", direction="callers")`
 
 ### `add_knowledge_base`
+
 Add a folder as a knowledge base to be indexed alongside project code.
+
 - **Use for**: Indexing external documentation, API references, example programs.
 - **Parameters**: `path` (folder path, absolute or relative), `reindex` (optional, default `true`).
 - **Example**: `add_knowledge_base(path="/path/to/docs")`
 
 ### `list_knowledge_bases`
+
 List all configured knowledge base folders and their status.
 
 ### `remove_knowledge_base`
+
 Remove a knowledge base folder from the index.
+
 - **Parameters**: `path` (folder path to remove), `reindex` (optional, default `false`).
 - **Example**: `remove_knowledge_base(path="/path/to/docs")`
 
@@ -395,7 +440,7 @@ The plugin can index **external documentation** alongside your project code. The
 
 Use the built-in tools to add documentation folders:
 
-```
+```text
 add_knowledge_base(path="/path/to/api-docs")
 add_knowledge_base(path="/path/to/examples")
 ```
@@ -404,7 +449,7 @@ The folder will be indexed into the **same database** as your project code. All 
 
 ### Managing Knowledge Bases
 
-```
+```text
 list_knowledge_bases          # Show configured knowledge bases
 remove_knowledge_base(path="/path/to/api-docs")  # Remove a knowledge base
 ```
@@ -412,6 +457,7 @@ remove_knowledge_base(path="/path/to/api-docs")  # Remove a knowledge base
 ### Configuration Example
 
 Project-level config (`.opencode/codebase-index.json`):
+
 ```json
 {
   "knowledgeBases": [
@@ -422,6 +468,7 @@ Project-level config (`.opencode/codebase-index.json`):
 ```
 
 Global-level config (`~/.config/opencode/codebase-index.json`):
+
 ```json
 {
   "embeddingProvider": "custom",
@@ -434,7 +481,7 @@ Global-level config (`~/.config/opencode/codebase-index.json`):
 }
 ```
 
-Config merging: Global config is the base, project config overrides. Knowledge bases from both levels are merged.
+Config merging: Global config is the base, project config deep-merges on top. Object fields (`indexing`, `search`, `debug`, `database.pgvector`) are deep-merged key-by-key so you can override a single sub-field without losing global defaults. Knowledge bases and `additionalInclude` arrays are union-merged from both levels.
 
 ### Syncing Changes
 
@@ -461,10 +508,8 @@ Add to your config (`.opencode/codebase-index.json` or global config):
 }
 ```
 
-### Reranker Options
-
 | Option | Default | Description |
-|--------|---------|-------------|
+| --- | --- | --- |
 | `enabled` | `false` | Enable reranking |
 | `baseUrl` | - | Rerank API endpoint |
 | `model` | - | Reranking model name |
@@ -472,9 +517,9 @@ Add to your config (`.opencode/codebase-index.json` or global config):
 | `topN` | `20` | Number of top results to rerank |
 | `timeoutMs` | `30000` | Request timeout |
 
-### How It Works
+### Search Pipeline
 
-```
+```text
 Query → Embedding Search → BM25 Search → Fusion → Reranking → Results
 ```
 
@@ -487,6 +532,7 @@ Query → Embedding Search → BM25 Search → Fusion → Reranking → Results
 ### Supported Reranking APIs
 
 Any OpenAI-compatible reranking endpoint. Examples:
+
 - **SiliconFlow**: `BAAI/bge-reranker-v2-m3`
 - **Cohere**: `rerank-english-v3.0`
 - **Local models**: Any server implementing `/v1/rerank` format
@@ -537,6 +583,7 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
   // === Indexing ===
   "indexing": {
     "autoIndex": false,                       // Auto-index on plugin load
+    "skipAutoIndexOnLoad": false,             // Skip auto-index on startup (useful for MCP servers)
     "watchFiles": true,                       // Re-index on file changes
     "maxFileSize": 1048576,                   // Max file size in bytes (default: 1MB)
     "maxChunksPerFile": 100,                  // Max chunks per file
@@ -571,6 +618,23 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "topN": 15,
     "timeoutMs": 10000
   },
+  // === Database Engine ===
+  "database": {
+    "engine": "sqlite",                       // sqlite (default) | pgvector
+    "pgvector": {                             // Required when engine = "pgvector"
+      "connectionString": "",                // Full postgres:// URI (overrides individual fields)
+      "host": "localhost",
+      "port": 5432,
+      "database": "postgres",
+      "user": "postgres",
+      "password": "{env:PG_PASSWORD}",
+      "poolSize": 10,
+      "tablePrefix": "ci",                   // Prefix for all codebase-index tables
+      "connectionTimeoutMs": 5000,
+      "ssl": "disable"                       // disable | require | verify-full
+    }
+  },
+
   "debug": {
     "enabled": false,                         // Enable debug logging
     "logLevel": "info",                       // error | warn | info | debug
@@ -598,10 +662,8 @@ String values in `codebase-index.json` can reference environment variables with 
 }
 ```
 
-### Options Reference
-
 | Option | Default | Description |
-|--------|---------|-------------|
+| --- | --- | --- |
 | `embeddingProvider` | `"auto"` | Which AI to use: `auto`, `github-copilot`, `openai`, `google`, `ollama`, `custom` |
 | `scope` | `"project"` | `project` = index per repo, `global` = shared index across repos |
 | `include` | (defaults) | Override the default include patterns (replaces defaults) |
@@ -610,6 +672,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `knowledgeBases` | `[]` | External directories to index as knowledge bases (absolute or relative paths) |
 | **indexing** | | |
 | `autoIndex` | `false` | Automatically index on plugin load |
+| `skipAutoIndexOnLoad` | `false` | When `true`, skips calling `indexer.index()` on plugin load even if `autoIndex` is `true`. Useful for MCP servers or environments where you want explicit control over indexing |
 | `watchFiles` | `true` | Re-index when files change |
 | `maxFileSize` | `1048576` | Skip files larger than this (bytes). Default: 1MB |
 | `maxChunksPerFile` | `100` | Maximum chunks to index per file (controls token costs for large files) |
@@ -649,6 +712,46 @@ String values in `codebase-index.json` can reference environment variables with 
 | `logGc` | `true` | Log garbage collection operations |
 | `logBranch` | `true` | Log branch detection and switches |
 | `metrics` | `false` | Enable metrics collection (indexing stats, search timing, cache performance) |
+
+**Debug Logging Details**:
+
+When `debug.enabled` is `true`, the plugin logs:
+
+- **Final merged configuration**: Shows aggregated global + project config with embedding provider, database settings, indexing options, and search settings
+- **Database connection info**: Shows which database backend is being used:
+  - SQLite: `[codebase-index] Debug: Using local SQLite database at: /path/to/.opencode/index/`
+  - pgvector: `[codebase-index] Debug: Connecting to pgvector database: user@host:5432/database` + table prefix if configured
+- **Skip auto-index**: If `autoIndex: true` but `skipAutoIndexOnLoad: true`, logs `[codebase-index] Debug: Skipping auto-index on load (skipAutoIndexOnLoad is true)`
+
+Example debug output:
+
+```text
+[codebase-index] Debug: Final merged configuration: {
+  "embeddingProvider": "ollama",
+  "database": {
+    "engine": "sqlite"
+  },
+  "indexing": {
+    "autoIndex": true,
+    "skipAutoIndexOnLoad": false,
+    "watchFiles": true
+  }
+}
+[codebase-index] Debug: Using local SQLite database at: /project/.opencode/index/
+```
+
+| **database** | | |
+| `engine` | `"sqlite"` | Storage backend: `"sqlite"` (local, default) or `"pgvector"` (remote PostgreSQL) |
+| `pgvector.connectionString` | — | Full PostgreSQL URI, e.g. `postgresql://user:pass@host:5432/dbname`. When set, individual host/port/… fields are ignored |
+| `pgvector.host` | `"localhost"` | PostgreSQL server hostname |
+| `pgvector.port` | `5432` | PostgreSQL server port |
+| `pgvector.database` | `"postgres"` | Database name |
+| `pgvector.user` | `"postgres"` | PostgreSQL user |
+| `pgvector.password` | — | PostgreSQL password (use `{env:VAR}` to avoid committing credentials) |
+| `pgvector.poolSize` | `10` | Maximum number of connections in the pool |
+| `pgvector.tablePrefix` | `"ci"` | Prefix applied to all table names. Change this to run multiple independent indexes in the same database |
+| `pgvector.connectionTimeoutMs` | `5000` | Connection timeout in milliseconds |
+| `pgvector.ssl` | `"disable"` | SSL mode: `"disable"`, `"require"`, or `"verify-full"` |
 
 ### Retrieval ranking behavior
 
@@ -690,7 +793,7 @@ Optional override secrets for another OpenAI-compatible endpoint:
 - `EVAL_EMBED_MODEL` (optional, default `text-embedding-3-small`)
 - `EVAL_EMBED_DIMENSIONS` (optional, default `1536`)
 
-If you override the provider, set both `EVAL_EMBED_BASE_URL` and `EVAL_EMBED_API_KEY`. Otherwise the workflow falls back to GitHub Models automatically. Override providers continue to use the baseline-driven budget in `benchmarks/budgets/default.json`.
+If you override the provider, set both `EVAL_EMBED_BASE_URL` and `EVAL_EMBED_API_KEY`. Otherwise, the workflow falls back to GitHub Models automatically. Override providers continue to use the baseline-driven budget in `benchmarks/budgets/default.json`.
 
 No OpenAI API access? Use Ollama quality gate locally:
 
@@ -759,7 +862,7 @@ Methodology for the snapshot below:
 #### Without reindex (`--no-reindex`, default)
 
 | Metric | Plugin | ripgrep | ast-grep (5/10 queries) |
-|---|---:|---:|---:|
+| --- | ---: | ---: | ---: |
 | Hit@5 | 50% | 5% | 100% |
 | MRR@10 | 0.48 | 0.04 | 0.90 |
 | nDCG@10 | 0.48 | 0.08 | 0.93 |
@@ -769,7 +872,7 @@ Methodology for the snapshot below:
 #### With reindex (`--reindex`)
 
 | Metric | Plugin | ripgrep | ast-grep (5/10 queries) |
-|---|---:|---:|---:|
+| --- | ---: | ---: | ---: |
 | Hit@5 | 50% | 5% | 100% |
 | MRR@10 | 0.48 | 0.04 | 0.98 |
 | nDCG@10 | 0.48 | 0.07 | 0.98 |
@@ -791,7 +894,9 @@ For reproducible setup and commands (including with/without reindex), see:
 - `docs/benchmarking-cross-repo.md`
 
 ### Embedding Providers
+
 The plugin automatically detects available credentials in this order:
+
 1. **GitHub Copilot** (Free if you have it)
 2. **OpenAI** (Standard Embeddings)
 3. **Google** (Gemini Embeddings)
@@ -804,7 +909,7 @@ You can also use **Custom** to connect any OpenAI-compatible embedding endpoint 
 Each provider has different rate limits. The plugin automatically adjusts concurrency and delays:
 
 | Provider | Concurrency | Delay | Best For |
-|----------|-------------|-------|----------|
+| --- | --- | --- | --- |
 | **GitHub Copilot** | 1 | 4s | Small codebases (<1k files) |
 | **OpenAI** | 3 | 500ms | Medium codebases |
 | **Google** | 5 | 200ms | Medium-large codebases |
@@ -853,7 +958,7 @@ Quick recommendation:
 ### Provider Comparison
 
 | Provider | Speed | Cost | Privacy | Best For |
-|----------|-------|------|---------|----------|
+| --- | --- | --- | --- | --- |
 | **Ollama** | Fastest | Free | Full | Large codebases, privacy-sensitive |
 | **GitHub Copilot** | Slow (rate limited) | Free* | Cloud | Small codebases, existing subscribers |
 | **OpenAI** | Medium | ~$0.0001/1K tokens | Cloud | General use |
@@ -874,6 +979,7 @@ Credentials (if required) are read from environment variables (for example `OPEN
 
 **Custom (OpenAI-compatible)**
 Works with any server that implements the OpenAI `/v1/embeddings` API format (llama.cpp, vLLM, text-embeddings-inference, LiteLLM, etc.).
+
 ```json
 {
   "embeddingProvider": "custom",
@@ -888,9 +994,11 @@ Works with any server that implements the OpenAI `/v1/embeddings` API format (ll
   }
 }
 ```
+
 Required fields: `baseUrl`, `model`, `dimensions` (positive integer). Optional: `apiKey`, `maxTokens`, `timeoutMs` (default: 30000), `maxBatchSize` (or `max_batch_size`) to cap inputs per `/embeddings` request for servers like text-embeddings-inference. `{env:VAR_NAME}` placeholders are resolved before config validation for fields that are actually used and throw if the referenced environment variable is missing or malformed.
 
-**Custom Ollama models via OpenAI-compatible API**
+### Custom Ollama models via OpenAI-compatible API
+
 If you are running Ollama locally and want to use an embedding model other than the built-in `ollama` setup, point the custom provider at Ollama's OpenAI-compatible base URL with the `/v1` suffix:
 
 ```json
@@ -906,6 +1014,7 @@ If you are running Ollama locally and want to use an embedding model other than 
 ```
 
 Notes:
+
 - The plugin appends `/embeddings`, so `baseUrl` should be `http://127.0.0.1:11434/v1`, not just `http://127.0.0.1:11434`.
 - Ollama ignores the API key, but some OpenAI-compatible clients expect one, so a placeholder like `"ollama"` is fine.
 - Make sure `dimensions` matches the actual output size of the model you pulled locally.
@@ -915,8 +1024,7 @@ Notes:
 Be aware of these characteristics:
 
 | Aspect | Reality |
-|--------|---------|
-| **Search latency** | ~800-1000ms per query (embedding API call) |
+| --- | --- |
 | **First index** | Takes time depending on codebase size (e.g., ~30s for 500 chunks) |
 | **Requires API** | Needs an embedding provider (Copilot, OpenAI, Google, or local Ollama) |
 | **Token costs** | Uses embedding tokens (free with Copilot, minimal with others) |
@@ -925,11 +1033,13 @@ Be aware of these characteristics:
 ## 💻 Local Development
 
 1. **Build**:
+
    ```bash
    npm run build
    ```
 
 2. **Register in Test Project** (use `file://` URL in `opencode.json`):
+
    ```json
    {
      "plugin": [
@@ -937,8 +1047,134 @@ Be aware of these characteristics:
      ]
    }
    ```
-   
+
    This loads directly from your source directory, so changes take effect after rebuilding.
+
+## 🗄️ Remote Database (pgvector)
+
+By default, the plugin stores everything locally in SQLite + usearch files
+inside `.opencode/index/`. For shared or cloud deployments you can point the
+plugin at a remote PostgreSQL database with the
+[pgvector](https://github.com/pgvector/pgvector) extension instead.
+
+### Prerequisites
+
+- PostgreSQL 14+ with the `pgvector` extension installed:
+
+  ```sql
+  CREATE EXTENSION IF NOT EXISTS vector;
+  ```
+
+- The database user must have `CREATE TABLE` / `CREATE INDEX` privileges (the
+  plugin creates its schema on first run).
+
+### Configuration
+
+Add a `database` block to `.opencode/codebase-index.json`:
+
+### Using a connection string
+
+```json
+{
+  "database": {
+    "engine": "pgvector",
+    "pgvector": {
+      "connectionString": "{env:DATABASE_URL}"
+    }
+  }
+}
+```
+
+### Using individual fields
+
+```json
+{
+  "database": {
+    "engine": "pgvector",
+    "pgvector": {
+      "host": "db.example.com",
+      "port": 5432,
+      "database": "myapp",
+      "user": "indexer",
+      "password": "{env:PG_PASSWORD}",
+      "ssl": "require"
+    }
+  }
+}
+```
+
+### Running Multiple Indexes in One Database
+
+If several projects share the same PostgreSQL instance, give each one a unique `tablePrefix` so that their tables do not collide:
+
+```json
+{
+  "database": {
+    "engine": "pgvector",
+    "pgvector": {
+      "connectionString": "{env:DATABASE_URL}",
+      "tablePrefix": "myproject"
+    }
+  }
+}
+```
+
+This creates tables like `myproject_embeddings`, `myproject_chunks`, etc.
+
+### Config Merging with Global Defaults
+
+When using a shared global pgvector config, project-level configs can override specific fields without repeating everything:
+
+**Global config** (`~/.config/opencode/codebase-index.json`):
+
+```json
+{
+  "database": {
+    "engine": "pgvector",
+    "pgvector": {
+      "connectionString": "{env:DATABASE_URL}",
+      "poolSize": 20,
+      "ssl": "require"
+    }
+  }
+}
+```
+
+**Project config** (`.opencode/codebase-index.json`) - override table prefix only:
+
+```json
+{
+  "database": {
+    "pgvector": {
+      "tablePrefix": "my_project"
+    }
+  }
+}
+```
+
+**Result**: The project inherits `connectionString`, `poolSize`, and `ssl` from
+global config, but uses `tablePrefix: "my_project"` for its tables. No need to
+repeat the connection settings.
+
+### SSL
+
+| Value | Behavior |
+| --- | --- |
+| `"disable"` | No SSL (default, local/private networks) |
+| `"require"` | SSL required, certificate not verified |
+| `"verify-full"` | SSL required, full certificate verification |
+
+### Tradeoffs vs SQLite
+
+| | SQLite (default) | pgvector |
+| --- | --- | --- |
+| **Setup** | Zero-config | PostgreSQL + pgvector |
+| **Storage** | Local `.opencode/index/` | Remote database |
+| **Sharing** | Per-machine | Multiple machines / CI |
+| **Performance** | In-process (fast) | Network round-trips |
+| **Best for** | Local development | Teams / cloud deploys |
+
+---
 
 ## 🤝 Contributing
 
@@ -972,7 +1208,7 @@ PRs labeled `skip-changelog` are intentionally excluded from release notes.
 
 ### Project Structure
 
-```
+```text
 ├── src/
 │   ├── index.ts              # Plugin entry point
 │   ├── mcp-server.ts         # MCP server (Cursor, Claude Code, Windsurf)
@@ -996,6 +1232,7 @@ PRs labeled `skip-changelog` are intentionally excluded from release notes.
 ### Native Module
 
 The Rust native module handles performance-critical operations:
+
 - **tree-sitter**: Language-aware code parsing with JSDoc/docstring extraction
 - **usearch**: High-performance vector similarity search with F16 quantization
 - **SQLite**: Persistent storage for embeddings, chunks, branch catalog, symbols, and call edges
@@ -1010,7 +1247,7 @@ Rebuild with: `npm run build:native` (requires Rust toolchain)
 Pre-built native binaries are published for:
 
 | Platform | Architecture | SIMD Acceleration |
-|----------|-------------|--------------------|
+| --- | --- | --- ||
 | macOS | x86_64 | ✅ simsimd |
 | macOS | ARM64 (Apple Silicon) | ✅ simsimd |
 | Linux | x86_64 (GNU) | ✅ simsimd |

--- a/README.md
+++ b/README.md
@@ -643,7 +643,8 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "logCache": true,                         // Log cache hits/misses
     "logGc": true,                            // Log garbage collection
     "logBranch": true,                        // Log branch detection
-    "metrics": false                          // Enable metrics collection
+    "metrics": false,                         // Enable metrics collection
+    "progressLogFile": "/tmp/index-progress.log" // Optional: append live progress to this file
   }
 }
 ```
@@ -712,6 +713,37 @@ String values in `codebase-index.json` can reference environment variables with 
 | `logGc` | `true` | Log garbage collection operations |
 | `logBranch` | `true` | Log branch detection and switches |
 | `metrics` | `false` | Enable metrics collection (indexing stats, search timing, cache performance) |
+| `progressLogFile` | — | Path to a file where live indexing progress lines are appended. Each line is timestamped. Useful for monitoring long indexing runs with `tail -f`. Relative paths are resolved from the project root. Does not require `debug.enabled`. |
+
+**Live Progress Monitoring**:
+
+Set `debug.progressLogFile` to any writable path to get a live feed of indexing progress:
+
+```json
+{
+  "debug": {
+    "progressLogFile": "/tmp/index-progress.log"
+  }
+}
+```
+
+Then in a terminal:
+
+```bash
+tail -f /tmp/index-progress.log
+```
+
+Example output:
+
+```text
+[2026-05-02T14:17:00.123Z] Scanning files...
+[2026-05-02T14:17:00.456Z] Parsing: 10/47 files (src/indexer/index.ts)
+[2026-05-02T14:17:01.234Z] Embedding: 50/300 chunks (~2m 15s left)
+[2026-05-02T14:17:04.567Z] Embedding: 150/300 chunks (~1m 5s left)
+[2026-05-02T14:17:09.000Z] Indexing complete
+```
+
+This works for both the OpenCode plugin and MCP server paths. Each indexing run appends to the file (existing content is preserved). The file is created automatically if it doesn't exist.
 
 **Debug Logging Details**:
 
@@ -855,7 +887,7 @@ Methodology for the snapshot below:
 - Dataset: auto-generated cross-repo golden sets for `axios` + `express`
 - Repeats: **20** per mode
 - Aggregation: **median** metric per tool (then averaged across repos)
-- Reindex behavior: when enabled, index reset applies on repeat #1 only; subsequent repeats measure warm-index query behavior
+- Re-index behavior: when enabled, index reset applies on repeat #1 only; subsequent repeats measure warm-index query behavior
 - Sampling note: repository parsing can be capped; benchmark reports include truncation metadata
 - ast-grep scope note: sg metrics are computed on its compatible query subset (`definition`, `keyword-heavy`) with scoped denominators shown in run reports
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,6 +29,7 @@ Then jump to the relevant section below for provider, build, performance, or bra
 ## OpenCode Hangs in Home Directory
 
 **Symptoms:**
+
 - OpenCode becomes unresponsive when opened in home directory (`~`)
 - New session starts but nothing happens when typing
 - High CPU or memory usage
@@ -38,13 +39,17 @@ Then jump to the relevant section below for provider, build, performance, or bra
 **Solutions:**
 
 ### Default Behavior (v0.4.1+)
+
 The plugin now requires a project marker (`.git`, `package.json`, `Cargo.toml`, etc.) by default. If no marker is found, file watching and auto-indexing are disabled. You'll see this warning:
-```
+
+```text
 [codebase-index] Skipping file watching and auto-indexing: no project marker found
 ```
 
 ### If You Need to Index a Non-Project Directory
+
 Set `requireProjectMarker` to `false` in your config:
+
 ```json
 {
   "indexing": {
@@ -56,7 +61,9 @@ Set `requireProjectMarker` to `false` in your config:
 **Warning:** Only do this for specific directories you intend to index. Never disable this for your home directory.
 
 ### Recognized Project Markers
+
 The plugin looks for any of these files/directories:
+
 - `.git`
 - `package.json`
 - `Cargo.toml`
@@ -77,7 +84,8 @@ The plugin looks for any of these files/directories:
 ## No Embedding Provider Available
 
 **Error message:**
-```
+
+```text
 No embedding provider available. Configure GitHub, OpenAI, Google, or Ollama.
 ```
 
@@ -86,9 +94,11 @@ No embedding provider available. Configure GitHub, OpenAI, Google, or Ollama.
 **Solutions:**
 
 ### Option 1: Use GitHub Copilot (if you have a subscription)
+
 No additional configuration needed. The plugin automatically detects Copilot credentials.
 
 ### Option 2: Use OpenAI
+
 ```bash
 export OPENAI_API_KEY=sk-...
 ```
@@ -96,11 +106,13 @@ export OPENAI_API_KEY=sk-...
 Or set in your shell profile (`~/.bashrc`, `~/.zshrc`).
 
 ### Option 3: Use Google (Gemini)
+
 ```bash
 export GOOGLE_API_KEY=...
 ```
 
 ### Option 4: Use Ollama (local, free)
+
 ```bash
 # Install Ollama from https://ollama.ai
 # Then pull the embedding model:
@@ -115,9 +127,11 @@ ollama pull nomic-embed-text
 ```
 
 ### Verify Provider Detection
+
 Run `/status` in OpenCode to see which provider is detected.
 
 Auto-detect tries providers in this order:
+
 1. Ollama
 2. GitHub Copilot
 3. OpenAI
@@ -128,7 +142,8 @@ Auto-detect tries providers in this order:
 ## Rate Limiting Errors
 
 **Error messages:**
-```
+
+```text
 429 Too Many Requests
 Rate limit exceeded
 Too many requests
@@ -139,34 +154,44 @@ Too many requests
 **Solutions:**
 
 ### For GitHub Copilot
+
 GitHub Copilot has strict rate limits (~15 requests/minute). The plugin automatically:
+
 - Uses concurrency of 1
 - Adds 4-second delays between requests
 - Retries with exponential backoff
 
 **If still hitting limits:**
-1. Wait 1-2 minutes and retry
+
+1. Wait 1–2 minutes and retry
 2. Switch to a different provider for large codebases:
+
    ```json
    { "embeddingProvider": "ollama" }
    ```
 
 ### For OpenAI
+
 OpenAI has generous limits, but if you hit them:
+
 1. Check your OpenAI account tier (free tier has lower limits)
 2. Consider upgrading to a paid tier
 3. Use Ollama for initial indexing, then switch back
 
 ### For Google
+
 Similar to OpenAI. Check your quota at [Google Cloud Console](https://console.cloud.google.com/).
 
 If you see provider/model errors, verify that your configured Google credentials have access to the Gemini embeddings API.
 
 ### For Large Codebases (1k+ files)
-Use Ollama locally - no rate limits:
+
+Use Ollama locally — no rate limits:
+
 ```bash
 ollama pull nomic-embed-text
 ```
+
 ```json
 { "embeddingProvider": "ollama" }
 ```
@@ -176,6 +201,7 @@ ollama pull nomic-embed-text
 ## Index Corruption / Stale Results
 
 **Symptoms:**
+
 - Search returns deleted files
 - Results don't match current code
 - "Chunk not found" errors
@@ -183,13 +209,17 @@ ollama pull nomic-embed-text
 **Solutions:**
 
 ### Run Health Check
-```
+
+```text
 /status
 ```
+
 Then ask the agent to run `index_health_check` to remove orphaned entries.
 
 ### Force Re-index
+
 Ask the agent:
+
 > "Force reindex the codebase"
 
 Or run `/index force`.
@@ -197,7 +227,9 @@ Or run `/index force`.
 Only use force reindex for a full rebuild. If `/status` reports failed embedding batches, fix the provider/auth issue first and rerun `/index` normally.
 
 ### Reset Everything
+
 Delete the entire index directory:
+
 ```bash
 rm -rf .opencode/index/
 ```
@@ -209,32 +241,38 @@ The next `/index` will rebuild from scratch.
 ## Embedding Provider Changed
 
 **Error message:**
-```
+
+```text
 Index incompatible: <reason>. Run index with force=true to rebuild.
 ```
 
 **Cause:** The index was built with a different embedding provider or model than what's currently configured. Embeddings from different providers have different dimensions and are not compatible.
 
 **Common scenarios:**
+
 - Switched from GitHub Copilot to OpenAI
 - Changed Ollama embedding model
 - Updated to a new version of the embedding model
 
 **Solutions:**
 
-### Force Re-index
+### Rebuild Index After Provider Change
+
 Ask the agent:
+
 > "Force reindex the codebase"
 
 Or run `/index` with the force option. This will:
+
 1. Delete all existing embeddings
 2. Re-index all files with the new provider
 
 ### Why This Happens
+
 Different embedding providers produce vectors with different dimensions:
 
 | Provider | Model | Dimensions |
-|----------|-------|------------|
+| --- | --- | --- |
 | GitHub Copilot | text-embedding-3-small | 1536 |
 | OpenAI | text-embedding-3-small | 1536 |
 | Google | text-embedding-004 | 768 |
@@ -243,6 +281,7 @@ Different embedding providers produce vectors with different dimensions:
 Mixing embeddings from different providers would produce garbage search results, so the plugin refuses to search until you rebuild the index.
 
 ### Check Current Index Metadata
+
 Run `/status` to see what provider/model the index was built with.
 
 ---
@@ -250,7 +289,8 @@ Run `/status` to see what provider/model the index was built with.
 ## Native Module Build Failures
 
 **Error messages:**
-```
+
+```text
 Error loading native module
 NAPI_RS error
 dyld: Library not loaded
@@ -261,7 +301,9 @@ dyld: Library not loaded
 **Solutions:**
 
 ### Check Supported Platforms
+
 Pre-built binaries are available for:
+
 - macOS x64 (Intel)
 - macOS arm64 (Apple Silicon)
 - Linux x64 (glibc)
@@ -269,7 +311,9 @@ Pre-built binaries are available for:
 - Windows x64
 
 ### Rebuild from Source
+
 Requires Rust toolchain:
+
 ```bash
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -281,7 +325,9 @@ npx napi build --release --platform
 ```
 
 ### Linux Musl Issues
+
 If on Alpine Linux or musl-based systems, you need to build from source:
+
 ```bash
 # Install musl target
 rustup target add x86_64-unknown-linux-musl
@@ -296,26 +342,32 @@ cargo build --release --target x86_64-unknown-linux-musl
 ## Slow Indexing Performance
 
 **Symptoms:**
+
 - Initial indexing takes very long
 - Progress seems stuck
 
 **Causes and Solutions:**
 
 ### 1. Large Codebase with Cloud Provider
+
 Cloud providers have network latency and rate limits.
 
 **Solution:** Use Ollama locally:
+
 ```bash
 ollama pull nomic-embed-text
 ```
+
 ```json
 { "embeddingProvider": "ollama" }
 ```
 
 ### 2. Many Large Files
+
 Files over 1MB are skipped by default, but many medium-sized files can still be slow.
 
 **Solution:** Increase chunk limits or enable semantic-only mode:
+
 ```json
 {
   "indexing": {
@@ -326,15 +378,19 @@ Files over 1MB are skipped by default, but many medium-sized files can still be 
 ```
 
 ### 3. GitHub Copilot Rate Limits
+
 Copilot has 4-second delays between requests.
 
 **Solution:** For initial indexing, use a faster provider, then switch back:
+
 ```json
 { "embeddingProvider": "openai" }
 ```
 
 ### Check Progress
+
 Run `/status` to see current index stats and estimate remaining work with:
+
 > "Estimate indexing cost"
 
 ---
@@ -342,31 +398,38 @@ Run `/status` to see current index stats and estimate remaining work with:
 ## Search Returns No Results
 
 **Symptoms:**
+
 - Queries return empty results
 - "No matches found" for queries that should match
 
 **Solutions:**
 
 ### 1. Check Index Status
-```
+
+```text
 /status
 ```
+
 Verify the index exists and has chunks.
 
 ### 2. Index Hasn't Run Yet
+
 Run `/index` to index the codebase.
 
 ### 3. Query Too Vague or Too Specific
+
 Semantic search works best with descriptive queries:
 
 | Bad Query | Better Query |
-|-----------|--------------|
+| --- | --- |
 | "auth" | "authentication middleware that validates JWT tokens" |
 | "error" | "error handling for failed API calls" |
 | "user" | "function that creates new user accounts" |
 
 ### 4. Similarity Threshold Too High
+
 Lower the minimum score:
+
 ```json
 {
   "search": {
@@ -376,7 +439,9 @@ Lower the minimum score:
 ```
 
 ### 5. Files Excluded
+
 Check if your files are being excluded by `.gitignore` or size limits:
+
 > "Run `/index` in verbose mode"
 
 This shows which files were skipped and why.
@@ -390,12 +455,16 @@ This shows which files were skipped and why.
 **Cause:** The branch catalog may not have updated.
 
 **Solution:**
+
 1. Check current branch detection:
-   ```
+
+   ```text
    /status
    ```
+
 2. Re-index to update the branch catalog:
-   ```
+
+   ```text
    /index
    ```
 
@@ -404,6 +473,7 @@ This shows which files were skipped and why.
 **Cause:** Detached HEAD or unusual git state.
 
 **Solution:** Check your git state:
+
 ```bash
 git status
 cat .git/HEAD
@@ -416,6 +486,7 @@ The plugin reads `.git/HEAD` directly. If you're in detached HEAD state, it uses
 **Cause:** File watcher may not be running.
 
 **Solution:** Enable file watching:
+
 ```json
 {
   "indexing": {
@@ -425,7 +496,8 @@ The plugin reads `.git/HEAD` directly. If you're in detached HEAD state, it uses
 ```
 
 Or manually trigger re-index after switching branches:
-```
+
+```text
 /index
 ```
 
@@ -448,7 +520,7 @@ If none of these solutions work:
 ## Quick Reference
 
 | Problem | Quick Fix |
-|---------|-----------|
+| --- | --- |
 | Hangs in home dir | Ensure `indexing.requireProjectMarker` is `true` (default) |
 | No provider | `export OPENAI_API_KEY=...` or use Ollama |
 | Rate limited | Switch to Ollama for large codebases |

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,1058 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "opencode-codebase-index",
+      "dependencies": {
+        "@opencode-ai/plugin": "^1.0.0",
+        "@types/pg": "^8.20.0",
+        "chokidar": "^5.0.0",
+        "ignore": "^7.0.5",
+        "p-queue": "^9.1.1",
+        "p-retry": "^7.1.1",
+        "pg": "^8.20.0",
+        "tiktoken": "^1.0.15",
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.4",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@napi-rs/cli": "^3.6.0",
+        "@types/node": "^25.5.2",
+        "@vitest/coverage-v8": "^4.1.2",
+        "eslint": "^9.39.4",
+        "tsup": "^8.1.0",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.58.0",
+        "vitest": "^4.1.2",
+        "zod": "^3.25.76",
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@opencode-ai/plugin": "^1.0.0",
+        "zod": "^3.0.0",
+      },
+      "optionalPeers": [
+        "@modelcontextprotocol/sdk",
+        "@opencode-ai/plugin",
+        "zod",
+      ],
+    },
+  },
+  "overrides": {
+    "@hono/node-server": "1.19.14",
+    "hono": "4.12.12",
+    "vite": "8.0.8",
+  },
+  "packages": {
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.4", "", { "os": "android", "cpu": "arm64" }, "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.4", "", { "os": "android", "cpu": "x64" }, "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.4", "", { "os": "linux", "cpu": "arm" }, "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.4", "", { "os": "linux", "cpu": "ia32" }, "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.4", "", { "os": "linux", "cpu": "none" }, "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.4", "", { "os": "linux", "cpu": "x64" }, "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.4", "", { "os": "none", "cpu": "x64" }, "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.4", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.4", "", { "os": "none", "cpu": "arm64" }, "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.4", "", { "os": "sunos", "cpu": "x64" }, "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.4", "", {}, "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.2", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/core": "^11.1.7", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.7", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/external-editor": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@2.0.4", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.4", "", {}, "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ=="],
+
+    "@inquirer/input": ["@inquirer/input@5.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ=="],
+
+    "@inquirer/number": ["@inquirer/number@4.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA=="],
+
+    "@inquirer/password": ["@inquirer/password@5.0.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.3.2", "", { "dependencies": { "@inquirer/checkbox": "^5.1.2", "@inquirer/confirm": "^6.0.10", "@inquirer/editor": "^5.0.10", "@inquirer/expand": "^5.0.10", "@inquirer/input": "^5.0.10", "@inquirer/number": "^4.0.10", "@inquirer/password": "^5.0.10", "@inquirer/rawlist": "^5.2.6", "@inquirer/search": "^4.1.6", "@inquirer/select": "^5.1.2" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.2.6", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w=="],
+
+    "@inquirer/search": ["@inquirer/search@4.1.6", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ=="],
+
+    "@inquirer/select": ["@inquirer/select@5.1.2", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/core": "^11.1.7", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.4", "", { "peerDependencies": { "@types/node": ">=18" } }, "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+
+    "@napi-rs/cli": ["@napi-rs/cli@3.6.2", "", { "dependencies": { "@inquirer/prompts": "^8.0.0", "@napi-rs/cross-toolchain": "^1.0.3", "@napi-rs/wasm-tools": "^1.0.1", "@octokit/rest": "^22.0.1", "clipanion": "^4.0.0-rc.4", "colorette": "^2.0.20", "emnapi": "^1.9.1", "es-toolkit": "^1.41.0", "js-yaml": "^4.1.0", "obug": "^2.0.0", "semver": "^7.7.3", "typanion": "^3.14.0" }, "peerDependencies": { "@emnapi/runtime": "^1.7.1" }, "optionalPeers": ["@emnapi/runtime"], "bin": { "napi": "dist/cli.js", "napi-raw": "cli.mjs" } }, "sha512-jy5rABUh9tbE/vPRzw9kGzGuqZiVslyDQUV8LkvjzqVX/oJMN7g0U1uhtr9L3W1H+iRM/urXHXUf+CE4n8FvLA=="],
+
+    "@napi-rs/cross-toolchain": ["@napi-rs/cross-toolchain@1.0.3", "", { "dependencies": { "@napi-rs/lzma": "^1.4.5", "@napi-rs/tar": "^1.1.0", "debug": "^4.4.1" }, "peerDependencies": { "@napi-rs/cross-toolchain-arm64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-arm64-target-x86_64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-aarch64": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-armv7": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-ppc64le": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-s390x": "^1.0.3", "@napi-rs/cross-toolchain-x64-target-x86_64": "^1.0.3" }, "optionalPeers": ["@napi-rs/cross-toolchain-arm64-target-aarch64", "@napi-rs/cross-toolchain-arm64-target-armv7", "@napi-rs/cross-toolchain-arm64-target-ppc64le", "@napi-rs/cross-toolchain-arm64-target-s390x", "@napi-rs/cross-toolchain-arm64-target-x86_64", "@napi-rs/cross-toolchain-x64-target-aarch64", "@napi-rs/cross-toolchain-x64-target-armv7", "@napi-rs/cross-toolchain-x64-target-ppc64le", "@napi-rs/cross-toolchain-x64-target-s390x", "@napi-rs/cross-toolchain-x64-target-x86_64"] }, "sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg=="],
+
+    "@napi-rs/lzma": ["@napi-rs/lzma@1.4.5", "", { "optionalDependencies": { "@napi-rs/lzma-android-arm-eabi": "1.4.5", "@napi-rs/lzma-android-arm64": "1.4.5", "@napi-rs/lzma-darwin-arm64": "1.4.5", "@napi-rs/lzma-darwin-x64": "1.4.5", "@napi-rs/lzma-freebsd-x64": "1.4.5", "@napi-rs/lzma-linux-arm-gnueabihf": "1.4.5", "@napi-rs/lzma-linux-arm64-gnu": "1.4.5", "@napi-rs/lzma-linux-arm64-musl": "1.4.5", "@napi-rs/lzma-linux-ppc64-gnu": "1.4.5", "@napi-rs/lzma-linux-riscv64-gnu": "1.4.5", "@napi-rs/lzma-linux-s390x-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-gnu": "1.4.5", "@napi-rs/lzma-linux-x64-musl": "1.4.5", "@napi-rs/lzma-wasm32-wasi": "1.4.5", "@napi-rs/lzma-win32-arm64-msvc": "1.4.5", "@napi-rs/lzma-win32-ia32-msvc": "1.4.5", "@napi-rs/lzma-win32-x64-msvc": "1.4.5" } }, "sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg=="],
+
+    "@napi-rs/lzma-android-arm-eabi": ["@napi-rs/lzma-android-arm-eabi@1.4.5", "", { "os": "android", "cpu": "arm" }, "sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q=="],
+
+    "@napi-rs/lzma-android-arm64": ["@napi-rs/lzma-android-arm64@1.4.5", "", { "os": "android", "cpu": "arm64" }, "sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ=="],
+
+    "@napi-rs/lzma-darwin-arm64": ["@napi-rs/lzma-darwin-arm64@1.4.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA=="],
+
+    "@napi-rs/lzma-darwin-x64": ["@napi-rs/lzma-darwin-x64@1.4.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw=="],
+
+    "@napi-rs/lzma-freebsd-x64": ["@napi-rs/lzma-freebsd-x64@1.4.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw=="],
+
+    "@napi-rs/lzma-linux-arm-gnueabihf": ["@napi-rs/lzma-linux-arm-gnueabihf@1.4.5", "", { "os": "linux", "cpu": "arm" }, "sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw=="],
+
+    "@napi-rs/lzma-linux-arm64-gnu": ["@napi-rs/lzma-linux-arm64-gnu@1.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg=="],
+
+    "@napi-rs/lzma-linux-arm64-musl": ["@napi-rs/lzma-linux-arm64-musl@1.4.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w=="],
+
+    "@napi-rs/lzma-linux-ppc64-gnu": ["@napi-rs/lzma-linux-ppc64-gnu@1.4.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ=="],
+
+    "@napi-rs/lzma-linux-riscv64-gnu": ["@napi-rs/lzma-linux-riscv64-gnu@1.4.5", "", { "os": "linux", "cpu": "none" }, "sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA=="],
+
+    "@napi-rs/lzma-linux-s390x-gnu": ["@napi-rs/lzma-linux-s390x-gnu@1.4.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA=="],
+
+    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw=="],
+
+    "@napi-rs/lzma-linux-x64-musl": ["@napi-rs/lzma-linux-x64-musl@1.4.5", "", { "os": "linux", "cpu": "x64" }, "sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ=="],
+
+    "@napi-rs/lzma-wasm32-wasi": ["@napi-rs/lzma-wasm32-wasi@1.4.5", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA=="],
+
+    "@napi-rs/lzma-win32-arm64-msvc": ["@napi-rs/lzma-win32-arm64-msvc@1.4.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg=="],
+
+    "@napi-rs/lzma-win32-ia32-msvc": ["@napi-rs/lzma-win32-ia32-msvc@1.4.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg=="],
+
+    "@napi-rs/lzma-win32-x64-msvc": ["@napi-rs/lzma-win32-x64-msvc@1.4.5", "", { "os": "win32", "cpu": "x64" }, "sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q=="],
+
+    "@napi-rs/tar": ["@napi-rs/tar@1.1.0", "", { "optionalDependencies": { "@napi-rs/tar-android-arm-eabi": "1.1.0", "@napi-rs/tar-android-arm64": "1.1.0", "@napi-rs/tar-darwin-arm64": "1.1.0", "@napi-rs/tar-darwin-x64": "1.1.0", "@napi-rs/tar-freebsd-x64": "1.1.0", "@napi-rs/tar-linux-arm-gnueabihf": "1.1.0", "@napi-rs/tar-linux-arm64-gnu": "1.1.0", "@napi-rs/tar-linux-arm64-musl": "1.1.0", "@napi-rs/tar-linux-ppc64-gnu": "1.1.0", "@napi-rs/tar-linux-s390x-gnu": "1.1.0", "@napi-rs/tar-linux-x64-gnu": "1.1.0", "@napi-rs/tar-linux-x64-musl": "1.1.0", "@napi-rs/tar-wasm32-wasi": "1.1.0", "@napi-rs/tar-win32-arm64-msvc": "1.1.0", "@napi-rs/tar-win32-ia32-msvc": "1.1.0", "@napi-rs/tar-win32-x64-msvc": "1.1.0" } }, "sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ=="],
+
+    "@napi-rs/tar-android-arm-eabi": ["@napi-rs/tar-android-arm-eabi@1.1.0", "", { "os": "android", "cpu": "arm" }, "sha512-h2Ryndraj/YiKgMV/r5by1cDusluYIRT0CaE0/PekQ4u+Wpy2iUVqvzVU98ZPnhXaNeYxEvVJHNGafpOfaD0TA=="],
+
+    "@napi-rs/tar-android-arm64": ["@napi-rs/tar-android-arm64@1.1.0", "", { "os": "android", "cpu": "arm64" }, "sha512-DJFyQHr1ZxNZorm/gzc1qBNLF/FcKzcH0V0Vwan5P+o0aE2keQIGEjJ09FudkF9v6uOuJjHCVDdK6S6uHtShAw=="],
+
+    "@napi-rs/tar-darwin-arm64": ["@napi-rs/tar-darwin-arm64@1.1.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Zz2sXRzjIX4e532zD6xm2SjXEym6MkvfCvL2RMpG2+UwNVDVscHNcz3d47Pf3sysP2e2af7fBB3TIoK2f6trPw=="],
+
+    "@napi-rs/tar-darwin-x64": ["@napi-rs/tar-darwin-x64@1.1.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EI+CptIMNweT0ms9S3mkP/q+J6FNZ1Q6pvpJOEcWglRfyfQpLqjlC0O+dptruTPE8VamKYuqdjxfqD8hifZDOA=="],
+
+    "@napi-rs/tar-freebsd-x64": ["@napi-rs/tar-freebsd-x64@1.1.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J0PIqX+pl6lBIAckL/c87gpodLbjZB1OtIK+RDscKC9NLdpVv6VGOxzUV/fYev/hctcE8EfkLbgFOfpmVQPg2g=="],
+
+    "@napi-rs/tar-linux-arm-gnueabihf": ["@napi-rs/tar-linux-arm-gnueabihf@1.1.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SLgIQo3f3EjkZ82ZwvrEgFvMdDAhsxCYjyoSuWfHCz0U16qx3SuGCp8+FYOPYCECHN3ZlGjXnoAIt9ERd0dEUg=="],
+
+    "@napi-rs/tar-linux-arm64-gnu": ["@napi-rs/tar-linux-arm64-gnu@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-d014cdle52EGaH6GpYTQOP9Py7glMO1zz/+ynJPjjzYFSxvdYx0byrjumZk2UQdIyGZiJO2MEFpCkEEKFSgPYA=="],
+
+    "@napi-rs/tar-linux-arm64-musl": ["@napi-rs/tar-linux-arm64-musl@1.1.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ=="],
+
+    "@napi-rs/tar-linux-ppc64-gnu": ["@napi-rs/tar-linux-ppc64-gnu@1.1.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ=="],
+
+    "@napi-rs/tar-linux-s390x-gnu": ["@napi-rs/tar-linux-s390x-gnu@1.1.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ=="],
+
+    "@napi-rs/tar-linux-x64-gnu": ["@napi-rs/tar-linux-x64-gnu@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww=="],
+
+    "@napi-rs/tar-linux-x64-musl": ["@napi-rs/tar-linux-x64-musl@1.1.0", "", { "os": "linux", "cpu": "x64" }, "sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ=="],
+
+    "@napi-rs/tar-wasm32-wasi": ["@napi-rs/tar-wasm32-wasi@1.1.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw=="],
+
+    "@napi-rs/tar-win32-arm64-msvc": ["@napi-rs/tar-win32-arm64-msvc@1.1.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-vfpG71OB0ijtjemp3WTdmBKJm9R70KM8vsSExMsIQtV0lVzP07oM1CW6JbNRPXNLhRoue9ofYLiUDk8bE0Hckg=="],
+
+    "@napi-rs/tar-win32-ia32-msvc": ["@napi-rs/tar-win32-ia32-msvc@1.1.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-hGPyPW60YSpOSgzfy68DLBHgi6HxkAM+L59ZZZPMQ0TOXjQg+p2EW87+TjZfJOkSpbYiEkULwa/f4a2hcVjsqQ=="],
+
+    "@napi-rs/tar-win32-x64-msvc": ["@napi-rs/tar-win32-x64-msvc@1.1.0", "", { "os": "win32", "cpu": "x64" }, "sha512-L6Ed1DxXK9YSCMyvpR8MiNAyKNkQLjsHsHK9E0qnHa8NzLFqzDKhvs5LfnWxM2kJ+F7m/e5n9zPm24kHb3LsVw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
+
+    "@napi-rs/wasm-tools": ["@napi-rs/wasm-tools@1.0.1", "", { "optionalDependencies": { "@napi-rs/wasm-tools-android-arm-eabi": "1.0.1", "@napi-rs/wasm-tools-android-arm64": "1.0.1", "@napi-rs/wasm-tools-darwin-arm64": "1.0.1", "@napi-rs/wasm-tools-darwin-x64": "1.0.1", "@napi-rs/wasm-tools-freebsd-x64": "1.0.1", "@napi-rs/wasm-tools-linux-arm64-gnu": "1.0.1", "@napi-rs/wasm-tools-linux-arm64-musl": "1.0.1", "@napi-rs/wasm-tools-linux-x64-gnu": "1.0.1", "@napi-rs/wasm-tools-linux-x64-musl": "1.0.1", "@napi-rs/wasm-tools-wasm32-wasi": "1.0.1", "@napi-rs/wasm-tools-win32-arm64-msvc": "1.0.1", "@napi-rs/wasm-tools-win32-ia32-msvc": "1.0.1", "@napi-rs/wasm-tools-win32-x64-msvc": "1.0.1" } }, "sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ=="],
+
+    "@napi-rs/wasm-tools-android-arm-eabi": ["@napi-rs/wasm-tools-android-arm-eabi@1.0.1", "", { "os": "android", "cpu": "arm" }, "sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw=="],
+
+    "@napi-rs/wasm-tools-android-arm64": ["@napi-rs/wasm-tools-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg=="],
+
+    "@napi-rs/wasm-tools-darwin-arm64": ["@napi-rs/wasm-tools-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g=="],
+
+    "@napi-rs/wasm-tools-darwin-x64": ["@napi-rs/wasm-tools-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A=="],
+
+    "@napi-rs/wasm-tools-freebsd-x64": ["@napi-rs/wasm-tools-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg=="],
+
+    "@napi-rs/wasm-tools-linux-arm64-gnu": ["@napi-rs/wasm-tools-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q=="],
+
+    "@napi-rs/wasm-tools-linux-arm64-musl": ["@napi-rs/wasm-tools-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ=="],
+
+    "@napi-rs/wasm-tools-linux-x64-gnu": ["@napi-rs/wasm-tools-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw=="],
+
+    "@napi-rs/wasm-tools-linux-x64-musl": ["@napi-rs/wasm-tools-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ=="],
+
+    "@napi-rs/wasm-tools-wasm32-wasi": ["@napi-rs/wasm-tools-wasm32-wasi@1.0.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.0.3" }, "cpu": "none" }, "sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA=="],
+
+    "@napi-rs/wasm-tools-win32-arm64-msvc": ["@napi-rs/wasm-tools-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ=="],
+
+    "@napi-rs/wasm-tools-win32-ia32-msvc": ["@napi-rs/wasm-tools-win32-ia32-msvc@1.0.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw=="],
+
+    "@napi-rs/wasm-tools-win32-x64-msvc": ["@napi-rs/wasm-tools-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.8", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.14.31", "", { "dependencies": { "@opencode-ai/sdk": "1.14.31", "effect": "4.0.0-beta.57", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.0", "@opentui/solid": ">=0.2.0" }, "optionalPeers": ["@opentui/core", "@opentui/solid"] }, "sha512-ZF7UoNKtZDtgW/2KrcFw5I7R2HRj/NigBuRwKPonvSZS36LnghZ7PYcXYZFGCjEgBmLUMMrLVgxccKLyxsgB0g=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.31", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-QaV+ti3NYUITmgIDqtNMqGIYBXJOx2zheN1g+7w4HC8QQsbaW1c7glxXExQHRbdUzcQPP2vUQhnXOcEsTw5CcQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.15", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm" }, "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "ppc64" }, "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "s390x" }, "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.15", "", { "os": "linux", "cpu": "x64" }, "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.15", "", { "os": "none", "cpu": "arm64" }, "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.15", "", { "dependencies": { "@emnapi/core": "1.9.2", "@emnapi/runtime": "1.9.2", "@napi-rs/wasm-runtime": "^1.1.3" }, "cpu": "none" }, "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.15", "", { "os": "win32", "cpu": "x64" }, "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.1", "", { "os": "android", "cpu": "arm64" }, "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/type-utils": "8.59.1", "@typescript-eslint/utils": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.59.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.59.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.59.1", "@typescript-eslint/types": "^8.59.1", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1" } }, "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.59.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.59.1", "", {}, "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.1", "@typescript-eslint/tsconfig-utils": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/visitor-keys": "8.59.1", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.1", "@typescript-eslint/types": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.1", "", { "dependencies": { "@typescript-eslint/types": "8.59.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.5", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.5", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.5", "vitest": "4.1.5" }, "optionalPeers": ["@vitest/browser"] }, "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" }, "peerDependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "clipanion": ["clipanion@4.0.0-rc.4", "", { "dependencies": { "typanion": "^3.8.0" }, "peerDependencies": { "typanion": "*" } }, "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "effect": ["effect@4.0.0-beta.57", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-rg32VgXnLKaPRs9tbRDaZ5jxmzNY7ojXt85gSHGUTwdlbWH5Ik+OCUY2q14TXliygPGoHwCAvNWS4bQJOqf00g=="],
+
+    "emnapi": ["emnapi@1.9.2", "", { "peerDependencies": { "node-addon-api": ">= 6.1.0" }, "optionalPeers": ["node-addon-api"] }, "sha512-OdUoQe/8so7FvubnE/DNV9sNNSFwDYQiK4ZCAz4agMnD1s6faLuDn2gzxfJrmMoKfxZhhsckqGNwqPnS5K140A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
+
+    "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": "bin/esbuild" }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": "bin/eslint.js" }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-network-error": ["is-network-error@1.3.1", "", {}, "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "msgpackr": ["msgpackr@1.11.10", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-queue": ["p-queue@9.2.0", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g=="],
+
+    "p-retry": ["p-retry@7.1.1", "", { "dependencies": { "is-network-error": "^1.1.0" } }, "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w=="],
+
+    "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "rolldown": ["rolldown@1.0.0-rc.15", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@rolldown/pluginutils": "1.0.0-rc.15" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-arm64": "1.0.0-rc.15", "@rolldown/binding-darwin-x64": "1.0.0-rc.15", "@rolldown/binding-freebsd-x64": "1.0.0-rc.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15" }, "bin": "bin/cli.mjs" }, "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g=="],
+
+    "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tiktoken": ["tiktoken@1.0.22", "", {}, "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": "cli.js" }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
+
+    "typanion": ["typanion@3.14.0", "", {}, "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.59.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.1", "@typescript-eslint/parser": "8.59.1", "@typescript-eslint/typescript-estree": "8.59.1", "@typescript-eslint/utils": "8.59.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "uuid": ["uuid@13.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@vitejs/devtools", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
+
+    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "@types/pg/@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "vitest/tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+
+    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codebase-index-native"
-version = "0.1.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "ignore",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codebase-index-native"
-version = "0.1.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 description = "Native Rust core for opencode-codebase-index: tree-sitter parsing and vector search"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index-native",
-  "version": "0.1.0",
+  "version": "0.7.1",
   "napi": {
     "binaryName": "codebase-index-native",
     "targets": [

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1194,4 +1194,5 @@ impl Database {
             db::gc_orphan_call_edges(&conn).map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(count as u32)
     }
+
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1194,5 +1194,4 @@ impl Database {
             db::gc_orphan_call_edges(&conn).map_err(|e| Error::from_reason(e.to_string()))?;
         Ok(count as u32)
     }
-
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/plugin": "~1.3.13",
+        "@opencode-ai/plugin": "^1.0.0",
+        "@types/pg": "^8.20.0",
         "chokidar": "^5.0.0",
         "ignore": "^7.0.5",
-        "p-queue": "^9.1.1",
+        "p-queue": "^9.2.0",
         "p-retry": "^7.1.1",
-        "tiktoken": "^1.0.15"
+        "pg": "^8.20.0",
+        "tiktoken": "^1.0.22"
       },
       "bin": {
         "opencode-codebase-index-mcp": "dist/cli.js"
@@ -22,14 +24,14 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@napi-rs/cli": "^3.6.0",
-        "@types/node": "^25.5.2",
-        "@vitest/coverage-v8": "^4.1.2",
+        "@napi-rs/cli": "^3.6.2",
+        "@types/node": "^25.6.0",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9.39.4",
-        "tsup": "^8.1.0",
+        "tsup": "^8.5.1",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.58.0",
-        "vitest": "^4.1.2",
+        "typescript-eslint": "^8.59.1",
+        "vitest": "^4.1.5",
         "zod": "^3.25.76"
       },
       "engines": {
@@ -1255,10 +1257,88 @@
         }
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/cli": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.6.0.tgz",
-      "integrity": "sha512-aA8m4+9XxnK1+0sr4GplZP0Ze90gkzO8sMKaplOK0zXbLnzsLl6O2BQQt6rTCcTRzIN24wrrByakr/imM+CxhA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-3.6.2.tgz",
+      "integrity": "sha512-jy5rABUh9tbE/vPRzw9kGzGuqZiVslyDQUV8LkvjzqVX/oJMN7g0U1uhtr9L3W1H+iRM/urXHXUf+CE4n8FvLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2411,17 +2491,18 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.13.tgz",
-      "integrity": "sha512-zHgtWfdDz8Wu8srE8f8HUtPT9i6c3jTmgQKoFZUZ+RR5CMQF1kAlb1cxeEe9Xm2DRNFVJog9Cv/G1iUHYgXSUQ==",
+      "version": "1.14.31",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.31.tgz",
+      "integrity": "sha512-ZF7UoNKtZDtgW/2KrcFw5I7R2HRj/NigBuRwKPonvSZS36LnghZ7PYcXYZFGCjEgBmLUMMrLVgxccKLyxsgB0g==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.3.13",
+        "@opencode-ai/sdk": "1.14.31",
+        "effect": "4.0.0-beta.57",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.95",
-        "@opentui/solid": ">=0.1.95"
+        "@opentui/core": ">=0.2.0",
+        "@opentui/solid": ">=0.2.0"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -2442,10 +2523,13 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.13.tgz",
-      "integrity": "sha512-/M6HlNnba+xf1EId6qFb2tG0cvq0db3PCQDug1glrf8wYOU57LYNF8WvHX9zoDKPTMv0F+O4pcP/8J+WvDaxHA==",
-      "license": "MIT"
+      "version": "1.14.31",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.31.tgz",
+      "integrity": "sha512-QaV+ti3NYUITmgIDqtNMqGIYBXJOx2zheN1g+7w4HC8QQsbaW1c7glxXExQHRbdUzcQPP2vUQhnXOcEsTw5CcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
@@ -3075,7 +3159,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -3122,27 +3205,37 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
-      "dev": true,
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/type-utils": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3155,22 +3248,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.0",
+        "@typescript-eslint/parser": "^8.59.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3186,14 +3279,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.0",
-        "@typescript-eslint/types": "^8.58.0",
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3208,14 +3301,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3226,9 +3319,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3243,15 +3336,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3268,9 +3361,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3282,16 +3375,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.0",
-        "@typescript-eslint/tsconfig-utils": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3349,16 +3442,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0"
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3373,13 +3466,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.59.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3404,14 +3497,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
-      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -3425,8 +3518,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.2",
-        "vitest": "4.1.2"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3435,16 +3528,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3453,13 +3546,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3480,9 +3573,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3493,13 +3586,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3507,14 +3600,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3523,9 +3616,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3533,13 +3626,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4007,7 +4100,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4057,7 +4149,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4084,6 +4176,24 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.57.tgz",
+      "integrity": "sha512-rg32VgXnLKaPRs9tbRDaZ5jxmzNY7ojXt85gSHGUTwdlbWH5Ik+OCUY2q14TXliygPGoHwCAvNWS4bQJOqf00g==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
     },
     "node_modules/emnapi": {
       "version": "1.9.2",
@@ -4131,9 +4241,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4533,6 +4643,28 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
@@ -4649,6 +4781,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -4957,6 +5095,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
@@ -5023,7 +5170,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5149,6 +5295,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5609,6 +5761,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
+      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
     "node_modules/mute-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
@@ -5665,6 +5854,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -5775,12 +5979,12 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.1.tgz",
-      "integrity": "sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
+        "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
       },
       "engines": {
@@ -5854,7 +6058,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5877,6 +6080,95 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5931,9 +6223,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -6002,6 +6294,45 @@
         }
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6035,6 +6366,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -6285,7 +6632,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6298,7 +6644,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6420,6 +6765,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6438,9 +6792,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6589,6 +6943,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -6775,16 +7138,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.0",
-        "@typescript-eslint/parser": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0"
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6806,10 +7169,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -6837,6 +7199,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {
@@ -6928,19 +7303,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -6968,10 +7343,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6995,6 +7372,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -7010,9 +7393,9 @@
       }
     },
     "node_modules/vitest/node_modules/tinyexec": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7023,7 +7406,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7068,6 +7450,30 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",
@@ -70,24 +70,26 @@
     ]
   },
   "dependencies": {
-    "@opencode-ai/plugin": "~1.3.13",
+    "@opencode-ai/plugin": "^1.0.0",
+    "@types/pg": "^8.20.0",
     "chokidar": "^5.0.0",
     "ignore": "^7.0.5",
-    "p-queue": "^9.1.1",
+    "p-queue": "^9.2.0",
     "p-retry": "^7.1.1",
-    "tiktoken": "^1.0.15"
+    "pg": "^8.20.0",
+    "tiktoken": "^1.0.22"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@napi-rs/cli": "^3.6.0",
-    "@types/node": "^25.5.2",
-    "@vitest/coverage-v8": "^4.1.2",
+    "@napi-rs/cli": "^3.6.2",
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.39.4",
-    "tsup": "^8.1.0",
+    "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.58.0",
-    "vitest": "^4.1.2",
+    "typescript-eslint": "^8.59.1",
+    "vitest": "^4.1.5",
     "zod": "^3.25.76"
   },
   "overrides": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { formatIndexStats, formatProgressTitle } from "./tools/utils.js";
 import { formatCostEstimate } from "./utils/cost.js";
 import { initializeLogger } from "./utils/logger.js";
 import { writeProgressLog } from "./utils/progress-log.js";
+import { handleMigrateCommand } from "./migration/sqlite-to-pgvector.js";
 
 function parseArgs(argv: string[]): { project: string; config?: string } {
   let project = process.cwd();
@@ -115,6 +116,20 @@ Options:
   const indexer = new Indexer(project, config);
   await indexer.initialize();
 
+  // Confirm which backend actually connected (helps diagnose SQLite-vs-pgvector confusion).
+  if (config.database.engine === "pgvector" && config.database.pgvector) {
+    const pg = config.database.pgvector;
+    const connDesc = pg.connectionString
+      ? "connection string"
+      : `${pg.user ?? "postgres"}@${pg.host ?? "localhost"}:${pg.port ?? 5432}/${pg.database ?? "postgres"}`;
+    console.error(`Database backend: pgvector (${connDesc})`);
+  } else {
+    const { resolveProjectIndexPath } = await import("./config/paths.js");
+    const dbPath = path.join(resolveProjectIndexPath(project, config.scope), "codebase.db");
+    console.error(`Database backend: sqlite (${dbPath})`);
+  }
+  console.error("");
+
   if (estimateOnly) {
     const estimate = await indexer.estimateCost();
     console.log(formatCostEstimate(estimate));
@@ -144,6 +159,11 @@ async function main(): Promise<void> {
 
   if (process.argv[2] === "index") {
     await handleIndexCommand(process.argv.slice(3));
+    return;
+  }
+
+  if (process.argv[2] === "migrate") {
+    await handleMigrateCommand(process.argv.slice(3));
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,8 +7,11 @@ import { handleEvalCommand } from "./eval/cli.js";
 import { createMcpServer } from "./mcp-server.js";
 import { loadMergedConfig } from "./config/merger.js";
 import { Indexer } from "./indexer/index.js";
-import { formatIndexStats } from "./tools/utils.js";
+import type { IndexProgress } from "./indexer/index.js";
+import { formatIndexStats, formatProgressTitle } from "./tools/utils.js";
 import { formatCostEstimate } from "./utils/cost.js";
+import { initializeLogger } from "./utils/logger.js";
+import { writeProgressLog } from "./utils/progress-log.js";
 
 function parseArgs(argv: string[]): { project: string; config?: string } {
   let project = process.cwd();
@@ -54,7 +57,8 @@ Options:
   --project <path>   Project root directory (default: current directory)
   --force            Clear and rebuild the entire index from scratch
   --estimate-only    Show cost estimate without indexing
-  --verbose          Show detailed info about skipped files and parsing failures
+  --verbose          Show detailed info about skipped files and parsing failures,
+                     plus all internal log entries (info/debug) on the console
   -h, --help         Show this help message`);
     return;
   }
@@ -62,8 +66,53 @@ Options:
   const { project, force, estimateOnly, verbose } = parseIndexArgs(argv);
   const rawConfig = loadMergedConfig(project);
   const config = parseConfig(rawConfig);
-  const indexer = new Indexer(project, config);
 
+  // Echo the resolved config so the user can confirm which settings the run
+  // is actually using (project + global + defaults all merged).
+  console.error(`Project root: ${project}`);
+  console.error("Resolved config:");
+  console.error(JSON.stringify(config, null, 2));
+  console.error("");
+
+  // Wire the global Logger to mirror entries to stderr. CLI runs are
+  // interactive, so warn/error are surfaced by default and --verbose adds
+  // info/debug. We force debug.enabled when verbose so shouldLog() gates
+  // do not silence the very output the flag was meant to enable.
+  if (verbose) {
+    config.debug.enabled = true;
+    config.debug.logLevel = "debug";
+  }
+  const logger = initializeLogger(config.debug);
+  logger.setConsoleOutput(true, verbose ? "debug" : "warn");
+
+  // Resolve progress log path against the project root for relative paths.
+  const rawProgressLogFile = config.debug.progressLogFile;
+  const progressLogFile = rawProgressLogFile
+    ? path.isAbsolute(rawProgressLogFile)
+      ? rawProgressLogFile
+      : path.resolve(project, rawProgressLogFile)
+    : undefined;
+  if (progressLogFile) {
+    console.error(`Progress log: ${progressLogFile}`);
+    console.error("");
+  }
+
+  // De-duplicate identical progress snapshots so we don't spam stderr or the
+  // log file with repeats from the embedding loop.
+  let lastSnapshot = "";
+  const onProgress = (progress: IndexProgress): void => {
+    const snapshot = `${progress.phase}:${progress.filesProcessed}/${progress.totalFiles}:${progress.chunksProcessed}/${progress.totalChunks}:${progress.currentFiles?.join(",") ?? progress.currentFile ?? ""}`;
+    if (snapshot === lastSnapshot) return;
+    lastSnapshot = snapshot;
+
+    const message = formatProgressTitle(progress);
+    console.error(message);
+    if (progressLogFile) {
+      writeProgressLog(progressLogFile, message);
+    }
+  };
+
+  const indexer = new Indexer(project, config);
   await indexer.initialize();
 
   if (estimateOnly) {
@@ -73,16 +122,16 @@ Options:
   }
 
   if (force) {
-    console.log("Clearing existing index...");
+    console.error("Clearing existing index...");
     await indexer.clearIndex();
     const freshIndexer = new Indexer(project, config);
     await freshIndexer.initialize();
-    console.log("Indexing...");
-    const stats = await freshIndexer.index();
+    console.error("Indexing...");
+    const stats = await freshIndexer.index(onProgress);
     console.log(formatIndexStats(stats, verbose));
   } else {
-    console.log("Indexing...");
-    const stats = await indexer.index();
+    console.error("Indexing...");
+    const stats = await indexer.index(onProgress);
     console.log(formatIndexStats(stats, verbose));
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,9 @@ import { parseConfig } from "./config/schema.js";
 import { handleEvalCommand } from "./eval/cli.js";
 import { createMcpServer } from "./mcp-server.js";
 import { loadMergedConfig } from "./config/merger.js";
+import { Indexer } from "./indexer/index.js";
+import { formatIndexStats } from "./tools/utils.js";
+import { formatCostEstimate } from "./utils/cost.js";
 
 function parseArgs(argv: string[]): { project: string; config?: string } {
   let project = process.cwd();
@@ -22,10 +25,77 @@ function parseArgs(argv: string[]): { project: string; config?: string } {
   return { project, config };
 }
 
+function parseIndexArgs(argv: string[]): { project: string; force: boolean; estimateOnly: boolean; verbose: boolean } {
+  let project = process.cwd();
+  let force = false;
+  let estimateOnly = false;
+  let verbose = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project" && argv[i + 1]) {
+      project = path.resolve(argv[++i]);
+    } else if (argv[i] === "--force") {
+      force = true;
+    } else if (argv[i] === "--estimate-only") {
+      estimateOnly = true;
+    } else if (argv[i] === "--verbose") {
+      verbose = true;
+    }
+  }
+
+  return { project, force, estimateOnly, verbose };
+}
+
+async function handleIndexCommand(argv: string[]): Promise<void> {
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    console.log(`Usage: opencode-codebase-index-mcp index [options]
+
+Options:
+  --project <path>   Project root directory (default: current directory)
+  --force            Clear and rebuild the entire index from scratch
+  --estimate-only    Show cost estimate without indexing
+  --verbose          Show detailed info about skipped files and parsing failures
+  -h, --help         Show this help message`);
+    return;
+  }
+
+  const { project, force, estimateOnly, verbose } = parseIndexArgs(argv);
+  const rawConfig = loadMergedConfig(project);
+  const config = parseConfig(rawConfig);
+  const indexer = new Indexer(project, config);
+
+  await indexer.initialize();
+
+  if (estimateOnly) {
+    const estimate = await indexer.estimateCost();
+    console.log(formatCostEstimate(estimate));
+    return;
+  }
+
+  if (force) {
+    console.log("Clearing existing index...");
+    await indexer.clearIndex();
+    const freshIndexer = new Indexer(project, config);
+    await freshIndexer.initialize();
+    console.log("Indexing...");
+    const stats = await freshIndexer.index();
+    console.log(formatIndexStats(stats, verbose));
+  } else {
+    console.log("Indexing...");
+    const stats = await indexer.index();
+    console.log(formatIndexStats(stats, verbose));
+  }
+}
+
 async function main(): Promise<void> {
   if (process.argv[2] === "eval") {
     const exitCode = await handleEvalCommand(process.argv.slice(3), process.cwd());
     process.exit(exitCode);
+  }
+
+  if (process.argv[2] === "index") {
+    await handleIndexCommand(process.argv.slice(3));
+    return;
   }
 
   const args = parseArgs(process.argv);

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -111,7 +111,7 @@ export function loadProjectConfigLayer(projectRoot: string): Record<string, unkn
 
 /**
  * Loads and merges global and project configs.
- * 
+ *
  * Merge rules:
  * - Global config is the base
  * - For most fields: project overrides global if set, otherwise load global (fallback)
@@ -172,6 +172,30 @@ export function loadMergedConfig(projectRoot: string): unknown {
     merged.reranker = globalConfig.reranker;
   }
 
+  // For database: deep merge pgvector sub-object so project can override just specific fields
+  if (projectConfig && "database" in normalizedProjectConfig) {
+    const projectDb = normalizedProjectConfig.database as Record<string, unknown> | undefined;
+    const globalDb = globalConfig && (globalConfig.database as Record<string, unknown> | undefined);
+
+    if (projectDb) {
+      if (globalDb && projectDb.pgvector && globalDb.pgvector) {
+        // Deep merge pgvector: global base + project overrides
+        merged.database = {
+          ...projectDb,
+          pgvector: {
+            ...(globalDb.pgvector as Record<string, unknown>),
+            ...(projectDb.pgvector as Record<string, unknown>),
+          },
+        };
+      } else {
+        // Project has pgvector but global doesn't, or full override
+        merged.database = projectDb;
+      }
+    }
+  } else if (globalConfig && globalConfig.database) {
+    merged.database = globalConfig.database;
+  }
+
   // For include: project overrides if set, otherwise use global
   if (projectConfig && "include" in normalizedProjectConfig) {
     merged.include = normalizedProjectConfig.include;
@@ -186,23 +210,29 @@ export function loadMergedConfig(projectRoot: string): unknown {
     merged.exclude = globalConfig.exclude;
   }
 
-  // For indexing: project overrides if set, otherwise use global
+  // For indexing: deep merge so project can override individual sub-keys
   if (projectConfig && "indexing" in normalizedProjectConfig) {
-    merged.indexing = normalizedProjectConfig.indexing;
+    const globalIndexing = globalConfig && (globalConfig.indexing as Record<string, unknown> | undefined);
+    const projectIndexing = normalizedProjectConfig.indexing as Record<string, unknown> | undefined;
+    merged.indexing = projectIndexing ? { ...(globalIndexing ?? {}), ...projectIndexing } : globalIndexing;
   } else if (globalConfig && globalConfig.indexing) {
     merged.indexing = globalConfig.indexing;
   }
 
-  // For search: project overrides if set, otherwise use global
+  // For search: deep merge so project can override individual sub-keys
   if (projectConfig && "search" in normalizedProjectConfig) {
-    merged.search = normalizedProjectConfig.search;
+    const globalSearch = globalConfig && (globalConfig.search as Record<string, unknown> | undefined);
+    const projectSearch = normalizedProjectConfig.search as Record<string, unknown> | undefined;
+    merged.search = projectSearch ? { ...(globalSearch ?? {}), ...projectSearch } : globalSearch;
   } else if (globalConfig && globalConfig.search) {
     merged.search = globalConfig.search;
   }
 
-  // For debug: project overrides if set, otherwise use global
+  // For debug: deep merge so project can override individual sub-keys
   if (projectConfig && "debug" in normalizedProjectConfig) {
-    merged.debug = normalizedProjectConfig.debug;
+    const globalDebug = globalConfig && (globalConfig.debug as Record<string, unknown> | undefined);
+    const projectDebug = normalizedProjectConfig.debug as Record<string, unknown> | undefined;
+    merged.debug = projectDebug ? { ...(globalDebug ?? {}), ...projectDebug } : globalDebug;
   } else if (globalConfig && globalConfig.debug) {
     merged.debug = globalConfig.debug;
   }
@@ -222,6 +252,7 @@ export function loadMergedConfig(projectRoot: string): unknown {
         key === "customProvider" ||
         key === "embeddingModel" ||
         key === "reranker" ||
+        key === "database" ||
         key === "include" ||
         key === "exclude" ||
         key === "indexing" ||

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -120,7 +120,7 @@ export function loadProjectConfigLayer(projectRoot: string): Record<string, unkn
  * - For include/exclude: project overrides global if set, otherwise load global
  */
 export function loadMergedConfig(projectRoot: string): unknown {
-  const globalConfigPath = os.homedir() + "/.config/opencode/codebase-index.json";
+  const globalConfigPath = (process.env["HOME"] ?? process.env["USERPROFILE"] ?? os.homedir()) + "/.config/opencode/codebase-index.json";
   const globalConfig = loadJsonFile(globalConfigPath) as Record<string, unknown> | null;
   const projectConfigPath = resolveProjectConfigPath(projectRoot);
   const projectConfig = loadJsonFile(projectConfigPath) as Record<string, unknown> | null;

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -1,8 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import * as os from "os";
 import * as path from "path";
 
-import { resolveProjectConfigPath } from "./paths.js";
+import { getHomeDir, resolveProjectConfigPath } from "./paths.js";
 
 function loadJsonFile(filePath: string): unknown {
   try {
@@ -120,7 +119,7 @@ export function loadProjectConfigLayer(projectRoot: string): Record<string, unkn
  * - For include/exclude: project overrides global if set, otherwise load global
  */
 export function loadMergedConfig(projectRoot: string): unknown {
-  const globalConfigPath = (process.env["HOME"] ?? process.env["USERPROFILE"] ?? os.homedir()) + "/.config/opencode/codebase-index.json";
+  const globalConfigPath = getHomeDir() + "/.config/opencode/codebase-index.json";
   const globalConfig = loadJsonFile(globalConfigPath) as Record<string, unknown> | null;
   const projectConfigPath = resolveProjectConfigPath(projectRoot);
   const projectConfig = loadJsonFile(projectConfigPath) as Record<string, unknown> | null;

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -2,12 +2,19 @@ import { existsSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
-// os.homedir() uses native system calls and ignores process.env overrides on
-// Windows and some Linux configurations.  Read env vars first so that
-// vi.stubEnv("HOME"/"USERPROFILE") works correctly in tests.
+// Prefer env-var overrides so vi.stubEnv("HOME"/"USERPROFILE") works in tests,
+// but validate with existsSync first. On Windows, tools like Git Bash set HOME
+// to a Unix-style path (e.g. /c/Users/foo) that doesn't resolve on the Windows
+// filesystem; os.homedir() handles that case correctly.
 function getHomeDir(): string {
-  return process.env["HOME"] ?? process.env["USERPROFILE"] ?? os.homedir();
+  const fromEnv = process.env["HOME"] ?? process.env["USERPROFILE"];
+  if (fromEnv && existsSync(fromEnv)) {
+    return fromEnv;
+  }
+  return os.homedir();
 }
+
+export { getHomeDir };
 
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -2,6 +2,13 @@ import { existsSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
+// os.homedir() uses native system calls and ignores process.env overrides on
+// Windows and some Linux configurations.  Read env vars first so that
+// vi.stubEnv("HOME"/"USERPROFILE") works correctly in tests.
+function getHomeDir(): string {
+  return process.env["HOME"] ?? process.env["USERPROFILE"] ?? os.homedir();
+}
+
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
 
 const PROJECT_CONFIG_RELATIVE_PATH = path.join(".opencode", "codebase-index.json");
@@ -22,7 +29,7 @@ function hasProjectConfig(projectRoot: string): boolean {
 }
 
 export function getGlobalIndexPath(): string {
-  return path.join(os.homedir(), ".opencode", "global-index");
+  return path.join(getHomeDir(), ".opencode", "global-index");
 }
 
 export function resolveProjectConfigPath(projectRoot: string): string {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -7,6 +7,12 @@ export type IndexScope = "project" | "global";
 
 export interface IndexingConfig {
   autoIndex: boolean;
+  /**
+   * When true, skips calling indexer.index() on plugin load even if autoIndex is true.
+   * Useful for MCP servers or environments where you want explicit control over indexing.
+   * Default: false
+   */
+  skipAutoIndexOnLoad: boolean;
   watchFiles: boolean;
   maxFileSize: number;
   maxChunksPerFile: number;
@@ -82,6 +88,65 @@ export interface DebugConfig {
   metrics: boolean;
 }
 
+// ── Database Engine ────────────────────────────────────────────────────────
+
+export type DatabaseEngine = "sqlite" | "pgvector";
+
+/**
+ * Connection settings for a PostgreSQL/pgvector remote database backend.
+ * Provide either `connectionString` OR the individual host/port/… fields.
+ */
+export interface PgVectorConfig {
+  /**
+   * Full PostgreSQL connection string, e.g.
+   * "postgresql://user:pass@host:5432/dbname"
+   * When set, all other individual fields are ignored.
+   */
+  connectionString?: string;
+  /** Hostname of the PostgreSQL server. Default: "localhost" */
+  host?: string;
+  /** Port number. Default: 5432 */
+  port?: number;
+  /** Database name. Default: "postgres" */
+  database?: string;
+  /** PostgreSQL user. Default: "postgres" */
+  user?: string;
+  /** PostgreSQL password */
+  password?: string;
+  /**
+   * Maximum number of connections in the pool.
+   * Default: 10
+   */
+  poolSize?: number;
+  /**
+   * Table name prefix used for all codebase-index tables.
+   * Allows multiple independent indexes in the same database.
+   * Default: "ci"
+   */
+  tablePrefix?: string;
+  /**
+   * Connection timeout in milliseconds.
+   * Default: 5000
+   */
+  connectionTimeoutMs?: number;
+  /**
+   * SSL mode: "disable" | "require" | "verify-full".
+   * Default: "disable"
+   */
+  ssl?: "disable" | "require" | "verify-full";
+}
+
+export interface DatabaseConfig {
+  /**
+   * Storage engine to use.
+   * "sqlite" uses the local native SQLite + usearch index (default).
+   * "pgvector" stores everything in a remote PostgreSQL database with the pgvector extension.
+   */
+  engine: DatabaseEngine;
+  /** Required when engine = "pgvector". Contains pg connection settings. */
+  pgvector?: PgVectorConfig;
+}
+
 export interface CustomProviderConfig {
   /** Base URL of the OpenAI-compatible embeddings API. The path /embeddings is appended automatically (e.g. "http://localhost:11434/v1", "https://api.example.com/v1") */
   baseUrl: string;
@@ -106,6 +171,8 @@ export interface CustomProviderConfig {
 export interface CodebaseIndexConfig {
   embeddingProvider: EmbeddingProvider | 'custom' | 'auto';
   embeddingModel?: EmbeddingModelName;
+  /** Database backend configuration. Defaults to sqlite if omitted. */
+  database?: Partial<DatabaseConfig>;
   /** Configuration for custom OpenAI-compatible embedding providers (required when embeddingProvider is 'custom') */
   customProvider?: CustomProviderConfig;
   scope: IndexScope;
@@ -129,6 +196,7 @@ export type ParsedCodebaseIndexConfig = CodebaseIndexConfig & {
   search: SearchConfig;
   debug: DebugConfig;
   reranker?: RerankerConfig;
+  database: DatabaseConfig;
   knowledgeBases: string[];
   additionalInclude: string[];
 };
@@ -136,6 +204,7 @@ export type ParsedCodebaseIndexConfig = CodebaseIndexConfig & {
 function getDefaultIndexingConfig(): IndexingConfig {
   return {
     autoIndex: false,
+    skipAutoIndexOnLoad: false,
     watchFiles: true,
     maxFileSize: 1048576,
     maxChunksPerFile: 100,
@@ -183,6 +252,16 @@ function getDefaultRerankerBaseUrl(provider: RerankerProvider): string {
     case "custom":
       return "";
   }
+}
+
+function getDefaultDatabaseConfig(): DatabaseConfig {
+  return {
+    engine: "sqlite",
+  };
+}
+
+function isValidDatabaseEngine(value: unknown): value is DatabaseEngine {
+  return value === "sqlite" || value === "pgvector";
 }
 
 function getDefaultDebugConfig(): DebugConfig {
@@ -254,6 +333,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
   const rawIndexing = (input.indexing && typeof input.indexing === "object" ? input.indexing : {}) as Record<string, unknown>;
   const indexing: IndexingConfig = {
     autoIndex: typeof rawIndexing.autoIndex === "boolean" ? rawIndexing.autoIndex : defaultIndexing.autoIndex,
+    skipAutoIndexOnLoad: typeof rawIndexing.skipAutoIndexOnLoad === "boolean" ? rawIndexing.skipAutoIndexOnLoad : defaultIndexing.skipAutoIndexOnLoad,
     watchFiles: typeof rawIndexing.watchFiles === "boolean" ? rawIndexing.watchFiles : defaultIndexing.watchFiles,
     maxFileSize: typeof rawIndexing.maxFileSize === "number" ? rawIndexing.maxFileSize : defaultIndexing.maxFileSize,
     maxChunksPerFile: typeof rawIndexing.maxChunksPerFile === "number" ? Math.max(1, rawIndexing.maxChunksPerFile) : defaultIndexing.maxChunksPerFile,
@@ -308,7 +388,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
   let embeddingModel: EmbeddingModelName | undefined = undefined;
   let customProvider: CustomProviderConfig | undefined = undefined;
   let reranker: RerankerConfig | undefined = undefined;
-  
+
   if (embeddingProviderValue === 'custom') {
     embeddingProvider = 'custom';
     const rawCustom = (input.customProvider && typeof input.customProvider === 'object' ? input.customProvider : null) as Record<string, unknown> | null;
@@ -394,6 +474,54 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     };
   }
 
+  // ── Database backend ──────────────────────────────────────────────
+  const defaultDatabase = getDefaultDatabaseConfig();
+  const rawDatabase = (input.database && typeof input.database === "object" ? input.database : {}) as Record<string, unknown>;
+  const engine = isValidDatabaseEngine(rawDatabase.engine) ? rawDatabase.engine : defaultDatabase.engine;
+
+  let pgvector: PgVectorConfig | undefined = undefined;
+  if (engine === "pgvector") {
+    const rawPg = (rawDatabase.pgvector && typeof rawDatabase.pgvector === "object"
+      ? rawDatabase.pgvector
+      : {}) as Record<string, unknown>;
+
+    const connectionString = getResolvedString(rawPg.connectionString, "$root.database.pgvector.connectionString");
+    const host = getResolvedString(rawPg.host, "$root.database.pgvector.host");
+    const user = getResolvedString(rawPg.user, "$root.database.pgvector.user");
+    const password = getResolvedString(rawPg.password, "$root.database.pgvector.password");
+    const dbName = getResolvedString(rawPg.database, "$root.database.pgvector.database");
+
+    if (!connectionString && !host) {
+      throw new Error(
+        "database.engine is 'pgvector' but database.pgvector configuration is missing. " +
+        "Provide either connectionString or host/port/database/user/password."
+      );
+    }
+
+    const sslValue = rawPg.ssl;
+    const ssl: PgVectorConfig["ssl"] =
+      sslValue === "require" || sslValue === "verify-full" ? sslValue : "disable";
+
+    pgvector = {
+      connectionString: connectionString ?? undefined,
+      host: host ?? undefined,
+      port: typeof rawPg.port === "number" ? rawPg.port : undefined,
+      database: dbName ?? undefined,
+      user: user ?? undefined,
+      password: password ?? undefined,
+      poolSize: typeof rawPg.poolSize === "number" ? Math.max(1, Math.floor(rawPg.poolSize)) : undefined,
+      tablePrefix: typeof rawPg.tablePrefix === "string" && rawPg.tablePrefix.trim().length > 0
+        ? rawPg.tablePrefix.trim().replace(/[^a-zA-Z0-9_]/g, "_")
+        : undefined,
+      connectionTimeoutMs: typeof rawPg.connectionTimeoutMs === "number"
+        ? Math.max(1000, rawPg.connectionTimeoutMs)
+        : undefined,
+      ssl,
+    };
+  }
+
+  const database: DatabaseConfig = { engine, pgvector };
+
   return {
     embeddingProvider,
     embeddingModel,
@@ -406,6 +534,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     search,
     debug,
     reranker,
+    database,
     knowledgeBases,
   };
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -42,6 +42,12 @@ export interface IndexingConfig {
    * instead of skipping the rest of the file. Default: true
    */
   fallbackToTextOnMaxChunks: boolean;
+  /**
+   * Number of changed files to process per batch during indexing.
+   * Lower values reduce peak memory at the cost of more DB round-trips.
+   * Default: 100
+   */
+  fileBatchSize: number;
 }
 
 export interface SearchConfig {
@@ -86,6 +92,8 @@ export interface DebugConfig {
   logGc: boolean;
   logBranch: boolean;
   metrics: boolean;
+  /** When set, indexing progress lines are appended to this file path (useful for tail -f monitoring). */
+  progressLogFile?: string;
 }
 
 // ── Database Engine ────────────────────────────────────────────────────────
@@ -218,6 +226,7 @@ function getDefaultIndexingConfig(): IndexingConfig {
     maxDepth: 5,
     maxFilesPerDirectory: 100,
     fallbackToTextOnMaxChunks: true,
+    fileBatchSize: 100,
   };
 }
 
@@ -274,6 +283,7 @@ function getDefaultDebugConfig(): DebugConfig {
     logGc: true,
     logBranch: true,
     metrics: true,
+    progressLogFile: undefined,
   };
 }
 
@@ -347,6 +357,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     maxDepth: typeof rawIndexing.maxDepth === "number" ? (rawIndexing.maxDepth < -1 ? -1 : rawIndexing.maxDepth) : defaultIndexing.maxDepth,
     maxFilesPerDirectory: typeof rawIndexing.maxFilesPerDirectory === "number" ? Math.max(1, rawIndexing.maxFilesPerDirectory) : defaultIndexing.maxFilesPerDirectory,
     fallbackToTextOnMaxChunks: typeof rawIndexing.fallbackToTextOnMaxChunks === "boolean" ? rawIndexing.fallbackToTextOnMaxChunks : defaultIndexing.fallbackToTextOnMaxChunks,
+    fileBatchSize: typeof rawIndexing.fileBatchSize === "number" ? Math.max(1, rawIndexing.fileBatchSize) : defaultIndexing.fileBatchSize,
   };
 
   const rawSearch = (input.search && typeof input.search === "object" ? input.search : {}) as Record<string, unknown>;
@@ -372,6 +383,9 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     logGc: typeof rawDebug.logGc === "boolean" ? rawDebug.logGc : defaultDebug.logGc,
     logBranch: typeof rawDebug.logBranch === "boolean" ? rawDebug.logBranch : defaultDebug.logBranch,
     metrics: typeof rawDebug.metrics === "boolean" ? rawDebug.metrics : defaultDebug.metrics,
+    progressLogFile: typeof rawDebug.progressLogFile === "string" && rawDebug.progressLogFile.trim().length > 0
+      ? rawDebug.progressLogFile.trim()
+      : undefined,
   };
 
   const rawKnowledgeBases = input.knowledgeBases;

--- a/src/db/backend.ts
+++ b/src/db/backend.ts
@@ -42,13 +42,20 @@ export interface IVectorStoreBackend {
   /** Persist in-memory state to disk / remote.  No-op for pgvector. */
   save(): Promise<void>;
 
-  add(id: string, vector: number[], metadata: ChunkMetadata): Promise<void>;
+  add(id: string, vector: number[], metadata: ChunkMetadata, sourceId?: string): Promise<void>;
 
   addBatch(
-    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>
+    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>,
+    sourceId?: string
   ): Promise<void>;
 
-  search(queryVector: number[], limit: number): Promise<VectorSearchResult[]>;
+  /**
+   * Search for nearest neighbours.
+   * @param sourceIds  When provided, restrict results to chunks belonging to
+   *                   these sources.  Ignored by the SQLite backend (single-
+   *                   project files have no cross-source ambiguity).
+   */
+  search(queryVector: number[], limit: number, sourceIds?: string[]): Promise<VectorSearchResult[]>;
 
   remove(id: string): Promise<boolean>;
 
@@ -85,6 +92,21 @@ export interface IDatabaseBackend {
   /** Close any open connections / file handles. */
   close(): Promise<void>;
 
+  /**
+   * Whether this backend supports per-source isolation via source IDs.
+   * pgvector returns true; SQLite returns false (single-project-per-file,
+   * isolation is handled by the projectHash:branch catalog key instead).
+   */
+  supportsSourceIsolation(): boolean;
+
+  /**
+   * Register or retrieve a source (project root or knowledge-base root).
+   * Returns a stable source ID (hash of rootPath) that is used to tag all
+   * data written by that source.
+   * No-op on SQLite (returns hash of rootPath without persisting).
+   */
+  getOrCreateSource(rootPath: string): Promise<string>;
+
   // ── Embeddings ──────────────────────────────────────────────────
 
   embeddingExists(contentHash: string): Promise<boolean>;
@@ -113,34 +135,46 @@ export interface IDatabaseBackend {
 
   upsertChunk(chunk: ChunkData): Promise<void>;
 
-  upsertChunksBatch(chunks: ChunkData[]): Promise<void>;
+  /** @param sourceId  Ignored by SQLite (no Rust-layer column yet). Defaults to '' when omitted. */
+  upsertChunksBatch(chunks: ChunkData[], sourceId?: string): Promise<void>;
 
   getChunk(chunkId: string): Promise<ChunkData | null>;
 
-  getChunksByFile(filePath: string): Promise<ChunkData[]>;
+  /** @param sourceId  Ignored by SQLite. Omit to return chunks from all sources. */
+  getChunksByFile(filePath: string, sourceId?: string): Promise<ChunkData[]>;
 
   getChunksByName(name: string): Promise<ChunkData[]>;
 
   getChunksByNameCi(name: string): Promise<ChunkData[]>;
 
-  deleteChunksByFile(filePath: string): Promise<number>;
+  /** @param sourceId  Ignored by SQLite. Omit to delete across all sources. */
+  deleteChunksByFile(filePath: string, sourceId?: string): Promise<number>;
 
-  /** All distinct file paths that have at least one chunk stored. */
-  getChunkFilePaths(): Promise<string[]>;
+  /**
+   * All distinct file paths that have at least one chunk stored.
+   * @param sourceId  Scoped to this source. Ignored by SQLite (returns all paths). Omit for all sources.
+   */
+  getChunkFilePaths(sourceId?: string): Promise<string[]>;
 
   // ── Branch catalog ───────────────────────────────────────────────
 
   addChunksToBranch(branch: string, chunkIds: string[]): Promise<void>;
 
-  addChunksToBranchBatch(branch: string, chunkIds: string[]): Promise<void>;
+  /** @param sourceId  Ignored by SQLite (branch key encodes project identity). Defaults to '' when omitted. */
+  addChunksToBranchBatch(branch: string, chunkIds: string[], sourceId?: string): Promise<void>;
 
-  clearBranch(branch: string): Promise<number>;
+  /** @param sourceId  Ignored by SQLite. Omit to clear across all sources. */
+  clearBranch(branch: string, sourceId?: string): Promise<number>;
 
   deleteBranchChunksByChunkIds(chunkIds: string[]): Promise<number>;
 
   deleteBranchChunksForBranch(branch: string, chunkIds: string[]): Promise<number>;
 
-  getBranchChunkIds(branch: string): Promise<string[]>;
+  /**
+   * IDs of chunks on this branch, optionally restricted to given sources.
+   * @param sourceIds  Ignored by SQLite.
+   */
+  getBranchChunkIds(branch: string, sourceIds?: string[]): Promise<string[]>;
 
   getBranchDelta(branch: string, baseBranch: string): Promise<BranchDelta>;
 
@@ -174,9 +208,11 @@ export interface IDatabaseBackend {
 
   upsertSymbol(symbol: SymbolData): Promise<void>;
 
-  upsertSymbolsBatch(symbols: SymbolData[]): Promise<void>;
+  /** @param sourceId  Ignored by SQLite. Defaults to '' when omitted. */
+  upsertSymbolsBatch(symbols: SymbolData[], sourceId?: string): Promise<void>;
 
-  getSymbolsByFile(filePath: string): Promise<SymbolData[]>;
+  /** @param sourceId  Ignored by SQLite. Omit to return symbols from all sources. */
+  getSymbolsByFile(filePath: string, sourceId?: string): Promise<SymbolData[]>;
 
   getSymbolByName(name: string, filePath: string): Promise<SymbolData | null>;
 
@@ -184,21 +220,27 @@ export interface IDatabaseBackend {
 
   getSymbolsByNameCi(name: string): Promise<SymbolData[]>;
 
-  deleteSymbolsByFile(filePath: string): Promise<number>;
+  /** @param sourceId  Ignored by SQLite. Omit to delete across all sources. */
+  deleteSymbolsByFile(filePath: string, sourceId?: string): Promise<number>;
 
   // ── Call edges ───────────────────────────────────────────────────
 
   upsertCallEdge(edge: CallEdgeData): Promise<void>;
 
-  upsertCallEdgesBatch(edges: CallEdgeData[]): Promise<void>;
+  /** @param sourceId  Ignored by SQLite. Defaults to '' when omitted. */
+  upsertCallEdgesBatch(edges: CallEdgeData[], sourceId?: string): Promise<void>;
 
-  getCallers(targetName: string, branch: string): Promise<CallEdgeData[]>;
+  /** @param sourceIds  Ignored by SQLite. */
+  getCallers(targetName: string, branch: string, sourceIds?: string[]): Promise<CallEdgeData[]>;
 
-  getCallersWithContext(targetName: string, branch: string): Promise<CallEdgeData[]>;
+  /** @param sourceIds  Ignored by SQLite. */
+  getCallersWithContext(targetName: string, branch: string, sourceIds?: string[]): Promise<CallEdgeData[]>;
 
-  getCallees(symbolId: string, branch: string): Promise<CallEdgeData[]>;
+  /** @param sourceIds  Ignored by SQLite. */
+  getCallees(symbolId: string, branch: string, sourceIds?: string[]): Promise<CallEdgeData[]>;
 
-  deleteCallEdgesByFile(filePath: string): Promise<number>;
+  /** @param sourceId  Ignored by SQLite. Omit to delete across all sources. */
+  deleteCallEdgesByFile(filePath: string, sourceId?: string): Promise<number>;
 
   resolveCallEdge(edgeId: string, toSymbolId: string): Promise<void>;
 
@@ -206,11 +248,16 @@ export interface IDatabaseBackend {
 
   addSymbolsToBranch(branch: string, symbolIds: string[]): Promise<void>;
 
-  addSymbolsToBranchBatch(branch: string, symbolIds: string[]): Promise<void>;
+  /** @param sourceId  Ignored by SQLite. Defaults to '' when omitted. */
+  addSymbolsToBranchBatch(branch: string, symbolIds: string[], sourceId?: string): Promise<void>;
 
-  getBranchSymbolIds(branch: string): Promise<string[]>;
+  /**
+   * @param sourceIds  Ignored by SQLite.
+   */
+  getBranchSymbolIds(branch: string, sourceIds?: string[]): Promise<string[]>;
 
-  clearBranchSymbols(branch: string): Promise<number>;
+  /** @param sourceId  Ignored by SQLite. Omit to clear across all sources. */
+  clearBranchSymbols(branch: string, sourceId?: string): Promise<number>;
 
   getReferencedSymbolIds(symbolIds: string[]): Promise<string[]>;
 
@@ -234,24 +281,31 @@ export interface IDatabaseBackend {
 
   getAllFileHashes(): Promise<Map<string, string>>;
 
-  setFileHashesBatch(hashes: Map<string, string>): Promise<void>;
+  /** @param sourceId  Scopes the batch to this source. Defaults to '' when omitted. */
+  setFileHashesBatch(hashes: Map<string, string>, sourceId?: string): Promise<void>;
 
   deleteFileHashesBatch(filePaths: string[]): Promise<void>;
 
-  /** Atomically replace the entire file-hash store with the given map. */
-  replaceAllFileHashes(hashes: Map<string, string>): Promise<void>;
+  /**
+   * Atomically replace the file-hash store for one source.
+   * @param sourceId  Scopes the replacement to this source only. Defaults to '' when omitted.
+   */
+  replaceAllFileHashes(hashes: Map<string, string>, sourceId?: string): Promise<void>;
 
-  /** Fetch stored hashes for only the given paths (avoids a full table load). */
-  getFileHashBatch(filePaths: string[]): Promise<Map<string, string>>;
+  /** Fetch stored hashes for the given paths scoped to one source. Defaults to '' when omitted. */
+  getFileHashBatch(filePaths: string[], sourceId?: string): Promise<Map<string, string>>;
 
-  /** True if the store contains any path not under any of the given roots. */
-  hasFileHashesOutsideRoots(roots: string[]): Promise<boolean>;
+  /**
+   * True if there are file hashes belonging to sources other than those listed.
+   * Used to detect foreign data in a shared DB.  SQLite always returns false.
+   */
+  hasSourcesOtherThan(sourceIds: string[]): Promise<boolean>;
 
-  /** All stored paths that fall under at least one of the given roots. */
-  getFilePathsInRoots(roots: string[]): Promise<string[]>;
+  /** All stored file paths for the given source. */
+  getFilePathsBySource(sourceId: string): Promise<string[]>;
 
-  /** Delete every hash record whose path is under any of the given roots. */
-  deleteFileHashesInRoots(roots: string[]): Promise<void>;
+  /** Delete all file hash records for the given source. */
+  deleteFileHashesBySource(sourceId: string): Promise<void>;
 
   // ── Inverted index ───────────────────────────────────────────────
 
@@ -261,8 +315,8 @@ export interface IDatabaseBackend {
 
   /**
    * Incrementally upsert posting data for a batch of chunks.
-   * For pgvector: writes directly to the posting tables (term, chunk_id, token_count)
-   * and doc_lengths table. For SQLite: no-op (in-memory Rust struct is authoritative).
+   * For pgvector: writes directly to the posting tables.
+   * For SQLite: no-op (in-memory Rust struct is authoritative).
    */
   upsertInvertedIndexChunkBatch(entries: Array<{ chunkId: string; content: string }>): Promise<void>;
 
@@ -276,9 +330,9 @@ export interface IDatabaseBackend {
   /**
    * BM25 keyword search against the persisted inverted index.
    * Returns null for SQLite (caller uses the in-memory Rust struct instead).
-   * pgvector returns scored results directly from the DB.
+   * @param sourceIds  Restrict results to these sources.  Ignored by SQLite.
    */
-  searchBm25(query: string, limit: number): Promise<Map<string, number> | null>;
+  searchBm25(query: string, limit: number, sourceIds?: string[]): Promise<Map<string, number> | null>;
 
   // ── Indexing lock ────────────────────────────────────────────────
 

--- a/src/db/backend.ts
+++ b/src/db/backend.ts
@@ -156,6 +156,10 @@ export interface IDatabaseBackend {
    */
   getChunkFilePaths(sourceId?: string): Promise<string[]>;
 
+  /** Return all distinct file paths stored in chunks that fall under at least one of the given root directories. */
+  getFilePathsInRoots(roots: string[]): Promise<string[]>;
+
+
   // ── Branch catalog ───────────────────────────────────────────────
 
   addChunksToBranch(branch: string, chunkIds: string[]): Promise<void>;

--- a/src/db/backend.ts
+++ b/src/db/backend.ts
@@ -1,0 +1,273 @@
+/**
+ * Abstract async interfaces for the database and vector-store backends.
+ *
+ * Both the SQLite (local) backend and the pgvector (remote) backend implement
+ * these interfaces.  All methods return Promises so that the pgvector backend
+ * can perform network I/O without blocking the Node.js event loop.  The SQLite
+ * backend wraps the synchronous native calls in Promise.resolve() with zero
+ * overhead.
+ */
+
+import type { ChunkData, BranchDelta, DatabaseStats, SymbolData, CallEdgeData, ChunkMetadata } from "../native/index.js";
+
+// Re-export so callers can import from a single location.
+export type { ChunkData, BranchDelta, DatabaseStats, SymbolData, CallEdgeData, ChunkMetadata };
+
+// ── Vector-store result type ────────────────────────────────────────────────
+
+export interface VectorSearchResult {
+  id: string;
+  score: number;
+  metadata: ChunkMetadata;
+}
+
+// ── IVectorStoreBackend ─────────────────────────────────────────────────────
+
+/**
+ * Async abstraction over a vector similarity-search store.
+ *
+ * For SQLite: backed by the native usearch index persisted as a local file.
+ * For pgvector: backed by a PostgreSQL table with a `vector` column.
+ */
+export interface IVectorStoreBackend {
+  /**
+   * Initialize (or validate) the store for the given embedding dimension.
+   * Called once per `Indexer.initialize()`.
+   */
+  initialize(dimensions: number): Promise<void>;
+
+  /** Load persisted state from disk / remote.  No-op for pgvector. */
+  load(): Promise<void>;
+
+  /** Persist in-memory state to disk / remote.  No-op for pgvector. */
+  save(): Promise<void>;
+
+  add(id: string, vector: number[], metadata: ChunkMetadata): Promise<void>;
+
+  addBatch(
+    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>
+  ): Promise<void>;
+
+  search(queryVector: number[], limit: number): Promise<VectorSearchResult[]>;
+
+  remove(id: string): Promise<boolean>;
+
+  count(): Promise<number>;
+
+  clear(): Promise<void>;
+
+  getDimensions(): number;
+
+  getAllKeys(): Promise<string[]>;
+
+  getAllMetadata(): Promise<Array<{ key: string; metadata: ChunkMetadata }>>;
+
+  getMetadata(id: string): Promise<ChunkMetadata | undefined>;
+
+  getMetadataBatch(ids: string[]): Promise<Map<string, ChunkMetadata>>;
+}
+
+// ── IDatabaseBackend ────────────────────────────────────────────────────────
+
+/**
+ * Async abstraction over the relational metadata + embedding store.
+ *
+ * For SQLite: backed by the native rusqlite bindings.
+ * For pgvector: backed by a PostgreSQL connection pool.
+ */
+export interface IDatabaseBackend {
+  /**
+   * Initialize the database schema (run migrations, create tables, etc.).
+   * Called once per `Indexer.initialize()`.
+   */
+  initialize(): Promise<void>;
+
+  /** Close any open connections / file handles. */
+  close(): Promise<void>;
+
+  // ── Embeddings ──────────────────────────────────────────────────
+
+  embeddingExists(contentHash: string): Promise<boolean>;
+
+  getEmbedding(contentHash: string): Promise<Buffer | null>;
+
+  upsertEmbedding(
+    contentHash: string,
+    embedding: Buffer,
+    chunkText: string,
+    model: string
+  ): Promise<void>;
+
+  upsertEmbeddingsBatch(
+    items: Array<{
+      contentHash: string;
+      embedding: Buffer;
+      chunkText: string;
+      model: string;
+    }>
+  ): Promise<void>;
+
+  getMissingEmbeddings(contentHashes: string[]): Promise<string[]>;
+
+  // ── Chunks ──────────────────────────────────────────────────────
+
+  upsertChunk(chunk: ChunkData): Promise<void>;
+
+  upsertChunksBatch(chunks: ChunkData[]): Promise<void>;
+
+  getChunk(chunkId: string): Promise<ChunkData | null>;
+
+  getChunksByFile(filePath: string): Promise<ChunkData[]>;
+
+  getChunksByName(name: string): Promise<ChunkData[]>;
+
+  getChunksByNameCi(name: string): Promise<ChunkData[]>;
+
+  deleteChunksByFile(filePath: string): Promise<number>;
+
+  // ── Branch catalog ───────────────────────────────────────────────
+
+  addChunksToBranch(branch: string, chunkIds: string[]): Promise<void>;
+
+  addChunksToBranchBatch(branch: string, chunkIds: string[]): Promise<void>;
+
+  clearBranch(branch: string): Promise<number>;
+
+  deleteBranchChunksByChunkIds(chunkIds: string[]): Promise<number>;
+
+  deleteBranchChunksForBranch(branch: string, chunkIds: string[]): Promise<number>;
+
+  getBranchChunkIds(branch: string): Promise<string[]>;
+
+  getBranchDelta(branch: string, baseBranch: string): Promise<BranchDelta>;
+
+  getReferencedChunkIds(chunkIds: string[]): Promise<string[]>;
+
+  chunkExistsOnBranch(branch: string, chunkId: string): Promise<boolean>;
+
+  getAllBranches(): Promise<string[]>;
+
+  // ── Metadata key-value store ─────────────────────────────────────
+
+  getMetadata(key: string): Promise<string | null>;
+
+  setMetadata(key: string, value: string): Promise<void>;
+
+  deleteMetadata(key: string): Promise<boolean>;
+
+  // ── Maintenance ─────────────────────────────────────────────────
+
+  clearAllIndexedData(): Promise<void>;
+
+  clearCallEdgeTargetsForSymbols(symbolIds: string[]): Promise<number>;
+
+  gcOrphanEmbeddings(): Promise<number>;
+
+  gcOrphanChunks(): Promise<number>;
+
+  getStats(): Promise<DatabaseStats>;
+
+  // ── Symbols ─────────────────────────────────────────────────────
+
+  upsertSymbol(symbol: SymbolData): Promise<void>;
+
+  upsertSymbolsBatch(symbols: SymbolData[]): Promise<void>;
+
+  getSymbolsByFile(filePath: string): Promise<SymbolData[]>;
+
+  getSymbolByName(name: string, filePath: string): Promise<SymbolData | null>;
+
+  getSymbolsByName(name: string): Promise<SymbolData[]>;
+
+  getSymbolsByNameCi(name: string): Promise<SymbolData[]>;
+
+  deleteSymbolsByFile(filePath: string): Promise<number>;
+
+  // ── Call edges ───────────────────────────────────────────────────
+
+  upsertCallEdge(edge: CallEdgeData): Promise<void>;
+
+  upsertCallEdgesBatch(edges: CallEdgeData[]): Promise<void>;
+
+  getCallers(targetName: string, branch: string): Promise<CallEdgeData[]>;
+
+  getCallersWithContext(targetName: string, branch: string): Promise<CallEdgeData[]>;
+
+  getCallees(symbolId: string, branch: string): Promise<CallEdgeData[]>;
+
+  deleteCallEdgesByFile(filePath: string): Promise<number>;
+
+  resolveCallEdge(edgeId: string, toSymbolId: string): Promise<void>;
+
+  // ── Branch symbols ───────────────────────────────────────────────
+
+  addSymbolsToBranch(branch: string, symbolIds: string[]): Promise<void>;
+
+  addSymbolsToBranchBatch(branch: string, symbolIds: string[]): Promise<void>;
+
+  getBranchSymbolIds(branch: string): Promise<string[]>;
+
+  clearBranchSymbols(branch: string): Promise<number>;
+
+  getReferencedSymbolIds(symbolIds: string[]): Promise<string[]>;
+
+  deleteBranchSymbolsBySymbolIds(symbolIds: string[]): Promise<number>;
+
+  deleteBranchSymbolsForBranch(branch: string, symbolIds: string[]): Promise<number>;
+
+  // ── GC for symbols / edges ───────────────────────────────────────
+
+  gcOrphanSymbols(): Promise<number>;
+
+  gcOrphanCallEdges(): Promise<number>;
+
+  // ── File hashes ──────────────────────────────────────────────────
+
+  getFileHash(filePath: string): Promise<string | null>;
+
+  setFileHash(filePath: string, hash: string): Promise<void>;
+
+  deleteFileHash(filePath: string): Promise<void>;
+
+  getAllFileHashes(): Promise<Map<string, string>>;
+
+  setFileHashesBatch(hashes: Map<string, string>): Promise<void>;
+
+  deleteFileHashesBatch(filePaths: string[]): Promise<void>;
+
+  /** Atomically replace the entire file-hash store with the given map. */
+  replaceAllFileHashes(hashes: Map<string, string>): Promise<void>;
+
+  /** Fetch stored hashes for only the given paths (avoids a full table load). */
+  getFileHashBatch(filePaths: string[]): Promise<Map<string, string>>;
+
+  /** True if the store contains any path not under any of the given roots. */
+  hasFileHashesOutsideRoots(roots: string[]): Promise<boolean>;
+
+  /** All stored paths that fall under at least one of the given roots. */
+  getFilePathsInRoots(roots: string[]): Promise<string[]>;
+
+  /** Delete every hash record whose path is under any of the given roots. */
+  deleteFileHashesInRoots(roots: string[]): Promise<void>;
+
+  // ── Inverted index ───────────────────────────────────────────────
+
+  saveInvertedIndex(json: string): Promise<void>;
+
+  loadInvertedIndex(): Promise<string | null>;
+
+  /**
+   * BM25 keyword search against the persisted inverted index.
+   * Returns null for SQLite (caller uses the in-memory Rust struct instead).
+   * pgvector returns scored results directly from the DB.
+   */
+  searchBm25(query: string, limit: number): Promise<Map<string, number> | null>;
+
+  // ── Indexing lock ────────────────────────────────────────────────
+
+  tryAcquireLock(pid: number, startedAt: string): Promise<boolean>;
+
+  releaseLock(): Promise<void>;
+
+  isLocked(): Promise<boolean>;
+}

--- a/src/db/backend.ts
+++ b/src/db/backend.ts
@@ -260,6 +260,20 @@ export interface IDatabaseBackend {
   loadInvertedIndex(): Promise<string | null>;
 
   /**
+   * Incrementally upsert posting data for a batch of chunks.
+   * For pgvector: writes directly to the posting tables (term, chunk_id, token_count)
+   * and doc_lengths table. For SQLite: no-op (in-memory Rust struct is authoritative).
+   */
+  upsertInvertedIndexChunkBatch(entries: Array<{ chunkId: string; content: string }>): Promise<void>;
+
+  /**
+   * Remove posting data for a batch of chunk IDs.
+   * For pgvector: deletes from posting and doc_lengths tables.
+   * For SQLite: no-op.
+   */
+  deleteInvertedIndexChunkBatch(chunkIds: string[]): Promise<void>;
+
+  /**
    * BM25 keyword search against the persisted inverted index.
    * Returns null for SQLite (caller uses the in-memory Rust struct instead).
    * pgvector returns scored results directly from the DB.
@@ -273,4 +287,6 @@ export interface IDatabaseBackend {
   releaseLock(): Promise<void>;
 
   isLocked(): Promise<boolean>;
+
+  getLockInfo(): Promise<{ pid: number; startedAt: string } | null>;
 }

--- a/src/db/backend.ts
+++ b/src/db/backend.ts
@@ -125,6 +125,9 @@ export interface IDatabaseBackend {
 
   deleteChunksByFile(filePath: string): Promise<number>;
 
+  /** All distinct file paths that have at least one chunk stored. */
+  getChunkFilePaths(): Promise<string[]>;
+
   // ── Branch catalog ───────────────────────────────────────────────
 
   addChunksToBranch(branch: string, chunkIds: string[]): Promise<void>;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Factory functions for creating database and vector-store backend instances.
+ *
+ * Callers should use these instead of constructing backends directly so that
+ * the correct implementation is selected based on the active configuration.
+ */
+
+import * as path from "path";
+import type { DatabaseConfig } from "../config/schema.js";
+import type { IDatabaseBackend, IVectorStoreBackend } from "./backend.js";
+import { SqliteDatabaseBackend, SqliteVectorStoreBackend } from "./sqlite-backend.js";
+import { PgDatabaseBackend, PgVectorStoreBackend } from "./pg-backend.js";
+
+export type { IDatabaseBackend, IVectorStoreBackend };
+export type { VectorSearchResult } from "./backend.js";
+export { SqliteDatabaseBackend, SqliteVectorStoreBackend } from "./sqlite-backend.js";
+export { PgDatabaseBackend, PgVectorStoreBackend } from "./pg-backend.js";
+
+// ── Database backend factory ─────────────────────────────────────────────────
+
+/**
+ * Create an IDatabaseBackend for the given config.
+ *
+ * @param config  The resolved DatabaseConfig from parseConfig().
+ * @param dbPath  Absolute path for the SQLite file (ignored for pgvector).
+ */
+export async function createDatabaseBackend(
+  config: DatabaseConfig,
+  dbPath: string
+): Promise<IDatabaseBackend> {
+  if (config.engine === "pgvector") {
+    if (!config.pgvector) {
+      throw new Error(
+        "[codebase-index] database.engine is 'pgvector' but no database.pgvector config was provided"
+      );
+    }
+    const backend = new PgDatabaseBackend(config.pgvector);
+    await backend.initialize();
+    return backend;
+  }
+
+  // Default: SQLite
+  const backend = new SqliteDatabaseBackend(dbPath);
+  await backend.initialize();
+  return backend;
+}
+
+// ── Vector store backend factory ─────────────────────────────────────────────
+
+/**
+ * Create an IVectorStoreBackend for the given config.
+ *
+ * @param config      The resolved DatabaseConfig from parseConfig().
+ * @param storePath   Base path for the usearch vector file (ignored for pgvector).
+ * @param dimensions  Embedding dimensions (must match the chosen model).
+ */
+export async function createVectorStoreBackend(
+  config: DatabaseConfig,
+  storePath: string,
+  dimensions: number
+): Promise<IVectorStoreBackend> {
+  if (config.engine === "pgvector") {
+    if (!config.pgvector) {
+      throw new Error(
+        "[codebase-index] database.engine is 'pgvector' but no database.pgvector config was provided"
+      );
+    }
+    const backend = new PgVectorStoreBackend(config.pgvector);
+    await backend.initialize(dimensions);
+    return backend;
+  }
+
+  // Default: SQLite / usearch
+  const vectorPath = path.join(storePath, "vectors");
+  const backend = new SqliteVectorStoreBackend(vectorPath);
+  await backend.initialize(dimensions);
+  return backend;
+}

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -721,16 +721,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
         CREATE INDEX IF NOT EXISTS ${this.t("call_edges_source_idx")}
           ON ${this.t("call_edges")} (source_id)
       `);
-      // Drop and recreate composite branch indexes: old definition was (branch)
-      // only; new definition is (source_id, branch) to support source filtering.
-      await client.query(`DROP INDEX IF EXISTS ${this.t("branch_chunks_branch_idx")}`);
+      // Add source-aware composite branch indexes. We intentionally use new
+      // names to avoid collisions with legacy branch-only indexes on existing
+      // databases and to keep migration idempotent across concurrent initializers.
       await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("branch_chunks_branch_idx")}
+        CREATE INDEX IF NOT EXISTS ${this.t("branch_chunks_source_branch_idx")}
           ON ${this.t("branch_chunks")} (source_id, branch)
       `);
-      await client.query(`DROP INDEX IF EXISTS ${this.t("branch_symbols_branch_idx")}`);
       await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("branch_symbols_branch_idx")}
+        CREATE INDEX IF NOT EXISTS ${this.t("branch_symbols_source_branch_idx")}
           ON ${this.t("branch_symbols")} (source_id, branch)
       `);
     });

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -168,9 +168,6 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
       await client.query("CREATE EXTENSION IF NOT EXISTS vector");
 
       // Create the chunk_vectors table with the correct dimension.
-      // We store the embedding as both a pgvector `vector` column (for ANN
-      // search) and — on the companion PgDatabaseBackend — as raw BYTEA for
-      // fast byte-exact retrieval.  Here we only manage the vector side.
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.vectorsTable} (
           chunk_id   TEXT PRIMARY KEY,

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -1403,71 +1403,103 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.length > 0;
   }
 
+  async getLockInfo(): Promise<{ pid: number; startedAt: string } | null> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ value: string }>(
+      `SELECT value FROM ${this.t("metadata")} WHERE key = 'indexing_lock'`
+    );
+    if (rows.length === 0) return null;
+    try {
+      return JSON.parse(rows[0].value) as { pid: number; startedAt: string };
+    } catch {
+      return null;
+    }
+  }
+
   // ── Inverted index (structured tables + SQL BM25) ────────────────
 
   /**
-   * Parse the Rust-serialized JSON and sync the full posting list to the DB.
-   * Replaces the entire table atomically so searches are always consistent.
+   * No-op for pgvector: posting tables are kept current by
+   * upsertInvertedIndexChunkBatch / deleteInvertedIndexChunkBatch as each
+   * chunk is processed, so there is nothing to bulk-sync at run end.
+   * The json argument (from the in-memory Rust struct) is intentionally ignored.
    */
-  async saveInvertedIndex(json: string): Promise<void> {
-    type IndexData = {
-      term_to_chunks: Record<string, string[]>;
-      chunk_tokens: Record<string, Record<string, number>>;
-      avg_doc_length: number;
-    };
-    const data: IndexData = JSON.parse(json);
-
-    // Compute per-chunk doc lengths from chunk_tokens
-    const docLengths = new Map<string, number>();
-    for (const [chunkId, tokens] of Object.entries(data.chunk_tokens)) {
-      const len = Object.values(tokens).reduce((s, n) => s + n, 0);
-      docLengths.set(chunkId, len);
-    }
-
-    await this.withClient(async (client) => {
-      await client.query("BEGIN");
-      await client.query(`TRUNCATE TABLE ${this.t("inverted_index_postings")}`);
-      await client.query(`TRUNCATE TABLE ${this.t("inverted_index_doc_lengths")}`);
-
-      // Batch insert postings
-      const postingRows: Array<[string, string, number]> = [];
-      for (const [term, chunkIds] of Object.entries(data.term_to_chunks)) {
-        for (const chunkId of chunkIds) {
-          const count = data.chunk_tokens[chunkId]?.[term] ?? 1;
-          postingRows.push([term, chunkId, count]);
-        }
-      }
-      // Insert in chunks to avoid overly large statements
-      const BATCH = 500;
-      for (let i = 0; i < postingRows.length; i += BATCH) {
-        const slice = postingRows.slice(i, i + BATCH);
-        const placeholders = slice.map((_, j) => `($${j * 3 + 1},$${j * 3 + 2},$${j * 3 + 3})`).join(",");
-        const values = slice.flat();
-        await client.query(
-          `INSERT INTO ${this.t("inverted_index_postings")} (term, chunk_id, token_count) VALUES ${placeholders}`,
-          values
-        );
-      }
-
-      // Insert doc lengths
-      const dlRows = Array.from(docLengths.entries());
-      for (let i = 0; i < dlRows.length; i += BATCH) {
-        const slice = dlRows.slice(i, i + BATCH);
-        const placeholders = slice.map((_, j) => `($${j * 2 + 1},$${j * 2 + 2})`).join(",");
-        const values = slice.flat();
-        await client.query(
-          `INSERT INTO ${this.t("inverted_index_doc_lengths")} (chunk_id, doc_len) VALUES ${placeholders}`,
-          values
-        );
-      }
-
-      await client.query("COMMIT");
-    });
-  }
+  async saveInvertedIndex(_json: string): Promise<void> {}
 
   /** For pgvector, always skip loading the Rust in-memory struct — SQL BM25 is used for search. */
   async loadInvertedIndex(): Promise<string | null> {
     return null;
+  }
+
+  async upsertInvertedIndexChunkBatch(entries: Array<{ chunkId: string; content: string }>): Promise<void> {
+    if (entries.length === 0) return;
+
+    const postingRows: Array<[string, string, number]> = [];
+    const docLengthRows: Array<[string, number]> = [];
+
+    for (const { chunkId, content } of entries) {
+      const termCounts = new Map<string, number>();
+      for (const term of tokenizeText(content)) {
+        termCounts.set(term, (termCounts.get(term) ?? 0) + 1);
+      }
+      let docLen = 0;
+      for (const [term, count] of termCounts) {
+        postingRows.push([term, chunkId, count]);
+        docLen += count;
+      }
+      docLengthRows.push([chunkId, docLen]);
+    }
+
+    const BATCH = 500;
+    const pool = await this.getPool();
+
+    // Upsert doc lengths
+    for (let i = 0; i < docLengthRows.length; i += BATCH) {
+      const slice = docLengthRows.slice(i, i + BATCH);
+      const placeholders = slice.map((_, j) => `($${j * 2 + 1},$${j * 2 + 2})`).join(",");
+      await pool.query(
+        `INSERT INTO ${this.t("inverted_index_doc_lengths")} (chunk_id, doc_len) VALUES ${placeholders}
+         ON CONFLICT (chunk_id) DO UPDATE SET doc_len = EXCLUDED.doc_len`,
+        slice.flat()
+      );
+    }
+
+    // Delete old postings for these chunks, then insert fresh ones
+    const chunkIds = entries.map(e => e.chunkId);
+    for (let i = 0; i < chunkIds.length; i += BATCH) {
+      const slice = chunkIds.slice(i, i + BATCH);
+      const placeholders = slice.map((_, j) => `$${j + 1}`).join(",");
+      await pool.query(
+        `DELETE FROM ${this.t("inverted_index_postings")} WHERE chunk_id IN (${placeholders})`,
+        slice
+      );
+    }
+    for (let i = 0; i < postingRows.length; i += BATCH) {
+      const slice = postingRows.slice(i, i + BATCH);
+      const placeholders = slice.map((_, j) => `($${j * 3 + 1},$${j * 3 + 2},$${j * 3 + 3})`).join(",");
+      await pool.query(
+        `INSERT INTO ${this.t("inverted_index_postings")} (term, chunk_id, token_count) VALUES ${placeholders}`,
+        slice.flat()
+      );
+    }
+  }
+
+  async deleteInvertedIndexChunkBatch(chunkIds: string[]): Promise<void> {
+    if (chunkIds.length === 0) return;
+    const pool = await this.getPool();
+    const BATCH = 500;
+    for (let i = 0; i < chunkIds.length; i += BATCH) {
+      const slice = chunkIds.slice(i, i + BATCH);
+      const placeholders = slice.map((_, j) => `$${j + 1}`).join(",");
+      await pool.query(
+        `DELETE FROM ${this.t("inverted_index_postings")} WHERE chunk_id IN (${placeholders})`,
+        slice
+      );
+      await pool.query(
+        `DELETE FROM ${this.t("inverted_index_doc_lengths")} WHERE chunk_id IN (${placeholders})`,
+        slice
+      );
+    }
   }
 
   async searchBm25(query: string, limit: number): Promise<Map<string, number> | null> {

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -955,6 +955,18 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map((r: { file_path: string }) => r.file_path);
   }
 
+  async getFilePathsInRoots(roots: string[]): Promise<string[]> {
+    if (roots.length === 0) return [];
+    const pool = await this.getPool();
+    const conditions = roots.map((_, i) => `file_path LIKE $${i + 1}`).join(" OR ");
+    const params = roots.map((root) => `${root}%`);
+    const { rows } = await pool.query<{ file_path: string }>(
+      `SELECT DISTINCT file_path FROM ${this.t("chunks")} WHERE ${conditions}`,
+      params
+    );
+    return rows.map((r) => r.file_path);
+  }
+
   // ── Branch catalog ────────────────────────────────────────────────
 
   async addChunksToBranch(branch: string, chunkIds: string[]): Promise<void> {

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -1,0 +1,1577 @@
+/**
+ * PostgreSQL / pgvector implementations of IDatabaseBackend and IVectorStoreBackend.
+ *
+ * Requires:
+ *   - PostgreSQL 14+ with the pgvector extension (CREATE EXTENSION vector)
+ *   - The `pg` npm package (node-postgres)
+ *
+ * All tables use a configurable prefix (default "ci_") so that multiple
+ * independent indexes can coexist in the same database.
+ *
+ * Security note: every query uses parameterized statements ($1, $2, …) to
+ * prevent SQL injection.  Table / column names are derived only from the
+ * validated tablePrefix config value (sanitized to [a-zA-Z0-9_] only).
+ */
+
+import type {
+  IDatabaseBackend,
+  IVectorStoreBackend,
+  VectorSearchResult,
+} from "./backend.js";
+import type {
+  ChunkData,
+  BranchDelta,
+  DatabaseStats,
+  SymbolData,
+  CallEdgeData,
+  ChunkMetadata,
+} from "./backend.js";
+import type { PgVectorConfig } from "../config/schema.js";
+
+// ── Lazy import of `pg` ────────────────────────────────────────────────────
+// `pg` is an optional runtime dependency.  We import it lazily so that users
+// who only use the SQLite backend never pay the cost of loading it.
+
+type PgPool = import("pg").Pool;
+type PgPoolClient = import("pg").PoolClient;
+type PgSslMode = "disable" | "require" | "verify-full";
+
+async function loadPg(): Promise<typeof import("pg")> {
+  try {
+    return await import("pg");
+  } catch {
+    throw new Error(
+      "[codebase-index] The `pg` package is required for the pgvector database backend. " +
+        "Install it with: npm install pg"
+    );
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function pgSslConfig(mode: PgSslMode | undefined): boolean | { rejectUnauthorized: boolean } | undefined {
+  if (!mode || mode === "disable") return undefined;
+  if (mode === "require") return { rejectUnauthorized: false };
+  return true; // verify-full
+}
+
+/**
+ * Replicates the Rust InvertedIndex tokenizer: lowercase, replace
+ * non-alphanumeric with space, split on whitespace, drop tokens ≤ 2 chars.
+ */
+function tokenizeText(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length > 2);
+}
+
+/** Format a Float32Array / number[] as pgvector literal: '[1.0,2.0,...]' */
+function formatVector(vector: number[]): string {
+  return `[${vector.join(",")}]`;
+}
+
+function rowToChunkData(row: Record<string, unknown>): ChunkData {
+  return {
+    chunkId: row.chunk_id as string,
+    contentHash: row.content_hash as string,
+    filePath: row.file_path as string,
+    startLine: Number(row.start_line),
+    endLine: Number(row.end_line),
+    nodeType: (row.node_type as string | null) ?? undefined,
+    name: (row.name as string | null) ?? undefined,
+    language: row.language as string,
+  };
+}
+
+function rowToSymbolData(row: Record<string, unknown>): SymbolData {
+  return {
+    id: row.id as string,
+    filePath: row.file_path as string,
+    name: row.name as string,
+    kind: row.kind as string,
+    startLine: Number(row.start_line),
+    startCol: Number(row.start_col),
+    endLine: Number(row.end_line),
+    endCol: Number(row.end_col),
+    language: row.language as string,
+  };
+}
+
+function rowToCallEdgeData(row: Record<string, unknown>, withContext = false): CallEdgeData {
+  return {
+    id: row.id as string,
+    fromSymbolId: row.from_symbol_id as string,
+    fromSymbolName: withContext ? ((row.from_symbol_name as string | null) ?? undefined) : undefined,
+    fromSymbolFilePath: withContext ? ((row.from_symbol_file_path as string | null) ?? undefined) : undefined,
+    targetName: row.target_name as string,
+    toSymbolId: (row.to_symbol_id as string | null) ?? undefined,
+    callType: row.call_type as string,
+    line: Number(row.line),
+    col: Number(row.col),
+    isResolved: Boolean(row.is_resolved),
+  };
+}
+
+// ── PgVectorStoreBackend ─────────────────────────────────────────────────────
+
+export class PgVectorStoreBackend implements IVectorStoreBackend {
+  private pool: PgPool | null = null;
+  private dimensions = 0;
+  private readonly config: PgVectorConfig;
+  private readonly prefix: string;
+
+  constructor(config: PgVectorConfig) {
+    this.config = config;
+    this.prefix = config.tablePrefix ?? "ci";
+  }
+
+  private get vectorsTable(): string {
+    return `${this.prefix}_chunk_vectors`;
+  }
+
+  private async getPool(): Promise<PgPool> {
+    if (!this.pool) throw new Error("PgVectorStoreBackend not initialized");
+    return this.pool;
+  }
+
+  async initialize(dimensions: number): Promise<void> {
+    this.dimensions = dimensions;
+
+    const pg = await loadPg();
+    const cfg = this.config;
+
+    this.pool = new pg.Pool(
+      cfg.connectionString
+        ? {
+            connectionString: cfg.connectionString,
+            max: cfg.poolSize ?? 10,
+            connectionTimeoutMillis: cfg.connectionTimeoutMs ?? 5000,
+            ssl: pgSslConfig(cfg.ssl) as import("pg").PoolConfig["ssl"],
+          }
+        : {
+            host: cfg.host ?? "localhost",
+            port: cfg.port ?? 5432,
+            database: cfg.database ?? "postgres",
+            user: cfg.user ?? "postgres",
+            password: cfg.password,
+            max: cfg.poolSize ?? 10,
+            connectionTimeoutMillis: cfg.connectionTimeoutMs ?? 5000,
+            ssl: pgSslConfig(cfg.ssl) as import("pg").PoolConfig["ssl"],
+          }
+    );
+
+    const client = await this.pool.connect();
+    try {
+      // Ensure pgvector extension is installed before any schema work.
+      await client.query("CREATE EXTENSION IF NOT EXISTS vector");
+
+      // Create the chunk_vectors table with the correct dimension.
+      // We store the embedding as both a pgvector `vector` column (for ANN
+      // search) and — on the companion PgDatabaseBackend — as raw BYTEA for
+      // fast byte-exact retrieval.  Here we only manage the vector side.
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.vectorsTable} (
+          chunk_id   TEXT PRIMARY KEY,
+          embedding  vector(${dimensions}),
+          file_path  TEXT NOT NULL,
+          start_line INTEGER NOT NULL,
+          end_line   INTEGER NOT NULL,
+          chunk_type TEXT NOT NULL,
+          name       TEXT,
+          language   TEXT NOT NULL,
+          hash       TEXT NOT NULL
+        )
+      `);
+
+      // HNSW index for fast approximate nearest-neighbour search.
+      // Using cosine distance, consistent with the usearch backend.
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.vectorsTable}_embedding_idx
+          ON ${this.vectorsTable}
+          USING hnsw (embedding vector_cosine_ops)
+      `);
+    } finally {
+      client.release();
+    }
+  }
+
+  /** No-op: pgvector persists writes immediately. */
+  async load(): Promise<void> {}
+  async save(): Promise<void> {}
+
+  async add(id: string, vector: number[], metadata: ChunkMetadata): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.vectorsTable}
+         (chunk_id, embedding, file_path, start_line, end_line, chunk_type, name, language, hash)
+       VALUES ($1, $2::vector, $3, $4, $5, $6, $7, $8, $9)
+       ON CONFLICT (chunk_id) DO UPDATE SET
+         embedding  = EXCLUDED.embedding,
+         file_path  = EXCLUDED.file_path,
+         start_line = EXCLUDED.start_line,
+         end_line   = EXCLUDED.end_line,
+         chunk_type = EXCLUDED.chunk_type,
+         name       = EXCLUDED.name,
+         language   = EXCLUDED.language,
+         hash       = EXCLUDED.hash`,
+      [
+        id,
+        formatVector(vector),
+        metadata.filePath,
+        metadata.startLine,
+        metadata.endLine,
+        metadata.chunkType,
+        metadata.name ?? null,
+        metadata.language,
+        metadata.hash,
+      ]
+    );
+  }
+
+  async addBatch(
+    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>
+  ): Promise<void> {
+    if (items.length === 0) return;
+    const pool = await this.getPool();
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      for (const item of items) {
+        await client.query(
+          `INSERT INTO ${this.vectorsTable}
+             (chunk_id, embedding, file_path, start_line, end_line, chunk_type, name, language, hash)
+           VALUES ($1, $2::vector, $3, $4, $5, $6, $7, $8, $9)
+           ON CONFLICT (chunk_id) DO UPDATE SET
+             embedding  = EXCLUDED.embedding,
+             file_path  = EXCLUDED.file_path,
+             start_line = EXCLUDED.start_line,
+             end_line   = EXCLUDED.end_line,
+             chunk_type = EXCLUDED.chunk_type,
+             name       = EXCLUDED.name,
+             language   = EXCLUDED.language,
+             hash       = EXCLUDED.hash`,
+          [
+            item.id,
+            formatVector(item.vector),
+            item.metadata.filePath,
+            item.metadata.startLine,
+            item.metadata.endLine,
+            item.metadata.chunkType,
+            item.metadata.name ?? null,
+            item.metadata.language,
+            item.metadata.hash,
+          ]
+        );
+      }
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async search(queryVector: number[], limit: number): Promise<VectorSearchResult[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT chunk_id,
+              1 - (embedding <=> $1::vector) AS score,
+              file_path, start_line, end_line, chunk_type, name, language, hash
+       FROM ${this.vectorsTable}
+       ORDER BY embedding <=> $1::vector
+       LIMIT $2`,
+      [formatVector(queryVector), limit]
+    );
+
+    return rows.map((row) => ({
+      id: row.chunk_id as string,
+      score: Number(row.score),
+      metadata: {
+        filePath: row.file_path as string,
+        startLine: Number(row.start_line),
+        endLine: Number(row.end_line),
+        chunkType: row.chunk_type as ChunkMetadata["chunkType"],
+        name: (row.name as string | null) ?? undefined,
+        language: row.language as string,
+        hash: row.hash as string,
+      },
+    }));
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.vectorsTable} WHERE chunk_id = $1`,
+      [id]
+    );
+    return (rowCount ?? 0) > 0;
+  }
+
+  async count(): Promise<number> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ cnt: string }>(
+      `SELECT COUNT(*) AS cnt FROM ${this.vectorsTable}`
+    );
+    return parseInt(rows[0]?.cnt ?? "0", 10);
+  }
+
+  async clear(): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(`TRUNCATE TABLE ${this.vectorsTable}`);
+  }
+
+  getDimensions(): number {
+    return this.dimensions;
+  }
+
+  async getAllKeys(): Promise<string[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ chunk_id: string }>(
+      `SELECT chunk_id FROM ${this.vectorsTable}`
+    );
+    return rows.map((r) => r.chunk_id);
+  }
+
+  async getAllMetadata(): Promise<Array<{ key: string; metadata: ChunkMetadata }>> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT chunk_id, file_path, start_line, end_line, chunk_type, name, language, hash
+       FROM ${this.vectorsTable}`
+    );
+    return rows.map((row) => ({
+      key: row.chunk_id as string,
+      metadata: {
+        filePath: row.file_path as string,
+        startLine: Number(row.start_line),
+        endLine: Number(row.end_line),
+        chunkType: row.chunk_type as ChunkMetadata["chunkType"],
+        name: (row.name as string | null) ?? undefined,
+        language: row.language as string,
+        hash: row.hash as string,
+      },
+    }));
+  }
+
+  async getMetadata(id: string): Promise<ChunkMetadata | undefined> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT file_path, start_line, end_line, chunk_type, name, language, hash
+       FROM ${this.vectorsTable}
+       WHERE chunk_id = $1`,
+      [id]
+    );
+    const row = rows[0];
+    if (!row) return undefined;
+    return {
+      filePath: row.file_path as string,
+      startLine: Number(row.start_line),
+      endLine: Number(row.end_line),
+      chunkType: row.chunk_type as ChunkMetadata["chunkType"],
+      name: (row.name as string | null) ?? undefined,
+      language: row.language as string,
+      hash: row.hash as string,
+    };
+  }
+
+  async getMetadataBatch(ids: string[]): Promise<Map<string, ChunkMetadata>> {
+    if (ids.length === 0) return new Map();
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT chunk_id, file_path, start_line, end_line, chunk_type, name, language, hash
+       FROM ${this.vectorsTable}
+       WHERE chunk_id = ANY($1::text[])`,
+      [ids]
+    );
+    const map = new Map<string, ChunkMetadata>();
+    for (const row of rows) {
+      map.set(row.chunk_id as string, {
+        filePath: row.file_path as string,
+        startLine: Number(row.start_line),
+        endLine: Number(row.end_line),
+        chunkType: row.chunk_type as ChunkMetadata["chunkType"],
+        name: (row.name as string | null) ?? undefined,
+        language: row.language as string,
+        hash: row.hash as string,
+      });
+    }
+    return map;
+  }
+
+  async close(): Promise<void> {
+    await this.pool?.end();
+    this.pool = null;
+  }
+}
+
+// ── PgDatabaseBackend ────────────────────────────────────────────────────────
+
+export class PgDatabaseBackend implements IDatabaseBackend {
+  private pool: PgPool | null = null;
+  private readonly config: PgVectorConfig;
+  private readonly p: string; // table prefix
+
+  constructor(config: PgVectorConfig) {
+    this.config = config;
+    this.p = config.tablePrefix ?? "ci";
+  }
+
+  // Convenience getter for fully-qualified table names.
+  private t(name: string): string {
+    return `${this.p}_${name}`;
+  }
+
+  private async getPool(): Promise<PgPool> {
+    if (!this.pool) throw new Error("PgDatabaseBackend not initialized");
+    return this.pool;
+  }
+
+  private async withClient<T>(fn: (client: PgPoolClient) => Promise<T>): Promise<T> {
+    const pool = await this.getPool();
+    const client = await pool.connect();
+    try {
+      return await fn(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  async initialize(): Promise<void> {
+    const pg = await loadPg();
+    const cfg = this.config;
+
+    this.pool = new pg.Pool(
+      cfg.connectionString
+        ? {
+            connectionString: cfg.connectionString,
+            max: cfg.poolSize ?? 10,
+            connectionTimeoutMillis: cfg.connectionTimeoutMs ?? 5000,
+            ssl: pgSslConfig(cfg.ssl) as import("pg").PoolConfig["ssl"],
+          }
+        : {
+            host: cfg.host ?? "localhost",
+            port: cfg.port ?? 5432,
+            database: cfg.database ?? "postgres",
+            user: cfg.user ?? "postgres",
+            password: cfg.password,
+            max: cfg.poolSize ?? 10,
+            connectionTimeoutMillis: cfg.connectionTimeoutMs ?? 5000,
+            ssl: pgSslConfig(cfg.ssl) as import("pg").PoolConfig["ssl"],
+          }
+    );
+
+    await this.createSchema();
+  }
+
+  private async createSchema(): Promise<void> {
+    await this.withClient(async (client) => {
+      // Ensure pgvector extension is installed before any schema work.
+      await client.query("CREATE EXTENSION IF NOT EXISTS vector");
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("metadata")} (
+          key   TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("embeddings")} (
+          content_hash TEXT PRIMARY KEY,
+          embedding    BYTEA NOT NULL,
+          chunk_text   TEXT NOT NULL,
+          model        TEXT NOT NULL,
+          created_at   BIGINT NOT NULL
+        )
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("chunks")} (
+          chunk_id     TEXT PRIMARY KEY,
+          content_hash TEXT NOT NULL,
+          file_path    TEXT NOT NULL,
+          start_line   INTEGER NOT NULL,
+          end_line     INTEGER NOT NULL,
+          node_type    TEXT,
+          name         TEXT,
+          language     TEXT NOT NULL
+        )
+      `);
+
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("chunks_content_hash_idx")}
+          ON ${this.t("chunks")} (content_hash)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("chunks_file_path_idx")}
+          ON ${this.t("chunks")} (file_path)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("chunks_name_idx")}
+          ON ${this.t("chunks")} (name)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("chunks_name_lower_idx")}
+          ON ${this.t("chunks")} (lower(name))
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("branch_chunks")} (
+          branch   TEXT NOT NULL,
+          chunk_id TEXT NOT NULL,
+          PRIMARY KEY (branch, chunk_id)
+        )
+      `);
+
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("branch_chunks_branch_idx")}
+          ON ${this.t("branch_chunks")} (branch)
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("symbols")} (
+          id         TEXT PRIMARY KEY,
+          file_path  TEXT NOT NULL,
+          name       TEXT NOT NULL,
+          kind       TEXT NOT NULL,
+          start_line INTEGER NOT NULL,
+          start_col  INTEGER NOT NULL,
+          end_line   INTEGER NOT NULL,
+          end_col    INTEGER NOT NULL,
+          language   TEXT NOT NULL
+        )
+      `);
+
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("symbols_file_path_idx")}
+          ON ${this.t("symbols")} (file_path)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("symbols_name_idx")}
+          ON ${this.t("symbols")} (name)
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("call_edges")} (
+          id             TEXT PRIMARY KEY,
+          from_symbol_id TEXT NOT NULL,
+          target_name    TEXT NOT NULL,
+          to_symbol_id   TEXT,
+          call_type      TEXT NOT NULL,
+          line           INTEGER NOT NULL,
+          col            INTEGER NOT NULL,
+          is_resolved    BOOLEAN NOT NULL DEFAULT FALSE
+        )
+      `);
+
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("call_edges_from_idx")}
+          ON ${this.t("call_edges")} (from_symbol_id)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("call_edges_to_idx")}
+          ON ${this.t("call_edges")} (to_symbol_id)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("call_edges_target_idx")}
+          ON ${this.t("call_edges")} (target_name)
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("branch_symbols")} (
+          branch    TEXT NOT NULL,
+          symbol_id TEXT NOT NULL,
+          PRIMARY KEY (branch, symbol_id)
+        )
+      `);
+
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("branch_symbols_branch_idx")}
+          ON ${this.t("branch_symbols")} (branch)
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("file_hashes")} (
+          file_path TEXT PRIMARY KEY,
+          hash      TEXT NOT NULL
+        )
+      `);
+
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("inverted_index_postings")} (
+          term        TEXT    NOT NULL,
+          chunk_id    TEXT    NOT NULL,
+          token_count INTEGER NOT NULL,
+          PRIMARY KEY (term, chunk_id)
+        )
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("iip_term_idx")}
+          ON ${this.t("inverted_index_postings")} (term)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("iip_chunk_idx")}
+          ON ${this.t("inverted_index_postings")} (chunk_id)
+      `);
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("inverted_index_doc_lengths")} (
+          chunk_id TEXT    PRIMARY KEY,
+          doc_len  INTEGER NOT NULL
+        )
+      `);
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.pool?.end();
+    this.pool = null;
+  }
+
+  // ── Embeddings ───────────────────────────────────────────────────
+
+  async embeddingExists(contentHash: string): Promise<boolean> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ cnt: string }>(
+      `SELECT COUNT(*) AS cnt FROM ${this.t("embeddings")} WHERE content_hash = $1`,
+      [contentHash]
+    );
+    return parseInt(rows[0]?.cnt ?? "0", 10) > 0;
+  }
+
+  async getEmbedding(contentHash: string): Promise<Buffer | null> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ embedding: Buffer }>(
+      `SELECT embedding FROM ${this.t("embeddings")} WHERE content_hash = $1`,
+      [contentHash]
+    );
+    return rows[0]?.embedding ?? null;
+  }
+
+  async upsertEmbedding(
+    contentHash: string,
+    embedding: Buffer,
+    chunkText: string,
+    model: string
+  ): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("embeddings")} (content_hash, embedding, chunk_text, model, created_at)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (content_hash) DO UPDATE SET
+         embedding  = EXCLUDED.embedding,
+         model      = EXCLUDED.model`,
+      [contentHash, embedding, chunkText, model, Date.now()]
+    );
+  }
+
+  async upsertEmbeddingsBatch(
+    items: Array<{ contentHash: string; embedding: Buffer; chunkText: string; model: string }>
+  ): Promise<void> {
+    if (items.length === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const item of items) {
+        await client.query(
+          `INSERT INTO ${this.t("embeddings")} (content_hash, embedding, chunk_text, model, created_at)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (content_hash) DO UPDATE SET
+             embedding = EXCLUDED.embedding,
+             model     = EXCLUDED.model`,
+          [item.contentHash, item.embedding, item.chunkText, item.model, Date.now()]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async getMissingEmbeddings(contentHashes: string[]): Promise<string[]> {
+    if (contentHashes.length === 0) return [];
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ content_hash: string }>(
+      `SELECT content_hash FROM ${this.t("embeddings")}
+       WHERE content_hash = ANY($1::text[])`,
+      [contentHashes]
+    );
+    const existing = new Set(rows.map((r) => r.content_hash));
+    return contentHashes.filter((h) => !existing.has(h));
+  }
+
+  // ── Chunks ────────────────────────────────────────────────────────
+
+  async upsertChunk(chunk: ChunkData): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("chunks")}
+         (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (chunk_id) DO UPDATE SET
+         content_hash = EXCLUDED.content_hash,
+         file_path    = EXCLUDED.file_path,
+         start_line   = EXCLUDED.start_line,
+         end_line     = EXCLUDED.end_line,
+         node_type    = EXCLUDED.node_type,
+         name         = EXCLUDED.name,
+         language     = EXCLUDED.language`,
+      [
+        chunk.chunkId, chunk.contentHash, chunk.filePath,
+        chunk.startLine, chunk.endLine,
+        chunk.nodeType ?? null, chunk.name ?? null, chunk.language,
+      ]
+    );
+  }
+
+  async upsertChunksBatch(chunks: ChunkData[]): Promise<void> {
+    if (chunks.length === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const chunk of chunks) {
+        await client.query(
+          `INSERT INTO ${this.t("chunks")}
+             (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+           ON CONFLICT (chunk_id) DO UPDATE SET
+             content_hash = EXCLUDED.content_hash,
+             file_path    = EXCLUDED.file_path,
+             start_line   = EXCLUDED.start_line,
+             end_line     = EXCLUDED.end_line,
+             node_type    = EXCLUDED.node_type,
+             name         = EXCLUDED.name,
+             language     = EXCLUDED.language`,
+          [
+            chunk.chunkId, chunk.contentHash, chunk.filePath,
+            chunk.startLine, chunk.endLine,
+            chunk.nodeType ?? null, chunk.name ?? null, chunk.language,
+          ]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async getChunk(chunkId: string): Promise<ChunkData | null> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("chunks")} WHERE chunk_id = $1`,
+      [chunkId]
+    );
+    return rows[0] ? rowToChunkData(rows[0]) : null;
+  }
+
+  async getChunksByFile(filePath: string): Promise<ChunkData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("chunks")} WHERE file_path = $1 ORDER BY start_line`,
+      [filePath]
+    );
+    return rows.map(rowToChunkData);
+  }
+
+  async getChunksByName(name: string): Promise<ChunkData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("chunks")} WHERE name = $1`,
+      [name]
+    );
+    return rows.map(rowToChunkData);
+  }
+
+  async getChunksByNameCi(name: string): Promise<ChunkData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("chunks")} WHERE lower(name) = lower($1)`,
+      [name]
+    );
+    return rows.map(rowToChunkData);
+  }
+
+  async deleteChunksByFile(filePath: string): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("chunks")} WHERE file_path = $1`,
+      [filePath]
+    );
+    return rowCount ?? 0;
+  }
+
+  // ── Branch catalog ────────────────────────────────────────────────
+
+  async addChunksToBranch(branch: string, chunkIds: string[]): Promise<void> {
+    if (chunkIds.length === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const id of chunkIds) {
+        await client.query(
+          `INSERT INTO ${this.t("branch_chunks")} (branch, chunk_id)
+           VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+          [branch, id]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async addChunksToBranchBatch(branch: string, chunkIds: string[]): Promise<void> {
+    return this.addChunksToBranch(branch, chunkIds);
+  }
+
+  async clearBranch(branch: string): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("branch_chunks")} WHERE branch = $1`,
+      [branch]
+    );
+    return rowCount ?? 0;
+  }
+
+  async deleteBranchChunksByChunkIds(chunkIds: string[]): Promise<number> {
+    if (chunkIds.length === 0) return 0;
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("branch_chunks")} WHERE chunk_id = ANY($1::text[])`,
+      [chunkIds]
+    );
+    return rowCount ?? 0;
+  }
+
+  async deleteBranchChunksForBranch(branch: string, chunkIds: string[]): Promise<number> {
+    if (chunkIds.length === 0) return 0;
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("branch_chunks")}
+       WHERE branch = $1 AND chunk_id = ANY($2::text[])`,
+      [branch, chunkIds]
+    );
+    return rowCount ?? 0;
+  }
+
+  async getBranchChunkIds(branch: string): Promise<string[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ chunk_id: string }>(
+      `SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $1`,
+      [branch]
+    );
+    return rows.map((r) => r.chunk_id);
+  }
+
+  async getBranchDelta(branch: string, baseBranch: string): Promise<BranchDelta> {
+    const pool = await this.getPool();
+    const { rows: addedRows } = await pool.query<{ chunk_id: string }>(
+      `SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $1
+       EXCEPT
+       SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $2`,
+      [branch, baseBranch]
+    );
+    const { rows: removedRows } = await pool.query<{ chunk_id: string }>(
+      `SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $1
+       EXCEPT
+       SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $2`,
+      [baseBranch, branch]
+    );
+    return {
+      added: addedRows.map((r) => r.chunk_id),
+      removed: removedRows.map((r) => r.chunk_id),
+    };
+  }
+
+  async getReferencedChunkIds(chunkIds: string[]): Promise<string[]> {
+    if (chunkIds.length === 0) return [];
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ chunk_id: string }>(
+      `SELECT DISTINCT chunk_id FROM ${this.t("branch_chunks")}
+       WHERE chunk_id = ANY($1::text[])`,
+      [chunkIds]
+    );
+    return rows.map((r) => r.chunk_id);
+  }
+
+  async chunkExistsOnBranch(branch: string, chunkId: string): Promise<boolean> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ cnt: string }>(
+      `SELECT COUNT(*) AS cnt FROM ${this.t("branch_chunks")}
+       WHERE branch = $1 AND chunk_id = $2`,
+      [branch, chunkId]
+    );
+    return parseInt(rows[0]?.cnt ?? "0", 10) > 0;
+  }
+
+  async getAllBranches(): Promise<string[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ branch: string }>(
+      `SELECT DISTINCT branch FROM ${this.t("branch_chunks")}`
+    );
+    return rows.map((r) => r.branch);
+  }
+
+  // ── Metadata key-value ────────────────────────────────────────────
+
+  async getMetadata(key: string): Promise<string | null> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ value: string }>(
+      `SELECT value FROM ${this.t("metadata")} WHERE key = $1`,
+      [key]
+    );
+    return rows[0]?.value ?? null;
+  }
+
+  async setMetadata(key: string, value: string): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("metadata")} (key, value)
+       VALUES ($1, $2)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [key, value]
+    );
+  }
+
+  async deleteMetadata(key: string): Promise<boolean> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("metadata")} WHERE key = $1`,
+      [key]
+    );
+    return (rowCount ?? 0) > 0;
+  }
+
+  // ── Maintenance ───────────────────────────────────────────────────
+
+  async clearAllIndexedData(): Promise<void> {
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const table of [
+        "branch_symbols", "branch_chunks",
+        "call_edges", "symbols", "chunks", "embeddings", "file_hashes",
+        "inverted_index_postings", "inverted_index_doc_lengths",
+      ]) {
+        await client.query(`TRUNCATE TABLE ${this.t(table)}`);
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async clearCallEdgeTargetsForSymbols(symbolIds: string[]): Promise<number> {
+    if (symbolIds.length === 0) return 0;
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `UPDATE ${this.t("call_edges")} SET to_symbol_id = NULL, is_resolved = FALSE
+       WHERE from_symbol_id = ANY($1::text[])`,
+      [symbolIds]
+    );
+    return rowCount ?? 0;
+  }
+
+  async gcOrphanEmbeddings(): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("embeddings")} e
+       WHERE NOT EXISTS (
+         SELECT 1 FROM ${this.t("chunks")} c WHERE c.content_hash = e.content_hash
+       )`
+    );
+    return rowCount ?? 0;
+  }
+
+  async gcOrphanChunks(): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("chunks")} c
+       WHERE NOT EXISTS (
+         SELECT 1 FROM ${this.t("branch_chunks")} bc WHERE bc.chunk_id = c.chunk_id
+       )`
+    );
+    return rowCount ?? 0;
+  }
+
+  async getStats(): Promise<DatabaseStats> {
+    const pool = await this.getPool();
+    const queries = [
+      pool.query<{ cnt: string }>(`SELECT COUNT(*) AS cnt FROM ${this.t("embeddings")}`),
+      pool.query<{ cnt: string }>(`SELECT COUNT(*) AS cnt FROM ${this.t("chunks")}`),
+      pool.query<{ cnt: string }>(`SELECT COUNT(*) AS cnt FROM ${this.t("branch_chunks")}`),
+      pool.query<{ cnt: string }>(`SELECT COUNT(DISTINCT branch) AS cnt FROM ${this.t("branch_chunks")}`),
+      pool.query<{ cnt: string }>(`SELECT COUNT(*) AS cnt FROM ${this.t("symbols")}`),
+      pool.query<{ cnt: string }>(`SELECT COUNT(*) AS cnt FROM ${this.t("call_edges")}`),
+    ];
+    const results = await Promise.all(queries);
+    return {
+      embeddingCount: parseInt(results[0].rows[0]?.cnt ?? "0", 10),
+      chunkCount: parseInt(results[1].rows[0]?.cnt ?? "0", 10),
+      branchChunkCount: parseInt(results[2].rows[0]?.cnt ?? "0", 10),
+      branchCount: parseInt(results[3].rows[0]?.cnt ?? "0", 10),
+      symbolCount: parseInt(results[4].rows[0]?.cnt ?? "0", 10),
+      callEdgeCount: parseInt(results[5].rows[0]?.cnt ?? "0", 10),
+    };
+  }
+
+  // ── Symbols ───────────────────────────────────────────────────────
+
+  async upsertSymbol(symbol: SymbolData): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("symbols")}
+         (id, file_path, name, kind, start_line, start_col, end_line, end_col, language)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       ON CONFLICT (id) DO UPDATE SET
+         file_path  = EXCLUDED.file_path,
+         name       = EXCLUDED.name,
+         kind       = EXCLUDED.kind,
+         start_line = EXCLUDED.start_line,
+         start_col  = EXCLUDED.start_col,
+         end_line   = EXCLUDED.end_line,
+         end_col    = EXCLUDED.end_col,
+         language   = EXCLUDED.language`,
+      [symbol.id, symbol.filePath, symbol.name, symbol.kind,
+       symbol.startLine, symbol.startCol, symbol.endLine, symbol.endCol, symbol.language]
+    );
+  }
+
+  async upsertSymbolsBatch(symbols: SymbolData[]): Promise<void> {
+    if (symbols.length === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const symbol of symbols) {
+        await client.query(
+          `INSERT INTO ${this.t("symbols")}
+             (id, file_path, name, kind, start_line, start_col, end_line, end_col, language)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+           ON CONFLICT (id) DO UPDATE SET
+             file_path  = EXCLUDED.file_path,
+             name       = EXCLUDED.name,
+             kind       = EXCLUDED.kind,
+             start_line = EXCLUDED.start_line,
+             start_col  = EXCLUDED.start_col,
+             end_line   = EXCLUDED.end_line,
+             end_col    = EXCLUDED.end_col,
+             language   = EXCLUDED.language`,
+          [symbol.id, symbol.filePath, symbol.name, symbol.kind,
+           symbol.startLine, symbol.startCol, symbol.endLine, symbol.endCol, symbol.language]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async getSymbolsByFile(filePath: string): Promise<SymbolData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("symbols")} WHERE file_path = $1`,
+      [filePath]
+    );
+    return rows.map(rowToSymbolData);
+  }
+
+  async getSymbolByName(name: string, filePath: string): Promise<SymbolData | null> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("symbols")} WHERE name = $1 AND file_path = $2 LIMIT 1`,
+      [name, filePath]
+    );
+    return rows[0] ? rowToSymbolData(rows[0]) : null;
+  }
+
+  async getSymbolsByName(name: string): Promise<SymbolData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("symbols")} WHERE name = $1`,
+      [name]
+    );
+    return rows.map(rowToSymbolData);
+  }
+
+  async getSymbolsByNameCi(name: string): Promise<SymbolData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT * FROM ${this.t("symbols")} WHERE lower(name) = lower($1)`,
+      [name]
+    );
+    return rows.map(rowToSymbolData);
+  }
+
+  async deleteSymbolsByFile(filePath: string): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("symbols")} WHERE file_path = $1`,
+      [filePath]
+    );
+    return rowCount ?? 0;
+  }
+
+  // ── Call edges ────────────────────────────────────────────────────
+
+  async upsertCallEdge(edge: CallEdgeData): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("call_edges")}
+         (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (id) DO UPDATE SET
+         from_symbol_id = EXCLUDED.from_symbol_id,
+         target_name    = EXCLUDED.target_name,
+         to_symbol_id   = EXCLUDED.to_symbol_id,
+         call_type      = EXCLUDED.call_type,
+         line           = EXCLUDED.line,
+         col            = EXCLUDED.col,
+         is_resolved    = EXCLUDED.is_resolved`,
+      [edge.id, edge.fromSymbolId, edge.targetName, edge.toSymbolId ?? null,
+       edge.callType, edge.line, edge.col, edge.isResolved]
+    );
+  }
+
+  async upsertCallEdgesBatch(edges: CallEdgeData[]): Promise<void> {
+    if (edges.length === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const edge of edges) {
+        await client.query(
+          `INSERT INTO ${this.t("call_edges")}
+             (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+           ON CONFLICT (id) DO UPDATE SET
+             from_symbol_id = EXCLUDED.from_symbol_id,
+             target_name    = EXCLUDED.target_name,
+             to_symbol_id   = EXCLUDED.to_symbol_id,
+             call_type      = EXCLUDED.call_type,
+             line           = EXCLUDED.line,
+             col            = EXCLUDED.col,
+             is_resolved    = EXCLUDED.is_resolved`,
+          [edge.id, edge.fromSymbolId, edge.targetName, edge.toSymbolId ?? null,
+           edge.callType, edge.line, edge.col, edge.isResolved]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async getCallers(targetName: string, branch: string): Promise<CallEdgeData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT ce.*
+       FROM ${this.t("call_edges")} ce
+       JOIN ${this.t("branch_symbols")} bs ON bs.symbol_id = ce.from_symbol_id
+       WHERE ce.target_name = $1 AND bs.branch = $2`,
+      [targetName, branch]
+    );
+    return rows.map((r) => rowToCallEdgeData(r));
+  }
+
+  async getCallersWithContext(targetName: string, branch: string): Promise<CallEdgeData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT ce.*,
+              s.name      AS from_symbol_name,
+              s.file_path AS from_symbol_file_path
+       FROM ${this.t("call_edges")} ce
+       JOIN ${this.t("symbols")} s           ON s.id = ce.from_symbol_id
+       JOIN ${this.t("branch_symbols")} bs   ON bs.symbol_id = ce.from_symbol_id
+       WHERE ce.target_name = $1 AND bs.branch = $2`,
+      [targetName, branch]
+    );
+    return rows.map((r) => rowToCallEdgeData(r, true));
+  }
+
+  async getCallees(symbolId: string, branch: string): Promise<CallEdgeData[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<Record<string, unknown>>(
+      `SELECT ce.*
+       FROM ${this.t("call_edges")} ce
+       JOIN ${this.t("branch_symbols")} bs ON bs.symbol_id = ce.from_symbol_id
+       WHERE ce.from_symbol_id = $1 AND bs.branch = $2`,
+      [symbolId, branch]
+    );
+    return rows.map((r) => rowToCallEdgeData(r));
+  }
+
+  async deleteCallEdgesByFile(filePath: string): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("call_edges")}
+       WHERE from_symbol_id IN (
+         SELECT id FROM ${this.t("symbols")} WHERE file_path = $1
+       )`,
+      [filePath]
+    );
+    return rowCount ?? 0;
+  }
+
+  async resolveCallEdge(edgeId: string, toSymbolId: string): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `UPDATE ${this.t("call_edges")}
+       SET to_symbol_id = $2, is_resolved = TRUE
+       WHERE id = $1`,
+      [edgeId, toSymbolId]
+    );
+  }
+
+  // ── Branch symbols ────────────────────────────────────────────────
+
+  async addSymbolsToBranch(branch: string, symbolIds: string[]): Promise<void> {
+    if (symbolIds.length === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const id of symbolIds) {
+        await client.query(
+          `INSERT INTO ${this.t("branch_symbols")} (branch, symbol_id)
+           VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+          [branch, id]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async addSymbolsToBranchBatch(branch: string, symbolIds: string[]): Promise<void> {
+    return this.addSymbolsToBranch(branch, symbolIds);
+  }
+
+  async getBranchSymbolIds(branch: string): Promise<string[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ symbol_id: string }>(
+      `SELECT symbol_id FROM ${this.t("branch_symbols")} WHERE branch = $1`,
+      [branch]
+    );
+    return rows.map((r) => r.symbol_id);
+  }
+
+  async clearBranchSymbols(branch: string): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("branch_symbols")} WHERE branch = $1`,
+      [branch]
+    );
+    return rowCount ?? 0;
+  }
+
+  async getReferencedSymbolIds(symbolIds: string[]): Promise<string[]> {
+    if (symbolIds.length === 0) return [];
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ symbol_id: string }>(
+      `SELECT DISTINCT symbol_id FROM ${this.t("branch_symbols")}
+       WHERE symbol_id = ANY($1::text[])`,
+      [symbolIds]
+    );
+    return rows.map((r) => r.symbol_id);
+  }
+
+  async deleteBranchSymbolsBySymbolIds(symbolIds: string[]): Promise<number> {
+    if (symbolIds.length === 0) return 0;
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("branch_symbols")} WHERE symbol_id = ANY($1::text[])`,
+      [symbolIds]
+    );
+    return rowCount ?? 0;
+  }
+
+  async deleteBranchSymbolsForBranch(branch: string, symbolIds: string[]): Promise<number> {
+    if (symbolIds.length === 0) return 0;
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("branch_symbols")}
+       WHERE branch = $1 AND symbol_id = ANY($2::text[])`,
+      [branch, symbolIds]
+    );
+    return rowCount ?? 0;
+  }
+
+  // ── GC ────────────────────────────────────────────────────────────
+
+  async gcOrphanSymbols(): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("symbols")} s
+       WHERE NOT EXISTS (
+         SELECT 1 FROM ${this.t("branch_symbols")} bs WHERE bs.symbol_id = s.id
+       )`
+    );
+    return rowCount ?? 0;
+  }
+
+  async gcOrphanCallEdges(): Promise<number> {
+    const pool = await this.getPool();
+    const { rowCount } = await pool.query(
+      `DELETE FROM ${this.t("call_edges")} ce
+       WHERE NOT EXISTS (
+         SELECT 1 FROM ${this.t("symbols")} s WHERE s.id = ce.from_symbol_id
+       )`
+    );
+    return rowCount ?? 0;
+  }
+
+  // ── File hashes ──────────────────────────────────────────────────
+
+  async getFileHash(filePath: string): Promise<string | null> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ hash: string }>(
+      `SELECT hash FROM ${this.t("file_hashes")} WHERE file_path = $1`,
+      [filePath]
+    );
+    return rows[0]?.hash ?? null;
+  }
+
+  async setFileHash(filePath: string, hash: string): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("file_hashes")} (file_path, hash) VALUES ($1, $2)
+       ON CONFLICT (file_path) DO UPDATE SET hash = EXCLUDED.hash`,
+      [filePath, hash]
+    );
+  }
+
+  async deleteFileHash(filePath: string): Promise<void> {
+    const pool = await this.getPool();
+    await pool.query(
+      `DELETE FROM ${this.t("file_hashes")} WHERE file_path = $1`,
+      [filePath]
+    );
+  }
+
+  async getAllFileHashes(): Promise<Map<string, string>> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ file_path: string; hash: string }>(
+      `SELECT file_path, hash FROM ${this.t("file_hashes")}`
+    );
+    return new Map(rows.map((r) => [r.file_path, r.hash]));
+  }
+
+  async setFileHashesBatch(hashes: Map<string, string>): Promise<void> {
+    if (hashes.size === 0) return;
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const [filePath, hash] of hashes) {
+        await client.query(
+          `INSERT INTO ${this.t("file_hashes")} (file_path, hash) VALUES ($1, $2)
+           ON CONFLICT (file_path) DO UPDATE SET hash = EXCLUDED.hash`,
+          [filePath, hash]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async deleteFileHashesBatch(filePaths: string[]): Promise<void> {
+    if (filePaths.length === 0) return;
+    const pool = await this.getPool();
+    await pool.query(
+      `DELETE FROM ${this.t("file_hashes")} WHERE file_path = ANY($1::text[])`,
+      [filePaths]
+    );
+  }
+
+  // ── Indexing lock (PostgreSQL advisory locks) ─────────────────────
+
+  async tryAcquireLock(pid: number, startedAt: string): Promise<boolean> {
+    const pool = await this.getPool();
+    const lockKey = this.t("indexing_lock");
+    const { rows } = await pool.query<{ result: boolean }>(
+      `SELECT pg_try_advisory_lock(hashtext($1)) AS result`,
+      [lockKey]
+    );
+    if (!rows[0]?.result) return false;
+    // Store metadata so isLocked() and recovery can see who holds it.
+    await pool.query(
+      `INSERT INTO ${this.t("metadata")} (key, value) VALUES ('indexing_lock', $1)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [JSON.stringify({ pid, startedAt })]
+    );
+    return true;
+  }
+
+  async releaseLock(): Promise<void> {
+    const pool = await this.getPool();
+    const lockKey = this.t("indexing_lock");
+    await pool.query(`SELECT pg_advisory_unlock(hashtext($1))`, [lockKey]);
+    await pool.query(
+      `DELETE FROM ${this.t("metadata")} WHERE key = 'indexing_lock'`
+    );
+  }
+
+  async isLocked(): Promise<boolean> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ value: string }>(
+      `SELECT value FROM ${this.t("metadata")} WHERE key = 'indexing_lock'`
+    );
+    return rows.length > 0;
+  }
+
+  // ── Inverted index (structured tables + SQL BM25) ────────────────
+
+  /**
+   * Parse the Rust-serialized JSON and sync the full posting list to the DB.
+   * Replaces the entire table atomically so searches are always consistent.
+   */
+  async saveInvertedIndex(json: string): Promise<void> {
+    type IndexData = {
+      term_to_chunks: Record<string, string[]>;
+      chunk_tokens: Record<string, Record<string, number>>;
+      avg_doc_length: number;
+    };
+    const data: IndexData = JSON.parse(json);
+
+    // Compute per-chunk doc lengths from chunk_tokens
+    const docLengths = new Map<string, number>();
+    for (const [chunkId, tokens] of Object.entries(data.chunk_tokens)) {
+      const len = Object.values(tokens).reduce((s, n) => s + n, 0);
+      docLengths.set(chunkId, len);
+    }
+
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      await client.query(`TRUNCATE TABLE ${this.t("inverted_index_postings")}`);
+      await client.query(`TRUNCATE TABLE ${this.t("inverted_index_doc_lengths")}`);
+
+      // Batch insert postings
+      const postingRows: Array<[string, string, number]> = [];
+      for (const [term, chunkIds] of Object.entries(data.term_to_chunks)) {
+        for (const chunkId of chunkIds) {
+          const count = data.chunk_tokens[chunkId]?.[term] ?? 1;
+          postingRows.push([term, chunkId, count]);
+        }
+      }
+      // Insert in chunks to avoid overly large statements
+      const BATCH = 500;
+      for (let i = 0; i < postingRows.length; i += BATCH) {
+        const slice = postingRows.slice(i, i + BATCH);
+        const placeholders = slice.map((_, j) => `($${j * 3 + 1},$${j * 3 + 2},$${j * 3 + 3})`).join(",");
+        const values = slice.flat();
+        await client.query(
+          `INSERT INTO ${this.t("inverted_index_postings")} (term, chunk_id, token_count) VALUES ${placeholders}`,
+          values
+        );
+      }
+
+      // Insert doc lengths
+      const dlRows = Array.from(docLengths.entries());
+      for (let i = 0; i < dlRows.length; i += BATCH) {
+        const slice = dlRows.slice(i, i + BATCH);
+        const placeholders = slice.map((_, j) => `($${j * 2 + 1},$${j * 2 + 2})`).join(",");
+        const values = slice.flat();
+        await client.query(
+          `INSERT INTO ${this.t("inverted_index_doc_lengths")} (chunk_id, doc_len) VALUES ${placeholders}`,
+          values
+        );
+      }
+
+      await client.query("COMMIT");
+    });
+  }
+
+  /** For pgvector, always skip loading the Rust in-memory struct — SQL BM25 is used for search. */
+  async loadInvertedIndex(): Promise<string | null> {
+    return null;
+  }
+
+  async searchBm25(query: string, limit: number): Promise<Map<string, number> | null> {
+    const terms = tokenizeText(query);
+    if (terms.length === 0) return new Map();
+
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ chunk_id: string; score: number }>(
+      `WITH
+        qt AS (SELECT UNNEST($1::text[]) AS term),
+        tdf AS (
+          SELECT p.term, COUNT(DISTINCT p.chunk_id)::FLOAT AS df
+          FROM ${this.t("inverted_index_postings")} p
+          JOIN qt ON p.term = qt.term
+          GROUP BY p.term
+        ),
+        stats AS (
+          SELECT
+            COUNT(*)::FLOAT                                         AS total_docs,
+            COALESCE(AVG(doc_len)::FLOAT, 1.0)                     AS avg_dl
+          FROM ${this.t("inverted_index_doc_lengths")}
+        ),
+        scored AS (
+          SELECT
+            p.chunk_id,
+            SUM(
+              LN((s.total_docs - t.df + 0.5) / (t.df + 0.5) + 1.0)
+              * (p.token_count::FLOAT * 2.2)
+              / (p.token_count::FLOAT + 1.2 * (0.25 + 0.75 * dl.doc_len::FLOAT / s.avg_dl))
+            ) AS score
+          FROM ${this.t("inverted_index_postings")} p
+          JOIN qt                                          ON p.term     = qt.term
+          JOIN tdf t                                       ON p.term     = t.term
+          JOIN ${this.t("inverted_index_doc_lengths")} dl ON p.chunk_id = dl.chunk_id
+          CROSS JOIN stats s
+          GROUP BY p.chunk_id
+        )
+      SELECT chunk_id, score FROM scored ORDER BY score DESC LIMIT $2`,
+      [terms, limit]
+    );
+
+    const result = new Map<string, number>();
+    for (const row of rows) result.set(row.chunk_id, Number(row.score));
+    return result;
+  }
+
+  // ── Bulk file-hash replacement ────────────────────────────────────
+
+  async replaceAllFileHashes(hashes: Map<string, string>): Promise<void> {
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      await client.query(`TRUNCATE TABLE ${this.t("file_hashes")}`);
+      for (const [filePath, hash] of hashes) {
+        await client.query(
+          `INSERT INTO ${this.t("file_hashes")} (file_path, hash) VALUES ($1, $2)`,
+          [filePath, hash]
+        );
+      }
+      await client.query("COMMIT");
+    });
+  }
+
+  async getFileHashBatch(filePaths: string[]): Promise<Map<string, string>> {
+    if (filePaths.length === 0) return new Map();
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ file_path: string; hash: string }>(
+      `SELECT file_path, hash FROM ${this.t("file_hashes")} WHERE file_path = ANY($1::text[])`,
+      [filePaths]
+    );
+    return new Map(rows.map((r) => [r.file_path, r.hash]));
+  }
+
+  async hasFileHashesOutsideRoots(roots: string[]): Promise<boolean> {
+    if (roots.length === 0) return false;
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS(
+         SELECT 1 FROM ${this.t("file_hashes")}
+         WHERE NOT EXISTS (
+           SELECT 1 FROM UNNEST($1::text[]) AS r(root)
+           WHERE file_path = r.root OR file_path LIKE r.root || '/%'
+         )
+       ) AS exists`,
+      [roots]
+    );
+    return rows[0]?.exists ?? false;
+  }
+
+  async getFilePathsInRoots(roots: string[]): Promise<string[]> {
+    if (roots.length === 0) return [];
+    const pool = await this.getPool();
+    const { rows } = await pool.query<{ file_path: string }>(
+      `SELECT file_path FROM ${this.t("file_hashes")}
+       WHERE EXISTS (
+         SELECT 1 FROM UNNEST($1::text[]) AS r(root)
+         WHERE file_path = r.root OR file_path LIKE r.root || '/%'
+       )`,
+      [roots]
+    );
+    return rows.map((r) => r.file_path);
+  }
+
+  async deleteFileHashesInRoots(roots: string[]): Promise<void> {
+    if (roots.length === 0) return;
+    const pool = await this.getPool();
+    await pool.query(
+      `DELETE FROM ${this.t("file_hashes")}
+       WHERE EXISTS (
+         SELECT 1 FROM UNNEST($1::text[]) AS r(root)
+         WHERE file_path = r.root OR file_path LIKE r.root || '/%'
+       )`,
+      [roots]
+    );
+  }
+}

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -684,26 +684,50 @@ export class PgDatabaseBackend implements IDatabaseBackend {
 
       // ── Migrations for existing databases ────────────────────────
       // Add source_id columns to tables that may have been created before
-      // this schema version.  All are idempotent (IF NOT EXISTS / IF EXISTS).
+      // this schema version.  ADD COLUMN IF NOT EXISTS is idempotent.
       await client.query(`ALTER TABLE ${this.t("chunks")}        ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
       await client.query(`ALTER TABLE ${this.t("symbols")}       ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
       await client.query(`ALTER TABLE ${this.t("call_edges")}    ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
 
+      // For tables whose PK must gain a source_id prefix, only run the
+      // DROP+ADD when source_id is not yet part of the primary key —
+      // avoids an ACCESS EXCLUSIVE lock on every startup.
+      const pkNeedsMigration = async (table: string): Promise<boolean> => {
+        const { rows } = await client.query<{ exists: boolean }>(
+          `SELECT EXISTS (
+             SELECT 1
+             FROM   pg_index     i
+             JOIN   pg_attribute a ON a.attrelid = i.indrelid
+                                  AND a.attnum   = ANY(i.indkey)
+             WHERE  i.indrelid  = $1::regclass
+               AND  i.indisprimary
+               AND  a.attname   = 'source_id'
+           ) AS exists`,
+          [table]
+        );
+        return !rows[0]!.exists;
+      };
+
       // branch_chunks: old PK was (branch, chunk_id); new PK is (source_id, branch, chunk_id).
-      // Drop old PK, add source_id column, add new PK.
       await client.query(`ALTER TABLE ${this.t("branch_chunks")} ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
-      await client.query(`ALTER TABLE ${this.t("branch_chunks")} DROP CONSTRAINT IF EXISTS ${this.t("branch_chunks_pkey")}`);
-      await client.query(`ALTER TABLE ${this.t("branch_chunks")} ADD PRIMARY KEY (source_id, branch, chunk_id)`);
+      if (await pkNeedsMigration(this.t("branch_chunks"))) {
+        await client.query(`ALTER TABLE ${this.t("branch_chunks")} DROP CONSTRAINT IF EXISTS ${this.t("branch_chunks_pkey")}`);
+        await client.query(`ALTER TABLE ${this.t("branch_chunks")} ADD PRIMARY KEY (source_id, branch, chunk_id)`);
+      }
 
       // branch_symbols: old PK was (branch, symbol_id); new PK is (source_id, branch, symbol_id).
       await client.query(`ALTER TABLE ${this.t("branch_symbols")} ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
-      await client.query(`ALTER TABLE ${this.t("branch_symbols")} DROP CONSTRAINT IF EXISTS ${this.t("branch_symbols_pkey")}`);
-      await client.query(`ALTER TABLE ${this.t("branch_symbols")} ADD PRIMARY KEY (source_id, branch, symbol_id)`);
+      if (await pkNeedsMigration(this.t("branch_symbols"))) {
+        await client.query(`ALTER TABLE ${this.t("branch_symbols")} DROP CONSTRAINT IF EXISTS ${this.t("branch_symbols_pkey")}`);
+        await client.query(`ALTER TABLE ${this.t("branch_symbols")} ADD PRIMARY KEY (source_id, branch, symbol_id)`);
+      }
 
       // file_hashes: old PK was (file_path); new PK is (source_id, file_path).
       await client.query(`ALTER TABLE ${this.t("file_hashes")} ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
-      await client.query(`ALTER TABLE ${this.t("file_hashes")} DROP CONSTRAINT IF EXISTS ${this.t("file_hashes_pkey")}`);
-      await client.query(`ALTER TABLE ${this.t("file_hashes")} ADD PRIMARY KEY (source_id, file_path)`);
+      if (await pkNeedsMigration(this.t("file_hashes"))) {
+        await client.query(`ALTER TABLE ${this.t("file_hashes")} DROP CONSTRAINT IF EXISTS ${this.t("file_hashes_pkey")}`);
+        await client.query(`ALTER TABLE ${this.t("file_hashes")} ADD PRIMARY KEY (source_id, file_path)`);
+      }
     });
   }
 

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -13,6 +13,7 @@
  * validated tablePrefix config value (sanitized to [a-zA-Z0-9_] only).
  */
 
+import { createHash } from "crypto";
 import type {
   IDatabaseBackend,
   IVectorStoreBackend,
@@ -181,7 +182,8 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
           chunk_type TEXT NOT NULL,
           name       TEXT,
           language   TEXT NOT NULL,
-          hash       TEXT NOT NULL
+          hash       TEXT NOT NULL,
+          source_id  TEXT NOT NULL DEFAULT ''
         )
       `);
 
@@ -192,6 +194,16 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
           ON ${this.vectorsTable}
           USING hnsw (embedding vector_cosine_ops)
       `);
+
+      // Migration: add source_id for multi-source isolation (idempotent).
+      await client.query(`
+        ALTER TABLE ${this.vectorsTable}
+          ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.vectorsTable}_source_idx
+          ON ${this.vectorsTable} (source_id)
+      `);
     } finally {
       client.release();
     }
@@ -201,12 +213,12 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
   async load(): Promise<void> {}
   async save(): Promise<void> {}
 
-  async add(id: string, vector: number[], metadata: ChunkMetadata): Promise<void> {
+  async add(id: string, vector: number[], metadata: ChunkMetadata, sourceId?: string): Promise<void> {
     const pool = await this.getPool();
     await pool.query(
       `INSERT INTO ${this.vectorsTable}
-         (chunk_id, embedding, file_path, start_line, end_line, chunk_type, name, language, hash)
-       VALUES ($1, $2::vector, $3, $4, $5, $6, $7, $8, $9)
+         (chunk_id, embedding, file_path, start_line, end_line, chunk_type, name, language, hash, source_id)
+       VALUES ($1, $2::vector, $3, $4, $5, $6, $7, $8, $9, $10)
        ON CONFLICT (chunk_id) DO UPDATE SET
          embedding  = EXCLUDED.embedding,
          file_path  = EXCLUDED.file_path,
@@ -215,7 +227,8 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
          chunk_type = EXCLUDED.chunk_type,
          name       = EXCLUDED.name,
          language   = EXCLUDED.language,
-         hash       = EXCLUDED.hash`,
+         hash       = EXCLUDED.hash,
+         source_id  = EXCLUDED.source_id`,
       [
         id,
         formatVector(vector),
@@ -226,23 +239,26 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
         metadata.name ?? null,
         metadata.language,
         metadata.hash,
+        sourceId ?? "",
       ]
     );
   }
 
   async addBatch(
-    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>
+    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>,
+    sourceId?: string
   ): Promise<void> {
     if (items.length === 0) return;
     const pool = await this.getPool();
     const client = await pool.connect();
+    const sid = sourceId ?? "";
     try {
       await client.query("BEGIN");
       for (const item of items) {
         await client.query(
           `INSERT INTO ${this.vectorsTable}
-             (chunk_id, embedding, file_path, start_line, end_line, chunk_type, name, language, hash)
-           VALUES ($1, $2::vector, $3, $4, $5, $6, $7, $8, $9)
+             (chunk_id, embedding, file_path, start_line, end_line, chunk_type, name, language, hash, source_id)
+           VALUES ($1, $2::vector, $3, $4, $5, $6, $7, $8, $9, $10)
            ON CONFLICT (chunk_id) DO UPDATE SET
              embedding  = EXCLUDED.embedding,
              file_path  = EXCLUDED.file_path,
@@ -251,7 +267,8 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
              chunk_type = EXCLUDED.chunk_type,
              name       = EXCLUDED.name,
              language   = EXCLUDED.language,
-             hash       = EXCLUDED.hash`,
+             hash       = EXCLUDED.hash,
+             source_id  = EXCLUDED.source_id`,
           [
             item.id,
             formatVector(item.vector),
@@ -262,6 +279,7 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
             item.metadata.name ?? null,
             item.metadata.language,
             item.metadata.hash,
+            sid,
           ]
         );
       }
@@ -274,17 +292,30 @@ export class PgVectorStoreBackend implements IVectorStoreBackend {
     }
   }
 
-  async search(queryVector: number[], limit: number): Promise<VectorSearchResult[]> {
+  async search(queryVector: number[], limit: number, sourceIds?: string[]): Promise<VectorSearchResult[]> {
     const pool = await this.getPool();
-    const { rows } = await pool.query<Record<string, unknown>>(
-      `SELECT chunk_id,
+    const vectorStr = formatVector(queryVector);
+    let queryText: string;
+    let params: unknown[];
+    if (sourceIds && sourceIds.length > 0) {
+      queryText = `SELECT chunk_id,
+              1 - (embedding <=> $1::vector) AS score,
+              file_path, start_line, end_line, chunk_type, name, language, hash
+       FROM ${this.vectorsTable}
+       WHERE source_id = ANY($3::text[])
+       ORDER BY embedding <=> $1::vector
+       LIMIT $2`;
+      params = [vectorStr, limit, sourceIds];
+    } else {
+      queryText = `SELECT chunk_id,
               1 - (embedding <=> $1::vector) AS score,
               file_path, start_line, end_line, chunk_type, name, language, hash
        FROM ${this.vectorsTable}
        ORDER BY embedding <=> $1::vector
-       LIMIT $2`,
-      [formatVector(queryVector), limit]
-    );
+       LIMIT $2`;
+      params = [vectorStr, limit];
+    }
+    const { rows } = await pool.query<Record<string, unknown>>(queryText, params);
 
     return rows.map((row) => ({
       id: row.chunk_id as string,
@@ -470,6 +501,16 @@ export class PgDatabaseBackend implements IDatabaseBackend {
       // Ensure pgvector extension is installed before any schema work.
       await client.query("CREATE EXTENSION IF NOT EXISTS vector");
 
+      // ── Sources registry ─────────────────────────────────────────
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${this.t("sources")} (
+          source_id   TEXT PRIMARY KEY,
+          root_path   TEXT NOT NULL UNIQUE,
+          created_at  BIGINT NOT NULL
+        )
+      `);
+
+      // ── Core tables ──────────────────────────────────────────────
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("metadata")} (
           key   TEXT PRIMARY KEY,
@@ -496,7 +537,8 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           end_line     INTEGER NOT NULL,
           node_type    TEXT,
           name         TEXT,
-          language     TEXT NOT NULL
+          language     TEXT NOT NULL,
+          source_id    TEXT NOT NULL DEFAULT ''
         )
       `);
 
@@ -516,18 +558,23 @@ export class PgDatabaseBackend implements IDatabaseBackend {
         CREATE INDEX IF NOT EXISTS ${this.t("chunks_name_lower_idx")}
           ON ${this.t("chunks")} (lower(name))
       `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("chunks_source_idx")}
+          ON ${this.t("chunks")} (source_id)
+      `);
 
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("branch_chunks")} (
-          branch   TEXT NOT NULL,
-          chunk_id TEXT NOT NULL,
-          PRIMARY KEY (branch, chunk_id)
+          source_id TEXT NOT NULL DEFAULT '',
+          branch    TEXT NOT NULL,
+          chunk_id  TEXT NOT NULL,
+          PRIMARY KEY (source_id, branch, chunk_id)
         )
       `);
 
       await client.query(`
         CREATE INDEX IF NOT EXISTS ${this.t("branch_chunks_branch_idx")}
-          ON ${this.t("branch_chunks")} (branch)
+          ON ${this.t("branch_chunks")} (source_id, branch)
       `);
 
       await client.query(`
@@ -540,7 +587,8 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           start_col  INTEGER NOT NULL,
           end_line   INTEGER NOT NULL,
           end_col    INTEGER NOT NULL,
-          language   TEXT NOT NULL
+          language   TEXT NOT NULL,
+          source_id  TEXT NOT NULL DEFAULT ''
         )
       `);
 
@@ -552,6 +600,10 @@ export class PgDatabaseBackend implements IDatabaseBackend {
         CREATE INDEX IF NOT EXISTS ${this.t("symbols_name_idx")}
           ON ${this.t("symbols")} (name)
       `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("symbols_source_idx")}
+          ON ${this.t("symbols")} (source_id)
+      `);
 
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("call_edges")} (
@@ -562,7 +614,8 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           call_type      TEXT NOT NULL,
           line           INTEGER NOT NULL,
           col            INTEGER NOT NULL,
-          is_resolved    BOOLEAN NOT NULL DEFAULT FALSE
+          is_resolved    BOOLEAN NOT NULL DEFAULT FALSE,
+          source_id      TEXT NOT NULL DEFAULT ''
         )
       `);
 
@@ -578,24 +631,31 @@ export class PgDatabaseBackend implements IDatabaseBackend {
         CREATE INDEX IF NOT EXISTS ${this.t("call_edges_target_idx")}
           ON ${this.t("call_edges")} (target_name)
       `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("call_edges_source_idx")}
+          ON ${this.t("call_edges")} (source_id)
+      `);
 
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("branch_symbols")} (
+          source_id TEXT NOT NULL DEFAULT '',
           branch    TEXT NOT NULL,
           symbol_id TEXT NOT NULL,
-          PRIMARY KEY (branch, symbol_id)
+          PRIMARY KEY (source_id, branch, symbol_id)
         )
       `);
 
       await client.query(`
         CREATE INDEX IF NOT EXISTS ${this.t("branch_symbols_branch_idx")}
-          ON ${this.t("branch_symbols")} (branch)
+          ON ${this.t("branch_symbols")} (source_id, branch)
       `);
 
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("file_hashes")} (
-          file_path TEXT PRIMARY KEY,
-          hash      TEXT NOT NULL
+          source_id TEXT NOT NULL DEFAULT '',
+          file_path TEXT NOT NULL,
+          hash      TEXT NOT NULL,
+          PRIMARY KEY (source_id, file_path)
         )
       `);
 
@@ -621,12 +681,51 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           doc_len  INTEGER NOT NULL
         )
       `);
+
+      // ── Migrations for existing databases ────────────────────────
+      // Add source_id columns to tables that may have been created before
+      // this schema version.  All are idempotent (IF NOT EXISTS / IF EXISTS).
+      await client.query(`ALTER TABLE ${this.t("chunks")}        ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
+      await client.query(`ALTER TABLE ${this.t("symbols")}       ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
+      await client.query(`ALTER TABLE ${this.t("call_edges")}    ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
+
+      // branch_chunks: old PK was (branch, chunk_id); new PK is (source_id, branch, chunk_id).
+      // Drop old PK, add source_id column, add new PK.
+      await client.query(`ALTER TABLE ${this.t("branch_chunks")} ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
+      await client.query(`ALTER TABLE ${this.t("branch_chunks")} DROP CONSTRAINT IF EXISTS ${this.t("branch_chunks_pkey")}`);
+      await client.query(`ALTER TABLE ${this.t("branch_chunks")} ADD PRIMARY KEY (source_id, branch, chunk_id)`);
+
+      // branch_symbols: old PK was (branch, symbol_id); new PK is (source_id, branch, symbol_id).
+      await client.query(`ALTER TABLE ${this.t("branch_symbols")} ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
+      await client.query(`ALTER TABLE ${this.t("branch_symbols")} DROP CONSTRAINT IF EXISTS ${this.t("branch_symbols_pkey")}`);
+      await client.query(`ALTER TABLE ${this.t("branch_symbols")} ADD PRIMARY KEY (source_id, branch, symbol_id)`);
+
+      // file_hashes: old PK was (file_path); new PK is (source_id, file_path).
+      await client.query(`ALTER TABLE ${this.t("file_hashes")} ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''`);
+      await client.query(`ALTER TABLE ${this.t("file_hashes")} DROP CONSTRAINT IF EXISTS ${this.t("file_hashes_pkey")}`);
+      await client.query(`ALTER TABLE ${this.t("file_hashes")} ADD PRIMARY KEY (source_id, file_path)`);
     });
   }
 
   async close(): Promise<void> {
     await this.pool?.end();
     this.pool = null;
+  }
+
+  supportsSourceIsolation(): boolean {
+    return true;
+  }
+
+  async getOrCreateSource(rootPath: string): Promise<string> {
+    const sourceId = createHash("sha256").update(rootPath).digest("hex").slice(0, 32);
+    const pool = await this.getPool();
+    await pool.query(
+      `INSERT INTO ${this.t("sources")} (source_id, root_path, created_at)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (source_id) DO NOTHING`,
+      [sourceId, rootPath, Date.now()]
+    );
+    return sourceId;
   }
 
   // ── Embeddings ───────────────────────────────────────────────────
@@ -722,15 +821,16 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     );
   }
 
-  async upsertChunksBatch(chunks: ChunkData[]): Promise<void> {
+  async upsertChunksBatch(chunks: ChunkData[], sourceId?: string): Promise<void> {
     if (chunks.length === 0) return;
+    const sid = sourceId ?? "";
     await this.withClient(async (client) => {
       await client.query("BEGIN");
       for (const chunk of chunks) {
         await client.query(
           `INSERT INTO ${this.t("chunks")}
-             (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language)
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+             (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, source_id)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
            ON CONFLICT (chunk_id) DO UPDATE SET
              content_hash = EXCLUDED.content_hash,
              file_path    = EXCLUDED.file_path,
@@ -738,11 +838,13 @@ export class PgDatabaseBackend implements IDatabaseBackend {
              end_line     = EXCLUDED.end_line,
              node_type    = EXCLUDED.node_type,
              name         = EXCLUDED.name,
-             language     = EXCLUDED.language`,
+             language     = EXCLUDED.language,
+             source_id    = EXCLUDED.source_id`,
           [
             chunk.chunkId, chunk.contentHash, chunk.filePath,
             chunk.startLine, chunk.endLine,
             chunk.nodeType ?? null, chunk.name ?? null, chunk.language,
+            sid,
           ]
         );
       }
@@ -759,8 +861,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows[0] ? rowToChunkData(rows[0]) : null;
   }
 
-  async getChunksByFile(filePath: string): Promise<ChunkData[]> {
+  async getChunksByFile(filePath: string, sourceId?: string): Promise<ChunkData[]> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rows } = await pool.query<Record<string, unknown>>(
+        `SELECT * FROM ${this.t("chunks")} WHERE file_path = $1 AND source_id = $2 ORDER BY start_line`,
+        [filePath, sourceId]
+      );
+      return rows.map(rowToChunkData);
+    }
     const { rows } = await pool.query<Record<string, unknown>>(
       `SELECT * FROM ${this.t("chunks")} WHERE file_path = $1 ORDER BY start_line`,
       [filePath]
@@ -786,8 +895,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map(rowToChunkData);
   }
 
-  async deleteChunksByFile(filePath: string): Promise<number> {
+  async deleteChunksByFile(filePath: string, sourceId?: string): Promise<number> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM ${this.t("chunks")} WHERE file_path = $1 AND source_id = $2`,
+        [filePath, sourceId]
+      );
+      return rowCount ?? 0;
+    }
     const { rowCount } = await pool.query(
       `DELETE FROM ${this.t("chunks")} WHERE file_path = $1`,
       [filePath]
@@ -795,8 +911,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rowCount ?? 0;
   }
 
-  async getChunkFilePaths(): Promise<string[]> {
+  async getChunkFilePaths(sourceId?: string): Promise<string[]> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rows } = await pool.query(
+        `SELECT DISTINCT file_path FROM ${this.t("chunks")} WHERE source_id = $1`,
+        [sourceId]
+      );
+      return rows.map((r: { file_path: string }) => r.file_path);
+    }
     const { rows } = await pool.query(
       `SELECT DISTINCT file_path FROM ${this.t("chunks")}`
     );
@@ -811,8 +934,8 @@ export class PgDatabaseBackend implements IDatabaseBackend {
       await client.query("BEGIN");
       for (const id of chunkIds) {
         await client.query(
-          `INSERT INTO ${this.t("branch_chunks")} (branch, chunk_id)
-           VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+          `INSERT INTO ${this.t("branch_chunks")} (source_id, branch, chunk_id)
+           VALUES ('', $1, $2) ON CONFLICT DO NOTHING`,
           [branch, id]
         );
       }
@@ -820,12 +943,31 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     });
   }
 
-  async addChunksToBranchBatch(branch: string, chunkIds: string[]): Promise<void> {
-    return this.addChunksToBranch(branch, chunkIds);
+  async addChunksToBranchBatch(branch: string, chunkIds: string[], sourceId?: string): Promise<void> {
+    if (chunkIds.length === 0) return;
+    const sid = sourceId ?? "";
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const id of chunkIds) {
+        await client.query(
+          `INSERT INTO ${this.t("branch_chunks")} (source_id, branch, chunk_id)
+           VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+          [sid, branch, id]
+        );
+      }
+      await client.query("COMMIT");
+    });
   }
 
-  async clearBranch(branch: string): Promise<number> {
+  async clearBranch(branch: string, sourceId?: string): Promise<number> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM ${this.t("branch_chunks")} WHERE branch = $1 AND source_id = $2`,
+        [branch, sourceId]
+      );
+      return rowCount ?? 0;
+    }
     const { rowCount } = await pool.query(
       `DELETE FROM ${this.t("branch_chunks")} WHERE branch = $1`,
       [branch]
@@ -854,8 +996,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rowCount ?? 0;
   }
 
-  async getBranchChunkIds(branch: string): Promise<string[]> {
+  async getBranchChunkIds(branch: string, sourceIds?: string[]): Promise<string[]> {
     const pool = await this.getPool();
+    if (sourceIds && sourceIds.length > 0) {
+      const { rows } = await pool.query<{ chunk_id: string }>(
+        `SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $1 AND source_id = ANY($2::text[])`,
+        [branch, sourceIds]
+      );
+      return rows.map((r) => r.chunk_id);
+    }
     const { rows } = await pool.query<{ chunk_id: string }>(
       `SELECT chunk_id FROM ${this.t("branch_chunks")} WHERE branch = $1`,
       [branch]
@@ -1034,15 +1183,16 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     );
   }
 
-  async upsertSymbolsBatch(symbols: SymbolData[]): Promise<void> {
+  async upsertSymbolsBatch(symbols: SymbolData[], sourceId?: string): Promise<void> {
+    const sid = sourceId ?? "";
     if (symbols.length === 0) return;
     await this.withClient(async (client) => {
       await client.query("BEGIN");
       for (const symbol of symbols) {
         await client.query(
           `INSERT INTO ${this.t("symbols")}
-             (id, file_path, name, kind, start_line, start_col, end_line, end_col, language)
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+             (id, file_path, name, kind, start_line, start_col, end_line, end_col, language, source_id)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
            ON CONFLICT (id) DO UPDATE SET
              file_path  = EXCLUDED.file_path,
              name       = EXCLUDED.name,
@@ -1051,17 +1201,26 @@ export class PgDatabaseBackend implements IDatabaseBackend {
              start_col  = EXCLUDED.start_col,
              end_line   = EXCLUDED.end_line,
              end_col    = EXCLUDED.end_col,
-             language   = EXCLUDED.language`,
+             language   = EXCLUDED.language,
+             source_id  = EXCLUDED.source_id`,
           [symbol.id, symbol.filePath, symbol.name, symbol.kind,
-           symbol.startLine, symbol.startCol, symbol.endLine, symbol.endCol, symbol.language]
+           symbol.startLine, symbol.startCol, symbol.endLine, symbol.endCol, symbol.language,
+           sid]
         );
       }
       await client.query("COMMIT");
     });
   }
 
-  async getSymbolsByFile(filePath: string): Promise<SymbolData[]> {
+  async getSymbolsByFile(filePath: string, sourceId?: string): Promise<SymbolData[]> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rows } = await pool.query<Record<string, unknown>>(
+        `SELECT * FROM ${this.t("symbols")} WHERE file_path = $1 AND source_id = $2`,
+        [filePath, sourceId]
+      );
+      return rows.map(rowToSymbolData);
+    }
     const { rows } = await pool.query<Record<string, unknown>>(
       `SELECT * FROM ${this.t("symbols")} WHERE file_path = $1`,
       [filePath]
@@ -1096,8 +1255,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map(rowToSymbolData);
   }
 
-  async deleteSymbolsByFile(filePath: string): Promise<number> {
+  async deleteSymbolsByFile(filePath: string, sourceId?: string): Promise<number> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM ${this.t("symbols")} WHERE file_path = $1 AND source_id = $2`,
+        [filePath, sourceId]
+      );
+      return rowCount ?? 0;
+    }
     const { rowCount } = await pool.query(
       `DELETE FROM ${this.t("symbols")} WHERE file_path = $1`,
       [filePath]
@@ -1126,15 +1292,16 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     );
   }
 
-  async upsertCallEdgesBatch(edges: CallEdgeData[]): Promise<void> {
+  async upsertCallEdgesBatch(edges: CallEdgeData[], sourceId?: string): Promise<void> {
+    const sid = sourceId ?? "";
     if (edges.length === 0) return;
     await this.withClient(async (client) => {
       await client.query("BEGIN");
       for (const edge of edges) {
         await client.query(
           `INSERT INTO ${this.t("call_edges")}
-             (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved)
-           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+             (id, from_symbol_id, target_name, to_symbol_id, call_type, line, col, is_resolved, source_id)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
            ON CONFLICT (id) DO UPDATE SET
              from_symbol_id = EXCLUDED.from_symbol_id,
              target_name    = EXCLUDED.target_name,
@@ -1142,17 +1309,28 @@ export class PgDatabaseBackend implements IDatabaseBackend {
              call_type      = EXCLUDED.call_type,
              line           = EXCLUDED.line,
              col            = EXCLUDED.col,
-             is_resolved    = EXCLUDED.is_resolved`,
+             is_resolved    = EXCLUDED.is_resolved,
+             source_id      = EXCLUDED.source_id`,
           [edge.id, edge.fromSymbolId, edge.targetName, edge.toSymbolId ?? null,
-           edge.callType, edge.line, edge.col, edge.isResolved]
+           edge.callType, edge.line, edge.col, edge.isResolved, sid]
         );
       }
       await client.query("COMMIT");
     });
   }
 
-  async getCallers(targetName: string, branch: string): Promise<CallEdgeData[]> {
+  async getCallers(targetName: string, branch: string, sourceIds?: string[]): Promise<CallEdgeData[]> {
     const pool = await this.getPool();
+    if (sourceIds && sourceIds.length > 0) {
+      const { rows } = await pool.query<Record<string, unknown>>(
+        `SELECT ce.*
+         FROM ${this.t("call_edges")} ce
+         JOIN ${this.t("branch_symbols")} bs ON bs.symbol_id = ce.from_symbol_id
+         WHERE ce.target_name = $1 AND bs.branch = $2 AND bs.source_id = ANY($3::text[])`,
+        [targetName, branch, sourceIds]
+      );
+      return rows.map((r) => rowToCallEdgeData(r));
+    }
     const { rows } = await pool.query<Record<string, unknown>>(
       `SELECT ce.*
        FROM ${this.t("call_edges")} ce
@@ -1163,8 +1341,21 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map((r) => rowToCallEdgeData(r));
   }
 
-  async getCallersWithContext(targetName: string, branch: string): Promise<CallEdgeData[]> {
+  async getCallersWithContext(targetName: string, branch: string, sourceIds?: string[]): Promise<CallEdgeData[]> {
     const pool = await this.getPool();
+    if (sourceIds && sourceIds.length > 0) {
+      const { rows } = await pool.query<Record<string, unknown>>(
+        `SELECT ce.*,
+                s.name      AS from_symbol_name,
+                s.file_path AS from_symbol_file_path
+         FROM ${this.t("call_edges")} ce
+         JOIN ${this.t("symbols")} s           ON s.id = ce.from_symbol_id
+         JOIN ${this.t("branch_symbols")} bs   ON bs.symbol_id = ce.from_symbol_id
+         WHERE ce.target_name = $1 AND bs.branch = $2 AND bs.source_id = ANY($3::text[])`,
+        [targetName, branch, sourceIds]
+      );
+      return rows.map((r) => rowToCallEdgeData(r, true));
+    }
     const { rows } = await pool.query<Record<string, unknown>>(
       `SELECT ce.*,
               s.name      AS from_symbol_name,
@@ -1178,8 +1369,18 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map((r) => rowToCallEdgeData(r, true));
   }
 
-  async getCallees(symbolId: string, branch: string): Promise<CallEdgeData[]> {
+  async getCallees(symbolId: string, branch: string, sourceIds?: string[]): Promise<CallEdgeData[]> {
     const pool = await this.getPool();
+    if (sourceIds && sourceIds.length > 0) {
+      const { rows } = await pool.query<Record<string, unknown>>(
+        `SELECT ce.*
+         FROM ${this.t("call_edges")} ce
+         JOIN ${this.t("branch_symbols")} bs ON bs.symbol_id = ce.from_symbol_id
+         WHERE ce.from_symbol_id = $1 AND bs.branch = $2 AND bs.source_id = ANY($3::text[])`,
+        [symbolId, branch, sourceIds]
+      );
+      return rows.map((r) => rowToCallEdgeData(r));
+    }
     const { rows } = await pool.query<Record<string, unknown>>(
       `SELECT ce.*
        FROM ${this.t("call_edges")} ce
@@ -1190,8 +1391,18 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map((r) => rowToCallEdgeData(r));
   }
 
-  async deleteCallEdgesByFile(filePath: string): Promise<number> {
+  async deleteCallEdgesByFile(filePath: string, sourceId?: string): Promise<number> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM ${this.t("call_edges")}
+         WHERE from_symbol_id IN (
+           SELECT id FROM ${this.t("symbols")} WHERE file_path = $1 AND source_id = $2
+         )`,
+        [filePath, sourceId]
+      );
+      return rowCount ?? 0;
+    }
     const { rowCount } = await pool.query(
       `DELETE FROM ${this.t("call_edges")}
        WHERE from_symbol_id IN (
@@ -1220,8 +1431,8 @@ export class PgDatabaseBackend implements IDatabaseBackend {
       await client.query("BEGIN");
       for (const id of symbolIds) {
         await client.query(
-          `INSERT INTO ${this.t("branch_symbols")} (branch, symbol_id)
-           VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+          `INSERT INTO ${this.t("branch_symbols")} (source_id, branch, symbol_id)
+           VALUES ('', $1, $2) ON CONFLICT DO NOTHING`,
           [branch, id]
         );
       }
@@ -1229,12 +1440,31 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     });
   }
 
-  async addSymbolsToBranchBatch(branch: string, symbolIds: string[]): Promise<void> {
-    return this.addSymbolsToBranch(branch, symbolIds);
+  async addSymbolsToBranchBatch(branch: string, symbolIds: string[], sourceId?: string): Promise<void> {
+    if (symbolIds.length === 0) return;
+    const sid = sourceId ?? "";
+    await this.withClient(async (client) => {
+      await client.query("BEGIN");
+      for (const id of symbolIds) {
+        await client.query(
+          `INSERT INTO ${this.t("branch_symbols")} (source_id, branch, symbol_id)
+           VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+          [sid, branch, id]
+        );
+      }
+      await client.query("COMMIT");
+    });
   }
 
-  async getBranchSymbolIds(branch: string): Promise<string[]> {
+  async getBranchSymbolIds(branch: string, sourceIds?: string[]): Promise<string[]> {
     const pool = await this.getPool();
+    if (sourceIds && sourceIds.length > 0) {
+      const { rows } = await pool.query<{ symbol_id: string }>(
+        `SELECT symbol_id FROM ${this.t("branch_symbols")} WHERE branch = $1 AND source_id = ANY($2::text[])`,
+        [branch, sourceIds]
+      );
+      return rows.map((r) => r.symbol_id);
+    }
     const { rows } = await pool.query<{ symbol_id: string }>(
       `SELECT symbol_id FROM ${this.t("branch_symbols")} WHERE branch = $1`,
       [branch]
@@ -1242,8 +1472,15 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rows.map((r) => r.symbol_id);
   }
 
-  async clearBranchSymbols(branch: string): Promise<number> {
+  async clearBranchSymbols(branch: string, sourceId?: string): Promise<number> {
     const pool = await this.getPool();
+    if (sourceId !== undefined) {
+      const { rowCount } = await pool.query(
+        `DELETE FROM ${this.t("branch_symbols")} WHERE branch = $1 AND source_id = $2`,
+        [branch, sourceId]
+      );
+      return rowCount ?? 0;
+    }
     const { rowCount } = await pool.query(
       `DELETE FROM ${this.t("branch_symbols")} WHERE branch = $1`,
       [branch]
@@ -1321,8 +1558,8 @@ export class PgDatabaseBackend implements IDatabaseBackend {
   async setFileHash(filePath: string, hash: string): Promise<void> {
     const pool = await this.getPool();
     await pool.query(
-      `INSERT INTO ${this.t("file_hashes")} (file_path, hash) VALUES ($1, $2)
-       ON CONFLICT (file_path) DO UPDATE SET hash = EXCLUDED.hash`,
+      `INSERT INTO ${this.t("file_hashes")} (source_id, file_path, hash) VALUES ('', $1, $2)
+       ON CONFLICT (source_id, file_path) DO UPDATE SET hash = EXCLUDED.hash`,
       [filePath, hash]
     );
   }
@@ -1330,7 +1567,7 @@ export class PgDatabaseBackend implements IDatabaseBackend {
   async deleteFileHash(filePath: string): Promise<void> {
     const pool = await this.getPool();
     await pool.query(
-      `DELETE FROM ${this.t("file_hashes")} WHERE file_path = $1`,
+      `DELETE FROM ${this.t("file_hashes")} WHERE source_id = '' AND file_path = $1`,
       [filePath]
     );
   }
@@ -1343,15 +1580,16 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return new Map(rows.map((r) => [r.file_path, r.hash]));
   }
 
-  async setFileHashesBatch(hashes: Map<string, string>): Promise<void> {
+  async setFileHashesBatch(hashes: Map<string, string>, sourceId?: string): Promise<void> {
     if (hashes.size === 0) return;
+    const sid = sourceId ?? "";
     await this.withClient(async (client) => {
       await client.query("BEGIN");
       for (const [filePath, hash] of hashes) {
         await client.query(
-          `INSERT INTO ${this.t("file_hashes")} (file_path, hash) VALUES ($1, $2)
-           ON CONFLICT (file_path) DO UPDATE SET hash = EXCLUDED.hash`,
-          [filePath, hash]
+          `INSERT INTO ${this.t("file_hashes")} (source_id, file_path, hash) VALUES ($1, $2, $3)
+           ON CONFLICT (source_id, file_path) DO UPDATE SET hash = EXCLUDED.hash`,
+          [sid, filePath, hash]
         );
       }
       await client.query("COMMIT");
@@ -1502,13 +1740,55 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     }
   }
 
-  async searchBm25(query: string, limit: number): Promise<Map<string, number> | null> {
+  async searchBm25(query: string, limit: number, sourceIds?: string[]): Promise<Map<string, number> | null> {
     const terms = tokenizeText(query);
     if (terms.length === 0) return new Map();
 
     const pool = await this.getPool();
-    const { rows } = await pool.query<{ chunk_id: string; score: number }>(
-      `WITH
+    let queryText: string;
+    let params: unknown[];
+
+    if (sourceIds && sourceIds.length > 0) {
+      // Scope BM25 corpus stats and results to the given sources by joining chunks.
+      queryText = `WITH
+        qt AS (SELECT UNNEST($1::text[]) AS term),
+        src_chunks AS (
+          SELECT chunk_id FROM ${this.t("chunks")} WHERE source_id = ANY($3::text[])
+        ),
+        tdf AS (
+          SELECT p.term, COUNT(DISTINCT p.chunk_id)::FLOAT AS df
+          FROM ${this.t("inverted_index_postings")} p
+          JOIN src_chunks sc ON p.chunk_id = sc.chunk_id
+          JOIN qt ON p.term = qt.term
+          GROUP BY p.term
+        ),
+        stats AS (
+          SELECT
+            COUNT(*)::FLOAT                      AS total_docs,
+            COALESCE(AVG(dl.doc_len)::FLOAT, 1.0) AS avg_dl
+          FROM ${this.t("inverted_index_doc_lengths")} dl
+          JOIN src_chunks sc ON dl.chunk_id = sc.chunk_id
+        ),
+        scored AS (
+          SELECT
+            p.chunk_id,
+            SUM(
+              LN((s.total_docs - t.df + 0.5) / (t.df + 0.5) + 1.0)
+              * (p.token_count::FLOAT * 2.2)
+              / (p.token_count::FLOAT + 1.2 * (0.25 + 0.75 * dl.doc_len::FLOAT / s.avg_dl))
+            ) AS score
+          FROM ${this.t("inverted_index_postings")} p
+          JOIN src_chunks sc                              ON p.chunk_id = sc.chunk_id
+          JOIN qt                                         ON p.term     = qt.term
+          JOIN tdf t                                      ON p.term     = t.term
+          JOIN ${this.t("inverted_index_doc_lengths")} dl ON p.chunk_id = dl.chunk_id
+          CROSS JOIN stats s
+          GROUP BY p.chunk_id
+        )
+      SELECT chunk_id, score FROM scored ORDER BY score DESC LIMIT $2`;
+      params = [terms, limit, sourceIds];
+    } else {
+      queryText = `WITH
         qt AS (SELECT UNNEST($1::text[]) AS term),
         tdf AS (
           SELECT p.term, COUNT(DISTINCT p.chunk_id)::FLOAT AS df
@@ -1537,10 +1817,11 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           CROSS JOIN stats s
           GROUP BY p.chunk_id
         )
-      SELECT chunk_id, score FROM scored ORDER BY score DESC LIMIT $2`,
-      [terms, limit]
-    );
+      SELECT chunk_id, score FROM scored ORDER BY score DESC LIMIT $2`;
+      params = [terms, limit];
+    }
 
+    const { rows } = await pool.query<{ chunk_id: string; score: number }>(queryText, params);
     const result = new Map<string, number>();
     for (const row of rows) result.set(row.chunk_id, Number(row.score));
     return result;
@@ -1548,70 +1829,69 @@ export class PgDatabaseBackend implements IDatabaseBackend {
 
   // ── Bulk file-hash replacement ────────────────────────────────────
 
-  async replaceAllFileHashes(hashes: Map<string, string>): Promise<void> {
+  async replaceAllFileHashes(hashes: Map<string, string>, sourceId?: string): Promise<void> {
+    const sid = sourceId ?? "";
     await this.withClient(async (client) => {
       await client.query("BEGIN");
-      await client.query(`TRUNCATE TABLE ${this.t("file_hashes")}`);
+      await client.query(
+        `DELETE FROM ${this.t("file_hashes")} WHERE source_id = $1`,
+        [sid]
+      );
       for (const [filePath, hash] of hashes) {
         await client.query(
-          `INSERT INTO ${this.t("file_hashes")} (file_path, hash) VALUES ($1, $2)`,
-          [filePath, hash]
+          `INSERT INTO ${this.t("file_hashes")} (source_id, file_path, hash) VALUES ($1, $2, $3)`,
+          [sid, filePath, hash]
         );
       }
       await client.query("COMMIT");
     });
   }
 
-  async getFileHashBatch(filePaths: string[]): Promise<Map<string, string>> {
+  async getFileHashBatch(filePaths: string[], sourceId?: string): Promise<Map<string, string>> {
     if (filePaths.length === 0) return new Map();
     const pool = await this.getPool();
+    const sid = sourceId ?? "";
     const { rows } = await pool.query<{ file_path: string; hash: string }>(
-      `SELECT file_path, hash FROM ${this.t("file_hashes")} WHERE file_path = ANY($1::text[])`,
-      [filePaths]
+      `SELECT file_path, hash FROM ${this.t("file_hashes")}
+       WHERE source_id = $1 AND file_path = ANY($2::text[])`,
+      [sid, filePaths]
     );
     return new Map(rows.map((r) => [r.file_path, r.hash]));
   }
 
-  async hasFileHashesOutsideRoots(roots: string[]): Promise<boolean> {
-    if (roots.length === 0) return false;
+  async hasSourcesOtherThan(sourceIds: string[]): Promise<boolean> {
+    if (sourceIds.length === 0) {
+      const pool = await this.getPool();
+      const { rows } = await pool.query<{ cnt: string }>(
+        `SELECT COUNT(*) AS cnt FROM ${this.t("file_hashes")}`
+      );
+      return parseInt(rows[0]?.cnt ?? "0", 10) > 0;
+    }
     const pool = await this.getPool();
     const { rows } = await pool.query<{ exists: boolean }>(
       `SELECT EXISTS(
          SELECT 1 FROM ${this.t("file_hashes")}
-         WHERE NOT EXISTS (
-           SELECT 1 FROM UNNEST($1::text[]) AS r(root)
-           WHERE file_path = r.root OR file_path LIKE r.root || '/%'
-         )
+         WHERE source_id != ALL($1::text[])
        ) AS exists`,
-      [roots]
+      [sourceIds]
     );
     return rows[0]?.exists ?? false;
   }
 
-  async getFilePathsInRoots(roots: string[]): Promise<string[]> {
-    if (roots.length === 0) return [];
+  async getFilePathsBySource(sourceId: string): Promise<string[]> {
     const pool = await this.getPool();
     const { rows } = await pool.query<{ file_path: string }>(
-      `SELECT file_path FROM ${this.t("file_hashes")}
-       WHERE EXISTS (
-         SELECT 1 FROM UNNEST($1::text[]) AS r(root)
-         WHERE file_path = r.root OR file_path LIKE r.root || '/%'
-       )`,
-      [roots]
+      `SELECT file_path FROM ${this.t("file_hashes")} WHERE source_id = $1`,
+      [sourceId]
     );
     return rows.map((r) => r.file_path);
   }
 
-  async deleteFileHashesInRoots(roots: string[]): Promise<void> {
-    if (roots.length === 0) return;
+  async deleteFileHashesBySource(sourceId: string): Promise<void> {
     const pool = await this.getPool();
     await pool.query(
-      `DELETE FROM ${this.t("file_hashes")}
-       WHERE EXISTS (
-         SELECT 1 FROM UNNEST($1::text[]) AS r(root)
-         WHERE file_path = r.root OR file_path LIKE r.root || '/%'
-       )`,
-      [roots]
+      `DELETE FROM ${this.t("file_hashes")} WHERE source_id = $1`,
+      [sourceId]
     );
   }
 }

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -559,22 +559,12 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           ON ${this.t("chunks")} (lower(name))
       `);
       await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("chunks_source_idx")}
-          ON ${this.t("chunks")} (source_id)
-      `);
-
-      await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("branch_chunks")} (
           source_id TEXT NOT NULL DEFAULT '',
           branch    TEXT NOT NULL,
           chunk_id  TEXT NOT NULL,
           PRIMARY KEY (source_id, branch, chunk_id)
         )
-      `);
-
-      await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("branch_chunks_branch_idx")}
-          ON ${this.t("branch_chunks")} (source_id, branch)
       `);
 
       await client.query(`
@@ -599,10 +589,6 @@ export class PgDatabaseBackend implements IDatabaseBackend {
       await client.query(`
         CREATE INDEX IF NOT EXISTS ${this.t("symbols_name_idx")}
           ON ${this.t("symbols")} (name)
-      `);
-      await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("symbols_source_idx")}
-          ON ${this.t("symbols")} (source_id)
       `);
 
       await client.query(`
@@ -631,10 +617,6 @@ export class PgDatabaseBackend implements IDatabaseBackend {
         CREATE INDEX IF NOT EXISTS ${this.t("call_edges_target_idx")}
           ON ${this.t("call_edges")} (target_name)
       `);
-      await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("call_edges_source_idx")}
-          ON ${this.t("call_edges")} (source_id)
-      `);
 
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.t("branch_symbols")} (
@@ -643,11 +625,6 @@ export class PgDatabaseBackend implements IDatabaseBackend {
           symbol_id TEXT NOT NULL,
           PRIMARY KEY (source_id, branch, symbol_id)
         )
-      `);
-
-      await client.query(`
-        CREATE INDEX IF NOT EXISTS ${this.t("branch_symbols_branch_idx")}
-          ON ${this.t("branch_symbols")} (source_id, branch)
       `);
 
       await client.query(`
@@ -728,6 +705,34 @@ export class PgDatabaseBackend implements IDatabaseBackend {
         await client.query(`ALTER TABLE ${this.t("file_hashes")} DROP CONSTRAINT IF EXISTS ${this.t("file_hashes_pkey")}`);
         await client.query(`ALTER TABLE ${this.t("file_hashes")} ADD PRIMARY KEY (source_id, file_path)`);
       }
+
+      // ── Indexes on source_id (must come after ADD COLUMN migrations) ─
+      // These are deferred so that CREATE INDEX doesn't fire before the
+      // column exists on databases that pre-date source_id support.
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("chunks_source_idx")}
+          ON ${this.t("chunks")} (source_id)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("symbols_source_idx")}
+          ON ${this.t("symbols")} (source_id)
+      `);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("call_edges_source_idx")}
+          ON ${this.t("call_edges")} (source_id)
+      `);
+      // Drop and recreate composite branch indexes: old definition was (branch)
+      // only; new definition is (source_id, branch) to support source filtering.
+      await client.query(`DROP INDEX IF EXISTS ${this.t("branch_chunks_branch_idx")}`);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("branch_chunks_branch_idx")}
+          ON ${this.t("branch_chunks")} (source_id, branch)
+      `);
+      await client.query(`DROP INDEX IF EXISTS ${this.t("branch_symbols_branch_idx")}`);
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS ${this.t("branch_symbols_branch_idx")}
+          ON ${this.t("branch_symbols")} (source_id, branch)
+      `);
     });
   }
 

--- a/src/db/pg-backend.ts
+++ b/src/db/pg-backend.ts
@@ -795,6 +795,14 @@ export class PgDatabaseBackend implements IDatabaseBackend {
     return rowCount ?? 0;
   }
 
+  async getChunkFilePaths(): Promise<string[]> {
+    const pool = await this.getPool();
+    const { rows } = await pool.query(
+      `SELECT DISTINCT file_path FROM ${this.t("chunks")}`
+    );
+    return rows.map((r: { file_path: string }) => r.file_path);
+  }
+
   // ── Branch catalog ────────────────────────────────────────────────
 
   async addChunksToBranch(branch: string, chunkIds: string[]): Promise<void> {

--- a/src/db/sqlite-backend.ts
+++ b/src/db/sqlite-backend.ts
@@ -210,6 +210,12 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return Array.from(this.readFileHashesFromDisk().keys());
   }
 
+  async getFilePathsInRoots(roots: string[]): Promise<string[]> {
+    if (roots.length === 0) return [];
+    const all = Array.from(this.readFileHashesFromDisk().keys());
+    return all.filter((fp) => roots.some((root) => fp.startsWith(root)));
+  }
+
   // ── Branch catalog ───────────────────────────────────────────────
 
   async addChunksToBranch(branch: string, chunkIds: string[]): Promise<void> {

--- a/src/db/sqlite-backend.ts
+++ b/src/db/sqlite-backend.ts
@@ -450,9 +450,28 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.readFileHashesFromDisk();
   }
 
-  async setFileHashesBatch(hashes: Map<string, string>, _sourceId?: string): Promise<void> {
+  private sourceScopedFileHashKey(filePath: string, sourceId?: string): string {
+    return sourceId ? `${sourceId}::${filePath}` : filePath;
+  }
+
+  private parseSourceScopedFileHashKey(key: string): { sourceId?: string; filePath: string } {
+    const delimiter = key.indexOf("::");
+    if (delimiter === -1) {
+      return { filePath: key };
+    }
+
+    return {
+      sourceId: key.slice(0, delimiter),
+      filePath: key.slice(delimiter + 2),
+    };
+  }
+
+  async setFileHashesBatch(hashes: Map<string, string>, sourceId?: string): Promise<void> {
     const existing = this.readFileHashesFromDisk();
-    for (const [k, v] of hashes) existing.set(k, v);
+    for (const [filePath, hash] of hashes) {
+      existing.set(this.sourceScopedFileHashKey(filePath, sourceId), hash);
+      existing.set(filePath, hash);
+    }
     this.writeFileHashesToDisk(existing);
   }
 
@@ -462,31 +481,108 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.writeFileHashesToDisk(hashes);
   }
 
-  async replaceAllFileHashes(hashes: Map<string, string>, _sourceId?: string): Promise<void> {
-    this.writeFileHashesToDisk(hashes);
+  async replaceAllFileHashes(hashes: Map<string, string>, sourceId?: string): Promise<void> {
+    if (!sourceId) {
+      this.writeFileHashesToDisk(hashes);
+      return;
+    }
+
+    const existing = this.readFileHashesFromDisk();
+    const removedFilePaths = new Set<string>();
+    for (const key of Array.from(existing.keys())) {
+      const parsed = this.parseSourceScopedFileHashKey(key);
+      if (parsed.sourceId === sourceId) {
+        existing.delete(key);
+        removedFilePaths.add(parsed.filePath);
+      }
+    }
+
+    for (const filePath of removedFilePaths) {
+      existing.delete(filePath);
+    }
+
+    for (const [filePath, hash] of hashes) {
+      existing.set(this.sourceScopedFileHashKey(filePath, sourceId), hash);
+      existing.set(filePath, hash);
+    }
+
+    this.writeFileHashesToDisk(existing);
   }
 
-  async getFileHashBatch(filePaths: string[], _sourceId?: string): Promise<Map<string, string>> {
+  async getFileHashBatch(filePaths: string[], sourceId?: string): Promise<Map<string, string>> {
     if (filePaths.length === 0) return new Map();
     const all = this.readFileHashesFromDisk();
     const result = new Map<string, string>();
     for (const fp of filePaths) {
-      const h = all.get(fp);
+      const scopedKey = this.sourceScopedFileHashKey(fp, sourceId);
+      const h = all.get(scopedKey) ?? all.get(fp);
       if (h !== undefined) result.set(fp, h);
     }
     return result;
   }
 
-  async hasSourcesOtherThan(_sourceIds: string[]): Promise<boolean> {
-    return false; // SQLite is single-source by design
+  async hasSourcesOtherThan(sourceIds: string[]): Promise<boolean> {
+    const scopedIds = new Set<string>();
+    for (const key of this.readFileHashesFromDisk().keys()) {
+      const parsed = this.parseSourceScopedFileHashKey(key);
+      if (parsed.sourceId) {
+        scopedIds.add(parsed.sourceId);
+      }
+    }
+
+    if (scopedIds.size === 0) {
+      return false;
+    }
+
+    for (const sourceId of scopedIds) {
+      if (!sourceIds.includes(sourceId)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
-  async getFilePathsBySource(_sourceId: string): Promise<string[]> {
-    return Array.from(this.readFileHashesFromDisk().keys());
+  async getFilePathsBySource(sourceId: string): Promise<string[]> {
+    const all = this.readFileHashesFromDisk();
+    const scopedPaths = new Set<string>();
+    for (const key of all.keys()) {
+      const parsed = this.parseSourceScopedFileHashKey(key);
+      if (parsed.sourceId === sourceId) {
+        scopedPaths.add(parsed.filePath);
+      }
+    }
+
+    if (scopedPaths.size > 0) {
+      return Array.from(scopedPaths);
+    }
+
+    const legacyPaths = new Set<string>();
+    for (const key of all.keys()) {
+      const parsed = this.parseSourceScopedFileHashKey(key);
+      if (!parsed.sourceId) {
+        legacyPaths.add(parsed.filePath);
+      }
+    }
+    return Array.from(legacyPaths);
   }
 
-  async deleteFileHashesBySource(_sourceId: string): Promise<void> {
-    this.writeFileHashesToDisk(new Map());
+  async deleteFileHashesBySource(sourceId: string): Promise<void> {
+    const existing = this.readFileHashesFromDisk();
+    const removedFilePaths = new Set<string>();
+    for (const key of Array.from(existing.keys())) {
+      const parsed = this.parseSourceScopedFileHashKey(key);
+      if (parsed.sourceId === sourceId) {
+        existing.delete(key);
+        removedFilePaths.add(parsed.filePath);
+      }
+    }
+
+    for (const filePath of removedFilePaths) {
+      existing.delete(filePath);
+    }
+
+    this.writeFileHashesToDisk(existing);
   }
 
   // ── Inverted index (inverted-index.json) ──────────────────────────

--- a/src/db/sqlite-backend.ts
+++ b/src/db/sqlite-backend.ts
@@ -1,0 +1,539 @@
+/**
+ * SQLite implementations of IDatabaseBackend and IVectorStoreBackend.
+ *
+ * These are thin synchronous wrappers around the existing native Rust/NAPI
+ * classes.  Every method returns Promise.resolve() so the async interface is
+ * satisfied with zero overhead.
+ */
+
+import * as path from "path";
+import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "fs";
+
+function isPathUnderRoot(filePath: string, root: string): boolean {
+  const r = path.resolve(root);
+  const f = path.resolve(filePath);
+  return f === r || f.startsWith(r + path.sep);
+}
+import { promises as fsPromises } from "fs";
+import type {
+  IDatabaseBackend,
+  IVectorStoreBackend,
+  VectorSearchResult,
+} from "./backend.js";
+import type { ChunkData, BranchDelta, DatabaseStats, SymbolData, CallEdgeData, ChunkMetadata } from "./backend.js";
+import { Database, VectorStore, InvertedIndex } from "../native/index.js";
+
+// ── SqliteVectorStoreBackend ────────────────────────────────────────────────
+
+export class SqliteVectorStoreBackend implements IVectorStoreBackend {
+  private inner: VectorStore | null = null;
+  private dimensions = 0;
+  private readonly storePath: string;
+
+  constructor(storePath: string) {
+    this.storePath = storePath;
+  }
+
+  async initialize(dimensions: number): Promise<void> {
+    this.dimensions = dimensions;
+    this.inner = new VectorStore(this.storePath, dimensions);
+  }
+
+  async load(): Promise<void> {
+    const indexFile = `${this.storePath}.usearch`;
+    if (existsSync(indexFile)) {
+      this.inner!.load();
+    }
+  }
+
+  async save(): Promise<void> {
+    this.inner!.save();
+  }
+
+  async add(id: string, vector: number[], metadata: ChunkMetadata): Promise<void> {
+    this.inner!.add(id, vector, metadata);
+  }
+
+  async addBatch(
+    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>
+  ): Promise<void> {
+    this.inner!.addBatch(items);
+  }
+
+  async search(queryVector: number[], limit: number): Promise<VectorSearchResult[]> {
+    return this.inner!.search(queryVector, limit);
+  }
+
+  async remove(id: string): Promise<boolean> {
+    return this.inner!.remove(id);
+  }
+
+  async count(): Promise<number> {
+    return this.inner!.count();
+  }
+
+  async clear(): Promise<void> {
+    this.inner!.clear();
+  }
+
+  getDimensions(): number {
+    return this.dimensions;
+  }
+
+  async getAllKeys(): Promise<string[]> {
+    return this.inner!.getAllKeys();
+  }
+
+  async getAllMetadata(): Promise<Array<{ key: string; metadata: ChunkMetadata }>> {
+    return this.inner!.getAllMetadata();
+  }
+
+  async getMetadata(id: string): Promise<ChunkMetadata | undefined> {
+    return this.inner!.getMetadata(id);
+  }
+
+  async getMetadataBatch(ids: string[]): Promise<Map<string, ChunkMetadata>> {
+    return this.inner!.getMetadataBatch(ids);
+  }
+
+  /** Expose the underlying InvertedIndex path for callers that still need the
+   *  native InvertedIndex (always local for both backends). */
+  getStorePath(): string {
+    return this.storePath;
+  }
+}
+
+// ── SqliteDatabaseBackend ───────────────────────────────────────────────────
+
+export class SqliteDatabaseBackend implements IDatabaseBackend {
+  private inner: Database | null = null;
+  private readonly dbPath: string;
+
+  constructor(dbPath: string) {
+    this.dbPath = dbPath;
+  }
+
+  async initialize(): Promise<void> {
+    this.inner = new Database(this.dbPath);
+  }
+
+  async close(): Promise<void> {
+    this.inner?.close();
+    this.inner = null;
+  }
+
+  /** Expose path so the Indexer can check for file existence and corruption. */
+  getDbPath(): string {
+    return this.dbPath;
+  }
+
+  /** Whether the DB file already existed before initialize() was called. */
+  async dbFileExists(): Promise<boolean> {
+    return existsSync(this.dbPath);
+  }
+
+  /** Delete all SQLite-related files (used on corruption reset). */
+  async deleteFiles(): Promise<void> {
+    for (const suffix of ["", "-shm", "-wal"]) {
+      try {
+        await fsPromises.rm(this.dbPath + suffix, { force: true });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
+  // ── Embeddings ──────────────────────────────────────────────────
+
+  async embeddingExists(contentHash: string): Promise<boolean> {
+    return this.inner!.embeddingExists(contentHash);
+  }
+
+  async getEmbedding(contentHash: string): Promise<Buffer | null> {
+    return this.inner!.getEmbedding(contentHash);
+  }
+
+  async upsertEmbedding(
+    contentHash: string,
+    embedding: Buffer,
+    chunkText: string,
+    model: string
+  ): Promise<void> {
+    this.inner!.upsertEmbedding(contentHash, embedding, chunkText, model);
+  }
+
+  async upsertEmbeddingsBatch(
+    items: Array<{ contentHash: string; embedding: Buffer; chunkText: string; model: string }>
+  ): Promise<void> {
+    this.inner!.upsertEmbeddingsBatch(items);
+  }
+
+  async getMissingEmbeddings(contentHashes: string[]): Promise<string[]> {
+    return this.inner!.getMissingEmbeddings(contentHashes);
+  }
+
+  // ── Chunks ──────────────────────────────────────────────────────
+
+  async upsertChunk(chunk: ChunkData): Promise<void> {
+    this.inner!.upsertChunk(chunk);
+  }
+
+  async upsertChunksBatch(chunks: ChunkData[]): Promise<void> {
+    this.inner!.upsertChunksBatch(chunks);
+  }
+
+  async getChunk(chunkId: string): Promise<ChunkData | null> {
+    return this.inner!.getChunk(chunkId);
+  }
+
+  async getChunksByFile(filePath: string): Promise<ChunkData[]> {
+    return this.inner!.getChunksByFile(filePath);
+  }
+
+  async getChunksByName(name: string): Promise<ChunkData[]> {
+    return this.inner!.getChunksByName(name);
+  }
+
+  async getChunksByNameCi(name: string): Promise<ChunkData[]> {
+    return this.inner!.getChunksByNameCi(name);
+  }
+
+  async deleteChunksByFile(filePath: string): Promise<number> {
+    return this.inner!.deleteChunksByFile(filePath);
+  }
+
+  // ── Branch catalog ───────────────────────────────────────────────
+
+  async addChunksToBranch(branch: string, chunkIds: string[]): Promise<void> {
+    this.inner!.addChunksToBranch(branch, chunkIds);
+  }
+
+  async addChunksToBranchBatch(branch: string, chunkIds: string[]): Promise<void> {
+    this.inner!.addChunksToBranchBatch(branch, chunkIds);
+  }
+
+  async clearBranch(branch: string): Promise<number> {
+    return this.inner!.clearBranch(branch);
+  }
+
+  async deleteBranchChunksByChunkIds(chunkIds: string[]): Promise<number> {
+    return this.inner!.deleteBranchChunksByChunkIds(chunkIds);
+  }
+
+  async deleteBranchChunksForBranch(branch: string, chunkIds: string[]): Promise<number> {
+    return this.inner!.deleteBranchChunksForBranch(branch, chunkIds);
+  }
+
+  async getBranchChunkIds(branch: string): Promise<string[]> {
+    return this.inner!.getBranchChunkIds(branch);
+  }
+
+  async getBranchDelta(branch: string, baseBranch: string): Promise<BranchDelta> {
+    return this.inner!.getBranchDelta(branch, baseBranch);
+  }
+
+  async getReferencedChunkIds(chunkIds: string[]): Promise<string[]> {
+    return this.inner!.getReferencedChunkIds(chunkIds);
+  }
+
+  async chunkExistsOnBranch(branch: string, chunkId: string): Promise<boolean> {
+    return this.inner!.chunkExistsOnBranch(branch, chunkId);
+  }
+
+  async getAllBranches(): Promise<string[]> {
+    return this.inner!.getAllBranches();
+  }
+
+  // ── Metadata ─────────────────────────────────────────────────────
+
+  async getMetadata(key: string): Promise<string | null> {
+    return this.inner!.getMetadata(key);
+  }
+
+  async setMetadata(key: string, value: string): Promise<void> {
+    this.inner!.setMetadata(key, value);
+  }
+
+  async deleteMetadata(key: string): Promise<boolean> {
+    return this.inner!.deleteMetadata(key);
+  }
+
+  // ── Maintenance ──────────────────────────────────────────────────
+
+  async clearAllIndexedData(): Promise<void> {
+    this.inner!.clearAllIndexedData();
+  }
+
+  async clearCallEdgeTargetsForSymbols(symbolIds: string[]): Promise<number> {
+    return this.inner!.clearCallEdgeTargetsForSymbols(symbolIds);
+  }
+
+  async gcOrphanEmbeddings(): Promise<number> {
+    return this.inner!.gcOrphanEmbeddings();
+  }
+
+  async gcOrphanChunks(): Promise<number> {
+    return this.inner!.gcOrphanChunks();
+  }
+
+  async getStats(): Promise<DatabaseStats> {
+    return this.inner!.getStats();
+  }
+
+  // ── Symbols ──────────────────────────────────────────────────────
+
+  async upsertSymbol(symbol: SymbolData): Promise<void> {
+    this.inner!.upsertSymbol(symbol);
+  }
+
+  async upsertSymbolsBatch(symbols: SymbolData[]): Promise<void> {
+    this.inner!.upsertSymbolsBatch(symbols);
+  }
+
+  async getSymbolsByFile(filePath: string): Promise<SymbolData[]> {
+    return this.inner!.getSymbolsByFile(filePath);
+  }
+
+  async getSymbolByName(name: string, filePath: string): Promise<SymbolData | null> {
+    return this.inner!.getSymbolByName(name, filePath);
+  }
+
+  async getSymbolsByName(name: string): Promise<SymbolData[]> {
+    return this.inner!.getSymbolsByName(name);
+  }
+
+  async getSymbolsByNameCi(name: string): Promise<SymbolData[]> {
+    return this.inner!.getSymbolsByNameCi(name);
+  }
+
+  async deleteSymbolsByFile(filePath: string): Promise<number> {
+    return this.inner!.deleteSymbolsByFile(filePath);
+  }
+
+  // ── Call edges ────────────────────────────────────────────────────
+
+  async upsertCallEdge(edge: CallEdgeData): Promise<void> {
+    this.inner!.upsertCallEdge(edge);
+  }
+
+  async upsertCallEdgesBatch(edges: CallEdgeData[]): Promise<void> {
+    this.inner!.upsertCallEdgesBatch(edges);
+  }
+
+  async getCallers(targetName: string, branch: string): Promise<CallEdgeData[]> {
+    return this.inner!.getCallers(targetName, branch);
+  }
+
+  async getCallersWithContext(targetName: string, branch: string): Promise<CallEdgeData[]> {
+    return this.inner!.getCallersWithContext(targetName, branch);
+  }
+
+  async getCallees(symbolId: string, branch: string): Promise<CallEdgeData[]> {
+    return this.inner!.getCallees(symbolId, branch);
+  }
+
+  async deleteCallEdgesByFile(filePath: string): Promise<number> {
+    return this.inner!.deleteCallEdgesByFile(filePath);
+  }
+
+  async resolveCallEdge(edgeId: string, toSymbolId: string): Promise<void> {
+    this.inner!.resolveCallEdge(edgeId, toSymbolId);
+  }
+
+  // ── Branch symbols ────────────────────────────────────────────────
+
+  async addSymbolsToBranch(branch: string, symbolIds: string[]): Promise<void> {
+    this.inner!.addSymbolsToBranch(branch, symbolIds);
+  }
+
+  async addSymbolsToBranchBatch(branch: string, symbolIds: string[]): Promise<void> {
+    this.inner!.addSymbolsToBranchBatch(branch, symbolIds);
+  }
+
+  async getBranchSymbolIds(branch: string): Promise<string[]> {
+    return this.inner!.getBranchSymbolIds(branch);
+  }
+
+  async clearBranchSymbols(branch: string): Promise<number> {
+    return this.inner!.clearBranchSymbols(branch);
+  }
+
+  async getReferencedSymbolIds(symbolIds: string[]): Promise<string[]> {
+    return this.inner!.getReferencedSymbolIds(symbolIds);
+  }
+
+  async deleteBranchSymbolsBySymbolIds(symbolIds: string[]): Promise<number> {
+    return this.inner!.deleteBranchSymbolsBySymbolIds(symbolIds);
+  }
+
+  async deleteBranchSymbolsForBranch(branch: string, symbolIds: string[]): Promise<number> {
+    return this.inner!.deleteBranchSymbolsForBranch(branch, symbolIds);
+  }
+
+  // ── GC ───────────────────────────────────────────────────────────
+
+  async gcOrphanSymbols(): Promise<number> {
+    return this.inner!.gcOrphanSymbols();
+  }
+
+  async gcOrphanCallEdges(): Promise<number> {
+    return this.inner!.gcOrphanCallEdges();
+  }
+
+  // ── File hashes (file-hashes.json) ───────────────────────────────
+
+  private fileHashesPath(): string {
+    return path.join(path.dirname(this.dbPath), "file-hashes.json");
+  }
+
+  private invertedIndexFilePath(): string {
+    return path.join(path.dirname(this.dbPath), "inverted-index.json");
+  }
+
+  private lockFilePath(): string {
+    return path.join(path.dirname(this.dbPath), "indexing.lock");
+  }
+
+  private readFileHashesFromDisk(): Map<string, string> {
+    const p = this.fileHashesPath();
+    if (!existsSync(p)) return new Map();
+    try {
+      return new Map(Object.entries(JSON.parse(readFileSync(p, "utf-8"))));
+    } catch {
+      return new Map();
+    }
+  }
+
+  private atomicWriteSync(targetPath: string, data: string): void {
+    const tempPath = `${targetPath}.tmp`;
+    writeFileSync(tempPath, data);
+    renameSync(tempPath, targetPath);
+  }
+
+  private writeFileHashesToDisk(hashes: Map<string, string>): void {
+    const obj: Record<string, string> = {};
+    for (const [k, v] of hashes) obj[k] = v;
+    this.atomicWriteSync(this.fileHashesPath(), JSON.stringify(obj));
+  }
+
+  async getFileHash(filePath: string): Promise<string | null> {
+    return this.readFileHashesFromDisk().get(filePath) ?? null;
+  }
+
+  async setFileHash(filePath: string, hash: string): Promise<void> {
+    const hashes = this.readFileHashesFromDisk();
+    hashes.set(filePath, hash);
+    this.writeFileHashesToDisk(hashes);
+  }
+
+  async deleteFileHash(filePath: string): Promise<void> {
+    const hashes = this.readFileHashesFromDisk();
+    hashes.delete(filePath);
+    this.writeFileHashesToDisk(hashes);
+  }
+
+  async getAllFileHashes(): Promise<Map<string, string>> {
+    return this.readFileHashesFromDisk();
+  }
+
+  async setFileHashesBatch(hashes: Map<string, string>): Promise<void> {
+    const existing = this.readFileHashesFromDisk();
+    for (const [k, v] of hashes) existing.set(k, v);
+    this.writeFileHashesToDisk(existing);
+  }
+
+  async deleteFileHashesBatch(filePaths: string[]): Promise<void> {
+    const hashes = this.readFileHashesFromDisk();
+    for (const p of filePaths) hashes.delete(p);
+    this.writeFileHashesToDisk(hashes);
+  }
+
+  async replaceAllFileHashes(hashes: Map<string, string>): Promise<void> {
+    this.writeFileHashesToDisk(hashes);
+  }
+
+  async getFileHashBatch(filePaths: string[]): Promise<Map<string, string>> {
+    if (filePaths.length === 0) return new Map();
+    const all = this.readFileHashesFromDisk();
+    const result = new Map<string, string>();
+    for (const fp of filePaths) {
+      const h = all.get(fp);
+      if (h !== undefined) result.set(fp, h);
+    }
+    return result;
+  }
+
+  async hasFileHashesOutsideRoots(roots: string[]): Promise<boolean> {
+    if (roots.length === 0) return false;
+    const all = this.readFileHashesFromDisk();
+    for (const fp of all.keys()) {
+      if (!roots.some((r) => isPathUnderRoot(fp, r))) return true;
+    }
+    return false;
+  }
+
+  async getFilePathsInRoots(roots: string[]): Promise<string[]> {
+    if (roots.length === 0) return [];
+    const all = this.readFileHashesFromDisk();
+    return Array.from(all.keys()).filter((fp) => roots.some((r) => isPathUnderRoot(fp, r)));
+  }
+
+  async deleteFileHashesInRoots(roots: string[]): Promise<void> {
+    if (roots.length === 0) return;
+    const hashes = this.readFileHashesFromDisk();
+    for (const fp of Array.from(hashes.keys())) {
+      if (roots.some((r) => isPathUnderRoot(fp, r))) hashes.delete(fp);
+    }
+    this.writeFileHashesToDisk(hashes);
+  }
+
+  // ── Inverted index (inverted-index.json) ──────────────────────────
+
+  async saveInvertedIndex(json: string): Promise<void> {
+    this.atomicWriteSync(this.invertedIndexFilePath(), json);
+  }
+
+  async loadInvertedIndex(): Promise<string | null> {
+    const p = this.invertedIndexFilePath();
+    if (!existsSync(p)) return null;
+    try {
+      return readFileSync(p, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Indexing lock (indexing.lock) ─────────────────────────────────
+
+  async tryAcquireLock(pid: number, startedAt: string): Promise<boolean> {
+    const lockPath = this.lockFilePath();
+    if (existsSync(lockPath)) return false;
+    writeFileSync(lockPath, JSON.stringify({ pid, startedAt }));
+    return true;
+  }
+
+  async releaseLock(): Promise<void> {
+    const lockPath = this.lockFilePath();
+    if (existsSync(lockPath)) unlinkSync(lockPath);
+  }
+
+  async isLocked(): Promise<boolean> {
+    return existsSync(this.lockFilePath());
+  }
+
+  // ── Inverted index search (handled by in-memory Rust struct for SQLite) ──
+
+  async searchBm25(_query: string, _limit: number): Promise<Map<string, number> | null> {
+    return null; // caller falls back to this.invertedIndex.search()
+  }
+}
+
+// ── Helpers exported for Indexer use ─────────────────────────────────────────
+
+/**
+ * Create and wire up the native InvertedIndex at the given path.
+ * This is always local for both backends.
+ */
+export function createLocalInvertedIndex(indexPath: string): InvertedIndex {
+  return new InvertedIndex(path.join(path.dirname(indexPath), "inverted-index.json"));
+}

--- a/src/db/sqlite-backend.ts
+++ b/src/db/sqlite-backend.ts
@@ -8,13 +8,8 @@
 
 import * as path from "path";
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync } from "fs";
-
-function isPathUnderRoot(filePath: string, root: string): boolean {
-  const r = path.resolve(root);
-  const f = path.resolve(filePath);
-  return f === r || f.startsWith(r + path.sep);
-}
 import { promises as fsPromises } from "fs";
+import { createHash } from "crypto";
 import type {
   IDatabaseBackend,
   IVectorStoreBackend,
@@ -50,17 +45,18 @@ export class SqliteVectorStoreBackend implements IVectorStoreBackend {
     this.inner!.save();
   }
 
-  async add(id: string, vector: number[], metadata: ChunkMetadata): Promise<void> {
+  async add(id: string, vector: number[], metadata: ChunkMetadata, _sourceId?: string): Promise<void> {
     this.inner!.add(id, vector, metadata);
   }
 
   async addBatch(
-    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>
+    items: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }>,
+    _sourceId?: string
   ): Promise<void> {
     this.inner!.addBatch(items);
   }
 
-  async search(queryVector: number[], limit: number): Promise<VectorSearchResult[]> {
+  async search(queryVector: number[], limit: number, _sourceIds?: string[]): Promise<VectorSearchResult[]> {
     return this.inner!.search(queryVector, limit);
   }
 
@@ -122,6 +118,14 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.inner = null;
   }
 
+  supportsSourceIsolation(): boolean {
+    return false;
+  }
+
+  async getOrCreateSource(rootPath: string): Promise<string> {
+    return createHash("sha256").update(rootPath).digest("hex").slice(0, 32);
+  }
+
   /** Expose path so the Indexer can check for file existence and corruption. */
   getDbPath(): string {
     return this.dbPath;
@@ -178,7 +182,7 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.inner!.upsertChunk(chunk);
   }
 
-  async upsertChunksBatch(chunks: ChunkData[]): Promise<void> {
+  async upsertChunksBatch(chunks: ChunkData[], _sourceId?: string): Promise<void> {
     this.inner!.upsertChunksBatch(chunks);
   }
 
@@ -186,7 +190,7 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.inner!.getChunk(chunkId);
   }
 
-  async getChunksByFile(filePath: string): Promise<ChunkData[]> {
+  async getChunksByFile(filePath: string, _sourceId?: string): Promise<ChunkData[]> {
     return this.inner!.getChunksByFile(filePath);
   }
 
@@ -198,11 +202,11 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.inner!.getChunksByNameCi(name);
   }
 
-  async deleteChunksByFile(filePath: string): Promise<number> {
+  async deleteChunksByFile(filePath: string, _sourceId?: string): Promise<number> {
     return this.inner!.deleteChunksByFile(filePath);
   }
 
-  async getChunkFilePaths(): Promise<string[]> {
+  async getChunkFilePaths(_sourceId?: string): Promise<string[]> {
     return Array.from(this.readFileHashesFromDisk().keys());
   }
 
@@ -212,11 +216,11 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.inner!.addChunksToBranch(branch, chunkIds);
   }
 
-  async addChunksToBranchBatch(branch: string, chunkIds: string[]): Promise<void> {
+  async addChunksToBranchBatch(branch: string, chunkIds: string[], _sourceId?: string): Promise<void> {
     this.inner!.addChunksToBranchBatch(branch, chunkIds);
   }
 
-  async clearBranch(branch: string): Promise<number> {
+  async clearBranch(branch: string, _sourceId?: string): Promise<number> {
     return this.inner!.clearBranch(branch);
   }
 
@@ -228,7 +232,7 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.inner!.deleteBranchChunksForBranch(branch, chunkIds);
   }
 
-  async getBranchChunkIds(branch: string): Promise<string[]> {
+  async getBranchChunkIds(branch: string, _sourceIds?: string[]): Promise<string[]> {
     return this.inner!.getBranchChunkIds(branch);
   }
 
@@ -290,11 +294,11 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.inner!.upsertSymbol(symbol);
   }
 
-  async upsertSymbolsBatch(symbols: SymbolData[]): Promise<void> {
+  async upsertSymbolsBatch(symbols: SymbolData[], _sourceId?: string): Promise<void> {
     this.inner!.upsertSymbolsBatch(symbols);
   }
 
-  async getSymbolsByFile(filePath: string): Promise<SymbolData[]> {
+  async getSymbolsByFile(filePath: string, _sourceId?: string): Promise<SymbolData[]> {
     return this.inner!.getSymbolsByFile(filePath);
   }
 
@@ -310,7 +314,7 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.inner!.getSymbolsByNameCi(name);
   }
 
-  async deleteSymbolsByFile(filePath: string): Promise<number> {
+  async deleteSymbolsByFile(filePath: string, _sourceId?: string): Promise<number> {
     return this.inner!.deleteSymbolsByFile(filePath);
   }
 
@@ -320,23 +324,23 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.inner!.upsertCallEdge(edge);
   }
 
-  async upsertCallEdgesBatch(edges: CallEdgeData[]): Promise<void> {
+  async upsertCallEdgesBatch(edges: CallEdgeData[], _sourceId?: string): Promise<void> {
     this.inner!.upsertCallEdgesBatch(edges);
   }
 
-  async getCallers(targetName: string, branch: string): Promise<CallEdgeData[]> {
+  async getCallers(targetName: string, branch: string, _sourceIds?: string[]): Promise<CallEdgeData[]> {
     return this.inner!.getCallers(targetName, branch);
   }
 
-  async getCallersWithContext(targetName: string, branch: string): Promise<CallEdgeData[]> {
+  async getCallersWithContext(targetName: string, branch: string, _sourceIds?: string[]): Promise<CallEdgeData[]> {
     return this.inner!.getCallersWithContext(targetName, branch);
   }
 
-  async getCallees(symbolId: string, branch: string): Promise<CallEdgeData[]> {
+  async getCallees(symbolId: string, branch: string, _sourceIds?: string[]): Promise<CallEdgeData[]> {
     return this.inner!.getCallees(symbolId, branch);
   }
 
-  async deleteCallEdgesByFile(filePath: string): Promise<number> {
+  async deleteCallEdgesByFile(filePath: string, _sourceId?: string): Promise<number> {
     return this.inner!.deleteCallEdgesByFile(filePath);
   }
 
@@ -350,15 +354,15 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.inner!.addSymbolsToBranch(branch, symbolIds);
   }
 
-  async addSymbolsToBranchBatch(branch: string, symbolIds: string[]): Promise<void> {
+  async addSymbolsToBranchBatch(branch: string, symbolIds: string[], _sourceId?: string): Promise<void> {
     this.inner!.addSymbolsToBranchBatch(branch, symbolIds);
   }
 
-  async getBranchSymbolIds(branch: string): Promise<string[]> {
+  async getBranchSymbolIds(branch: string, _sourceIds?: string[]): Promise<string[]> {
     return this.inner!.getBranchSymbolIds(branch);
   }
 
-  async clearBranchSymbols(branch: string): Promise<number> {
+  async clearBranchSymbols(branch: string, _sourceId?: string): Promise<number> {
     return this.inner!.clearBranchSymbols(branch);
   }
 
@@ -440,7 +444,7 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.readFileHashesFromDisk();
   }
 
-  async setFileHashesBatch(hashes: Map<string, string>): Promise<void> {
+  async setFileHashesBatch(hashes: Map<string, string>, _sourceId?: string): Promise<void> {
     const existing = this.readFileHashesFromDisk();
     for (const [k, v] of hashes) existing.set(k, v);
     this.writeFileHashesToDisk(existing);
@@ -452,11 +456,11 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     this.writeFileHashesToDisk(hashes);
   }
 
-  async replaceAllFileHashes(hashes: Map<string, string>): Promise<void> {
+  async replaceAllFileHashes(hashes: Map<string, string>, _sourceId?: string): Promise<void> {
     this.writeFileHashesToDisk(hashes);
   }
 
-  async getFileHashBatch(filePaths: string[]): Promise<Map<string, string>> {
+  async getFileHashBatch(filePaths: string[], _sourceId?: string): Promise<Map<string, string>> {
     if (filePaths.length === 0) return new Map();
     const all = this.readFileHashesFromDisk();
     const result = new Map<string, string>();
@@ -467,28 +471,16 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return result;
   }
 
-  async hasFileHashesOutsideRoots(roots: string[]): Promise<boolean> {
-    if (roots.length === 0) return false;
-    const all = this.readFileHashesFromDisk();
-    for (const fp of all.keys()) {
-      if (!roots.some((r) => isPathUnderRoot(fp, r))) return true;
-    }
-    return false;
+  async hasSourcesOtherThan(_sourceIds: string[]): Promise<boolean> {
+    return false; // SQLite is single-source by design
   }
 
-  async getFilePathsInRoots(roots: string[]): Promise<string[]> {
-    if (roots.length === 0) return [];
-    const all = this.readFileHashesFromDisk();
-    return Array.from(all.keys()).filter((fp) => roots.some((r) => isPathUnderRoot(fp, r)));
+  async getFilePathsBySource(_sourceId: string): Promise<string[]> {
+    return Array.from(this.readFileHashesFromDisk().keys());
   }
 
-  async deleteFileHashesInRoots(roots: string[]): Promise<void> {
-    if (roots.length === 0) return;
-    const hashes = this.readFileHashesFromDisk();
-    for (const fp of Array.from(hashes.keys())) {
-      if (roots.some((r) => isPathUnderRoot(fp, r))) hashes.delete(fp);
-    }
-    this.writeFileHashesToDisk(hashes);
+  async deleteFileHashesBySource(_sourceId: string): Promise<void> {
+    this.writeFileHashesToDisk(new Map());
   }
 
   // ── Inverted index (inverted-index.json) ──────────────────────────
@@ -541,7 +533,7 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
 
   // ── Inverted index search (handled by in-memory Rust struct for SQLite) ──
 
-  async searchBm25(_query: string, _limit: number): Promise<Map<string, number> | null> {
+  async searchBm25(_query: string, _limit: number, _sourceIds?: string[]): Promise<Map<string, number> | null> {
     return null; // caller falls back to this.invertedIndex.search()
   }
 }

--- a/src/db/sqlite-backend.ts
+++ b/src/db/sqlite-backend.ts
@@ -507,6 +507,10 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     }
   }
 
+  // In-memory Rust struct is authoritative for SQLite BM25; no DB tables to update.
+  async upsertInvertedIndexChunkBatch(_entries: Array<{ chunkId: string; content: string }>): Promise<void> {}
+  async deleteInvertedIndexChunkBatch(_chunkIds: string[]): Promise<void> {}
+
   // ── Indexing lock (indexing.lock) ─────────────────────────────────
 
   async tryAcquireLock(pid: number, startedAt: string): Promise<boolean> {
@@ -523,6 +527,16 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
 
   async isLocked(): Promise<boolean> {
     return existsSync(this.lockFilePath());
+  }
+
+  async getLockInfo(): Promise<{ pid: number; startedAt: string } | null> {
+    const lockPath = this.lockFilePath();
+    if (!existsSync(lockPath)) return null;
+    try {
+      return JSON.parse(readFileSync(lockPath, "utf-8")) as { pid: number; startedAt: string };
+    } catch {
+      return null;
+    }
   }
 
   // ── Inverted index search (handled by in-memory Rust struct for SQLite) ──

--- a/src/db/sqlite-backend.ts
+++ b/src/db/sqlite-backend.ts
@@ -202,6 +202,10 @@ export class SqliteDatabaseBackend implements IDatabaseBackend {
     return this.inner!.deleteChunksByFile(filePath);
   }
 
+  async getChunkFilePaths(): Promise<string[]> {
+    return Array.from(this.readFileHashesFromDisk().keys());
+  }
+
   // ── Branch catalog ───────────────────────────────────────────────
 
   async addChunksToBranch(branch: string, chunkIds: string[]): Promise<void> {

--- a/src/embeddings/detector.ts
+++ b/src/embeddings/detector.ts
@@ -46,7 +46,8 @@ interface OpenCodeAuthAPI {
 type OpenCodeAuth = OpenCodeAuthOAuth | OpenCodeAuthAPI;
 
 function getOpenCodeAuthPath(): string {
-  return path.join(os.homedir(), ".local", "share", "opencode", "auth.json");
+  const home = process.env["HOME"] ?? process.env["USERPROFILE"] ?? os.homedir();
+  return path.join(home, ".local", "share", "opencode", "auth.json");
 }
 
 function loadOpenCodeAuth(): Record<string, OpenCodeAuth> {

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -93,7 +93,7 @@ function loadRawConfig(projectRoot: string, configPath?: string): unknown {
     );
   }
 
-  const globalConfig = path.join(os.homedir(), ".config", "opencode", "codebase-index.json");
+  const globalConfig = path.join(process.env["HOME"] ?? process.env["USERPROFILE"] ?? os.homedir(), ".config", "opencode", "codebase-index.json");
   if (existsSync(globalConfig)) {
     return JSON.parse(readFileSync(globalConfig, "utf-8"));
   }

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -210,107 +210,107 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
   const indexer = new Indexer(options.projectRoot, effectiveConfig);
 
   try {
-  await indexer.index();
+    await indexer.index();
 
-  const perQuery: PerQueryEvalResult[] = [];
+    const perQuery: PerQueryEvalResult[] = [];
 
-  for (const query of dataset.queries) {
-    if (query.expected.branch && query.expected.branch !== indexer.getCurrentBranch()) {
-      throw new Error(
-        `Query '${query.id}' expects branch '${query.expected.branch}', but current branch is '${indexer.getCurrentBranch()}'. Switch branch before running this dataset.`
-      );
-    }
-
-    const start = performance.now();
-    const result = await indexer.search(query.query, 10, {
-      metadataOnly: true,
-      filterByBranch: query.expected.branch ? true : false,
-    });
-    const elapsed = performance.now() - start;
-
-    const materialized = result.map((item) => ({
-      filePath: item.filePath,
-      startLine: item.startLine,
-      endLine: item.endLine,
-      score: item.score,
-      chunkType: item.chunkType,
-      name: item.name,
-    }));
-
-    perQuery.push(buildPerQueryResult(query, materialized, elapsed, 10));
-  }
-
-  const logger = indexer.getLogger();
-  const metricSnapshot = logger.getMetrics();
-
-  const costPer1MTokensUsd =
-    effectiveConfig.embeddingProvider === "custom" || effectiveConfig.embeddingProvider === "auto"
-      ? 0
-      : getDefaultModelForProvider(effectiveConfig.embeddingProvider).costPer1MTokens;
-
-  const summary: EvalSummary = {
-    generatedAt: new Date().toISOString(),
-    projectRoot: options.projectRoot,
-    datasetPath,
-    datasetName: dataset.name,
-    datasetVersion: dataset.version,
-    queryCount: dataset.queries.length,
-    topK: 10,
-    searchConfig: {
-      fusionStrategy: effectiveConfig.search.fusionStrategy,
-      hybridWeight: effectiveConfig.search.hybridWeight,
-      rrfK: effectiveConfig.search.rrfK,
-      rerankTopN: effectiveConfig.search.rerankTopN,
-    },
-    metrics: computeEvalMetrics(
-      dataset.queries,
-      perQuery,
-      metricSnapshot.embeddingApiCalls,
-      metricSnapshot.embeddingTokensUsed,
-      costPer1MTokensUsd
-    ),
-  };
-
-  const outputDir = createRunDirectory(toAbsolute(options.projectRoot, options.outputRoot));
-  const perQueryArtifact = buildPerQueryArtifact(perQuery);
-
-  writeJson(path.join(outputDir, "summary.json"), summary);
-  writeJson(path.join(outputDir, "per-query.json"), perQueryArtifact);
-
-  let comparison: EvalComparison | undefined;
-  if (againstPath) {
-    const baseline = loadSummary(againstPath);
-    comparison = compareSummaries(summary, baseline, againstPath);
-    writeJson(path.join(outputDir, "compare.json"), comparison);
-  }
-
-  let gate: EvalGateResult | undefined;
-  if (options.ciMode) {
-    if (!budgetPath) {
-      throw new Error("CI mode requires --budget path");
-    }
-    const budget = loadBudget(budgetPath);
-
-    if (!comparison && budget.baselinePath) {
-      const resolvedBaseline = toAbsolute(options.projectRoot, budget.baselinePath);
-      if (existsSync(resolvedBaseline)) {
-        const baselineSummary = loadSummary(resolvedBaseline);
-        comparison = compareSummaries(summary, baselineSummary, resolvedBaseline);
-        writeJson(path.join(outputDir, "compare.json"), comparison);
-      } else if (budget.failOnMissingBaseline) {
+    for (const query of dataset.queries) {
+      if (query.expected.branch && query.expected.branch !== indexer.getCurrentBranch()) {
         throw new Error(
-          `Budget baseline is missing: ${resolvedBaseline}. Set failOnMissingBaseline=false to allow CI run without baseline.`
+          `Query '${query.id}' expects branch '${query.expected.branch}', but current branch is '${indexer.getCurrentBranch()}'. Switch branch before running this dataset.`
         );
       }
+
+      const start = performance.now();
+      const result = await indexer.search(query.query, 10, {
+        metadataOnly: true,
+        filterByBranch: query.expected.branch ? true : false,
+      });
+      const elapsed = performance.now() - start;
+
+      const materialized = result.map((item) => ({
+        filePath: item.filePath,
+        startLine: item.startLine,
+        endLine: item.endLine,
+        score: item.score,
+        chunkType: item.chunkType,
+        name: item.name,
+      }));
+
+      perQuery.push(buildPerQueryResult(query, materialized, elapsed, 10));
     }
 
-    gate = evaluateBudgetGate(budget, summary, comparison);
-  }
+    const logger = indexer.getLogger();
+    const metricSnapshot = logger.getMetrics();
 
-  const markdown = createSummaryMarkdown(summary, comparison, gate);
-  writeText(path.join(outputDir, "summary.md"), markdown);
+    const costPer1MTokensUsd =
+      effectiveConfig.embeddingProvider === "custom" || effectiveConfig.embeddingProvider === "auto"
+        ? 0
+        : getDefaultModelForProvider(effectiveConfig.embeddingProvider).costPer1MTokens;
 
-  return { outputDir, summary, perQuery, comparison, gate };
+    const summary: EvalSummary = {
+      generatedAt: new Date().toISOString(),
+      projectRoot: options.projectRoot,
+      datasetPath,
+      datasetName: dataset.name,
+      datasetVersion: dataset.version,
+      queryCount: dataset.queries.length,
+      topK: 10,
+      searchConfig: {
+        fusionStrategy: effectiveConfig.search.fusionStrategy,
+        hybridWeight: effectiveConfig.search.hybridWeight,
+        rrfK: effectiveConfig.search.rrfK,
+        rerankTopN: effectiveConfig.search.rerankTopN,
+      },
+      metrics: computeEvalMetrics(
+        dataset.queries,
+        perQuery,
+        metricSnapshot.embeddingApiCalls,
+        metricSnapshot.embeddingTokensUsed,
+        costPer1MTokensUsd
+      ),
+    };
+
+    const outputDir = createRunDirectory(toAbsolute(options.projectRoot, options.outputRoot));
+    const perQueryArtifact = buildPerQueryArtifact(perQuery);
+
+    writeJson(path.join(outputDir, "summary.json"), summary);
+    writeJson(path.join(outputDir, "per-query.json"), perQueryArtifact);
+
+    let comparison: EvalComparison | undefined;
+    if (againstPath) {
+      const baseline = loadSummary(againstPath);
+      comparison = compareSummaries(summary, baseline, againstPath);
+      writeJson(path.join(outputDir, "compare.json"), comparison);
+    }
+
+    let gate: EvalGateResult | undefined;
+    if (options.ciMode) {
+      if (!budgetPath) {
+        throw new Error("CI mode requires --budget path");
+      }
+      const budget = loadBudget(budgetPath);
+
+      if (!comparison && budget.baselinePath) {
+        const resolvedBaseline = toAbsolute(options.projectRoot, budget.baselinePath);
+        if (existsSync(resolvedBaseline)) {
+          const baselineSummary = loadSummary(resolvedBaseline);
+          comparison = compareSummaries(summary, baselineSummary, resolvedBaseline);
+          writeJson(path.join(outputDir, "compare.json"), comparison);
+        } else if (budget.failOnMissingBaseline) {
+          throw new Error(
+            `Budget baseline is missing: ${resolvedBaseline}. Set failOnMissingBaseline=false to allow CI run without baseline.`
+          );
+        }
+      }
+
+      gate = evaluateBudgetGate(budget, summary, comparison);
+    }
+
+    const markdown = createSummaryMarkdown(summary, comparison, gate);
+    writeText(path.join(outputDir, "summary.md"), markdown);
+
+    return { outputDir, summary, perQuery, comparison, gate };
   } finally {
     await indexer.close();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { parseConfig } from "./config/schema.js";
 import { loadMergedConfig } from "./config/merger.js";
 import { createWatcherWithIndexer } from "./watcher/index.js";
+import { initializeLogger } from "./utils/logger.js";
 import {
   codebase_search,
   codebase_peek,
@@ -21,6 +22,7 @@ import {
   remove_knowledge_base,
   getSharedIndexer,
   initializeTools,
+  refreshIndexerFromConfig,
 } from "./tools/index.js";
 import { loadCommandsFromDirectory } from "./commands/loader.js";
 import { RoutingHintController } from "./routing-hints.js";
@@ -36,19 +38,105 @@ function replaceActiveWatcher(nextWatcher: CombinedWatcher | null): void {
 
 function getCommandsDir(): string {
   let currentDir = process.cwd();
-  
+
   if (typeof import.meta !== "undefined" && import.meta.url) {
     currentDir = path.dirname(fileURLToPath(import.meta.url));
   }
-  
+
   return path.join(currentDir, "..", "commands");
 }
 
-const plugin: Plugin = async ({ directory }) => {
+const plugin: Plugin = async ({ directory, client }) => {
   try {
     const projectRoot = directory;
     const rawConfig = loadMergedConfig(projectRoot);
     const config = parseConfig(rawConfig);
+
+    // Initialize logger for file-based logging
+    const logger = initializeLogger(config.debug);
+
+    // Forward error/warn log entries to the client system log so they are
+    // always visible regardless of debug.enabled or log level settings.
+    logger.setClientLogger((level, message, extra) => {
+      client.app.log({
+        body: { service: "codebase-index", level, message, extra },
+      }).catch(() => { /* best-effort; never throw from logger callback */ });
+    });
+
+    // Log final merged configuration if debug is enabled
+    if (config.debug.enabled) {
+      await client.app.log({
+        body: {
+          service: "codebase-index",
+          level: "info",
+          message: "Final merged configuration",
+          extra: {
+        embeddingProvider: config.embeddingProvider,
+        embeddingModel: config.embeddingModel,
+        scope: config.scope,
+        database: {
+          engine: config.database.engine,
+          pgvectorHost: config.database.engine === "pgvector" && config.database.pgvector?.host
+            ? `${config.database.pgvector.host}:${config.database.pgvector.port || 5432}`
+            : undefined,
+          pgvectorDatabase: config.database.engine === "pgvector" ? config.database.pgvector?.database : undefined,
+          pgvectorTablePrefix: config.database.engine === "pgvector" ? config.database.pgvector?.tablePrefix : undefined,
+        },
+        indexing: {
+          autoIndex: config.indexing.autoIndex,
+          skipAutoIndexOnLoad: config.indexing.skipAutoIndexOnLoad,
+          watchFiles: config.indexing.watchFiles,
+          requireProjectMarker: config.indexing.requireProjectMarker,
+          semanticOnly: config.indexing.semanticOnly,
+          maxFileSize: config.indexing.maxFileSize,
+          maxChunksPerFile: config.indexing.maxChunksPerFile,
+        },
+        search: {
+          hybridWeight: config.search.hybridWeight,
+          fusionStrategy: config.search.fusionStrategy,
+          rerankTopN: config.search.rerankTopN,
+          routingHints: config.search.routingHints,
+        },
+        reranker: {
+          enabled: config.reranker?.enabled ?? false,
+          provider: config.reranker?.provider,
+        },
+          }
+        }
+      });
+
+      // Log database connection info
+      if (config.database.engine === "pgvector" && config.database.pgvector) {
+        const pgConfig = config.database.pgvector;
+        const connectionInfo = pgConfig.connectionString
+          ? "(via connection string)"
+          : `${pgConfig.user}@${pgConfig.host}:${pgConfig.port}/${pgConfig.database}`;
+        await client.app.log({
+          body: {
+            service: "codebase-index",
+            level: "info",
+            message: `Connecting to pgvector database: ${connectionInfo}`,
+          }
+        });
+        if (pgConfig.tablePrefix) {
+          await client.app.log({
+            body: {
+              service: "codebase-index",
+              level: "info",
+              message: `Using table prefix: "${pgConfig.tablePrefix}"`,
+            }
+          });
+        }
+      } else {
+        await client.app.log({
+          body: {
+            service: "codebase-index",
+            level: "info",
+            message: `Using local SQLite database at: ${projectRoot}/.opencode/index/`,
+          }
+        });
+      }
+    }
 
     initializeTools(projectRoot, config);
 
@@ -60,16 +148,40 @@ const plugin: Plugin = async ({ directory }) => {
     const isValidProject = !config.indexing.requireProjectMarker || hasProjectMarker(projectRoot);
 
     if (!isValidProject) {
-      console.warn(
-        `[codebase-index] Skipping file watching and auto-indexing: no project marker found in "${projectRoot}". ` +
+      logger.warn(
+        `Skipping file watching and auto-indexing: no project marker found in "${projectRoot}". ` +
         `Set "indexing.requireProjectMarker": false in config to override.`
       );
+      await client.app.log({
+        body: {
+          service: "codebase-index",
+          level: "warn",
+          message: `Skipping file watching and auto-indexing: no project marker found in "${projectRoot}". Set "indexing.requireProjectMarker": false in config to override.`,
+        }
+      });
     }
 
-    if (config.indexing.autoIndex && isValidProject) {
-      indexer.initialize().then(() => {
-        indexer.index().catch(() => {});
-      }).catch(() => {});
+    if (config.indexing.autoIndex && !config.indexing.skipAutoIndexOnLoad && isValidProject) {
+      // Defer to after the plugin function returns so the client is fully started
+      // before we begin connecting to the database and indexing.
+      // Also reload config at fire-time so the indexer always uses the latest
+      // merged config (e.g., pgvector credentials that may not have been fully
+      // resolved at plugin-load time).
+      setImmediate(() => {
+        refreshIndexerFromConfig();
+        const bgIndexer = getSharedIndexer();
+        bgIndexer.initialize(client).then(() => {
+          bgIndexer.index().catch(() => {});
+        }).catch(() => {});
+      });
+    } else if (config.indexing.autoIndex && config.indexing.skipAutoIndexOnLoad && config.debug.enabled) {
+      await client.app.log({
+        body: {
+          service: "codebase-index",
+          level: "debug",
+          message: "Skipping auto-index on load (skipAutoIndexOnLoad is true)",
+        }
+      });
     }
 
     if (config.indexing.watchFiles && isValidProject) {
@@ -120,7 +232,16 @@ const plugin: Plugin = async ({ directory }) => {
       },
     };
   } catch (error) {
-    console.error("[codebase-index] Failed to initialize plugin:", error);
+    await client.app.log({
+      body: {
+        service: "codebase-index",
+        level: "error",
+        message: "Failed to initialize plugin",
+        extra: {
+          error: error instanceof Error ? error.message : String(error)
+        }
+      }
+    }).catch(() => {});
     // Return a plugin with no tools to prevent opencode from crashing
     return {
       tool: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ const plugin: Plugin = async ({ directory, client }) => {
       setImmediate(() => {
         refreshIndexerFromConfig();
         const bgIndexer = getSharedIndexer();
-        bgIndexer.initialize(client).then(() => {
+        bgIndexer.initialize().then(() => {
           bgIndexer.index().catch(() => {});
         }).catch(() => {});
       });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2622,7 +2622,7 @@ export class Indexer {
 
     this.loadFileHashCache();
 
-    this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
+    this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
     if (!this.indexCompatibility.compatible) {
       this.logger.warn("Index compatibility issue detected", {
         reason: this.indexCompatibility.reason,
@@ -2658,11 +2658,11 @@ export class Indexer {
     if (shouldRunGc) {
       const result = await this.healthCheck();
       if (result.warning) {
-        this.database.setMetadata(STARTUP_WARNING_METADATA_KEY, result.warning);
+        await this.database.setMetadata(STARTUP_WARNING_METADATA_KEY, result.warning);
       } else {
-        this.database.deleteMetadata(STARTUP_WARNING_METADATA_KEY);
+        await this.database.deleteMetadata(STARTUP_WARNING_METADATA_KEY);
       }
-      this.database.setMetadata("lastGcTimestamp", now.toString());
+      await this.database.setMetadata("lastGcTimestamp", now.toString());
     }
   }
 
@@ -2686,7 +2686,7 @@ export class Indexer {
         }
         throw error;
       }
-      this.database.setMetadata("lastGcTimestamp", Date.now().toString());
+      await this.database.setMetadata("lastGcTimestamp", Date.now().toString());
     }
 
     return null;
@@ -2780,7 +2780,7 @@ export class Indexer {
     if (chunkDataBatch.length > 0) {
       this.database.upsertChunksBatch(chunkDataBatch);
     }
-    this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
+    await this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
   }
 
   private loadIndexMetadata(): IndexMetadata | null {
@@ -2807,25 +2807,25 @@ export class Indexer {
     const existingCreatedAt = this.database.getMetadata("index.createdAt");
     const completeProjectEmbeddingStrategyReset = !this.hasProjectForceReembedPending();
 
-    this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
-    this.database.setMetadata("index.embeddingProvider", provider.provider);
-    this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
-    this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
+    await this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
+    await this.database.setMetadata("index.embeddingProvider", provider.provider);
+    await this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
+    await this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
     if (this.config.scope === "global") {
       if (completeProjectEmbeddingStrategyReset) {
-        this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
+        await this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
       }
-      this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
+      await this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
       if (completeProjectEmbeddingStrategyReset) {
-        this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+        await this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
       }
     } else {
-      this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
+      await this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
     }
-    this.database.setMetadata("index.updatedAt", now);
+    await this.database.setMetadata("index.updatedAt", now);
 
     if (!existingCreatedAt) {
-      this.database.setMetadata("index.createdAt", now);
+      await this.database.setMetadata("index.createdAt", now);
     }
   }
 
@@ -2886,7 +2886,7 @@ export class Indexer {
         throw new Error('No embedding provider info, you must initialize the indexer first.');
       }
 
-      this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
+      this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
     }
     return this.indexCompatibility;
   }
@@ -3291,10 +3291,10 @@ export class Indexer {
     });
 
     if (pendingChunks.length === 0 && removedCount === 0) {
-      database.clearBranch(branchCatalogKey);
-      database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
-      database.clearBranchSymbols(branchCatalogKey);
-      database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+      await database.clearBranch(branchCatalogKey);
+      await database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
+      await database.clearBranchSymbols(branchCatalogKey);
+      await database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
       if (scopedRoots) {
         this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
         this.clearScopedFailedBatches(scopedRoots);
@@ -3303,7 +3303,7 @@ export class Indexer {
         this.saveFileHashCache();
         this.saveFailedBatches([]);
       }
-      this.saveIndexMetadata(configuredProviderInfo);
+      await this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
@@ -3318,10 +3318,10 @@ export class Indexer {
     }
 
     if (pendingChunks.length === 0) {
-      database.clearBranch(branchCatalogKey);
-      database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
-      database.clearBranchSymbols(branchCatalogKey);
-      database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+      await database.clearBranch(branchCatalogKey);
+      await database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
+      await database.clearBranchSymbols(branchCatalogKey);
+      await database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
       store.save();
       invertedIndex.save();
       if (scopedRoots) {
@@ -3332,7 +3332,7 @@ export class Indexer {
         this.saveFileHashCache();
         this.saveFailedBatches([]);
       }
-      this.saveIndexMetadata(configuredProviderInfo);
+      await this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
@@ -3355,7 +3355,7 @@ export class Indexer {
     });
 
     const allContentHashes = pendingChunks.map((c) => c.contentHash);
-    const missingHashes = new Set(database.getMissingEmbeddings(allContentHashes));
+    const missingHashes = new Set(await database.getMissingEmbeddings(allContentHashes));
     const forcedReembedChunkIds = forceScopedReembed
       ? new Set(pendingChunks.map((chunk) => chunk.id))
       : new Set<string>();
@@ -3491,7 +3491,7 @@ export class Indexer {
               metadata: chunk.metadata,
             }));
 
-            store.addBatch(items);
+            await store.addBatch(items);
 
             const embeddingBatchItems = pooledResults.map(({ chunk, vector }) => ({
               contentHash: chunk.contentHash,
@@ -3501,7 +3501,7 @@ export class Indexer {
             }));
 
             try {
-              database.upsertEmbeddingsBatch(embeddingBatchItems);
+              await database.upsertEmbeddingsBatch(embeddingBatchItems);
             } catch (dbError) {
               // Rollback vectors added to store if DB write fails
               for (const { chunk } of pooledResults) {
@@ -3607,10 +3607,10 @@ export class Indexer {
         return !isNewlyFailed && !isForcedFailed;
       }
     );
-    database.clearBranch(branchCatalogKey);
-    database.addChunksToBranchBatch(branchCatalogKey, branchChunkIds);
-    database.clearBranchSymbols(branchCatalogKey);
-    database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+    await database.clearBranch(branchCatalogKey);
+    await database.addChunksToBranchBatch(branchCatalogKey, branchChunkIds);
+    await database.clearBranchSymbols(branchCatalogKey);
+    await database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
 
     store.save();
     invertedIndex.save();
@@ -3647,9 +3647,9 @@ export class Indexer {
     stats.durationMs = Date.now() - startTime;
 
     if (forceScopedReembed && failedForcedChunkIds.size === 0) {
-      database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+      await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
     }
-    this.saveIndexMetadata(configuredProviderInfo);
+    await this.saveIndexMetadata(configuredProviderInfo);
     this.indexCompatibility = { compatible: true };
 
     this.logger.recordIndexingEnd();
@@ -4085,8 +4085,8 @@ export class Indexer {
           this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
           this.clearScopedFileHashCache(roots);
           this.clearScopedFailedBatches(roots);
-          database.setMetadata(this.getProjectForceReembedMetadataKey(), "true");
-          database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());
+          await database.setMetadata(this.getProjectForceReembedMetadataKey(), "true");
+          await database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());
           this.indexCompatibility = { compatible: true };
           return;
         }
@@ -4110,18 +4110,18 @@ export class Indexer {
         database.clearAllIndexedData();
         this.saveFailedBatches([]);
 
-        database.deleteMetadata("index.version");
-        database.deleteMetadata("index.embeddingProvider");
-        database.deleteMetadata("index.embeddingModel");
-        database.deleteMetadata("index.embeddingDimensions");
-        database.deleteMetadata("index.embeddingStrategyVersion");
-        database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());
-        database.deleteMetadata(this.getProjectForceReembedMetadataKey());
-        database.deleteMetadata(this.getLegacyMigrationMetadataKey());
-        database.deleteMetadata("index.createdAt");
-        database.deleteMetadata("index.updatedAt");
+        await database.deleteMetadata("index.version");
+        await database.deleteMetadata("index.embeddingProvider");
+        await database.deleteMetadata("index.embeddingModel");
+        await database.deleteMetadata("index.embeddingDimensions");
+        await database.deleteMetadata("index.embeddingStrategyVersion");
+        await database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());
+        await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+        await database.deleteMetadata(this.getLegacyMigrationMetadataKey());
+        await database.deleteMetadata("index.createdAt");
+        await database.deleteMetadata("index.updatedAt");
 
-        this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo!);
+        this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo!);
         return;
       }
 
@@ -4155,19 +4155,19 @@ export class Indexer {
     this.saveFailedBatches([]);
 
     // Clear index metadata so compatibility is re-evaluated from scratch
-    database.deleteMetadata("index.version");
-    database.deleteMetadata("index.embeddingProvider");
-    database.deleteMetadata("index.embeddingModel");
-    database.deleteMetadata("index.embeddingDimensions");
-    database.deleteMetadata("index.embeddingStrategyVersion");
-    database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());
-    database.deleteMetadata(this.getProjectForceReembedMetadataKey());
-    database.deleteMetadata(this.getLegacyMigrationMetadataKey());
-    database.deleteMetadata("index.createdAt");
-    database.deleteMetadata("index.updatedAt");
+    await database.deleteMetadata("index.version");
+    await database.deleteMetadata("index.embeddingProvider");
+    await database.deleteMetadata("index.embeddingModel");
+    await database.deleteMetadata("index.embeddingDimensions");
+    await database.deleteMetadata("index.embeddingStrategyVersion");
+    await database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());
+    await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+    await database.deleteMetadata(this.getLegacyMigrationMetadataKey());
+    await database.deleteMetadata("index.createdAt");
+    await database.deleteMetadata("index.updatedAt");
 
     // Re-validate compatibility (no stored metadata = compatible)
-    this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo!);
+    this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo!);
   }
 
   async healthCheck(): Promise<HealthCheckResult> {
@@ -4370,12 +4370,12 @@ export class Indexer {
         }));
 
         if (items.length > 0) {
-          store.addBatch(items);
+          await store.addBatch(items);
         }
 
         if (successfulResults.length > 0) {
           try {
-            database.upsertEmbeddingsBatch(
+            await database.upsertEmbeddingsBatch(
               successfulResults.map(({ chunk, vector }) => ({
                 contentHash: chunk.contentHash,
                 embedding: float32ArrayToBuffer(vector),
@@ -4399,7 +4399,7 @@ export class Indexer {
           embeddingPartsByChunk.delete(chunk.id);
         }
 
-        database.addChunksToBranchBatch(
+        await database.addChunksToBranchBatch(
           this.getBranchCatalogKey(),
           successfulResults.map(({ chunk }) => chunk.id)
         );
@@ -4444,8 +4444,8 @@ export class Indexer {
     }
 
     if (roots && succeeded > 0 && persistedStillFailing.length === 0 && this.hasProjectForceReembedPending()) {
-      database.deleteMetadata(this.getProjectForceReembedMetadataKey());
-      this.saveIndexMetadata(configuredProviderInfo);
+      await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+      await this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
     }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3390,7 +3390,7 @@ export class Indexer {
               embeddingPartsByChunk.delete(chunkId);
             }
             await database.upsertInvertedIndexChunkBatch(
-              batch.map(c => ({ chunkId: c.id, content: c.content }))
+              pooledResults.map(({ chunk }) => ({ chunkId: chunk.id, content: chunk.content }))
             );
 
             if (pooledResults.length > 0) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync, promises as fsPromises } from "fs";
+import { createHash } from "crypto";
 import * as path from "path";
 import { performance } from "perf_hooks";
 import PQueue from "p-queue";
@@ -2165,13 +2166,21 @@ export class Indexer {
     return roots.some((root) => isPathWithinRoot(filePath, root));
   }
 
+  private computeSourceId(rootPath: string): string {
+    return createHash("sha256").update(rootPath).digest("hex").slice(0, 32);
+  }
+
   private async clearScopedFileHashCache(roots: string[]): Promise<void> {
-    await this.database!.deleteFileHashesInRoots(roots);
+    for (const root of roots) {
+      await this.database!.deleteFileHashesBySource(this.computeSourceId(root));
+    }
   }
 
   private async replaceScopedFileHashCache(currentFileHashes: Map<string, string>, roots: string[]): Promise<void> {
-    await this.database!.deleteFileHashesInRoots(roots);
-    await this.database!.setFileHashesBatch(currentFileHashes);
+    for (const root of roots) {
+      await this.database!.deleteFileHashesBySource(this.computeSourceId(root));
+    }
+    await this.database!.setFileHashesBatch(currentFileHashes, this.computeSourceId(this.projectRoot));
   }
 
   private partitionFailedBatches(roots: string[], maxChunkTokens?: number): { scoped: FailedBatch[]; retained: SerializedFailedBatch[] } {
@@ -2209,7 +2218,7 @@ export class Indexer {
   }
 
   private async hasForeignScopedFileHashData(roots: string[]): Promise<boolean> {
-    return this.database!.hasFileHashesOutsideRoots(roots);
+    return this.database!.hasSourcesOtherThan(roots.map(r => this.computeSourceId(r)));
   }
 
   private hasForeignScopedFailedBatches(roots: string[]): boolean {
@@ -2263,10 +2272,14 @@ export class Indexer {
   ): Promise<{ removedChunkIds: string[]; hasForeignData: boolean }> {
     const allMetadata = await store.getAllMetadata();
     const scopedEntries = allMetadata.filter(({ metadata }) => this.isFileInCurrentScope(metadata.filePath, roots));
-    const filePaths = new Set<string>([
-      ...await this.database!.getFilePathsInRoots(roots),
-      ...scopedEntries.map(({ metadata }) => metadata.filePath),
-    ]);
+
+    // Collect file paths from all scoped sources + vector store metadata
+    const filePaths = new Set<string>(scopedEntries.map(({ metadata }) => metadata.filePath));
+    for (const root of roots) {
+      for (const fp of await this.database!.getFilePathsBySource(this.computeSourceId(root))) {
+        filePaths.add(fp);
+      }
+    }
 
     const projectRootPath = path.resolve(this.projectRoot);
     const projectLocalFilePaths = new Set<string>(
@@ -2994,7 +3007,7 @@ export class Indexer {
     if (chunkDataBatch.length > 0) {
       await this.database.upsertChunksBatch(chunkDataBatch);
     }
-    await this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
+    await this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds, this.computeSourceId(this.projectRoot));
   }
 
   private async loadIndexMetadata(): Promise<IndexMetadata | null> {
@@ -3152,6 +3165,7 @@ export class Indexer {
     }
 
     await this.acquireIndexingLock();
+    const sourceId = this.computeSourceId(this.projectRoot);
     // Clear any stale progress snapshot from a previous run
     void database.deleteMetadata(PROGRESS_SNAPSHOT_KEY).catch(() => { /* best-effort */ });
     this.embeddingPhaseStartTime = 0;
@@ -3205,7 +3219,7 @@ export class Indexer {
 
     // Fetch only the hashes for files we are about to scan — avoids a full
     // table load and skips stale records for deleted or out-of-scope files.
-    const storedHashes = await this.database!.getFileHashBatch(files.map((f) => f.path));
+    const storedHashes = await this.database!.getFileHashBatch(files.map((f) => f.path), sourceId);
 
     // Phase 1: Hash scan — classify files without reading content
     const changedFileMeta: Array<{ path: string; hash: string }> = [];
@@ -3234,11 +3248,11 @@ export class Indexer {
 
     // Phase 2: Deleted file cleanup — remove chunks for files no longer on disk
     let removedCount = 0;
-    const allChunkFilePaths = await this.database!.getChunkFilePaths();
+    const allChunkFilePaths = await this.database!.getChunkFilePaths(sourceId);
     for (const fp of allChunkFilePaths) {
       if (!currentFilePathSet.has(fp)) {
         if (scopedRoots && !this.isFileInCurrentScope(fp, scopedRoots)) continue;
-        const oldChunks = await this.database!.getChunksByFile(fp);
+        const oldChunks = await this.database!.getChunksByFile(fp, sourceId);
         const oldChunkIds = oldChunks.map(c => c.chunkId);
         for (const chunkId of oldChunkIds) {
           await store.remove(chunkId);
@@ -3250,22 +3264,22 @@ export class Indexer {
     }
 
     // Phase 3: Branch catalog init — clear upfront, rebuild incrementally below
-    await database.clearBranch(branchCatalogKey);
-    await database.clearBranchSymbols(branchCatalogKey);
+    await database.clearBranch(branchCatalogKey, sourceId);
+    await database.clearBranchSymbols(branchCatalogKey, sourceId);
 
     // Phase 4: Unchanged files → branch catalog (batched, parallel DB reads)
     const FILE_BATCH_SIZE = this.config.indexing.fileBatchSize;
     for (let i = 0; i < unchangedFilePaths.length; i += FILE_BATCH_SIZE) {
       const batch = unchangedFilePaths.slice(i, i + FILE_BATCH_SIZE);
       const [chunkResults, symbolResults] = await Promise.all([
-        Promise.all(batch.map(fp => this.database!.getChunksByFile(fp))),
-        Promise.all(batch.map(fp => this.database!.getSymbolsByFile(fp))),
+        Promise.all(batch.map(fp => this.database!.getChunksByFile(fp, sourceId))),
+        Promise.all(batch.map(fp => this.database!.getSymbolsByFile(fp, sourceId))),
       ]);
       const batchChunkIds = chunkResults.flat().map(c => c.chunkId);
       const batchSymbolIds = symbolResults.flat().map(s => s.id);
       stats.existingChunks += batchChunkIds.length;
-      if (batchChunkIds.length > 0) await database.addChunksToBranchBatch(branchCatalogKey, batchChunkIds);
-      if (batchSymbolIds.length > 0) await database.addSymbolsToBranchBatch(branchCatalogKey, batchSymbolIds);
+      if (batchChunkIds.length > 0) await database.addChunksToBranchBatch(branchCatalogKey, batchChunkIds, sourceId);
+      if (batchSymbolIds.length > 0) await database.addSymbolsToBranchBatch(branchCatalogKey, batchSymbolIds, sourceId);
     }
 
     // Phase 5: Changed files — main batch loop
@@ -3495,7 +3509,7 @@ export class Indexer {
         }
 
         // Per-file existing chunk lookup replaces the global existingChunks Map
-        const existingFileChunks = await this.database!.getChunksByFile(parsed.path);
+        const existingFileChunks = await this.database!.getChunksByFile(parsed.path, sourceId);
         const existingChunkHashes = new Map(existingFileChunks.map(c => [c.chunkId, c.contentHash]));
         const newChunkIdsForFile = new Set<string>();
         const chunkDataForFile: ChunkData[] = [];
@@ -3542,7 +3556,7 @@ export class Indexer {
         }
 
         if (chunkDataForFile.length > 0) {
-          await this.database!.upsertChunksBatch(chunkDataForFile);
+          await this.database!.upsertChunksBatch(chunkDataForFile, sourceId);
         }
 
         // Per-file orphan removal (chunks no longer produced by re-parsing)
@@ -3560,8 +3574,8 @@ export class Indexer {
         }
 
         // Call graph extraction for this file
-        await database.deleteCallEdgesByFile(parsed.path);
-        await database.deleteSymbolsByFile(parsed.path);
+        await database.deleteCallEdgesByFile(parsed.path, sourceId);
+        await database.deleteSymbolsByFile(parsed.path, sourceId);
         const fileSymbols: SymbolData[] = [];
         for (const chunk of parsed.chunks) {
           if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
@@ -3588,7 +3602,7 @@ export class Indexer {
         }
 
         if (fileSymbols.length > 0) {
-          await database.upsertSymbolsBatch(fileSymbols);
+          await database.upsertSymbolsBatch(fileSymbols, sourceId);
         }
 
         const fileLanguage = parsed.chunks[0]?.language;
@@ -3629,7 +3643,7 @@ export class Indexer {
                 });
               }
               if (edges.length > 0) {
-                await database.upsertCallEdgesBatch(edges);
+                await database.upsertCallEdgesBatch(edges, sourceId);
                 for (const edge of edges) {
                   const lookupKey = isCaseInsensitiveLanguage ? edge.targetName.toLowerCase() : edge.targetName;
                   const candidates = symbolsByName.get(lookupKey);
@@ -3644,15 +3658,15 @@ export class Indexer {
       }
 
       // Incremental branch catalog update for this file batch
-      if (batchChunkIds.length > 0) await database.addChunksToBranchBatch(branchCatalogKey, batchChunkIds);
-      if (batchSymbolIds.length > 0) await database.addSymbolsToBranchBatch(branchCatalogKey, batchSymbolIds);
+      if (batchChunkIds.length > 0) await database.addChunksToBranchBatch(branchCatalogKey, batchChunkIds, sourceId);
+      if (batchSymbolIds.length > 0) await database.addSymbolsToBranchBatch(branchCatalogKey, batchSymbolIds, sourceId);
       stats.totalChunks += batchPendingChunks.length;
 
       // Embed this batch; queue.onIdle() ensures we don't accumulate unbounded pending chunks
       await embedPendingChunks(batchPendingChunks);
 
       // Write hashes for this batch immediately so crash recovery can skip already-processed files
-      await this.database!.setFileHashesBatch(new Map(fileBatch.map(f => [f.path, f.hash])));
+      await this.database!.setFileHashesBatch(new Map(fileBatch.map(f => [f.path, f.hash])), sourceId);
 
       // Periodically flush the vector store so crash recovery can skip already-processed files
       // without re-adding their vectors. store.save() is a no-op for pgvector (already durable).
@@ -3715,7 +3729,7 @@ export class Indexer {
     if (scopedRoots) {
       await this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
     } else {
-      await this.database!.replaceAllFileHashes(currentFileHashes);
+      await this.database!.replaceAllFileHashes(currentFileHashes, sourceId);
     }
 
     // Auto-GC after indexing: check if orphan count exceeds threshold
@@ -4244,7 +4258,7 @@ export class Indexer {
         invertedIndex.clear();
         await this.database!.saveInvertedIndex(invertedIndex.serialize());
 
-        await this.database!.replaceAllFileHashes(new Map());
+        await this.database!.replaceAllFileHashes(new Map(), this.computeSourceId(this.projectRoot));
 
         await database.clearAllIndexedData();
         this.saveFailedBatches([]);
@@ -4285,7 +4299,7 @@ export class Indexer {
     await this.database!.saveInvertedIndex(invertedIndex.serialize());
 
     // Clear file hash cache so all files are re-parsed
-    await this.database!.replaceAllFileHashes(new Map());
+    await this.database!.replaceAllFileHashes(new Map(), this.computeSourceId(this.projectRoot));
 
     // Clear persisted index data across all branches so force rebuilds
     // cannot reuse stale chunks, symbols, or embeddings from a prior provider.

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2780,7 +2780,7 @@ export class Indexer {
     if (chunkDataBatch.length > 0) {
       this.database.upsertChunksBatch(chunkDataBatch);
     }
-    await this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
+    this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
   }
 
   private loadIndexMetadata(): IndexMetadata | null {
@@ -2807,25 +2807,25 @@ export class Indexer {
     const existingCreatedAt = this.database.getMetadata("index.createdAt");
     const completeProjectEmbeddingStrategyReset = !this.hasProjectForceReembedPending();
 
-    await this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
-    await this.database.setMetadata("index.embeddingProvider", provider.provider);
-    await this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
-    await this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
+    this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
+    this.database.setMetadata("index.embeddingProvider", provider.provider);
+    this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
+    this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
     if (this.config.scope === "global") {
       if (completeProjectEmbeddingStrategyReset) {
-        await this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
+        this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
       }
-      await this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
+      this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
       if (completeProjectEmbeddingStrategyReset) {
-        await this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+        this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
       }
     } else {
-      await this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
+      this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
     }
-    await this.database.setMetadata("index.updatedAt", now);
+    this.database.setMetadata("index.updatedAt", now);
 
     if (!existingCreatedAt) {
-      await this.database.setMetadata("index.createdAt", now);
+      this.database.setMetadata("index.createdAt", now);
     }
   }
 
@@ -2886,7 +2886,7 @@ export class Indexer {
         throw new Error('No embedding provider info, you must initialize the indexer first.');
       }
 
-      this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
+      this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
     }
     return this.indexCompatibility;
   }
@@ -4495,7 +4495,7 @@ export class Indexer {
     }
   ): Promise<SearchResult[]> {
     const { store, provider, database } = await this.ensureInitialized();
-    
+
     const compatibility = this.checkCompatibility();
     if (!compatibility.compatible) {
       throw new Error(

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -281,6 +281,16 @@ interface IndexCompatibility {
 const INDEX_METADATA_VERSION = "1";
 const EMBEDDING_STRATEGY_VERSION = "2";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
+const CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000;
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
 
 function createPendingChunkStorageText(texts: PendingChunk["texts"]): string {
   const primaryText = texts[0]?.text ?? "";
@@ -2341,8 +2351,11 @@ export class Indexer {
     };
   }
 
-  private async checkForInterruptedIndexing(): Promise<boolean> {
-    return this.database!.isLocked();
+  private async checkForInterruptedIndexing(): Promise<"none" | "stale" | "active"> {
+    const lockInfo = await this.database!.getLockInfo();
+    if (!lockInfo) return "none";
+    if (!isPidAlive(lockInfo.pid)) return "stale";
+    return "active";
   }
 
   private async acquireIndexingLock(): Promise<void> {
@@ -2357,11 +2370,10 @@ export class Indexer {
   }
 
   private async recoverFromInterruptedIndexing(): Promise<void> {
-    this.logger.warn("Detected interrupted indexing session, recovering...");
-    await this.database!.replaceAllFileHashes(new Map());
+    this.logger.warn("Detected stale lock from crashed/killed process, recovering...");
     await this.healthCheck();
     await this.releaseIndexingLock();
-    this.logger.info("Recovery complete, next index will re-process all files");
+    this.logger.info("Lock cleared; previously completed file batches will be skipped on next index");
   }
 
   private loadFailedBatches(maxChunkTokens?: number): FailedBatch[] {
@@ -2815,7 +2827,8 @@ export class Indexer {
     // are all initialized. healthCheck() calls ensureInitialized() which checks
     // these fields — if they're not set, it re-enters initialize() causing infinite
     // recursion and 70GB+ memory usage.
-    if (await this.checkForInterruptedIndexing()) {
+    const lockState = await this.checkForInterruptedIndexing();
+    if (lockState === "stale") {
       await this.recoverFromInterruptedIndexing();
     }
 
@@ -3144,6 +3157,7 @@ export class Indexer {
     this.embeddingPhaseStartTime = 0;
     this.embeddingChunksAtStart = 0;
     this.lastProgressPersistAt = 0;
+    let lastCheckpointAt = 0;
     this.logger.recordIndexingStart();
     this.logger.info("Starting indexing", { projectRoot: this.projectRoot });
 
@@ -3225,11 +3239,13 @@ export class Indexer {
       if (!currentFilePathSet.has(fp)) {
         if (scopedRoots && !this.isFileInCurrentScope(fp, scopedRoots)) continue;
         const oldChunks = await this.database!.getChunksByFile(fp);
-        for (const chunk of oldChunks) {
-          await store.remove(chunk.chunkId);
-          invertedIndex.removeChunk(chunk.chunkId);
+        const oldChunkIds = oldChunks.map(c => c.chunkId);
+        for (const chunkId of oldChunkIds) {
+          await store.remove(chunkId);
+          invertedIndex.removeChunk(chunkId);
           removedCount++;
         }
+        await database.deleteInvertedIndexChunkBatch(oldChunkIds);
       }
     }
 
@@ -3275,6 +3291,7 @@ export class Indexer {
       });
       this.logger.recordChunksFromCache(chunksWithExistingEmbedding.length);
 
+      const existingEmbeddingEntries: Array<{ chunkId: string; content: string }> = [];
       for (const chunk of chunksWithExistingEmbedding) {
         const embeddingBuffer = await database.getEmbedding(chunk.contentHash);
         if (embeddingBuffer) {
@@ -3282,9 +3299,11 @@ export class Indexer {
           await store.add(chunk.id, Array.from(vector), chunk.metadata);
           invertedIndex.removeChunk(chunk.id);
           invertedIndex.addChunk(chunk.id, chunk.content);
+          existingEmbeddingEntries.push({ chunkId: chunk.id, content: chunk.content });
           stats.indexedChunks++;
         }
       }
+      await database.upsertInvertedIndexChunkBatch(existingEmbeddingEntries);
 
       const pendingChunksById = new Map(chunksNeedingEmbedding.map((c) => [c.id, c]));
       const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
@@ -3354,6 +3373,9 @@ export class Indexer {
               });
               embeddingPartsByChunk.delete(chunkId);
             }
+            await database.upsertInvertedIndexChunkBatch(
+              batch.map(c => ({ chunkId: c.id, content: c.content }))
+            );
 
             if (pooledResults.length > 0) {
               const items = pooledResults.map(({ chunk, vector }) => ({
@@ -3524,12 +3546,17 @@ export class Indexer {
         }
 
         // Per-file orphan removal (chunks no longer produced by re-parsing)
+        const orphanedChunkIds: string[] = [];
         for (const [oldChunkId] of existingChunkHashes) {
           if (!newChunkIdsForFile.has(oldChunkId)) {
             await store.remove(oldChunkId);
             invertedIndex.removeChunk(oldChunkId);
+            orphanedChunkIds.push(oldChunkId);
             removedCount++;
           }
+        }
+        if (orphanedChunkIds.length > 0) {
+          await database.deleteInvertedIndexChunkBatch(orphanedChunkIds);
         }
 
         // Call graph extraction for this file
@@ -3623,6 +3650,19 @@ export class Indexer {
 
       // Embed this batch; queue.onIdle() ensures we don't accumulate unbounded pending chunks
       await embedPendingChunks(batchPendingChunks);
+
+      // Write hashes for this batch immediately so crash recovery can skip already-processed files
+      await this.database!.setFileHashesBatch(new Map(fileBatch.map(f => [f.path, f.hash])));
+
+      // Periodically flush the vector store so crash recovery can skip already-processed files
+      // without re-adding their vectors. store.save() is a no-op for pgvector (already durable).
+      // The inverted index is kept current per-chunk via upsertInvertedIndexChunkBatch above.
+      const now = Date.now();
+      if (now - lastCheckpointAt >= CHECKPOINT_INTERVAL_MS) {
+        lastCheckpointAt = now;
+        await store.save();
+        this.logger.debug("Checkpoint: flushed vector store");
+      }
 
       this.updateProgress({
         phase: "parsing",

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3710,13 +3710,310 @@ export class Indexer {
     // Phase 7: Finalization
     stats.removedChunks = removedCount;
 
+<<<<<<< HEAD
+=======
+    if (pendingChunks.length === 0) {
+      database.clearBranch(branchCatalogKey);
+      database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
+      database.clearBranchSymbols(branchCatalogKey);
+      database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+      store.save();
+      invertedIndex.save();
+      if (scopedRoots) {
+        this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+        this.clearScopedFailedBatches(scopedRoots);
+      } else {
+        this.fileHashCache = currentFileHashes;
+        this.saveFileHashCache();
+        this.saveFailedBatches([]);
+      }
+      this.saveIndexMetadata(configuredProviderInfo);
+      this.indexCompatibility = { compatible: true };
+      stats.durationMs = Date.now() - startTime;
+      onProgress?.({
+        phase: "complete",
+        filesProcessed: files.length,
+        totalFiles: files.length,
+        chunksProcessed: 0,
+        totalChunks: 0,
+      });
+      this.releaseIndexingLock();
+      return stats;
+    }
+
+    onProgress?.({
+      phase: "embedding",
+      filesProcessed: files.length,
+      totalFiles: files.length,
+      chunksProcessed: 0,
+      totalChunks: pendingChunks.length,
+    });
+
+    const allContentHashes = pendingChunks.map((c) => c.contentHash);
+    const missingHashes = new Set(database.getMissingEmbeddings(allContentHashes));
+    const forcedReembedChunkIds = forceScopedReembed
+      ? new Set(pendingChunks.map((chunk) => chunk.id))
+      : new Set<string>();
+
+    const chunksNeedingEmbedding = pendingChunks.filter((c) => forcedReembedChunkIds.has(c.id) || missingHashes.has(c.contentHash));
+    const chunksWithExistingEmbedding = pendingChunks.filter((c) => !forcedReembedChunkIds.has(c.id) && !missingHashes.has(c.contentHash));
+
+    this.logger.cache("info", "Embedding cache lookup", {
+      needsEmbedding: chunksNeedingEmbedding.length,
+      fromCache: chunksWithExistingEmbedding.length,
+    });
+    this.logger.recordChunksFromCache(chunksWithExistingEmbedding.length);
+
+    for (const chunk of chunksWithExistingEmbedding) {
+      const embeddingBuffer = database.getEmbedding(chunk.contentHash);
+      if (embeddingBuffer) {
+        const vector = bufferToFloat32Array(embeddingBuffer);
+        store.add(chunk.id, Array.from(vector), chunk.metadata);
+        invertedIndex.removeChunk(chunk.id);
+        invertedIndex.addChunk(chunk.id, chunk.content);
+        stats.indexedChunks++;
+      }
+    }
+
+    const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
+    const queue = new PQueue({
+      concurrency: providerRateLimits.concurrency,
+      interval: providerRateLimits.intervalMs,
+      intervalCap: providerRateLimits.concurrency
+    });
+    const pendingChunksById = new Map(chunksNeedingEmbedding.map((chunk) => [chunk.id, chunk]));
+    const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
+    const completedChunkIds = new Set<string>();
+    const failedChunkIds = new Set<string>();
+    const requestBatches = createPendingEmbeddingRequestBatches(
+      chunksNeedingEmbedding,
+      getDynamicBatchOptions(configuredProviderInfo)
+    );
+    let rateLimitBackoffMs = 0;
+
+    for (const requestBatch of requestBatches) {
+      queue.add(async () => {
+        if (rateLimitBackoffMs > 0) {
+          await new Promise(resolve => setTimeout(resolve, rateLimitBackoffMs));
+        }
+
+        try {
+          let failedAttemptsForRequest = 0;
+          const result = await pRetry(
+            async () => {
+              const texts = requestBatch.map((request) => request.text);
+              return provider.embedBatch(texts);
+            },
+            {
+              retries: this.config.indexing.retries,
+              minTimeout: Math.max(this.config.indexing.retryDelayMs, providerRateLimits.minRetryMs),
+              maxTimeout: providerRateLimits.maxRetryMs,
+              factor: 2,
+              shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
+              onFailedAttempt: (error) => {
+                const message = getErrorMessage(error);
+                if (isRateLimitError(error)) {
+                  rateLimitBackoffMs = Math.min(providerRateLimits.maxRetryMs, (rateLimitBackoffMs || providerRateLimits.minRetryMs) * 2);
+                  this.logger.embedding("warn", `Rate limited, backing off`, {
+                    attempt: error.attemptNumber,
+                    retriesLeft: error.retriesLeft,
+                    backoffMs: rateLimitBackoffMs,
+                  });
+                } else {
+                  failedAttemptsForRequest += 1;
+                  this.logger.embedding("warn", `Embedding batch attempt failed; retry scheduled`, {
+                    attempt: error.attemptNumber,
+                    retriesLeft: error.retriesLeft,
+                    willRetry: error.retriesLeft > 0,
+                    error: message,
+                  });
+                }
+              },
+            }
+          );
+
+          if (failedAttemptsForRequest > 0) {
+            this.logger.embedding("warn", `Embedding batch succeeded after retry`, {
+              failedAttempts: failedAttemptsForRequest,
+              successfulAttempt: failedAttemptsForRequest + 1,
+              requestCount: requestBatch.length,
+            });
+          }
+
+          if (rateLimitBackoffMs > 0) {
+            rateLimitBackoffMs = Math.max(0, rateLimitBackoffMs - 2000);
+          }
+
+          const touchedChunkIds = new Set<string>();
+
+          requestBatch.forEach((request, idx) => {
+            if (failedChunkIds.has(request.chunk.id) || completedChunkIds.has(request.chunk.id)) {
+              return;
+            }
+
+            const vector = result.embeddings[idx];
+            if (!vector) {
+              throw new Error(`Embedding API returned too few vectors for chunk ${request.chunk.id}`);
+            }
+
+            const parts = embeddingPartsByChunk.get(request.chunk.id) ?? [];
+            parts[request.partIndex] = {
+              vector,
+              tokenCount: request.tokenCount,
+            };
+            embeddingPartsByChunk.set(request.chunk.id, parts);
+            touchedChunkIds.add(request.chunk.id);
+          });
+
+          const pooledResults: Array<{ chunk: PendingChunk; vector: number[] }> = [];
+          for (const chunkId of touchedChunkIds) {
+            if (failedChunkIds.has(chunkId) || completedChunkIds.has(chunkId)) {
+              continue;
+            }
+
+            const chunk = pendingChunksById.get(chunkId);
+            if (!chunk) {
+              continue;
+            }
+
+            const parts = embeddingPartsByChunk.get(chunk.id) ?? [];
+            if (!hasAllEmbeddingParts(parts, chunk.texts.length)) {
+              continue;
+            }
+
+            const orderedParts = parts as Array<{ vector: number[]; tokenCount: number }>;
+            pooledResults.push({
+              chunk,
+              vector: poolEmbeddingVectors(
+                orderedParts.map((part) => part.vector),
+                orderedParts.map((part) => part.tokenCount)
+              ),
+            });
+          }
+
+          if (pooledResults.length > 0) {
+            const items = pooledResults.map(({ chunk, vector }) => ({
+              id: chunk.id,
+              vector,
+              metadata: chunk.metadata,
+            }));
+
+            store.addBatch(items);
+
+            const embeddingBatchItems = pooledResults.map(({ chunk, vector }) => ({
+              contentHash: chunk.contentHash,
+              embedding: float32ArrayToBuffer(vector),
+              chunkText: chunk.storageText,
+              model: configuredProviderInfo.modelInfo.model,
+            }));
+
+            try {
+              database.upsertEmbeddingsBatch(embeddingBatchItems);
+            } catch (dbError) {
+              // Rollback vectors added to store if DB write fails
+              for (const { chunk } of pooledResults) {
+                store.remove(chunk.id);
+              }
+              throw dbError;
+            }
+
+            for (const { chunk } of pooledResults) {
+              invertedIndex.removeChunk(chunk.id);
+              invertedIndex.addChunk(chunk.id, chunk.content);
+              completedChunkIds.add(chunk.id);
+              embeddingPartsByChunk.delete(chunk.id);
+            }
+
+            stats.indexedChunks += pooledResults.length;
+            this.logger.recordChunksEmbedded(pooledResults.length);
+          }
+
+          stats.tokensUsed += result.totalTokensUsed;
+
+          this.logger.recordEmbeddingApiCall(result.totalTokensUsed);
+          this.logger.embedding("debug", `Embedded batch`, {
+            batchSize: pooledResults.length,
+            requestCount: requestBatch.length,
+            tokens: result.totalTokensUsed,
+          });
+
+          onProgress?.({
+            phase: "embedding",
+            filesProcessed: files.length,
+            totalFiles: files.length,
+            chunksProcessed: stats.indexedChunks,
+            totalChunks: pendingChunks.length,
+          });
+        } catch (error) {
+          const failedChunks = getUniquePendingChunksFromRequests(requestBatch)
+            .filter((chunk) => !completedChunkIds.has(chunk.id));
+          const failureMessage = getErrorMessage(error);
+          const failureTimestamp = new Date().toISOString();
+
+          for (const chunk of failedChunks) {
+            if (!failedChunkIds.has(chunk.id)) {
+              failedChunkIds.add(chunk.id);
+              stats.failedChunks += 1;
+            }
+
+            if (forceScopedReembed) {
+              failedForcedChunkIds.add(chunk.id);
+            }
+
+            embeddingPartsByChunk.delete(chunk.id);
+
+            const existingFailedBatchIndex = failedBatchesForCurrentRun.findIndex(
+              (failedBatch) => failedBatch.chunks[0]?.id === chunk.id
+            );
+            const existingFailedBatch = existingFailedBatchIndex === -1
+              ? undefined
+              : failedBatchesForCurrentRun[existingFailedBatchIndex];
+            const failedBatch = {
+              chunks: [chunk],
+              error: failureMessage,
+              attemptCount: (existingFailedBatch?.attemptCount ?? retryableFailedAttemptCounts.get(chunk.id) ?? 0) + 1,
+              lastAttempt: failureTimestamp,
+            } satisfies FailedBatch;
+
+            if (existingFailedBatchIndex === -1) {
+              failedBatchesForCurrentRun.push(failedBatch);
+            } else {
+              failedBatchesForCurrentRun[existingFailedBatchIndex] = failedBatch;
+            }
+          }
+
+          this.logger.recordEmbeddingError();
+          this.logger.embedding("error", `Failed to embed batch after retries`, {
+            batchSize: failedChunks.length,
+            requestCount: requestBatch.length,
+            error: failureMessage,
+            willPersistForLaterRetry: true,
+          });
+        }
+      });
+    }
+
+    await queue.onIdle();
+>>>>>>> 7767842 (feat: improve batch success/fail logging)
     if (scopedRoots) {
       this.saveScopedFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun), scopedRoots);
     } else {
       this.saveFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun));
     }
 
+<<<<<<< HEAD
     this.updateProgress({
+=======
+    if (failedBatchesForCurrentRun.length > 0) {
+      this.logger.embedding("warn", "Persisted failed embedding batches for later retry", {
+        failedBatchCount: coalesceFailedBatches(failedBatchesForCurrentRun).length,
+        failedChunks: stats.failedChunks,
+        failedBatchesPath: this.failedBatchesPath,
+      });
+    }
+
+    onProgress?.({
+>>>>>>> 7767842 (feat: improve batch success/fail logging)
       phase: "storing",
       filesProcessed: files.length,
       totalFiles: files.length,

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -189,6 +189,8 @@ export interface IndexProgress {
   chunksProcessed: number;
   totalChunks: number;
   currentFiles?: string[];
+  /** True on the progress update emitted before a batch starts; false/absent on the one emitted after it completes. */
+  batchStarting?: boolean;
   /** Estimated seconds until embedding completes. Only present during the embedding phase. */
   estimatedSecondsRemaining?: number;
 }
@@ -3471,6 +3473,7 @@ export class Indexer {
         chunksProcessed: stats.indexedChunks,
         totalChunks: stats.totalChunks,
         currentFiles: fileBatch.map(f => f.path),
+        batchStarting: true,
       }, onProgress);
 
       // Read content for only this batch

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4076,14 +4076,14 @@ export class Indexer {
       const allMetadata = store.getAllMetadata();
       const hasForeignData =
         allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots)) ||
-        this.hasForeignScopedBranchData() ||
-        this.hasForeignScopedFileHashData(roots) ||
+  await this.hasForeignScopedBranchData() ||
+  await this.hasForeignScopedFileHashData(roots) ||
         this.hasForeignScopedFailedBatches(roots);
 
       if (!compatibility.compatible && hasForeignData) {
         if (compatibility.code === IncompatibilityCode.EMBEDDING_STRATEGY_MISMATCH) {
-          this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
-          this.clearScopedFileHashCache(roots);
+          await this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
+          await this.clearScopedFileHashCache(roots);
           this.clearScopedFailedBatches(roots);
           await database.setMetadata(this.getProjectForceReembedMetadataKey(), "true");
           await database.deleteMetadata(this.getProjectEmbeddingStrategyMetadataKey());

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, promises as fsPromises } from "fs";
+import { existsSync, readFileSync, writeFileSync, unlinkSync, promises as fsPromises } from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
 import PQueue from "p-queue";
@@ -16,9 +16,7 @@ import { collectFiles, SkippedFile } from "../utils/files.js";
 import { createCostEstimate, CostEstimate } from "../utils/cost.js";
 import { Logger, initializeLogger } from "../utils/logger.js";
 import {
-  VectorStore,
   InvertedIndex,
-  Database,
   parseFiles,
   createEmbeddingTexts,
   generateChunkId,
@@ -33,6 +31,8 @@ import {
   estimateTokens,
 } from "../native/index.js";
 import type { SymbolData, CallEdgeData } from "../native/index.js";
+import type { IDatabaseBackend, IVectorStoreBackend } from "../db/index.js";
+import { createDatabaseBackend, createVectorStoreBackend } from "../db/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 import { resolveProjectIndexPath } from "../config/paths.js";
 
@@ -174,9 +174,12 @@ export interface StatusResult {
   failedBatchesCount: number;
   failedBatchesPath?: string;
   warning?: string;
+  indexingInProgress: boolean;
+  progress?: IndexProgress;
 }
 
 const STARTUP_WARNING_METADATA_KEY = "index.startupWarning";
+const PROGRESS_SNAPSHOT_KEY = "index.progressSnapshot";
 
 export interface IndexProgress {
   phase: "scanning" | "parsing" | "embedding" | "storing" | "complete";
@@ -184,7 +187,9 @@ export interface IndexProgress {
   totalFiles: number;
   chunksProcessed: number;
   totalChunks: number;
-  currentFile?: string;
+  currentFiles?: string[];
+  /** Estimated seconds until embedding completes. Only present during the embedding phase. */
+  estimatedSecondsRemaining?: number;
 }
 
 export type ProgressCallback = (progress: IndexProgress) => void;
@@ -492,6 +497,10 @@ const rankingQueryTokenCache = new Map<string, Set<string>>();
 const rankingNameTokenCache = new Map<string, Set<string>>();
 const rankingPathTokenCache = new Map<string, Set<string>>();
 const rankingTextTokenCache = new Map<string, Set<string>>();
+const queryIntentRawCache = new Map<string, "source" | "doc_test">();
+const queryIdentifierHintsCache = new Map<string, string[]>();
+const implementationPathCache = new Map<string, boolean>();
+const testOrDocPathCache = new Map<string, boolean>();
 
 const STOPWORDS = new Set([
   "the", "and", "for", "with", "from", "that", "this", "into", "using", "where",
@@ -560,6 +569,68 @@ const DOC_INTENT_HINTS = new Set([
   "guide",
   "usage",
 ]);
+
+const CLASSIFY_RAW_SOURCE_HINTS = [
+  "implement",
+  "implementation",
+  "implements",
+  "function",
+  "method",
+  "class",
+  "logic",
+  "algorithm",
+  "pipeline",
+  "indexer",
+];
+
+const CLASSIFY_RAW_DOC_TEST_REGEXES = Array.from(DOC_TEST_INTENT_HINTS).map(
+  (hint) => new RegExp(`\\b${hint}\\b`)
+);
+const CLASSIFY_RAW_SOURCE_REGEXES = CLASSIFY_RAW_SOURCE_HINTS.map(
+  (hint) => new RegExp(`\\b${hint}\\b`)
+);
+const WHERE_IS_PATTERN = /\bwhere\s+is\b/;
+
+const IMPLEMENTATION_CHUNK_TYPES = new Set([
+  "export_statement",
+  "function",
+  "function_declaration",
+  "method",
+  "method_definition",
+  "class",
+  "class_declaration",
+  "interface",
+  "type",
+  "enum",
+  "module",
+]);
+
+const NON_IMPLEMENTATION_EXTENSIONS = new Set([
+  "md", "mdx", "txt", "rst", "adoc", "snap", "json", "yaml", "yml", "lock",
+]);
+
+const DOCUMENTATION_EXTENSIONS = new Set([
+  "md", "mdx", "rst", "adoc", "txt",
+]);
+
+const DOC_TEST_INTENT_TOKENS = ["test", "tests", "fixture", "fixtures", "benchmark"];
+
+const IDENTIFIER_HINT_PATTERN = /[A-Za-z_][A-Za-z0-9_]*/g;
+const HAS_UPPERCASE_PATTERN = /[A-Z]/;
+
+function setBoundedMapCache<V>(
+  cache: Map<string, V>,
+  key: string,
+  value: V
+): void {
+  if (cache.size >= RANKING_TOKEN_CACHE_LIMIT) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+  cache.set(key, value);
+}
 
 function setBoundedCache(
   cache: Map<string, Set<string>>,
@@ -658,27 +729,46 @@ function chunkTypeBoost(chunkType: string): number {
 }
 
 function isTestOrDocPath(filePath: string): boolean {
-  return TEST_PATH_SEGMENTS.some((segment) => filePath.includes(segment));
+  const cached = testOrDocPathCache.get(filePath);
+  if (cached !== undefined) return cached;
+  let result = false;
+  for (let i = 0; i < TEST_PATH_SEGMENTS.length; i += 1) {
+    if (filePath.includes(TEST_PATH_SEGMENTS[i])) {
+      result = true;
+      break;
+    }
+  }
+  setBoundedMapCache(testOrDocPathCache, filePath, result);
+  return result;
 }
 
 function isLikelyImplementationPath(filePath: string): boolean {
+  const cached = implementationPathCache.get(filePath);
+  if (cached !== undefined) return cached;
   const lowered = filePath.toLowerCase();
-  if (IMPLEMENTATION_EXCLUDE_PATH_SEGMENTS.some((segment) => lowered.includes(segment))) {
-    return false;
+  let result = true;
+  for (let i = 0; i < IMPLEMENTATION_EXCLUDE_PATH_SEGMENTS.length; i += 1) {
+    if (lowered.includes(IMPLEMENTATION_EXCLUDE_PATH_SEGMENTS[i])) {
+      result = false;
+      break;
+    }
   }
-
-  const ext = lowered.split(".").pop() ?? "";
-  if (["md", "mdx", "txt", "rst", "adoc", "snap", "json", "yaml", "yml", "lock"].includes(ext)) {
-    return false;
+  if (result) {
+    const dotIdx = lowered.lastIndexOf(".");
+    const ext = dotIdx >= 0 ? lowered.slice(dotIdx + 1) : "";
+    if (NON_IMPLEMENTATION_EXTENSIONS.has(ext)) {
+      result = false;
+    }
   }
-
-  return true;
+  setBoundedMapCache(implementationPathCache, filePath, result);
+  return result;
 }
 
 function isDocumentationPath(filePath: string): boolean {
   const lowered = filePath.toLowerCase();
-  const ext = lowered.split(".").pop() ?? "";
-  return lowered.includes("readme") || ["md", "mdx", "rst", "adoc", "txt"].includes(ext);
+  const dotIdx = lowered.lastIndexOf(".");
+  const ext = dotIdx >= 0 ? lowered.slice(dotIdx + 1) : "";
+  return lowered.includes("readme") || DOCUMENTATION_EXTENSIONS.has(ext);
 }
 
 function classifyExternalRerankBand(
@@ -712,50 +802,57 @@ function classifyExternalRerankBand(
 }
 
 function classifyQueryIntent(tokens: string[]): "source" | "doc_test" {
-  const sourceIntentHits = tokens.filter((t) => SOURCE_INTENT_HINTS.has(t)).length;
-  const docTestIntentHits = tokens.filter((t) => DOC_TEST_INTENT_HINTS.has(t)).length;
+  let sourceIntentHits = 0;
+  let docTestIntentHits = 0;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const t = tokens[i];
+    if (SOURCE_INTENT_HINTS.has(t)) sourceIntentHits += 1;
+    if (DOC_TEST_INTENT_HINTS.has(t)) docTestIntentHits += 1;
+  }
   return sourceIntentHits >= docTestIntentHits ? "source" : "doc_test";
 }
 
 function classifyQueryIntentRaw(query: string): "source" | "doc_test" {
+  const cached = queryIntentRawCache.get(query);
+  if (cached !== undefined) return cached;
+
   const lowerQuery = query.toLowerCase();
-  const docTestRawHits = Array.from(DOC_TEST_INTENT_HINTS).filter((hint) =>
-    new RegExp(`\\b${hint}\\b`).test(lowerQuery)
-  ).length;
-  const sourceRawHits = [
-    "implement",
-    "implementation",
-    "implements",
-    "function",
-    "method",
-    "class",
-    "logic",
-    "algorithm",
-    "pipeline",
-    "indexer",
-  ].filter((hint) => new RegExp(`\\b${hint}\\b`).test(lowerQuery)).length;
+  let docTestRawHits = 0;
+  for (let i = 0; i < CLASSIFY_RAW_DOC_TEST_REGEXES.length; i += 1) {
+    if (CLASSIFY_RAW_DOC_TEST_REGEXES[i].test(lowerQuery)) docTestRawHits += 1;
+  }
+  let sourceRawHits = 0;
+  for (let i = 0; i < CLASSIFY_RAW_SOURCE_REGEXES.length; i += 1) {
+    if (CLASSIFY_RAW_SOURCE_REGEXES[i].test(lowerQuery)) sourceRawHits += 1;
+  }
 
+  let result: "source" | "doc_test";
   if (docTestRawHits > sourceRawHits) {
-    return "doc_test";
+    result = "doc_test";
+  } else if (sourceRawHits > docTestRawHits) {
+    result = "source";
+  } else if (
+    WHERE_IS_PATTERN.test(lowerQuery) &&
+    extractIdentifierHints(query).length > 0 &&
+    docTestRawHits === 0
+  ) {
+    result = "source";
+  } else {
+    const queryTokens = Array.from(tokenizeTextForRanking(query));
+    result = classifyQueryIntent(queryTokens);
   }
-
-  if (sourceRawHits > docTestRawHits) {
-    return "source";
-  }
-
-  const hasWhereIsPattern = /\bwhere\s+is\b/.test(lowerQuery);
-  const hasIdentifierHints = extractIdentifierHints(query).length > 0;
-  if (hasWhereIsPattern && hasIdentifierHints && docTestRawHits === 0) {
-    return "source";
-  }
-
-  const queryTokens = Array.from(tokenizeTextForRanking(query));
-  return classifyQueryIntent(queryTokens);
+  setBoundedMapCache(queryIntentRawCache, query, result);
+  return result;
 }
 
 function classifyDocIntent(tokens: string[]): "docs" | "test" | "mixed" | "none" {
-  const docHits = tokens.filter((t) => DOC_INTENT_HINTS.has(t)).length;
-  const testHits = tokens.filter((t) => ["test", "tests", "fixture", "fixtures", "benchmark"].includes(t)).length;
+  let docHits = 0;
+  let testHits = 0;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const t = tokens[i];
+    if (DOC_INTENT_HINTS.has(t)) docHits += 1;
+    if (DOC_TEST_INTENT_TOKENS.indexOf(t) !== -1) testHits += 1;
+  }
 
   if (docHits > 0 && testHits === 0) return "docs";
   if (testHits > 0 && docHits === 0) return "test";
@@ -764,31 +861,32 @@ function classifyDocIntent(tokens: string[]): "docs" | "test" | "mixed" | "none"
 }
 
 function isImplementationChunkType(chunkType: string): boolean {
-  return [
-    "export_statement",
-    "function",
-    "function_declaration",
-    "method",
-    "method_definition",
-    "class",
-    "class_declaration",
-    "interface",
-    "type",
-    "enum",
-    "module",
-  ].includes(chunkType);
+  return IMPLEMENTATION_CHUNK_TYPES.has(chunkType);
 }
 
 function extractIdentifierHints(query: string): string[] {
-  const identifiers = query.match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? [];
-  return identifiers
-    .filter((id) => id.length >= 3)
-    .filter((id) => {
-      const lower = id.toLowerCase();
-      if (STOPWORDS.has(lower)) return false;
-      return /[A-Z]/.test(id) || id.includes("_") || id.endsWith("Results") || id.endsWith("Result");
-    })
-    .map((id) => id.toLowerCase());
+  const cached = queryIdentifierHintsCache.get(query);
+  if (cached !== undefined) return cached;
+
+  IDENTIFIER_HINT_PATTERN.lastIndex = 0;
+  const result: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = IDENTIFIER_HINT_PATTERN.exec(query)) !== null) {
+    const id = match[0];
+    if (id.length < 3) continue;
+    const lower = id.toLowerCase();
+    if (STOPWORDS.has(lower)) continue;
+    if (
+      HAS_UPPERCASE_PATTERN.test(id) ||
+      id.indexOf("_") !== -1 ||
+      id.endsWith("Results") ||
+      id.endsWith("Result")
+    ) {
+      result.push(lower);
+    }
+  }
+  setBoundedMapCache(queryIdentifierHintsCache, query, result);
+  return result;
 }
 
 function extractCodeTermHints(query: string): string[] {
@@ -1292,15 +1390,15 @@ export function rankSemanticOnlyResults(
   });
 }
 
-function promoteIdentifierMatches(
+async function promoteIdentifierMatches(
   query: string,
   combined: RankedCandidate[],
   semanticCandidates: RankedCandidate[],
   keywordCandidates: RankedCandidate[],
-  database?: Database,
+  database?: IDatabaseBackend,
   branchChunkIds?: Set<string> | null,
   prioritizeSourcePaths: boolean = classifyQueryIntentRaw(query) === "source"
-): RankedCandidate[] {
+): Promise<RankedCandidate[]> {
   if (combined.length === 0) {
     return combined;
   }
@@ -1327,9 +1425,9 @@ function promoteIdentifierMatches(
 
   if (database) {
     for (const identifier of identifierHints) {
-      const symbols = database.getSymbolsByName(identifier);
+      const symbols = await database.getSymbolsByName(identifier);
       for (const symbol of symbols) {
-        const chunks = database.getChunksByFile(symbol.filePath);
+        const chunks = await database.getChunksByFile(symbol.filePath);
         for (const chunk of chunks) {
           if (branchChunkIds && !branchChunkIds.has(chunk.chunkId)) {
             continue;
@@ -1413,14 +1511,14 @@ function promoteIdentifierMatches(
   return [...promoted, ...remainder];
 }
 
-function buildSymbolDefinitionLane(
+async function buildSymbolDefinitionLane(
   query: string,
-  database: Database,
+  database: IDatabaseBackend,
   branchChunkIds: Set<string> | null,
   limit: number,
   fallbackCandidates: RankedCandidate[],
   prioritizeSourcePaths: boolean = classifyQueryIntentRaw(query) === "source"
-): RankedCandidate[] {
+): Promise<RankedCandidate[]> {
   if (!prioritizeSourcePaths) {
     return [];
   }
@@ -1436,7 +1534,7 @@ function buildSymbolDefinitionLane(
   const primaryHint = extractPrimaryIdentifierQueryHint(query);
 
   const upsertChunkCandidate = (
-    chunk: ReturnType<Database["getChunksByName"]>[number],
+    chunk: ChunkData,
     identifier: string,
     normalizedIdentifier: string,
     baseScore?: number
@@ -1489,13 +1587,13 @@ function buildSymbolDefinitionLane(
 
   for (const identifier of normalizedHints) {
     const symbols = [
-      ...database.getSymbolsByName(identifier),
-      ...database.getSymbolsByNameCi(identifier),
+      ...(await database.getSymbolsByName(identifier)),
+      ...(await database.getSymbolsByNameCi(identifier)),
     ];
 
     const chunksByName = [
-      ...database.getChunksByName(identifier),
-      ...database.getChunksByNameCi(identifier),
+      ...(await database.getChunksByName(identifier)),
+      ...(await database.getChunksByNameCi(identifier)),
     ];
 
     const normalizedIdentifier = identifier.replace(/_/g, "");
@@ -1506,7 +1604,7 @@ function buildSymbolDefinitionLane(
     }
 
     for (const symbol of dedupSymbols.values()) {
-      const chunks = database.getChunksByFile(symbol.filePath);
+      const chunks = await database.getChunksByFile(symbol.filePath);
       for (const chunk of chunks) {
         if (chunk.startLine > symbol.startLine || chunk.endLine < symbol.endLine) {
           continue;
@@ -1528,8 +1626,8 @@ function buildSymbolDefinitionLane(
 
   if (filePathHint && primaryHint) {
     const primaryChunks = [
-      ...database.getChunksByName(primaryHint),
-      ...database.getChunksByNameCi(primaryHint),
+      ...(await database.getChunksByName(primaryHint)),
+      ...(await database.getChunksByNameCi(primaryHint)),
     ];
     const dedupPrimaryChunks = new Map<string, typeof primaryChunks[number]>();
     for (const chunk of primaryChunks) {
@@ -1703,63 +1801,133 @@ export class Indexer {
   private config: ParsedCodebaseIndexConfig;
   private projectRoot: string;
   private indexPath: string;
-  private store: VectorStore | null = null;
+  private store: IVectorStoreBackend | null = null;
   private invertedIndex: InvertedIndex | null = null;
-  private database: Database | null = null;
+  private database: IDatabaseBackend | null = null;
   private provider: EmbeddingProviderInterface | null = null;
   private configuredProviderInfo: ConfiguredProviderInfo | null = null;
   private reranker: RerankerInterface | null = null;
-  private fileHashCache: Map<string, string> = new Map();
-  private fileHashCachePath: string = "";
   private failedBatchesPath: string = "";
   private currentBranch: string = "default";
   private baseBranch: string = "main";
   private logger: Logger;
+  private client?: { app?: { log: (entry: unknown) => Promise<unknown> } };
+  private currentProgress?: IndexProgress;
+  private lastProgressLogAt = 0;
+  private lastProgressSnapshot = "";
+  private embeddingPhaseStartTime = 0;
+  private embeddingChunksAtStart = 0;
+  private lastProgressPersistAt = 0;
   private queryEmbeddingCache: Map<string, { embedding: number[]; timestamp: number }> = new Map();
   private readonly maxQueryCacheSize = 100;
   private readonly queryCacheTtlMs = 5 * 60 * 1000;
   private readonly querySimilarityThreshold = 0.85;
   private indexCompatibility: IndexCompatibility | null = null;
-  private indexingLockPath: string = "";
+  /** Cached flag: whether the global branch catalog migration has been completed. */
+  private branchMigrationDone = false;
 
   constructor(projectRoot: string, config: ParsedCodebaseIndexConfig) {
     this.projectRoot = projectRoot;
     this.config = config;
     this.indexPath = this.getIndexPath();
-    this.fileHashCachePath = path.join(this.indexPath, "file-hashes.json");
     this.failedBatchesPath = path.join(this.indexPath, "failed-batches.json");
-    this.indexingLockPath = path.join(this.indexPath, "indexing.lock");
     this.logger = initializeLogger(config.debug);
+  }
+
+  private updateProgress(progress: IndexProgress, onProgress?: ProgressCallback): void {
+    // Compute ETA for embedding phase
+    let estimatedSecondsRemaining: number | undefined;
+    if (progress.phase === "embedding") {
+      if (this.embeddingPhaseStartTime === 0 && progress.chunksProcessed > 0) {
+        this.embeddingPhaseStartTime = Date.now();
+        this.embeddingChunksAtStart = progress.chunksProcessed;
+      }
+      if (this.embeddingPhaseStartTime > 0) {
+        const elapsedMs = Date.now() - this.embeddingPhaseStartTime;
+        const done = progress.chunksProcessed - this.embeddingChunksAtStart;
+        const remaining = progress.totalChunks - progress.chunksProcessed;
+        if (done > 0 && elapsedMs > 0 && remaining >= 0) {
+          const ratePerSec = done / (elapsedMs / 1000);
+          estimatedSecondsRemaining = Math.ceil(remaining / ratePerSec);
+        }
+      }
+    } else {
+      this.embeddingPhaseStartTime = 0;
+      this.embeddingChunksAtStart = 0;
+    }
+
+    const enriched: IndexProgress = estimatedSecondsRemaining !== undefined
+      ? { ...progress, estimatedSecondsRemaining }
+      : progress;
+
+    this.currentProgress = enriched;
+    onProgress?.(enriched);
+    this.emitProgressLog(enriched);
+
+    // Persist snapshot to DB for cross-invocation status (debounced, fire-and-forget)
+    const now = Date.now();
+    if (this.database && progress.phase !== "complete" && now - this.lastProgressPersistAt >= 5000) {
+      this.lastProgressPersistAt = now;
+      void this.database.setMetadata(PROGRESS_SNAPSHOT_KEY, JSON.stringify({ ...enriched, persistedAt: now }))
+        .catch(() => { /* best-effort */ });
+    }
+  }
+
+  private emitProgressLog(progress: IndexProgress): void {
+    if (!this.client?.app?.log) {
+      return;
+    }
+
+    const now = Date.now();
+    const snapshot = `${progress.phase}:${progress.filesProcessed}/${progress.totalFiles}:${progress.chunksProcessed}/${progress.totalChunks}:${progress.currentFiles?.join(",") ?? ""}`;
+    const shouldLog =
+      progress.phase === "scanning"
+      || progress.phase === "storing"
+      || progress.phase === "complete"
+      || this.lastProgressSnapshot === ""
+      || snapshot !== this.lastProgressSnapshot && now - this.lastProgressLogAt >= 1500;
+
+    if (!shouldLog) {
+      return;
+    }
+
+    this.lastProgressLogAt = now;
+    this.lastProgressSnapshot = snapshot;
+
+    const message = (() => {
+      switch (progress.phase) {
+        case "scanning":
+          return "Indexing: scanning files";
+        case "parsing":
+          return `Indexing: parsed ${progress.filesProcessed}/${progress.totalFiles} files`;
+        case "embedding":
+          return `Indexing: embedded ${progress.chunksProcessed}/${progress.totalChunks} chunks`;
+        case "storing":
+          return "Indexing: saving index data";
+        case "complete":
+          return "Indexing complete";
+      }
+    })();
+
+    void this.client.app.log({
+      body: {
+        service: "codebase-index",
+        level: "info",
+        message,
+        extra: {
+          phase: progress.phase,
+          filesProcessed: progress.filesProcessed,
+          totalFiles: progress.totalFiles,
+          chunksProcessed: progress.chunksProcessed,
+          totalChunks: progress.totalChunks,
+          currentFiles: progress.currentFiles,
+        },
+      },
+    }).catch(() => { /* best-effort */ });
   }
 
   private getIndexPath(): string {
     return resolveProjectIndexPath(this.projectRoot, this.config.scope);
-  }
-
-  private loadFileHashCache(): void {
-    try {
-      if (existsSync(this.fileHashCachePath)) {
-        const data = readFileSync(this.fileHashCachePath, "utf-8");
-        const parsed = JSON.parse(data);
-        this.fileHashCache = new Map(Object.entries(parsed));
-      }
-    } catch {
-      this.fileHashCache = new Map();
-    }
-  }
-
-  private saveFileHashCache(): void {
-    const obj: Record<string, string> = {};
-    for (const [k, v] of this.fileHashCache) {
-      obj[k] = v;
-    }
-    this.atomicWriteSync(this.fileHashCachePath, JSON.stringify(obj));
-  }
-
-  private atomicWriteSync(targetPath: string, data: string): void {
-    const tempPath = `${targetPath}.tmp`;
-    writeFileSync(tempPath, data);
-    renameSync(tempPath, targetPath);
   }
 
   private getScopedRoots(): string[] {
@@ -1801,22 +1969,24 @@ export class Indexer {
     return `index.forceReembed.${projectHash}`;
   }
 
-  private hasProjectForceReembedPending(): boolean {
-    return this.config.scope === "global" && this.database?.getMetadata(this.getProjectForceReembedMetadataKey()) === "true";
+  private async hasProjectForceReembedPending(): Promise<boolean> {
+    return this.config.scope === "global"
+      && (await this.database?.getMetadata(this.getProjectForceReembedMetadataKey())) === "true";
   }
 
-  private hasScopedIndexedData(): boolean {
+  private async hasScopedIndexedData(): Promise<boolean> {
     if (!this.store || this.config.scope !== "global") {
       return false;
     }
 
-    if (this.hasProjectForceReembedPending()) {
+    if (await this.hasProjectForceReembedPending()) {
       return false;
     }
 
     const roots = this.getScopedRoots();
+    const scopedFilePaths = await this.database?.getFilePathsInRoots(roots) ?? [];
 
-    if (Array.from(this.fileHashCache.keys()).some((filePath) => this.isFileInCurrentScope(filePath, roots))) {
+    if (scopedFilePaths.length > 0) {
       return true;
     }
 
@@ -1833,52 +2003,53 @@ export class Indexer {
       return false;
     }
 
-    if (this.getBranchCatalogKeys().some((branchKey) => {
-      const branchChunkIds = this.database!.getBranchChunkIds(branchKey);
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      const branchChunkIds = await this.database!.getBranchChunkIds(branchKey);
       if (branchChunkIds.length > 0) {
         return true;
       }
 
-      return this.database!.getBranchSymbolIds(branchKey).length > 0;
-    })) {
-      return true;
+      if ((await this.database!.getBranchSymbolIds(branchKey)).length > 0) {
+        return true;
+      }
     }
 
-    const hasAnyBranchRows = this.database.getAllBranches().some((branchKey) => {
-      const branchChunkIds = this.database!.getBranchChunkIds(branchKey);
+    const allBranches = await this.database.getAllBranches();
+    const hasAnyBranchRows = await Promise.all(allBranches.map(async (branchKey) => {
+      const branchChunkIds = await this.database!.getBranchChunkIds(branchKey);
       if (branchChunkIds.length > 0) {
         return true;
       }
 
-      return this.database!.getBranchSymbolIds(branchKey).length > 0;
-    });
+      return (await this.database!.getBranchSymbolIds(branchKey)).length > 0;
+    })).then((results) => results.some(Boolean));
     if (hasAnyBranchRows) {
       return false;
     }
 
-    return this.store.getAllMetadata().some(({ metadata }) => this.isFileInCurrentScope(metadata.filePath, roots));
+    return (await this.store.getAllMetadata()).some(({ metadata }) => this.isFileInCurrentScope(metadata.filePath, roots));
   }
 
-  private loadStoredEmbeddingStrategyVersion(): string | null {
+  private async loadStoredEmbeddingStrategyVersion(): Promise<string | null> {
     if (!this.database) {
       return null;
     }
 
-    if (this.hasProjectForceReembedPending()) {
+    if (await this.hasProjectForceReembedPending()) {
       return null;
     }
 
     if (this.config.scope !== "global") {
-      return this.database.getMetadata("index.embeddingStrategyVersion") ?? "1";
+      return (await this.database.getMetadata("index.embeddingStrategyVersion")) ?? "1";
     }
 
-    const projectVersion = this.database.getMetadata(this.getProjectEmbeddingStrategyMetadataKey());
+    const projectVersion = await this.database.getMetadata(this.getProjectEmbeddingStrategyMetadataKey());
     if (projectVersion) {
       return projectVersion;
     }
 
-    const legacySharedVersion = this.database.getMetadata("index.embeddingStrategyVersion");
-    if (legacySharedVersion && this.hasScopedIndexedData()) {
+    const legacySharedVersion = await this.database.getMetadata("index.embeddingStrategyVersion");
+    if (legacySharedVersion && await this.hasScopedIndexedData()) {
       return legacySharedVersion;
     }
 
@@ -1891,7 +2062,7 @@ export class Indexer {
       return [primary];
     }
 
-    if (this.database?.getMetadata(this.getLegacyMigrationMetadataKey()) === "done") {
+    if (this.branchMigrationDone) {
       return [primary];
     }
 
@@ -1909,10 +2080,10 @@ export class Indexer {
     return primary === legacy ? [primary] : [primary, legacy];
   }
 
-  private getProjectLocalScopedOwnershipIds(roots: string[]): {
+  private async getProjectLocalScopedOwnershipIds(roots: string[]): Promise<{
     chunkIds: Set<string>;
     symbolIds: Set<string>;
-  } {
+  }> {
     const chunkIds = new Set<string>();
     const symbolIds = new Set<string>();
     if (!this.database) {
@@ -1920,11 +2091,13 @@ export class Indexer {
     }
 
     const projectRootPath = path.resolve(this.projectRoot);
+    const scopedFilePaths = await this.database.getFilePathsInRoots(roots);
+    const storeMetadata = this.store ? await this.store.getAllMetadata() : [];
     const projectLocalFilePaths = new Set<string>([
-      ...Array.from(this.fileHashCache.keys()).filter(
+      ...scopedFilePaths.filter(
         (filePath) => this.isFileInCurrentScope(filePath, roots) && isPathWithinRoot(filePath, projectRootPath)
       ),
-      ...(this.store?.getAllMetadata() ?? [])
+      ...storeMetadata
         .map(({ metadata }) => metadata.filePath)
         .filter(
           (filePath) => this.isFileInCurrentScope(filePath, roots) && isPathWithinRoot(filePath, projectRootPath)
@@ -1932,11 +2105,11 @@ export class Indexer {
     ]);
 
     for (const filePath of projectLocalFilePaths) {
-      for (const chunk of this.database.getChunksByFile(filePath)) {
+      for (const chunk of await this.database.getChunksByFile(filePath)) {
         chunkIds.add(chunk.chunkId);
       }
 
-      for (const symbol of this.database.getSymbolsByFile(filePath)) {
+      for (const symbol of await this.database.getSymbolsByFile(filePath)) {
         symbolIds.add(symbol.id);
       }
     }
@@ -1944,7 +2117,7 @@ export class Indexer {
     return { chunkIds, symbolIds };
   }
 
-  private getProjectScopedBranchCatalogCleanupKeys(projectChunkIds: string[], projectSymbolIds: string[]): string[] {
+  private async getProjectScopedBranchCatalogCleanupKeys(projectChunkIds: string[], projectSymbolIds: string[]): Promise<string[]> {
     if (this.config.scope !== "global") {
       return this.getBranchCatalogCleanupKeys();
     }
@@ -1954,7 +2127,7 @@ export class Indexer {
     const projectChunkIdSet = new Set(projectChunkIds);
     const projectSymbolIdSet = new Set(projectSymbolIds);
 
-    for (const branchKey of this.database?.getAllBranches() ?? []) {
+    for (const branchKey of await (this.database?.getAllBranches() ?? Promise.resolve([]))) {
       if (branchKey.startsWith(`${projectHash}:`)) {
         keys.add(branchKey);
         continue;
@@ -1964,8 +2137,8 @@ export class Indexer {
         continue;
       }
 
-      const referencesProjectChunks = this.database?.getBranchChunkIds(branchKey).some((chunkId) => projectChunkIdSet.has(chunkId)) ?? false;
-      const referencesProjectSymbols = this.database?.getBranchSymbolIds(branchKey).some((symbolId) => projectSymbolIdSet.has(symbolId)) ?? false;
+      const referencesProjectChunks = (await this.database?.getBranchChunkIds(branchKey) ?? []).some((chunkId) => projectChunkIdSet.has(chunkId));
+      const referencesProjectSymbols = (await this.database?.getBranchSymbolIds(branchKey) ?? []).some((symbolId) => projectSymbolIdSet.has(symbolId));
       if (referencesProjectChunks || referencesProjectSymbols) {
         keys.add(branchKey);
       }
@@ -1982,27 +2155,13 @@ export class Indexer {
     return roots.some((root) => isPathWithinRoot(filePath, root));
   }
 
-  private clearScopedFileHashCache(roots: string[]): void {
-    for (const filePath of Array.from(this.fileHashCache.keys())) {
-      if (this.isFileInCurrentScope(filePath, roots)) {
-        this.fileHashCache.delete(filePath);
-      }
-    }
-    this.saveFileHashCache();
+  private async clearScopedFileHashCache(roots: string[]): Promise<void> {
+    await this.database!.deleteFileHashesInRoots(roots);
   }
 
-  private replaceScopedFileHashCache(currentFileHashes: Map<string, string>, roots: string[]): void {
-    for (const filePath of Array.from(this.fileHashCache.keys())) {
-      if (this.isFileInCurrentScope(filePath, roots)) {
-        this.fileHashCache.delete(filePath);
-      }
-    }
-
-    for (const [filePath, hash] of currentFileHashes) {
-      this.fileHashCache.set(filePath, hash);
-    }
-
-    this.saveFileHashCache();
+  private async replaceScopedFileHashCache(currentFileHashes: Map<string, string>, roots: string[]): Promise<void> {
+    await this.database!.deleteFileHashesInRoots(roots);
+    await this.database!.setFileHashesBatch(currentFileHashes);
   }
 
   private partitionFailedBatches(roots: string[], maxChunkTokens?: number): { scoped: FailedBatch[]; retained: SerializedFailedBatch[] } {
@@ -2039,8 +2198,8 @@ export class Indexer {
     this.saveFailedBatches(retainedBatches);
   }
 
-  private hasForeignScopedFileHashData(roots: string[]): boolean {
-    return Array.from(this.fileHashCache.keys()).some((filePath) => !this.isFileInCurrentScope(filePath, roots));
+  private async hasForeignScopedFileHashData(roots: string[]): Promise<boolean> {
+    return this.database!.hasFileHashesOutsideRoots(roots);
   }
 
   private hasForeignScopedFailedBatches(roots: string[]): boolean {
@@ -2048,19 +2207,19 @@ export class Indexer {
     return retained.length > 0;
   }
 
-  private hasForeignScopedBranchData(): boolean {
+  private async hasForeignScopedBranchData(): Promise<boolean> {
     if (!this.database || this.config.scope !== "global") {
       return false;
     }
 
     const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
     const roots = this.getScopedRoots();
-    const { chunkIds: projectLocalChunkIds, symbolIds: projectLocalSymbolIds } = this.getProjectLocalScopedOwnershipIds(roots);
+    const { chunkIds: projectLocalChunkIds, symbolIds: projectLocalSymbolIds } = await this.getProjectLocalScopedOwnershipIds(roots);
 
-    return this.database.getAllBranches().some(
-      (branchKey) => {
-        const branchChunkIds = this.database!.getBranchChunkIds(branchKey);
-        const branchSymbolIds = this.database!.getBranchSymbolIds(branchKey);
+    const branchKeys = await this.database.getAllBranches();
+    return (await Promise.all(branchKeys.map(async (branchKey) => {
+        const branchChunkIds = await this.database!.getBranchChunkIds(branchKey);
+        const branchSymbolIds = await this.database!.getBranchSymbolIds(branchKey);
         const hasBranchData = branchChunkIds.length > 0 || branchSymbolIds.length > 0;
         if (!hasBranchData) {
           return false;
@@ -2078,7 +2237,7 @@ export class Indexer {
 
         return true;
       }
-    );
+    ))).some(Boolean);
   }
 
   private saveScopedFailedBatches(batches: FailedBatch[], roots: string[]): void {
@@ -2086,16 +2245,16 @@ export class Indexer {
     this.saveFailedBatches([...retained, ...batches]);
   }
 
-  private clearSharedIndexProjectData(
-    store: VectorStore,
+  private async clearSharedIndexProjectData(
+    store: IVectorStoreBackend,
     invertedIndex: InvertedIndex,
-    database: Database,
+    database: IDatabaseBackend,
     roots: string[]
-  ): { removedChunkIds: string[]; hasForeignData: boolean } {
-    const allMetadata = store.getAllMetadata();
+  ): Promise<{ removedChunkIds: string[]; hasForeignData: boolean }> {
+    const allMetadata = await store.getAllMetadata();
     const scopedEntries = allMetadata.filter(({ metadata }) => this.isFileInCurrentScope(metadata.filePath, roots));
     const filePaths = new Set<string>([
-      ...Array.from(this.fileHashCache.keys()).filter((filePath) => this.isFileInCurrentScope(filePath, roots)),
+      ...await this.database!.getFilePathsInRoots(roots),
       ...scopedEntries.map(({ metadata }) => metadata.filePath),
     ]);
 
@@ -2106,7 +2265,7 @@ export class Indexer {
 
     const removedChunkIds = new Set<string>(scopedEntries.map(({ key }) => key));
     for (const filePath of filePaths) {
-      for (const chunk of database.getChunksByFile(filePath)) {
+      for (const chunk of await database.getChunksByFile(filePath)) {
         removedChunkIds.add(chunk.chunkId);
       }
     }
@@ -2118,7 +2277,7 @@ export class Indexer {
         .map(({ key }) => key)
     );
     for (const filePath of projectLocalFilePaths) {
-      for (const chunk of database.getChunksByFile(filePath)) {
+      for (const chunk of await database.getChunksByFile(filePath)) {
         projectLocalChunkIds.add(chunk.chunkId);
       }
     }
@@ -2126,7 +2285,7 @@ export class Indexer {
     const symbolIds: string[] = [];
     const projectLocalSymbolIds = new Set<string>();
     for (const filePath of filePaths) {
-      for (const symbol of database.getSymbolsByFile(filePath)) {
+      for (const symbol of await database.getSymbolsByFile(filePath)) {
         symbolIds.push(symbol.id);
         if (projectLocalFilePaths.has(filePath)) {
           projectLocalSymbolIds.add(symbol.id);
@@ -2134,46 +2293,47 @@ export class Indexer {
       }
     }
 
-    for (const branchKey of this.getProjectScopedBranchCatalogCleanupKeys(Array.from(projectLocalChunkIds), Array.from(projectLocalSymbolIds))) {
-      database.deleteBranchChunksForBranch(branchKey, removedChunkIdList);
+    for (const branchKey of await this.getProjectScopedBranchCatalogCleanupKeys(Array.from(projectLocalChunkIds), Array.from(projectLocalSymbolIds))) {
+      await database.deleteBranchChunksForBranch(branchKey, removedChunkIdList);
     }
-    const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIdList));
+    const sharedChunkIds = new Set(await database.getReferencedChunkIds(removedChunkIdList));
     const removableChunkIds = removedChunkIdList.filter((chunkId) => !sharedChunkIds.has(chunkId));
 
     for (const chunkId of removableChunkIds) {
-      store.remove(chunkId);
+      await store.remove(chunkId);
       invertedIndex.removeChunk(chunkId);
     }
 
-    for (const branchKey of this.getProjectScopedBranchCatalogCleanupKeys(Array.from(projectLocalChunkIds), Array.from(projectLocalSymbolIds))) {
-      database.deleteBranchSymbolsForBranch(branchKey, symbolIds);
+    for (const branchKey of await this.getProjectScopedBranchCatalogCleanupKeys(Array.from(projectLocalChunkIds), Array.from(projectLocalSymbolIds))) {
+      await database.deleteBranchSymbolsForBranch(branchKey, symbolIds);
     }
-    const sharedSymbolIds = new Set(database.getReferencedSymbolIds(symbolIds));
+    const sharedSymbolIds = new Set(await database.getReferencedSymbolIds(symbolIds));
     const removableSymbolIds = symbolIds.filter((symbolId) => !sharedSymbolIds.has(symbolId));
 
-    database.clearCallEdgeTargetsForSymbols(removableSymbolIds);
+    await database.clearCallEdgeTargetsForSymbols(removableSymbolIds);
 
     for (const filePath of filePaths) {
-      const fileChunkIds = database.getChunksByFile(filePath).map((chunk) => chunk.chunkId);
-      const fileSymbols = database.getSymbolsByFile(filePath);
+      const fileChunks = await database.getChunksByFile(filePath);
+      const fileChunkIds = fileChunks.map((chunk) => chunk.chunkId);
+      const fileSymbols = await database.getSymbolsByFile(filePath);
 
       if (fileChunkIds.every((chunkId) => !sharedChunkIds.has(chunkId))) {
-        database.deleteChunksByFile(filePath);
+        await database.deleteChunksByFile(filePath);
       }
 
       if (fileSymbols.every((symbol) => !sharedSymbolIds.has(symbol.id))) {
-        database.deleteCallEdgesByFile(filePath);
-        database.deleteSymbolsByFile(filePath);
+        await database.deleteCallEdgesByFile(filePath);
+        await database.deleteSymbolsByFile(filePath);
       }
     }
 
-    database.gcOrphanCallEdges();
-    database.gcOrphanSymbols();
-    database.gcOrphanEmbeddings();
-    database.gcOrphanChunks();
+    await database.gcOrphanCallEdges();
+    await database.gcOrphanSymbols();
+    await database.gcOrphanEmbeddings();
+    await database.gcOrphanChunks();
 
-    store.save();
-    invertedIndex.save();
+    await store.save();
+    await this.database!.saveInvertedIndex(invertedIndex.serialize());
 
     return {
       removedChunkIds: removedChunkIdList,
@@ -2181,34 +2341,26 @@ export class Indexer {
     };
   }
 
-  private checkForInterruptedIndexing(): boolean {
-    return existsSync(this.indexingLockPath);
+  private async checkForInterruptedIndexing(): Promise<boolean> {
+    return this.database!.isLocked();
   }
 
-  private acquireIndexingLock(): void {
-    const lockData = {
-      startedAt: new Date().toISOString(),
-      pid: process.pid,
-    };
-    writeFileSync(this.indexingLockPath, JSON.stringify(lockData));
-  }
-
-  private releaseIndexingLock(): void {
-    if (existsSync(this.indexingLockPath)) {
-      unlinkSync(this.indexingLockPath);
+  private async acquireIndexingLock(): Promise<void> {
+    const acquired = await this.database!.tryAcquireLock(process.pid, new Date().toISOString());
+    if (!acquired) {
+      throw new Error("[codebase-index] Another indexing session is already in progress");
     }
+  }
+
+  private async releaseIndexingLock(): Promise<void> {
+    await this.database!.releaseLock();
   }
 
   private async recoverFromInterruptedIndexing(): Promise<void> {
     this.logger.warn("Detected interrupted indexing session, recovering...");
-
-    if (existsSync(this.fileHashCachePath)) {
-      unlinkSync(this.fileHashCachePath);
-    }
-
+    await this.database!.replaceAllFileHashes(new Map());
     await this.healthCheck();
-    this.releaseIndexingLock();
-
+    await this.releaseIndexingLock();
     this.logger.info("Recovery complete, next index will re-process all files");
   }
 
@@ -2515,7 +2667,9 @@ export class Indexer {
     return parts.join("\n");
   }
 
-  async initialize(): Promise<void> {
+  async initialize(client?: any): Promise<void> {
+    this.client = client;
+
     if (this.config.embeddingProvider === 'custom') {
       if (!this.config.customProvider) {
         throw new Error("embeddingProvider is 'custom' but customProvider config is missing.");
@@ -2561,38 +2715,87 @@ export class Indexer {
     // → initialize (store not yet set) → recovery → ...
 
     const dimensions = this.configuredProviderInfo.modelInfo.dimensions;
-    const storePath = path.join(this.indexPath, "vectors");
-    this.store = new VectorStore(storePath, dimensions);
+    const dbCfg = this.config.database;
 
-    const indexFilePath = path.join(this.indexPath, "vectors.usearch");
-    if (existsSync(indexFilePath)) {
-      this.store.load();
-    }
+    // ── Vector store ──────────────────────────────────────────────────────────
+    this.store = await createVectorStoreBackend(dbCfg, this.indexPath, dimensions);
+    await this.store.load();
 
+    // ── Inverted index ────────────────────────────────────────────────────────
     const invertedIndexPath = path.join(this.indexPath, "inverted-index.json");
     this.invertedIndex = new InvertedIndex(invertedIndexPath);
-    try {
-      this.invertedIndex.load();
-    } catch {
-      if (existsSync(invertedIndexPath)) {
-        await fsPromises.unlink(invertedIndexPath);
+
+    // ── Database ──────────────────────────────────────────────────────────────
+    const dbPath = path.join(this.indexPath, "codebase.db");
+    const dbIsNew = dbCfg.engine === "sqlite" && !existsSync(dbPath);
+
+    // Log database connection details
+    if (dbCfg.engine === "sqlite") {
+      const msg = `Initializing SQLite database at ${dbPath}`;
+      this.logger.info(msg, { path: dbPath, isNew: dbIsNew });
+      if (client) {
+        await client.app.log({
+          body: {
+            service: "codebase-index",
+            level: "info",
+            message: msg,
+            extra: { path: dbPath, isNew: dbIsNew },
+          },
+        });
       }
-      this.invertedIndex = new InvertedIndex(invertedIndexPath);
+    } else if (dbCfg.engine === "pgvector" && dbCfg.pgvector) {
+      const pgConfig = dbCfg.pgvector;
+      const connectionInfo = pgConfig.connectionString
+        ? "via connection string"
+        : `${pgConfig.user || "postgres"}@${pgConfig.host || "localhost"}:${pgConfig.port || 5432}/${pgConfig.database || "postgres"}`;
+      const msg = `Initializing pgvector database ${connectionInfo}`;
+      this.logger.info(msg, {
+        connectionInfo,
+        tablePrefix: pgConfig.tablePrefix || "ci",
+        ssl: pgConfig.ssl || "disable",
+      });
+      if (client) {
+        await client.app.log({
+          body: {
+            service: "codebase-index",
+            level: "info",
+            message: msg,
+            extra: {
+              connectionInfo,
+              tablePrefix: pgConfig.tablePrefix || "ci",
+              ssl: pgConfig.ssl || "disable",
+            },
+          },
+        });
+      }
     }
 
-    const dbPath = path.join(this.indexPath, "codebase.db");
-    let dbIsNew = !existsSync(dbPath);
     try {
-      this.database = new Database(dbPath);
+      this.database = await createDatabaseBackend(dbCfg, dbPath);
     } catch (error) {
-      if (!(await this.tryResetCorruptedIndex("initializing index database", error))) {
+      if (dbCfg.engine !== "sqlite" || !(await this.tryResetCorruptedIndex("initializing index database", error))) {
         throw error;
       }
 
-      this.store = new VectorStore(storePath, dimensions);
+      this.store = await createVectorStoreBackend(dbCfg, this.indexPath, dimensions);
       this.invertedIndex = new InvertedIndex(invertedIndexPath);
-      this.database = new Database(dbPath);
-      dbIsNew = true;
+      this.database = await createDatabaseBackend(dbCfg, dbPath);
+    }
+
+    // Hydrate the in-memory inverted index from whichever backend owns it.
+    try {
+      const invertedIndexJson = await this.database.loadInvertedIndex();
+      if (invertedIndexJson) {
+        this.invertedIndex.deserialize(invertedIndexJson);
+      }
+    } catch {
+      // Corrupted — will be rebuilt from scratch during next index run.
+    }
+
+    // Load the cached migration-done flag so getBranchCatalogKeys() stays synchronous.
+    if (this.config.scope === "global") {
+      const migVal = await this.database.getMetadata(this.getLegacyMigrationMetadataKey());
+      this.branchMigrationDone = migVal === "done";
     }
 
     if (isGitRepo(this.projectRoot)) {
@@ -2612,17 +2815,15 @@ export class Indexer {
     // are all initialized. healthCheck() calls ensureInitialized() which checks
     // these fields — if they're not set, it re-enters initialize() causing infinite
     // recursion and 70GB+ memory usage.
-    if (this.checkForInterruptedIndexing()) {
+    if (await this.checkForInterruptedIndexing()) {
       await this.recoverFromInterruptedIndexing();
     }
 
-    if (dbIsNew && this.store.count() > 0) {
-      this.migrateFromLegacyIndex();
+    if (dbIsNew && (await this.store.count()) > 0) {
+      await this.migrateFromLegacyIndex();
     }
 
-    this.loadFileHashCache();
-
-    this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
+  this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
     if (!this.indexCompatibility.compatible) {
       this.logger.warn("Index compatibility issue detected", {
         reason: this.indexCompatibility.reason,
@@ -2640,7 +2841,7 @@ export class Indexer {
   private async maybeRunAutoGc(): Promise<void> {
     if (!this.database) return;
 
-    const lastGcTimestamp = this.database.getMetadata("lastGcTimestamp");
+    const lastGcTimestamp = await this.database.getMetadata("lastGcTimestamp");
     const now = Date.now();
     const intervalMs = this.config.indexing.gcIntervalDays * 24 * 60 * 60 * 1000;
 
@@ -2669,14 +2870,14 @@ export class Indexer {
   private async maybeRunOrphanGc(): Promise<CorruptedIndexResetResult | null> {
     if (!this.database) return null;
 
-    const stats = this.database.getStats();
+    const stats = await this.database.getStats();
     if (!stats) return null;
 
     const orphanCount = stats.embeddingCount - stats.chunkCount;
     if (orphanCount > this.config.indexing.gcOrphanThreshold) {
       try {
-        this.database.gcOrphanEmbeddings();
-        this.database.gcOrphanChunks();
+        await this.database.gcOrphanEmbeddings();
+        await this.database.gcOrphanChunks();
       } catch (error) {
         if (await this.tryResetCorruptedIndex("running automatic orphan garbage collection", error)) {
           return {
@@ -2724,12 +2925,12 @@ export class Indexer {
       error: errorMessage,
     });
 
+    await this.database?.close();
     this.store = null;
     this.invertedIndex = null;
     this.database?.close();
     this.database = null;
     this.indexCompatibility = null;
-    this.fileHashCache.clear();
 
     const resetPaths = [
       path.join(this.indexPath, "codebase.db"),
@@ -2755,10 +2956,10 @@ export class Indexer {
     return true;
   }
 
-  private migrateFromLegacyIndex(): void {
+  private async migrateFromLegacyIndex(): Promise<void> {
     if (!this.store || !this.database) return;
 
-    const allMetadata = this.store.getAllMetadata();
+    const allMetadata = await this.store.getAllMetadata();
     const chunkIds: string[] = [];
     const chunkDataBatch: ChunkData[] = [];
 
@@ -2778,34 +2979,34 @@ export class Indexer {
     }
 
     if (chunkDataBatch.length > 0) {
-      this.database.upsertChunksBatch(chunkDataBatch);
+      await this.database.upsertChunksBatch(chunkDataBatch);
     }
     await this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
   }
 
-  private loadIndexMetadata(): IndexMetadata | null {
+  private async loadIndexMetadata(): Promise<IndexMetadata | null> {
     if (!this.database) return null;
 
-    const version = this.database.getMetadata("index.version");
+    const version = await this.database.getMetadata("index.version");
     if (!version) return null;
 
-      return {
-        indexVersion: version,
-        embeddingProvider: this.database.getMetadata("index.embeddingProvider") ?? "",
-        embeddingModel: this.database.getMetadata("index.embeddingModel") ?? "",
-        embeddingDimensions: parseInt(this.database.getMetadata("index.embeddingDimensions") ?? "0", 10),
-        embeddingStrategyVersion: this.loadStoredEmbeddingStrategyVersion() ?? EMBEDDING_STRATEGY_VERSION,
-        createdAt: this.database.getMetadata("index.createdAt") ?? "",
-        updatedAt: this.database.getMetadata("index.updatedAt") ?? "",
-      };
+    return {
+      indexVersion: version,
+      embeddingProvider: (await this.database.getMetadata("index.embeddingProvider")) ?? "",
+      embeddingModel: (await this.database.getMetadata("index.embeddingModel")) ?? "",
+      embeddingDimensions: parseInt((await this.database.getMetadata("index.embeddingDimensions")) ?? "0", 10),
+      embeddingStrategyVersion: (await this.loadStoredEmbeddingStrategyVersion()) ?? EMBEDDING_STRATEGY_VERSION,
+      createdAt: (await this.database.getMetadata("index.createdAt")) ?? "",
+      updatedAt: (await this.database.getMetadata("index.updatedAt")) ?? "",
+    };
   }
 
-  private saveIndexMetadata(provider: ConfiguredProviderInfo): void {
+  private async saveIndexMetadata(provider: ConfiguredProviderInfo): Promise<void> {
     if (!this.database) return;
 
     const now = new Date().toISOString();
-    const existingCreatedAt = this.database.getMetadata("index.createdAt");
-    const completeProjectEmbeddingStrategyReset = !this.hasProjectForceReembedPending();
+    const existingCreatedAt = await this.database.getMetadata("index.createdAt");
+    const completeProjectEmbeddingStrategyReset = !(await this.hasProjectForceReembedPending());
 
     await this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
     await this.database.setMetadata("index.embeddingProvider", provider.provider);
@@ -2819,6 +3020,7 @@ export class Indexer {
       if (completeProjectEmbeddingStrategyReset) {
         await this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
       }
+      this.branchMigrationDone = true;
     } else {
       await this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
     }
@@ -2829,8 +3031,8 @@ export class Indexer {
     }
   }
 
-  private validateIndexCompatibility(provider: ConfiguredProviderInfo): IndexCompatibility {
-    const storedMetadata = this.loadIndexMetadata();
+  private async validateIndexCompatibility(provider: ConfiguredProviderInfo): Promise<IndexCompatibility> {
+    const storedMetadata = await this.loadIndexMetadata();
 
     if (!storedMetadata) {
       return { compatible: true };
@@ -2882,21 +3084,17 @@ export class Indexer {
 
   checkCompatibility(): IndexCompatibility {
     if (!this.indexCompatibility) {
-      if (!this.configuredProviderInfo) {
-        throw new Error('No embedding provider info, you must initialize the indexer first.');
-      }
-
-      this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
+      throw new Error('No embedding provider info, you must initialize the indexer first.');
     }
     return this.indexCompatibility;
   }
 
   private async ensureInitialized(): Promise<{
-    store: VectorStore;
+    store: IVectorStoreBackend;
     provider: EmbeddingProviderInterface;
     invertedIndex: InvertedIndex;
     configuredProviderInfo: ConfiguredProviderInfo;
-    database: Database;
+    database: IDatabaseBackend;
   }> {
     if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
       await this.initialize();
@@ -2930,7 +3128,7 @@ export class Indexer {
     const { store, provider, invertedIndex, database, configuredProviderInfo } = await this.ensureInitialized();
     const scopedRoots = this.config.scope === "global" ? this.getScopedRoots() : null;
     const branchCatalogKey = this.getBranchCatalogKey();
-    const forceScopedReembed = scopedRoots !== null && database.getMetadata(this.getProjectForceReembedMetadataKey()) === "true";
+    const forceScopedReembed = scopedRoots !== null && (await database.getMetadata(this.getProjectForceReembedMetadataKey())) === "true";
     const failedForcedChunkIds = new Set<string>();
 
     if (!this.indexCompatibility?.compatible) {
@@ -2940,7 +3138,12 @@ export class Indexer {
       );
     }
 
-    this.acquireIndexingLock();
+    await this.acquireIndexingLock();
+    // Clear any stale progress snapshot from a previous run
+    void database.deleteMetadata(PROGRESS_SNAPSHOT_KEY).catch(() => { /* best-effort */ });
+    this.embeddingPhaseStartTime = 0;
+    this.embeddingChunksAtStart = 0;
+    this.lastProgressPersistAt = 0;
     this.logger.recordIndexingStart();
     this.logger.info("Starting indexing", { projectRoot: this.projectRoot });
 
@@ -2959,15 +3162,13 @@ export class Indexer {
     };
     const failedBatchesForCurrentRun: FailedBatch[] = [];
 
-    onProgress?.({
+    this.updateProgress({
       phase: "scanning",
       filesProcessed: 0,
       totalFiles: 0,
       chunksProcessed: 0,
       totalChunks: 0,
-    });
-
-    this.loadFileHashCache();
+    }, onProgress);
 
     const includePatterns = [...this.config.include, ...this.config.additionalInclude];
     const { files, skipped } = await collectFiles(
@@ -2988,637 +3189,493 @@ export class Indexer {
       skippedFiles: skipped.length,
     });
 
-    const changedFiles: Array<{ path: string; content: string; hash: string }> = [];
-    const unchangedFilePaths = new Set<string>();
+    // Fetch only the hashes for files we are about to scan — avoids a full
+    // table load and skips stale records for deleted or out-of-scope files.
+    const storedHashes = await this.database!.getFileHashBatch(files.map((f) => f.path));
+
+    // Phase 1: Hash scan — classify files without reading content
+    const changedFileMeta: Array<{ path: string; hash: string }> = [];
+    const unchangedFilePaths: string[] = [];
+    const unchangedFilePathSet = new Set<string>();
     const currentFileHashes = new Map<string, string>();
+    const currentFilePathSet = new Set<string>(files.map(f => f.path));
 
     for (const f of files) {
       const currentHash = hashFile(f.path);
       currentFileHashes.set(f.path, currentHash);
-
-      if (this.fileHashCache.get(f.path) === currentHash) {
-        unchangedFilePaths.add(f.path);
+      if (storedHashes.get(f.path) === currentHash) {
+        unchangedFilePaths.push(f.path);
+        unchangedFilePathSet.add(f.path);
         this.logger.recordCacheHit();
       } else {
-        const content = await fsPromises.readFile(f.path, "utf-8");
-        changedFiles.push({ path: f.path, content, hash: currentHash });
+        changedFileMeta.push({ path: f.path, hash: currentHash });
         this.logger.recordCacheMiss();
       }
     }
 
     this.logger.cache("info", "File hash cache results", {
-      unchanged: unchangedFilePaths.size,
-      changed: changedFiles.length,
+      unchanged: unchangedFilePaths.length,
+      changed: changedFileMeta.length,
     });
 
-    onProgress?.({
+    // Phase 2: Deleted file cleanup — remove chunks for files no longer on disk
+    let removedCount = 0;
+    const allChunkFilePaths = await this.database!.getChunkFilePaths();
+    for (const fp of allChunkFilePaths) {
+      if (!currentFilePathSet.has(fp)) {
+        if (scopedRoots && !this.isFileInCurrentScope(fp, scopedRoots)) continue;
+        const oldChunks = await this.database!.getChunksByFile(fp);
+        for (const chunk of oldChunks) {
+          await store.remove(chunk.chunkId);
+          invertedIndex.removeChunk(chunk.chunkId);
+          removedCount++;
+        }
+      }
+    }
+
+    // Phase 3: Branch catalog init — clear upfront, rebuild incrementally below
+    await database.clearBranch(branchCatalogKey);
+    await database.clearBranchSymbols(branchCatalogKey);
+
+    // Phase 4: Unchanged files → branch catalog (batched, parallel DB reads)
+    const FILE_BATCH_SIZE = this.config.indexing.fileBatchSize;
+    for (let i = 0; i < unchangedFilePaths.length; i += FILE_BATCH_SIZE) {
+      const batch = unchangedFilePaths.slice(i, i + FILE_BATCH_SIZE);
+      const [chunkResults, symbolResults] = await Promise.all([
+        Promise.all(batch.map(fp => this.database!.getChunksByFile(fp))),
+        Promise.all(batch.map(fp => this.database!.getSymbolsByFile(fp))),
+      ]);
+      const batchChunkIds = chunkResults.flat().map(c => c.chunkId);
+      const batchSymbolIds = symbolResults.flat().map(s => s.id);
+      stats.existingChunks += batchChunkIds.length;
+      if (batchChunkIds.length > 0) await database.addChunksToBranchBatch(branchCatalogKey, batchChunkIds);
+      if (batchSymbolIds.length > 0) await database.addSymbolsToBranchBatch(branchCatalogKey, batchSymbolIds);
+    }
+
+    // Phase 5: Changed files — main batch loop
+    const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
+    const queue = new PQueue({
+      concurrency: providerRateLimits.concurrency,
+      interval: providerRateLimits.intervalMs,
+      intervalCap: providerRateLimits.concurrency,
+    });
+    let rateLimitBackoffMs = 0;
+
+    const embedPendingChunks = async (batchPendingChunks: PendingChunk[]): Promise<void> => {
+      if (batchPendingChunks.length === 0) return;
+
+      const allContentHashes = batchPendingChunks.map(c => c.contentHash);
+      const missingHashes = new Set(await database.getMissingEmbeddings(allContentHashes));
+      const chunksNeedingEmbedding = batchPendingChunks.filter(c => missingHashes.has(c.contentHash));
+      const chunksWithExistingEmbedding = batchPendingChunks.filter(c => !missingHashes.has(c.contentHash));
+
+      this.logger.cache("info", "Embedding cache lookup", {
+        needsEmbedding: chunksNeedingEmbedding.length,
+        fromCache: chunksWithExistingEmbedding.length,
+      });
+      this.logger.recordChunksFromCache(chunksWithExistingEmbedding.length);
+
+      for (const chunk of chunksWithExistingEmbedding) {
+        const embeddingBuffer = await database.getEmbedding(chunk.contentHash);
+        if (embeddingBuffer) {
+          const vector = bufferToFloat32Array(embeddingBuffer);
+          await store.add(chunk.id, Array.from(vector), chunk.metadata);
+          invertedIndex.removeChunk(chunk.id);
+          invertedIndex.addChunk(chunk.id, chunk.content);
+          stats.indexedChunks++;
+        }
+      }
+
+      const pendingChunksById = new Map(chunksNeedingEmbedding.map((c) => [c.id, c]));
+      const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
+      const requestBatches = createPendingEmbeddingRequestBatches(chunksNeedingEmbedding, getDynamicBatchOptions(configuredProviderInfo));
+      for (const requestBatch of requestBatches) {
+        queue.add(async () => {
+          if (rateLimitBackoffMs > 0) {
+            await new Promise(resolve => setTimeout(resolve, rateLimitBackoffMs));
+          }
+          try {
+            const result = await pRetry(
+              async () => {
+                return provider.embedBatch(requestBatch.map((request) => request.text));
+              },
+              {
+                retries: this.config.indexing.retries,
+                minTimeout: Math.max(this.config.indexing.retryDelayMs, providerRateLimits.minRetryMs),
+                maxTimeout: providerRateLimits.maxRetryMs,
+                factor: 2,
+                shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
+                onFailedAttempt: (error) => {
+                  const message = getErrorMessage(error);
+                  if (isRateLimitError(error)) {
+                    rateLimitBackoffMs = Math.min(providerRateLimits.maxRetryMs, (rateLimitBackoffMs || providerRateLimits.minRetryMs) * 2);
+                    this.logger.embedding("warn", `Rate limited, backing off`, {
+                      attempt: error.attemptNumber,
+                      retriesLeft: error.retriesLeft,
+                      backoffMs: rateLimitBackoffMs,
+                    });
+                  } else {
+                    this.logger.embedding("error", `Embedding batch failed`, {
+                      attempt: error.attemptNumber,
+                      error: message,
+                    });
+                  }
+                },
+              }
+            );
+
+            if (rateLimitBackoffMs > 0) {
+              rateLimitBackoffMs = Math.max(0, rateLimitBackoffMs - 2000);
+            }
+
+            const touchedChunkIds = new Set<string>();
+            requestBatch.forEach((request, idx) => {
+              const vector = result.embeddings[idx];
+              if (!vector) return;
+              const parts = embeddingPartsByChunk.get(request.chunk.id) ?? [];
+              parts[request.partIndex] = { vector, tokenCount: request.tokenCount };
+              embeddingPartsByChunk.set(request.chunk.id, parts);
+              touchedChunkIds.add(request.chunk.id);
+            });
+
+            const pooledResults: Array<{ chunk: PendingChunk; vector: number[] }> = [];
+            for (const chunkId of touchedChunkIds) {
+              const chunk = pendingChunksById.get(chunkId);
+              if (!chunk) continue;
+              const parts = embeddingPartsByChunk.get(chunk.id) ?? [];
+              if (!hasAllEmbeddingParts(parts, chunk.texts.length)) continue;
+              const orderedParts = parts as Array<{ vector: number[]; tokenCount: number }>;
+              pooledResults.push({
+                chunk,
+                vector: poolEmbeddingVectors(
+                  orderedParts.map((p) => p.vector),
+                  orderedParts.map((p) => p.tokenCount),
+                ),
+              });
+              embeddingPartsByChunk.delete(chunkId);
+            }
+
+            if (pooledResults.length > 0) {
+              const items = pooledResults.map(({ chunk, vector }) => ({
+                id: chunk.id,
+                vector,
+                metadata: chunk.metadata,
+              }));
+              await store.addBatch(items);
+
+              const embeddingBatchItems = pooledResults.map(({ chunk, vector }) => ({
+                contentHash: chunk.contentHash,
+                embedding: float32ArrayToBuffer(vector),
+                chunkText: chunk.storageText,
+                model: configuredProviderInfo.modelInfo.model,
+              }));
+              await database.upsertEmbeddingsBatch(embeddingBatchItems);
+
+              for (const { chunk } of pooledResults) {
+                invertedIndex.removeChunk(chunk.id);
+                invertedIndex.addChunk(chunk.id, chunk.content);
+              }
+
+              stats.indexedChunks += pooledResults.length;
+              this.logger.recordChunksEmbedded(pooledResults.length);
+            }
+
+            stats.tokensUsed += result.totalTokensUsed;
+            this.logger.recordEmbeddingApiCall(result.totalTokensUsed);
+            this.logger.embedding("debug", `Embedded batch`, {
+              batchSize: pooledResults.length,
+              requestCount: requestBatch.length,
+              tokens: result.totalTokensUsed,
+            });
+
+            this.updateProgress({
+              phase: "embedding",
+              filesProcessed: files.length,
+              totalFiles: files.length,
+              chunksProcessed: stats.indexedChunks,
+              totalChunks: stats.totalChunks,
+              currentFiles: [...new Set(requestBatch.map(r => r.chunk.metadata.filePath))],
+            }, onProgress);
+          } catch (error) {
+            const failedChunks = getUniquePendingChunksFromRequests(requestBatch);
+            stats.failedChunks += failedChunks.length;
+            failedBatchesForCurrentRun.push({
+              chunks: failedChunks,
+              error: getErrorMessage(error),
+              attemptCount: 1,
+              lastAttempt: new Date().toISOString(),
+            });
+            this.logger.recordEmbeddingError();
+            this.logger.embedding("error", `Failed to embed batch after retries`, {
+              batchSize: requestBatch.length,
+              error: getErrorMessage(error),
+            });
+          }
+        });
+      }
+
+      await queue.onIdle();
+    };
+
+    this.updateProgress({
       phase: "parsing",
       filesProcessed: 0,
       totalFiles: files.length,
       chunksProcessed: 0,
       totalChunks: 0,
-    });
+    }, onProgress);
 
-    const parseStartTime = performance.now();
-    const parsedFiles = parseFiles(changedFiles);
-    const parseMs = performance.now() - parseStartTime;
+    for (let batchStart = 0; batchStart < changedFileMeta.length; batchStart += FILE_BATCH_SIZE) {
+      const fileBatch = changedFileMeta.slice(batchStart, batchStart + FILE_BATCH_SIZE);
 
-    this.logger.recordFilesParsed(parsedFiles.length);
-    this.logger.recordParseDuration(parseMs);
-    this.logger.debug("Parsed changed files", { parsedCount: parsedFiles.length, parseMs: parseMs.toFixed(2) });
+      this.updateProgress({
+        phase: "parsing",
+        filesProcessed: Math.min(batchStart, files.length),
+        totalFiles: files.length,
+        chunksProcessed: stats.indexedChunks,
+        totalChunks: stats.totalChunks,
+        currentFiles: fileBatch.map(f => f.path),
+      }, onProgress);
 
-    const existingChunks = new Map<string, string>();
-    const existingChunksByFile = new Map<string, Set<string>>();
-    for (const { key, metadata } of store.getAllMetadata()) {
-      if (scopedRoots && !this.isFileInCurrentScope(metadata.filePath, scopedRoots)) {
-        continue;
-      }
-      if (forceScopedReembed && scopedRoots && this.isFileInCurrentScope(metadata.filePath, scopedRoots)) {
-        continue;
-      }
-      existingChunks.set(key, metadata.hash);
-      const fileChunks = existingChunksByFile.get(metadata.filePath) || new Set();
-      fileChunks.add(key);
-      existingChunksByFile.set(metadata.filePath, fileChunks);
-    }
+      // Read content for only this batch
+      const fileInputs = await Promise.all(
+        fileBatch.map(async ({ path: fp, hash }) => ({
+          path: fp,
+          hash,
+          content: await fsPromises.readFile(fp, "utf-8"),
+        }))
+      );
 
-    const currentChunkIds = new Set<string>();
-    const currentFilePaths = new Set<string>();
-    const pendingChunks: PendingChunk[] = [];
+      const parseStartTime = performance.now();
+      const parsedBatch = parseFiles(fileInputs);
+      const parseMs = performance.now() - parseStartTime;
 
-    for (const filePath of unchangedFilePaths) {
-      currentFilePaths.add(filePath);
-      const fileChunks = existingChunksByFile.get(filePath);
-      if (fileChunks) {
-        for (const chunkId of fileChunks) {
-          currentChunkIds.add(chunkId);
-        }
-      }
-    }
+      this.logger.recordFilesParsed(parsedBatch.length);
+      this.logger.recordParseDuration(parseMs);
+      this.logger.debug("Parsed changed files batch", { parsedCount: parsedBatch.length, parseMs: parseMs.toFixed(2) });
 
-    const chunkDataBatch: ChunkData[] = [];
+      const contentByPath = new Map(fileInputs.map(f => [f.path, f.content]));
+      const batchPendingChunks: PendingChunk[] = [];
+      const batchChunkIds: string[] = [];
+      const batchSymbolIds: string[] = [];
 
-    for (const parsed of parsedFiles) {
-      currentFilePaths.add(parsed.path);
-
-      if (parsed.chunks.length === 0) {
-        const relativePath = path.relative(this.projectRoot, parsed.path);
-        stats.parseFailures.push(relativePath);
-      }
-
-      let fileChunkCount = 0;
-      let chunksToProcess = parsed.chunks;
-
-      if (this.config.indexing.fallbackToTextOnMaxChunks && chunksToProcess.length > this.config.indexing.maxChunksPerFile) {
-        const changedFile = changedFiles.find(f => f.path === parsed.path);
-        if (changedFile) {
-          const textChunks = parseFileAsText(parsed.path, changedFile.content);
-          chunksToProcess = textChunks;
-        }
-      }
-
-      for (const chunk of chunksToProcess) {
-        if (fileChunkCount >= this.config.indexing.maxChunksPerFile) {
-          break;
+      for (const parsed of parsedBatch) {
+        if (parsed.chunks.length === 0) {
+          stats.parseFailures.push(path.relative(this.projectRoot, parsed.path));
         }
 
-        if (this.config.indexing.semanticOnly && chunk.chunkType === "other") {
-          continue;
+        let chunksToProcess = parsed.chunks;
+        if (this.config.indexing.fallbackToTextOnMaxChunks && chunksToProcess.length > this.config.indexing.maxChunksPerFile) {
+          const content = contentByPath.get(parsed.path);
+          if (content) {
+            chunksToProcess = parseFileAsText(parsed.path, content);
+          }
         }
 
-        const id = generateChunkId(parsed.path, chunk);
-        const contentHash = generateChunkHash(chunk);
-        currentChunkIds.add(id);
+        // Per-file existing chunk lookup replaces the global existingChunks Map
+        const existingFileChunks = await this.database!.getChunksByFile(parsed.path);
+        const existingChunkHashes = new Map(existingFileChunks.map(c => [c.chunkId, c.contentHash]));
+        const newChunkIdsForFile = new Set<string>();
+        const chunkDataForFile: ChunkData[] = [];
 
-        chunkDataBatch.push({
-          chunkId: id,
-          contentHash,
-          filePath: parsed.path,
-          startLine: chunk.startLine,
-          endLine: chunk.endLine,
-          nodeType: chunk.chunkType,
-          name: chunk.name,
-          language: chunk.language,
-        });
+        let fileChunkCount = 0;
+        for (const chunk of chunksToProcess) {
+          if (fileChunkCount >= this.config.indexing.maxChunksPerFile) break;
+          if (this.config.indexing.semanticOnly && chunk.chunkType === "other") continue;
 
-        if (existingChunks.get(id) === contentHash) {
+          const id = generateChunkId(parsed.path, chunk);
+          const contentHash = generateChunkHash(chunk);
+          newChunkIdsForFile.add(id);
+          batchChunkIds.push(id);
+          chunkDataForFile.push({
+            chunkId: id,
+            contentHash,
+            filePath: parsed.path,
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            nodeType: chunk.chunkType,
+            name: chunk.name,
+            language: chunk.language,
+          });
+
+          if (existingChunkHashes.get(id) === contentHash) {
+            stats.existingChunks++;
+          } else {
+            const texts = createEmbeddingTexts(chunk, parsed.path, getSafeEmbeddingChunkTokenLimit(configuredProviderInfo)).map((text) => ({
+              text,
+              tokenCount: estimateTokens(text),
+            }));
+            const metadata: ChunkMetadata = {
+              filePath: parsed.path,
+              startLine: chunk.startLine,
+              endLine: chunk.endLine,
+              chunkType: chunk.chunkType,
+              name: chunk.name,
+              language: chunk.language,
+              hash: contentHash,
+            };
+            batchPendingChunks.push({ id, texts, storageText: createPendingChunkStorageText(texts), content: chunk.content, contentHash, metadata });
+          }
           fileChunkCount++;
-          continue;
         }
 
-        const texts = createEmbeddingTexts(chunk, parsed.path, getSafeEmbeddingChunkTokenLimit(configuredProviderInfo)).map((text) => ({
-          text,
-          tokenCount: estimateTokens(text),
-        }));
-        const metadata: ChunkMetadata = {
-          filePath: parsed.path,
-          startLine: chunk.startLine,
-          endLine: chunk.endLine,
-          chunkType: chunk.chunkType,
-          name: chunk.name,
-          language: chunk.language,
-          hash: contentHash,
-        };
-
-        pendingChunks.push({
-          id,
-          texts,
-          storageText: createPendingChunkStorageText(texts),
-          content: chunk.content,
-          contentHash,
-          metadata,
-        });
-        fileChunkCount++;
-      }
-    }
-
-    const retryableFailedChunks = this.collectRetryableFailedChunks(
-      currentFileHashes,
-      unchangedFilePaths,
-      getSafeEmbeddingChunkTokenLimit(configuredProviderInfo)
-    );
-    const retryableFailedAttemptCounts = new Map<string, number>();
-    const retryableChunksWithExistingData = new Set<string>();
-    if (retryableFailedChunks.length > 0) {
-      const pendingChunkIds = new Set(pendingChunks.map((chunk) => chunk.id));
-      for (const { chunk, attemptCount } of retryableFailedChunks) {
-        retryableFailedAttemptCounts.set(chunk.id, attemptCount);
-        if (existingChunks.has(chunk.id)) {
-          retryableChunksWithExistingData.add(chunk.id);
+        if (chunkDataForFile.length > 0) {
+          await this.database!.upsertChunksBatch(chunkDataForFile);
         }
-        if (!pendingChunkIds.has(chunk.id)) {
-          pendingChunks.push(chunk);
-          pendingChunkIds.add(chunk.id);
-          currentChunkIds.add(chunk.id);
+
+        // Per-file orphan removal (chunks no longer produced by re-parsing)
+        for (const [oldChunkId] of existingChunkHashes) {
+          if (!newChunkIdsForFile.has(oldChunkId)) {
+            await store.remove(oldChunkId);
+            invertedIndex.removeChunk(oldChunkId);
+            removedCount++;
+          }
         }
-      }
-    }
 
-    if (chunkDataBatch.length > 0) {
-      database.upsertChunksBatch(chunkDataBatch);
-    }
+        // Call graph extraction for this file
+        await database.deleteCallEdgesByFile(parsed.path);
+        await database.deleteSymbolsByFile(parsed.path);
+        const fileSymbols: SymbolData[] = [];
+        for (const chunk of parsed.chunks) {
+          if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
+          const symbolId = `sym_${hashContent(parsed.path + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`;
+          fileSymbols.push({
+            id: symbolId,
+            filePath: parsed.path,
+            name: chunk.name,
+            kind: chunk.chunkType,
+            startLine: chunk.startLine,
+            startCol: 0,
+            endLine: chunk.endLine,
+            endCol: 0,
+            language: chunk.language,
+          });
+          batchSymbolIds.push(symbolId);
+        }
 
+        const symbolsByName = new Map<string, SymbolData[]>();
+        for (const sym of fileSymbols) {
+          const existing = symbolsByName.get(sym.name) ?? [];
+          existing.push(sym);
+          symbolsByName.set(sym.name, existing);
+        }
 
-    // ── Call Graph Extraction ────────────────────────────────────────
-    // Extract symbols and call edges from changed files.
-    const allSymbolIds = new Set<string>();
-    const symbolsByFile = new Map<string, SymbolData[]>();
+        if (fileSymbols.length > 0) {
+          await database.upsertSymbolsBatch(fileSymbols);
+        }
 
-    // For changed files: delete old symbols/edges, extract new ones
-    for (let i = 0; i < parsedFiles.length; i++) {
-      const parsed = parsedFiles[i];
-      const changedFile = changedFiles[i];
-
-      // Clean up old call graph data for this file
-      database.deleteCallEdgesByFile(parsed.path);
-      database.deleteSymbolsByFile(parsed.path);
-
-      // Build symbols from parsed chunks
-      const fileSymbols: SymbolData[] = [];
-
-      for (const chunk of parsed.chunks) {
-        if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
-
-        const symbolId = `sym_${hashContent(parsed.path + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`;
-        const symbol: SymbolData = {
-          id: symbolId,
-          filePath: parsed.path,
-          name: chunk.name,
-          kind: chunk.chunkType,
-          startLine: chunk.startLine,
-          startCol: 0,
-          endLine: chunk.endLine,
-          endCol: 0,
-          language: chunk.language,
-        };
-        fileSymbols.push(symbol);
-        allSymbolIds.add(symbolId);
-      }
-
-      // For case-insensitive languages (e.g. Apex), the Rust call extractor
-      // already lowercases non-constructor / non-import callee names, so we
-      // must lowercase the symbol-map keys here too. Otherwise a declaration
-      // like `MyMethod` would not match a lowercased call edge target like
-      // `mymethod`, leaving same-file calls unresolved (toSymbolId = NULL).
-      const fileLanguage = parsed.chunks[0]?.language;
-      const isCaseInsensitiveLanguage =
-        !!fileLanguage && CASE_INSENSITIVE_LANGUAGES.has(fileLanguage);
-      const normalizeSymbolKey = (name: string): string =>
-        isCaseInsensitiveLanguage ? name.toLowerCase() : name;
-
-      const symbolsByName = new Map<string, SymbolData[]>();
-      for (const symbol of fileSymbols) {
-        const key = normalizeSymbolKey(symbol.name);
-        const existing = symbolsByName.get(key) ?? [];
-        existing.push(symbol);
-        symbolsByName.set(key, existing);
-      }
-
-      if (fileSymbols.length > 0) {
-        database.upsertSymbolsBatch(fileSymbols);
-        symbolsByFile.set(parsed.path, fileSymbols);
-      }
-
-      // Extract call sites from file content (only for supported languages)
-      if (!fileLanguage || !CALL_GRAPH_LANGUAGES.has(fileLanguage)) continue;
-
-      const callSites = extractCalls(changedFile.content, fileLanguage);
-      if (callSites.length === 0) continue;
-
-      // Map each call site to its enclosing symbol
-      const edges: CallEdgeData[] = [];
-      for (const site of callSites) {
-        // Find the enclosing symbol (function/method that contains this call)
-        const enclosingSymbol = fileSymbols.find(
-          (sym) => site.line >= sym.startLine && site.line <= sym.endLine
-        );
-        if (!enclosingSymbol) continue;
-
-        const edgeId = `edge_${hashContent(enclosingSymbol.id + ":" + site.calleeName + ":" + site.line + ":" + site.column).slice(0, 16)}`;
-        edges.push({
-          id: edgeId,
-          fromSymbolId: enclosingSymbol.id,
-          targetName: site.calleeName,
-          toSymbolId: undefined,
-          callType: site.callType,
-          line: site.line,
-          col: site.column,
-          isResolved: false,
-        });
-      }
-
-      if (edges.length > 0) {
-        database.upsertCallEdgesBatch(edges);
-
-        // Resolve same-file calls (with the same case-insensitivity rules
-        // used to build symbolsByName above).
-        for (const edge of edges) {
-          const candidates = symbolsByName.get(normalizeSymbolKey(edge.targetName));
-          if (candidates && candidates.length === 1) {
-            database.resolveCallEdge(edge.id, candidates[0].id);
+        const fileLanguage = parsed.chunks[0]?.language;
+        const isCaseInsensitiveLanguage = !!fileLanguage && CASE_INSENSITIVE_LANGUAGES.has(fileLanguage);
+        if (isCaseInsensitiveLanguage) {
+          // Re-key symbolsByName with lowercased keys for case-insensitive languages (e.g. Apex).
+          // The Rust call extractor already lowercases callee names for these languages,
+          // so the symbol map must use the same casing or same-file calls won't resolve.
+          symbolsByName.clear();
+          for (const sym of fileSymbols) {
+            const key = sym.name.toLowerCase();
+            const existing = symbolsByName.get(key) ?? [];
+            existing.push(sym);
+            symbolsByName.set(key, existing);
+          }
+        }
+        if (fileLanguage && CALL_GRAPH_LANGUAGES.has(fileLanguage)) {
+          const content = contentByPath.get(parsed.path);
+          if (content) {
+            const callSites = extractCalls(content, fileLanguage);
+            if (callSites.length > 0) {
+              const edges: CallEdgeData[] = [];
+              for (const site of callSites) {
+                const enclosingSymbol = fileSymbols.find(
+                  sym => site.line >= sym.startLine && site.line <= sym.endLine
+                );
+                if (!enclosingSymbol) continue;
+                const edgeId = `edge_${hashContent(enclosingSymbol.id + ":" + site.calleeName + ":" + site.line + ":" + site.column).slice(0, 16)}`;
+                edges.push({
+                  id: edgeId,
+                  fromSymbolId: enclosingSymbol.id,
+                  targetName: site.calleeName,
+                  toSymbolId: undefined,
+                  callType: site.callType,
+                  line: site.line,
+                  col: site.column,
+                  isResolved: false,
+                });
+              }
+              if (edges.length > 0) {
+                await database.upsertCallEdgesBatch(edges);
+                for (const edge of edges) {
+                  const lookupKey = isCaseInsensitiveLanguage ? edge.targetName.toLowerCase() : edge.targetName;
+                  const candidates = symbolsByName.get(lookupKey);
+                  if (candidates && candidates.length === 1) {
+                    await database.resolveCallEdge(edge.id, candidates[0].id);
+                  }
+                }
+              }
+            }
           }
         }
       }
+
+      // Incremental branch catalog update for this file batch
+      if (batchChunkIds.length > 0) await database.addChunksToBranchBatch(branchCatalogKey, batchChunkIds);
+      if (batchSymbolIds.length > 0) await database.addSymbolsToBranchBatch(branchCatalogKey, batchSymbolIds);
+      stats.totalChunks += batchPendingChunks.length;
+
+      // Embed this batch; queue.onIdle() ensures we don't accumulate unbounded pending chunks
+      await embedPendingChunks(batchPendingChunks);
+
+      this.updateProgress({
+        phase: "parsing",
+        filesProcessed: Math.min(batchStart + fileBatch.length, files.length),
+        totalFiles: files.length,
+        chunksProcessed: stats.indexedChunks,
+        totalChunks: stats.totalChunks,
+        currentFiles: fileBatch.map(f => f.path),
+      }, onProgress);
+      // fileInputs, parsedBatch, batchPendingChunks go out of scope → GC reclaims
     }
 
-    // Collect symbol IDs from unchanged files for branch association
-    for (const filePath of unchangedFilePaths) {
-      const existingSymbols = database.getSymbolsByFile(filePath);
-      for (const sym of existingSymbols) {
-        allSymbolIds.add(sym.id);
-      }
+    // Phase 6: Retryable failed chunks from previous incomplete runs
+    const retryableFailedChunks = this.collectRetryableFailedChunks(currentFileHashes, unchangedFilePathSet);
+    if (retryableFailedChunks.length > 0) {
+      stats.totalChunks += retryableFailedChunks.length;
+      await embedPendingChunks(retryableFailedChunks.map((r) => r.chunk));
     }
 
-    let removedCount = 0;
-    for (const [chunkId] of existingChunks) {
-      if (!currentChunkIds.has(chunkId)) {
-        store.remove(chunkId);
-        invertedIndex.removeChunk(chunkId);
-        removedCount++;
-      }
-    }
-
-    stats.totalChunks = pendingChunks.length;
-    stats.existingChunks = currentChunkIds.size - pendingChunks.length;
-    stats.removedChunks = removedCount;
-
-    this.logger.recordChunksProcessed(currentChunkIds.size);
+    this.logger.recordChunksProcessed(stats.totalChunks + stats.existingChunks);
     this.logger.recordChunksRemoved(removedCount);
     this.logger.info("Chunk analysis complete", {
-      pending: pendingChunks.length,
+      pending: stats.totalChunks,
       existing: stats.existingChunks,
       removed: removedCount,
     });
 
-    if (pendingChunks.length === 0 && removedCount === 0) {
-      await database.clearBranch(branchCatalogKey);
-      await database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
-      await database.clearBranchSymbols(branchCatalogKey);
-      await database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
-      if (scopedRoots) {
-        this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
-        this.clearScopedFailedBatches(scopedRoots);
-      } else {
-        this.fileHashCache = currentFileHashes;
-        this.saveFileHashCache();
-        this.saveFailedBatches([]);
-      }
-      await this.saveIndexMetadata(configuredProviderInfo);
-      this.indexCompatibility = { compatible: true };
-      stats.durationMs = Date.now() - startTime;
-      onProgress?.({
-        phase: "complete",
-        filesProcessed: files.length,
-        totalFiles: files.length,
-        chunksProcessed: 0,
-        totalChunks: 0,
-      });
-      this.releaseIndexingLock();
-      return stats;
-    }
+    // Phase 7: Finalization
+    stats.removedChunks = removedCount;
 
-    if (pendingChunks.length === 0) {
-      await database.clearBranch(branchCatalogKey);
-      await database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
-      await database.clearBranchSymbols(branchCatalogKey);
-      await database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
-      store.save();
-      invertedIndex.save();
-      if (scopedRoots) {
-        this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
-        this.clearScopedFailedBatches(scopedRoots);
-      } else {
-        this.fileHashCache = currentFileHashes;
-        this.saveFileHashCache();
-        this.saveFailedBatches([]);
-      }
-      await this.saveIndexMetadata(configuredProviderInfo);
-      this.indexCompatibility = { compatible: true };
-      stats.durationMs = Date.now() - startTime;
-      onProgress?.({
-        phase: "complete",
-        filesProcessed: files.length,
-        totalFiles: files.length,
-        chunksProcessed: 0,
-        totalChunks: 0,
-      });
-      this.releaseIndexingLock();
-      return stats;
-    }
-
-    onProgress?.({
-      phase: "embedding",
-      filesProcessed: files.length,
-      totalFiles: files.length,
-      chunksProcessed: 0,
-      totalChunks: pendingChunks.length,
-    });
-
-    const allContentHashes = pendingChunks.map((c) => c.contentHash);
-    const missingHashes = new Set(await database.getMissingEmbeddings(allContentHashes));
-    const forcedReembedChunkIds = forceScopedReembed
-      ? new Set(pendingChunks.map((chunk) => chunk.id))
-      : new Set<string>();
-
-    const chunksNeedingEmbedding = pendingChunks.filter((c) => forcedReembedChunkIds.has(c.id) || missingHashes.has(c.contentHash));
-    const chunksWithExistingEmbedding = pendingChunks.filter((c) => !forcedReembedChunkIds.has(c.id) && !missingHashes.has(c.contentHash));
-
-    this.logger.cache("info", "Embedding cache lookup", {
-      needsEmbedding: chunksNeedingEmbedding.length,
-      fromCache: chunksWithExistingEmbedding.length,
-    });
-    this.logger.recordChunksFromCache(chunksWithExistingEmbedding.length);
-
-    for (const chunk of chunksWithExistingEmbedding) {
-      const embeddingBuffer = database.getEmbedding(chunk.contentHash);
-      if (embeddingBuffer) {
-        const vector = bufferToFloat32Array(embeddingBuffer);
-        store.add(chunk.id, Array.from(vector), chunk.metadata);
-        invertedIndex.removeChunk(chunk.id);
-        invertedIndex.addChunk(chunk.id, chunk.content);
-        stats.indexedChunks++;
-      }
-    }
-
-    const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
-    const queue = new PQueue({
-      concurrency: providerRateLimits.concurrency,
-      interval: providerRateLimits.intervalMs,
-      intervalCap: providerRateLimits.concurrency
-    });
-    const pendingChunksById = new Map(chunksNeedingEmbedding.map((chunk) => [chunk.id, chunk]));
-    const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
-    const completedChunkIds = new Set<string>();
-    const failedChunkIds = new Set<string>();
-    const requestBatches = createPendingEmbeddingRequestBatches(
-      chunksNeedingEmbedding,
-      getDynamicBatchOptions(configuredProviderInfo)
-    );
-    let rateLimitBackoffMs = 0;
-
-    for (const requestBatch of requestBatches) {
-      queue.add(async () => {
-        if (rateLimitBackoffMs > 0) {
-          await new Promise(resolve => setTimeout(resolve, rateLimitBackoffMs));
-        }
-
-        try {
-          const result = await pRetry(
-            async () => {
-              const texts = requestBatch.map((request) => request.text);
-              return provider.embedBatch(texts);
-            },
-            {
-              retries: this.config.indexing.retries,
-              minTimeout: Math.max(this.config.indexing.retryDelayMs, providerRateLimits.minRetryMs),
-              maxTimeout: providerRateLimits.maxRetryMs,
-              factor: 2,
-              shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
-              onFailedAttempt: (error) => {
-                const message = getErrorMessage(error);
-                if (isRateLimitError(error)) {
-                  rateLimitBackoffMs = Math.min(providerRateLimits.maxRetryMs, (rateLimitBackoffMs || providerRateLimits.minRetryMs) * 2);
-                  this.logger.embedding("warn", `Rate limited, backing off`, {
-                    attempt: error.attemptNumber,
-                    retriesLeft: error.retriesLeft,
-                    backoffMs: rateLimitBackoffMs,
-                  });
-                } else {
-                  this.logger.embedding("error", `Embedding batch failed`, {
-                    attempt: error.attemptNumber,
-                    error: message,
-                  });
-                }
-              },
-            }
-          );
-
-          if (rateLimitBackoffMs > 0) {
-            rateLimitBackoffMs = Math.max(0, rateLimitBackoffMs - 2000);
-          }
-
-          const touchedChunkIds = new Set<string>();
-
-          requestBatch.forEach((request, idx) => {
-            if (failedChunkIds.has(request.chunk.id) || completedChunkIds.has(request.chunk.id)) {
-              return;
-            }
-
-            const vector = result.embeddings[idx];
-            if (!vector) {
-              throw new Error(`Embedding API returned too few vectors for chunk ${request.chunk.id}`);
-            }
-
-            const parts = embeddingPartsByChunk.get(request.chunk.id) ?? [];
-            parts[request.partIndex] = {
-              vector,
-              tokenCount: request.tokenCount,
-            };
-            embeddingPartsByChunk.set(request.chunk.id, parts);
-            touchedChunkIds.add(request.chunk.id);
-          });
-
-          const pooledResults: Array<{ chunk: PendingChunk; vector: number[] }> = [];
-          for (const chunkId of touchedChunkIds) {
-            if (failedChunkIds.has(chunkId) || completedChunkIds.has(chunkId)) {
-              continue;
-            }
-
-            const chunk = pendingChunksById.get(chunkId);
-            if (!chunk) {
-              continue;
-            }
-
-            const parts = embeddingPartsByChunk.get(chunk.id) ?? [];
-            if (!hasAllEmbeddingParts(parts, chunk.texts.length)) {
-              continue;
-            }
-
-            const orderedParts = parts as Array<{ vector: number[]; tokenCount: number }>;
-            pooledResults.push({
-              chunk,
-              vector: poolEmbeddingVectors(
-                orderedParts.map((part) => part.vector),
-                orderedParts.map((part) => part.tokenCount)
-              ),
-            });
-          }
-
-          if (pooledResults.length > 0) {
-            const items = pooledResults.map(({ chunk, vector }) => ({
-              id: chunk.id,
-              vector,
-              metadata: chunk.metadata,
-            }));
-
-            await store.addBatch(items);
-
-            const embeddingBatchItems = pooledResults.map(({ chunk, vector }) => ({
-              contentHash: chunk.contentHash,
-              embedding: float32ArrayToBuffer(vector),
-              chunkText: chunk.storageText,
-              model: configuredProviderInfo.modelInfo.model,
-            }));
-
-            try {
-              await database.upsertEmbeddingsBatch(embeddingBatchItems);
-            } catch (dbError) {
-              // Rollback vectors added to store if DB write fails
-              for (const { chunk } of pooledResults) {
-                store.remove(chunk.id);
-              }
-              throw dbError;
-            }
-
-            for (const { chunk } of pooledResults) {
-              invertedIndex.removeChunk(chunk.id);
-              invertedIndex.addChunk(chunk.id, chunk.content);
-              completedChunkIds.add(chunk.id);
-              embeddingPartsByChunk.delete(chunk.id);
-            }
-
-            stats.indexedChunks += pooledResults.length;
-            this.logger.recordChunksEmbedded(pooledResults.length);
-          }
-
-          stats.tokensUsed += result.totalTokensUsed;
-
-          this.logger.recordEmbeddingApiCall(result.totalTokensUsed);
-          this.logger.embedding("debug", `Embedded batch`, {
-            batchSize: pooledResults.length,
-            requestCount: requestBatch.length,
-            tokens: result.totalTokensUsed,
-          });
-
-          onProgress?.({
-            phase: "embedding",
-            filesProcessed: files.length,
-            totalFiles: files.length,
-            chunksProcessed: stats.indexedChunks,
-            totalChunks: pendingChunks.length,
-          });
-        } catch (error) {
-          const failedChunks = getUniquePendingChunksFromRequests(requestBatch)
-            .filter((chunk) => !completedChunkIds.has(chunk.id));
-          const failureMessage = getErrorMessage(error);
-          const failureTimestamp = new Date().toISOString();
-
-          for (const chunk of failedChunks) {
-            if (!failedChunkIds.has(chunk.id)) {
-              failedChunkIds.add(chunk.id);
-              stats.failedChunks += 1;
-            }
-
-            if (forceScopedReembed) {
-              failedForcedChunkIds.add(chunk.id);
-            }
-
-            embeddingPartsByChunk.delete(chunk.id);
-
-            const existingFailedBatchIndex = failedBatchesForCurrentRun.findIndex(
-              (failedBatch) => failedBatch.chunks[0]?.id === chunk.id
-            );
-            const existingFailedBatch = existingFailedBatchIndex === -1
-              ? undefined
-              : failedBatchesForCurrentRun[existingFailedBatchIndex];
-            const failedBatch = {
-              chunks: [chunk],
-              error: failureMessage,
-              attemptCount: (existingFailedBatch?.attemptCount ?? retryableFailedAttemptCounts.get(chunk.id) ?? 0) + 1,
-              lastAttempt: failureTimestamp,
-            } satisfies FailedBatch;
-
-            if (existingFailedBatchIndex === -1) {
-              failedBatchesForCurrentRun.push(failedBatch);
-            } else {
-              failedBatchesForCurrentRun[existingFailedBatchIndex] = failedBatch;
-            }
-          }
-
-          this.logger.recordEmbeddingError();
-          this.logger.embedding("error", `Failed to embed batch after retries`, {
-            batchSize: failedChunks.length,
-            requestCount: requestBatch.length,
-            error: failureMessage,
-          });
-        }
-      });
-    }
-
-    await queue.onIdle();
     if (scopedRoots) {
       this.saveScopedFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun), scopedRoots);
     } else {
       this.saveFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun));
     }
 
-    onProgress?.({
+    this.updateProgress({
       phase: "storing",
       filesProcessed: files.length,
       totalFiles: files.length,
       chunksProcessed: stats.indexedChunks,
-      totalChunks: pendingChunks.length,
-    });
+      totalChunks: stats.totalChunks,
+    }, onProgress);
 
-    const branchChunkIds = Array.from(currentChunkIds).filter(
-      (chunkId) => {
-        const isNewlyFailed = failedChunkIds.has(chunkId) && !retryableChunksWithExistingData.has(chunkId);
-        const isForcedFailed = forceScopedReembed && failedForcedChunkIds.has(chunkId);
-        return !isNewlyFailed && !isForcedFailed;
-      }
-    );
-    await database.clearBranch(branchCatalogKey);
-    await database.addChunksToBranchBatch(branchCatalogKey, branchChunkIds);
-    await database.clearBranchSymbols(branchCatalogKey);
-    await database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+    if (stats.indexedChunks > 0 || removedCount > 0) {
+      await store.save();
+      await this.database!.saveInvertedIndex(invertedIndex.serialize());
+    }
 
-    store.save();
-    invertedIndex.save();
     if (scopedRoots) {
-      this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+      await this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
     } else {
-      this.fileHashCache = currentFileHashes;
-      this.saveFileHashCache();
+      await this.database!.replaceAllFileHashes(currentFileHashes);
     }
 
     // Auto-GC after indexing: check if orphan count exceeds threshold
@@ -3646,6 +3703,7 @@ export class Indexer {
 
     stats.durationMs = Date.now() - startTime;
 
+    await this.saveIndexMetadata(configuredProviderInfo);
     if (forceScopedReembed && failedForcedChunkIds.size === 0) {
       await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
     }
@@ -3667,15 +3725,23 @@ export class Indexer {
       stats.failedBatchesPath = this.failedBatchesPath;
     }
 
-    onProgress?.({
+    this.updateProgress({
       phase: "complete",
       filesProcessed: files.length,
       totalFiles: files.length,
       chunksProcessed: stats.indexedChunks,
-      totalChunks: pendingChunks.length,
-    });
+      totalChunks: stats.totalChunks,
+    }, onProgress);
 
-    this.releaseIndexingLock();
+    this.currentProgress = undefined;
+    this.lastProgressSnapshot = "";
+    this.embeddingPhaseStartTime = 0;
+    this.embeddingChunksAtStart = 0;
+    this.lastProgressPersistAt = 0;
+    // Clear persisted snapshot now that indexing is done
+    void database.deleteMetadata(PROGRESS_SNAPSHOT_KEY).catch(() => { /* best-effort */ });
+
+    await this.releaseIndexingLock();
     return stats;
   }
 
@@ -3790,7 +3856,7 @@ export class Indexer {
 
     const searchStartTime = performance.now();
 
-    if (store.count() === 0) {
+    if ((await store.count()) === 0) {
       this.logger.search("debug", "Search on empty index", { query });
       return [];
     }
@@ -3820,7 +3886,7 @@ export class Indexer {
     const embeddingMs = performance.now() - embeddingStartTime;
 
     const vectorStartTime = performance.now();
-    const semanticResults = store.search(embedding, maxResults * 4);
+    const semanticResults = await store.search(embedding, maxResults * 4);
     const vectorMs = performance.now() - vectorStartTime;
 
     const keywordStartTime = performance.now();
@@ -3829,9 +3895,10 @@ export class Indexer {
 
     let branchChunkIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
-      branchChunkIds = new Set(
-        this.getBranchCatalogKeys().flatMap((branchKey) => database.getBranchChunkIds(branchKey))
-      );
+      const ids = (await Promise.all(
+        this.getBranchCatalogKeys().map((branchKey) => database.getBranchChunkIds(branchKey))
+      )).flat();
+      branchChunkIds = new Set(ids);
     }
 
     const prefilterStartTime = performance.now();
@@ -3885,7 +3952,7 @@ export class Indexer {
     });
     const fusionMs = performance.now() - fusionStartTime;
 
-    const rescued = promoteIdentifierMatches(
+    const rescued = await promoteIdentifierMatches(
       query,
       rerankedCombined,
       semanticCandidates,
@@ -3911,7 +3978,7 @@ export class Indexer {
       sourceIntent
     );
 
-    const symbolLane = buildSymbolDefinitionLane(
+    const symbolLane = await buildSymbolDefinitionLane(
       query,
       database,
       branchChunkIds,
@@ -4021,8 +4088,9 @@ export class Indexer {
     query: string,
     limit: number
   ): Promise<Array<{ id: string; score: number; metadata: ChunkMetadata }>> {
-    const { store, invertedIndex } = await this.ensureInitialized();
-    const scores = invertedIndex.search(query);
+    const { store, invertedIndex, database } = await this.ensureInitialized();
+    // pgvector: use SQL BM25 (no in-memory index loaded); SQLite: use Rust struct
+    const scores = await database.searchBm25(query, 100) ?? invertedIndex.search(query);
 
     if (scores.size === 0) {
       return [];
@@ -4031,7 +4099,7 @@ export class Indexer {
     // Only fetch metadata for chunks returned by BM25 (O(n) where n = result count)
     // instead of getAllMetadata() which fetches ALL chunks in the index
     const chunkIds = Array.from(scores.keys());
-    const metadataMap = store.getMetadataBatch(chunkIds);
+    const metadataMap = await store.getMetadataBatch(chunkIds);
 
     const results: Array<{ id: string; score: number; metadata: ChunkMetadata }> = [];
     for (const [chunkId, score] of scores) {
@@ -4048,10 +4116,28 @@ export class Indexer {
   async getStatus(): Promise<StatusResult> {
     const { store, configuredProviderInfo, database } = await this.ensureInitialized();
     const failedBatchesCount = this.getFailedBatchesCount();
+    const indexingInProgress = this.currentProgress !== undefined && this.currentProgress.phase !== "complete";
+
+    // If not actively indexing in this process, check for a persisted progress snapshot
+    // from another invocation (e.g., a watcher-triggered reindex running in parallel).
+    let persistedProgress: IndexProgress | undefined;
+    if (!indexingInProgress) {
+      const snapshotJson = await database.getMetadata(PROGRESS_SNAPSHOT_KEY);
+      if (snapshotJson) {
+        try {
+          const snapshot = JSON.parse(snapshotJson) as IndexProgress & { persistedAt?: number };
+          const ageMs = Date.now() - (snapshot.persistedAt ?? 0);
+          // Only surface if it's recent (< 30 min) and not already at "complete"
+          if (ageMs < 30 * 60 * 1000 && snapshot.phase !== "complete") {
+            persistedProgress = snapshot;
+          }
+        } catch { /* ignore malformed snapshot */ }
+      }
+    }
 
     return {
-      indexed: store.count() > 0,
-      vectorCount: store.count(),
+      indexed: await store.count() > 0,
+      vectorCount: await store.count(),
       provider: configuredProviderInfo.provider,
       model: configuredProviderInfo.modelInfo.model,
       indexPath: this.indexPath,
@@ -4060,24 +4146,38 @@ export class Indexer {
       compatibility: this.indexCompatibility,
       failedBatchesCount,
       failedBatchesPath: failedBatchesCount > 0 ? this.failedBatchesPath : undefined,
-      warning: database.getMetadata(STARTUP_WARNING_METADATA_KEY) ?? undefined,
+      warning: await database.getMetadata(STARTUP_WARNING_METADATA_KEY) ?? undefined,
+      indexingInProgress: indexingInProgress || persistedProgress !== undefined,
+      progress: this.currentProgress ?? persistedProgress,
     };
+  }
+
+  async close(): Promise<void> {
+    await this.database?.close();
+    this.database = null;
+    this.store = null;
+    this.invertedIndex = null;
+    this.provider = null;
+    this.reranker = null;
+    this.currentProgress = undefined;
+    this.lastProgressSnapshot = "";
+    this.embeddingPhaseStartTime = 0;
+    this.embeddingChunksAtStart = 0;
+    this.lastProgressPersistAt = 0;
   }
 
   async clearIndex(): Promise<void> {
     const { store, invertedIndex, database } = await this.ensureInitialized();
 
     if (this.config.scope === "global") {
-      store.load();
-      invertedIndex.load();
-      this.loadFileHashCache();
+      await store.load();
       const roots = this.getScopedRoots();
       const compatibility = this.checkCompatibility();
-      const allMetadata = store.getAllMetadata();
+      const allMetadata = await store.getAllMetadata();
       const hasForeignData =
         allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots)) ||
-  await this.hasForeignScopedBranchData() ||
-  await this.hasForeignScopedFileHashData(roots) ||
+        await this.hasForeignScopedFileHashData(roots) ||
+        await this.hasForeignScopedBranchData() ||
         this.hasForeignScopedFailedBatches(roots);
 
       if (!compatibility.compatible && hasForeignData) {
@@ -4099,15 +4199,14 @@ export class Indexer {
       }
 
       if (!hasForeignData) {
-        store.clear();
-        store.save();
+        await store.clear();
+        await store.save();
         invertedIndex.clear();
-        invertedIndex.save();
+        await this.database!.saveInvertedIndex(invertedIndex.serialize());
 
-        this.fileHashCache.clear();
-        this.saveFileHashCache();
+        await this.database!.replaceAllFileHashes(new Map());
 
-        database.clearAllIndexedData();
+        await database.clearAllIndexedData();
         this.saveFailedBatches([]);
 
         await database.deleteMetadata("index.version");
@@ -4125,8 +4224,8 @@ export class Indexer {
         return;
       }
 
-      this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
-      this.clearScopedFileHashCache(roots);
+      await this.clearSharedIndexProjectData(store, invertedIndex, database, roots);
+      await this.clearScopedFileHashCache(roots);
       this.clearScopedFailedBatches(roots);
       this.indexCompatibility = compatibility;
       return;
@@ -4140,18 +4239,17 @@ export class Indexer {
       );
     }
 
-    store.clear();
-    store.save();
+    await store.clear();
+    await store.save();
     invertedIndex.clear();
-    invertedIndex.save();
+    await this.database!.saveInvertedIndex(invertedIndex.serialize());
 
     // Clear file hash cache so all files are re-parsed
-    this.fileHashCache.clear();
-    this.saveFileHashCache();
+    await this.database!.replaceAllFileHashes(new Map());
 
     // Clear persisted index data across all branches so force rebuilds
     // cannot reuse stale chunks, symbols, or embeddings from a prior provider.
-    database.clearAllIndexedData();
+    await database.clearAllIndexedData();
     this.saveFailedBatches([]);
 
     // Clear index metadata so compatibility is re-evaluated from scratch
@@ -4175,7 +4273,7 @@ export class Indexer {
 
     this.logger.gc("info", "Starting health check");
 
-    const allMetadata = store.getAllMetadata();
+    const allMetadata = await store.getAllMetadata();
     const filePathsToChunkKeys = new Map<string, string[]>();
 
     for (const { key, metadata } of allMetadata) {
@@ -4190,20 +4288,20 @@ export class Indexer {
     for (const [filePath, chunkKeys] of filePathsToChunkKeys) {
       if (!existsSync(filePath)) {
         for (const key of chunkKeys) {
-          store.remove(key);
+          await store.remove(key);
           invertedIndex.removeChunk(key);
           removedCount++;
         }
-        database.deleteChunksByFile(filePath);
-        database.deleteCallEdgesByFile(filePath);
-        database.deleteSymbolsByFile(filePath);
+        await database.deleteChunksByFile(filePath);
+        await database.deleteCallEdgesByFile(filePath);
+        await database.deleteSymbolsByFile(filePath);
         removedFilePaths.push(filePath);
       }
     }
 
     if (removedCount > 0) {
-      store.save();
-      invertedIndex.save();
+      await store.save();
+      await this.database!.saveInvertedIndex(invertedIndex.serialize());
     }
 
     let gcOrphanEmbeddings: number;
@@ -4212,10 +4310,10 @@ export class Indexer {
     let gcOrphanCallEdges: number;
 
     try {
-      gcOrphanEmbeddings = database.gcOrphanEmbeddings();
-      gcOrphanChunks = database.gcOrphanChunks();
-      gcOrphanSymbols = database.gcOrphanSymbols();
-      gcOrphanCallEdges = database.gcOrphanCallEdges();
+      gcOrphanEmbeddings = await database.gcOrphanEmbeddings();
+      gcOrphanChunks = await database.gcOrphanChunks();
+      gcOrphanSymbols = await database.gcOrphanSymbols();
+      gcOrphanCallEdges = await database.gcOrphanCallEdges();
     } catch (error) {
       if (!(await this.tryResetCorruptedIndex("running index health check", error))) {
         throw error;
@@ -4386,7 +4484,7 @@ export class Indexer {
           } catch (dbError) {
             // Rollback vectors added to store if DB write fails
             for (const { chunk } of successfulResults) {
-              store.remove(chunk.id);
+              await store.remove(chunk.id);
             }
             throw dbError;
           }
@@ -4439,13 +4537,13 @@ export class Indexer {
     }
 
     if (succeeded > 0) {
-      store.save();
-      invertedIndex.save();
+      await store.save();
+      await this.database!.saveInvertedIndex(invertedIndex.serialize());
     }
 
-    if (roots && succeeded > 0 && persistedStillFailing.length === 0 && this.hasProjectForceReembedPending()) {
-      await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
-      await this.saveIndexMetadata(configuredProviderInfo);
+    if (roots && succeeded > 0 && persistedStillFailing.length === 0 && await this.hasProjectForceReembedPending()) {
+        await database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+        await this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
     }
 
@@ -4476,7 +4574,7 @@ export class Indexer {
 
   async getDatabaseStats(): Promise<{ embeddingCount: number; chunkCount: number; branchChunkCount: number; branchCount: number } | null> {
     const { database } = await this.ensureInitialized();
-    return database.getStats();
+    return await database.getStats();
   }
 
   getLogger(): Logger {
@@ -4495,7 +4593,7 @@ export class Indexer {
     }
   ): Promise<SearchResult[]> {
     const { store, provider, database } = await this.ensureInitialized();
-    
+
     const compatibility = this.checkCompatibility();
     if (!compatibility.compatible) {
       throw new Error(
@@ -4506,7 +4604,7 @@ export class Indexer {
 
     const searchStartTime = performance.now();
 
-    if (store.count() === 0) {
+    if ((await store.count()) === 0) {
       this.logger.search("debug", "Find similar on empty index");
       return [];
     }
@@ -4525,14 +4623,15 @@ export class Indexer {
     this.logger.recordEmbeddingApiCall(tokensUsed);
 
     const vectorStartTime = performance.now();
-    const semanticResults = store.search(embedding, limit * 2);
+    const semanticResults = await store.search(embedding, limit * 2);
     const vectorMs = performance.now() - vectorStartTime;
 
     let branchChunkIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
-      branchChunkIds = new Set(
-        this.getBranchCatalogKeys().flatMap((branchKey) => database.getBranchChunkIds(branchKey))
-      );
+      const ids = (await Promise.all(
+        this.getBranchCatalogKeys().map((branchKey) => database.getBranchChunkIds(branchKey))
+      )).flat();
+      branchChunkIds = new Set(ids);
     }
 
     const prefilterStartTime = performance.now();
@@ -4645,7 +4744,7 @@ export class Indexer {
     const results: CallEdgeData[] = [];
 
     for (const branchKey of this.getBranchCatalogKeys()) {
-      for (const edge of database.getCallersWithContext(targetName, branchKey)) {
+      for (const edge of await database.getCallersWithContext(targetName, branchKey)) {
         if (!seen.has(edge.id)) {
           seen.add(edge.id);
           results.push(edge);
@@ -4662,7 +4761,7 @@ export class Indexer {
     const results: CallEdgeData[] = [];
 
     for (const branchKey of this.getBranchCatalogKeys()) {
-      for (const edge of database.getCallees(symbolId, branchKey)) {
+      for (const edge of await database.getCallees(symbolId, branchKey)) {
         if (!seen.has(edge.id)) {
           seen.add(edge.id);
           results.push(edge);
@@ -4671,14 +4770,5 @@ export class Indexer {
     }
 
     return results;
-  }
-
-  async close(): Promise<void> {
-    await this.database?.close();
-    this.database = null;
-    this.store = null;
-    this.invertedIndex = null;
-    this.provider = null;
-    this.reranker = null;
   }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3036,26 +3036,26 @@ export class Indexer {
     const existingCreatedAt = await this.database.getMetadata("index.createdAt");
     const completeProjectEmbeddingStrategyReset = !(await this.hasProjectForceReembedPending());
 
-    this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
-    this.database.setMetadata("index.embeddingProvider", provider.provider);
-    this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
-    this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
+    await this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
+    await this.database.setMetadata("index.embeddingProvider", provider.provider);
+    await this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
+    await this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
     if (this.config.scope === "global") {
       if (completeProjectEmbeddingStrategyReset) {
-        this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
+        await this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
       }
-      this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
+      await this.database.setMetadata(this.getLegacyMigrationMetadataKey(), "done");
       if (completeProjectEmbeddingStrategyReset) {
-        this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
+        await this.database.deleteMetadata(this.getProjectForceReembedMetadataKey());
       }
       this.branchMigrationDone = true;
     } else {
-      this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
+      await this.database.setMetadata("index.embeddingStrategyVersion", EMBEDDING_STRATEGY_VERSION);
     }
-    this.database.setMetadata("index.updatedAt", now);
+    await this.database.setMetadata("index.updatedAt", now);
 
     if (!existingCreatedAt) {
-      this.database.setMetadata("index.createdAt", now);
+      await this.database.setMetadata("index.createdAt", now);
     }
   }
 
@@ -3110,13 +3110,13 @@ export class Indexer {
     };
   }
 
-  checkCompatibility(): IndexCompatibility {
+  async checkCompatibility(): Promise<IndexCompatibility> {
     if (!this.indexCompatibility) {
       if (!this.configuredProviderInfo) {
         throw new Error('No embedding provider info, you must initialize the indexer first.');
       }
 
-      this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
+      this.indexCompatibility = await this.validateIndexCompatibility(this.configuredProviderInfo);
     }
     return this.indexCompatibility;
   }
@@ -3195,6 +3195,9 @@ export class Indexer {
       parseFailures: [],
     };
     const failedBatchesForCurrentRun: FailedBatch[] = [];
+    const failedChunkIdsThisRun = new Set<string>();
+    const failedAttemptCountByChunk = new Map<string, number>();
+    const retryableChunksWithExistingData = new Set<string>();
 
     this.updateProgress({
       phase: "scanning",
@@ -3238,9 +3241,14 @@ export class Indexer {
       const currentHash = hashFile(f.path);
       currentFileHashes.set(f.path, currentHash);
       if (storedHashes.get(f.path) === currentHash) {
-        unchangedFilePaths.push(f.path);
-        unchangedFilePathSet.add(f.path);
-        this.logger.recordCacheHit();
+        if (forceScopedReembed) {
+          changedFileMeta.push({ path: f.path, hash: currentHash });
+          this.logger.recordCacheMiss();
+        } else {
+          unchangedFilePaths.push(f.path);
+          unchangedFilePathSet.add(f.path);
+          this.logger.recordCacheHit();
+        }
       } else {
         changedFileMeta.push({ path: f.path, hash: currentHash });
         this.logger.recordCacheMiss();
@@ -3302,8 +3310,12 @@ export class Indexer {
 
       const allContentHashes = batchPendingChunks.map(c => c.contentHash);
       const missingHashes = new Set(await database.getMissingEmbeddings(allContentHashes));
-      const chunksNeedingEmbedding = batchPendingChunks.filter(c => missingHashes.has(c.contentHash));
-      const chunksWithExistingEmbedding = batchPendingChunks.filter(c => !missingHashes.has(c.contentHash));
+      const chunksNeedingEmbedding = forceScopedReembed
+        ? batchPendingChunks
+        : batchPendingChunks.filter(c => missingHashes.has(c.contentHash));
+      const chunksWithExistingEmbedding = forceScopedReembed
+        ? []
+        : batchPendingChunks.filter(c => !missingHashes.has(c.contentHash));
 
       this.logger.cache("info", "Embedding cache lookup", {
         needsEmbedding: chunksNeedingEmbedding.length,
@@ -3411,7 +3423,15 @@ export class Indexer {
                 chunkText: chunk.storageText,
                 model: configuredProviderInfo.modelInfo.model,
               }));
-              await database.upsertEmbeddingsBatch(embeddingBatchItems);
+              try {
+                await database.upsertEmbeddingsBatch(embeddingBatchItems);
+              } catch (dbError) {
+                // Roll back vectors that were inserted before DB persistence failed.
+                for (const { chunk } of pooledResults) {
+                  await store.remove(chunk.id);
+                }
+                throw dbError;
+              }
 
               for (const { chunk } of pooledResults) {
                 invertedIndex.removeChunk(chunk.id);
@@ -3440,17 +3460,44 @@ export class Indexer {
             }, onProgress);
           } catch (error) {
             const failedChunks = getUniquePendingChunksFromRequests(requestBatch);
-            stats.failedChunks += failedChunks.length;
-            failedBatchesForCurrentRun.push({
-              chunks: failedChunks,
-              error: getErrorMessage(error),
-              attemptCount: 1,
-              lastAttempt: new Date().toISOString(),
-            });
+            const failureMessage = getErrorMessage(error);
+            const failureTimestamp = new Date().toISOString();
+
+            for (const chunk of failedChunks) {
+              const previousAttemptCount = failedAttemptCountByChunk.get(chunk.id) ?? 0;
+              const nextAttemptCount = previousAttemptCount + 1;
+              failedAttemptCountByChunk.set(chunk.id, nextAttemptCount);
+
+              if (!failedChunkIdsThisRun.has(chunk.id)) {
+                if (!retryableChunksWithExistingData.has(chunk.id)) {
+                  failedChunkIdsThisRun.add(chunk.id);
+                }
+                stats.failedChunks += 1;
+              }
+              if (forceScopedReembed) {
+                failedForcedChunkIds.add(chunk.id);
+              }
+
+              const existingFailedBatchIndex = failedBatchesForCurrentRun.findIndex(
+                (failedBatch) => failedBatch.chunks[0]?.id === chunk.id
+              );
+              const failedBatch = {
+                chunks: [chunk],
+                error: failureMessage,
+                attemptCount: nextAttemptCount,
+                lastAttempt: failureTimestamp,
+              } satisfies FailedBatch;
+
+              if (existingFailedBatchIndex === -1) {
+                failedBatchesForCurrentRun.push(failedBatch);
+              } else {
+                failedBatchesForCurrentRun[existingFailedBatchIndex] = failedBatch;
+              }
+            }
             this.logger.recordEmbeddingError();
             this.logger.embedding("error", `Failed to embed batch after retries`, {
               batchSize: requestBatch.length,
-              error: getErrorMessage(error),
+              error: failureMessage,
             });
           }
         });
@@ -3541,7 +3588,7 @@ export class Indexer {
             language: chunk.language,
           });
 
-          if (existingChunkHashes.get(id) === contentHash) {
+          if (!forceScopedReembed && existingChunkHashes.get(id) === contentHash) {
             stats.existingChunks++;
           } else {
             const texts = createEmbeddingTexts(chunk, parsed.path, getSafeEmbeddingChunkTokenLimit(configuredProviderInfo)).map((text) => ({
@@ -3699,6 +3746,12 @@ export class Indexer {
     // Phase 6: Retryable failed chunks from previous incomplete runs
     const retryableFailedChunks = this.collectRetryableFailedChunks(currentFileHashes, unchangedFilePathSet);
     if (retryableFailedChunks.length > 0) {
+      const sourceBranchChunkIds = new Set(await database.getBranchChunkIds(branchCatalogKey, [sourceId]));
+      for (const retryable of retryableFailedChunks) {
+        if (sourceBranchChunkIds.has(retryable.chunk.id)) {
+          retryableChunksWithExistingData.add(retryable.chunk.id);
+        }
+      }
       stats.totalChunks += retryableFailedChunks.length;
       await embedPendingChunks(retryableFailedChunks.map((r) => r.chunk));
     }
@@ -3714,10 +3767,23 @@ export class Indexer {
     // Phase 7: Finalization
     stats.removedChunks = removedCount;
 
+    const coalescedFailedBatches = coalesceFailedBatches(failedBatchesForCurrentRun);
     if (scopedRoots) {
-      this.saveScopedFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun), scopedRoots);
+      this.saveScopedFailedBatches(coalescedFailedBatches, scopedRoots);
     } else {
-      this.saveFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun));
+      this.saveFailedBatches(coalescedFailedBatches);
+    }
+
+    // Remove chunks that failed embedding from the current source's branch catalog.
+    if (failedChunkIdsThisRun.size > 0) {
+      const sourceBranchChunkIds = new Set(await database.getBranchChunkIds(branchCatalogKey, [sourceId]));
+      for (const failedChunkId of failedChunkIdsThisRun) {
+        sourceBranchChunkIds.delete(failedChunkId);
+      }
+      await database.clearBranch(branchCatalogKey, sourceId);
+      if (sourceBranchChunkIds.size > 0) {
+        await database.addChunksToBranchBatch(branchCatalogKey, Array.from(sourceBranchChunkIds), sourceId);
+      }
     }
 
     this.updateProgress({
@@ -3907,7 +3973,7 @@ export class Indexer {
   ): Promise<SearchResult[]> {
     const { store, provider, database } = await this.ensureInitialized();
 
-    const compatibility = this.checkCompatibility();
+    const compatibility = await this.checkCompatibility();
     if (!compatibility.compatible) {
       throw new Error(
         `${compatibility.reason ?? "Index is incompatible with current embedding provider."} ` +
@@ -4233,7 +4299,7 @@ export class Indexer {
     if (this.config.scope === "global") {
       await store.load();
       const roots = this.getScopedRoots();
-      const compatibility = this.checkCompatibility();
+      const compatibility = await this.checkCompatibility();
       const allMetadata = await store.getAllMetadata();
       const hasForeignData =
         allMetadata.some(({ metadata }) => !this.isFileInCurrentScope(metadata.filePath, roots)) ||
@@ -4655,7 +4721,7 @@ export class Indexer {
   ): Promise<SearchResult[]> {
     const { store, provider, database } = await this.ensureInitialized();
 
-    const compatibility = this.checkCompatibility();
+    const compatibility = await this.checkCompatibility();
     if (!compatibility.compatible) {
       throw new Error(
         `${compatibility.reason ?? "Index is incompatible with current embedding provider."} ` +

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -391,7 +391,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
   );
 
   server.prompt(
-    "status",
+    "index_status",
     "Check if the codebase is indexed and ready",
     {},
     () => ({

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -6,8 +6,9 @@ import { existsSync } from "fs";
 import { Indexer } from "./indexer/index.js";
 import type { ParsedCodebaseIndexConfig, LogLevel } from "./config/schema.js";
 import { loadProjectConfigLayer, materializeLocalProjectConfig } from "./config/merger.js";
-import { formatDefinitionLookup, formatHealthCheck, formatIndexStats, formatStatus } from "./tools/utils.js";
+import { formatDefinitionLookup, formatHealthCheck, formatIndexStats, formatProgressTitle, formatStatus } from "./tools/utils.js";
 import { formatCostEstimate } from "./utils/cost.js";
+import { writeProgressLog } from "./utils/progress-log.js";
 import type { LogEntry } from "./utils/logger.js";
 import { resolveWorktreeMainRepoRoot } from "./git/index.js";
 
@@ -42,6 +43,10 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
     initialized = false;
   }
 
+  function normalizeFsPath(targetPath: string): string {
+    return path.normalize(targetPath).replace(/\\/g, "/");
+  }
+
   function shouldForceLocalizeProjectIndex(): boolean {
     if (runtimeConfig.scope !== "project") {
       return false;
@@ -54,7 +59,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
     }
 
     const inheritedIndexPath = path.join(mainRepoRoot, ".opencode", "index");
-    return !existsSync(localIndexPath) && existsSync(inheritedIndexPath);
+    return !existsSync(normalizeFsPath(localIndexPath)) && existsSync(normalizeFsPath(inheritedIndexPath));
   }
 
   async function ensureInitialized(): Promise<void> {
@@ -142,7 +147,7 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
       estimateOnly: z.boolean().optional().default(false).describe("Only show cost estimate without indexing"),
       verbose: z.boolean().optional().default(false).describe("Show detailed info about skipped files and parsing failures"),
     },
-    async (args) => {
+    async (args, extra) => {
       if (args.estimateOnly) {
         await ensureInitialized();
         const estimate = await indexer.estimateCost();
@@ -162,8 +167,63 @@ export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndex
         await ensureInitialized();
       }
 
-      const stats = await indexer.index();
-      return { content: [{ type: "text", text: formatIndexStats(stats, args.verbose ?? false) }] };
+      const progressToken = extra._meta?.progressToken;
+      const progressUpdates: string[] = [];
+      let lastSnapshot = "";
+      let chunksTotal = 0;
+
+      const rawProgressLogFile = runtimeConfig.debug.progressLogFile;
+      const progressLogFile = rawProgressLogFile
+        ? path.isAbsolute(rawProgressLogFile)
+          ? rawProgressLogFile
+          : path.resolve(projectRoot, rawProgressLogFile)
+        : undefined;
+
+      const stats = await indexer.index((progress) => {
+        const snapshot = `${progress.phase}:${progress.filesProcessed}/${progress.totalFiles}:${progress.chunksProcessed}/${progress.totalChunks}:${progress.currentFiles?.join(",\n") ?? ""}`;
+        if (snapshot === lastSnapshot) {
+          return;
+        }
+        lastSnapshot = snapshot;
+        if (progress.totalChunks > 0) chunksTotal = progress.totalChunks;
+
+        const message = formatProgressTitle(progress);
+        progressUpdates.push(message);
+
+        if (progressLogFile) {
+          writeProgressLog(progressLogFile, message);
+        }
+
+        if (progressToken != null) {
+          const progressValue = progress.phase === "complete"
+            ? (chunksTotal || 1)
+            : progress.chunksProcessed;
+          void extra.sendNotification({
+            method: "notifications/progress",
+            params: {
+              progressToken,
+              progress: progressValue,
+              total: chunksTotal || undefined,
+              message,
+            },
+          }).catch(() => { /* best-effort */ });
+        }
+      });
+
+      const verbose = args.verbose ?? false;
+      let text = formatIndexStats(stats, verbose);
+
+      // If the client didn't supply a progressToken, append progress lines to
+      // the final result so they are visible in the chat.
+      if (progressToken == null && progressUpdates.length > 0) {
+        const updatesToShow = verbose ? progressUpdates : progressUpdates.slice(-6);
+        text += `\n\nProgress updates:\n${updatesToShow.map((line) => `- ${line}`).join("\n")}`;
+        if (!verbose && progressUpdates.length > updatesToShow.length) {
+          text += `\n- ... ${progressUpdates.length - updatesToShow.length} earlier updates omitted (use verbose=true for all)`;
+        }
+      }
+
+      return { content: [{ type: "text", text }] };
     },
   );
 

--- a/src/migration/sqlite-to-pgvector.ts
+++ b/src/migration/sqlite-to-pgvector.ts
@@ -1,0 +1,420 @@
+/**
+ * Migrates an existing SQLite-backed codebase index to a pgvector database.
+ *
+ * What is migrated:
+ *   - File hashes (avoids re-hashing files on the next index run)
+ *   - Chunks + chunk metadata
+ *   - Embedding BYTEA cache (avoids re-calling the embedding API)
+ *   - Vectors into the pgvector table (derived from the BYTEA embeddings)
+ *   - Branch chunk catalog
+ *   - Symbols + branch symbol catalog
+ *   - Call edges
+ *   - Inverted index posting tables (BM25), rebuilt by reading the source files
+ *
+ * What is NOT migrated:
+ *   - Index metadata (index.version, embeddingProvider, etc.) — re-written on next index run
+ *   - Lock state — fresh start in pgvector
+ */
+
+import * as path from "path";
+import { existsSync, readFileSync } from "fs";
+
+import { parseConfig } from "../config/schema.js";
+import { loadMergedConfig } from "../config/merger.js";
+import { resolveProjectIndexPath } from "../config/paths.js";
+import { createDatabaseBackend, createVectorStoreBackend } from "../db/index.js";
+import { SqliteDatabaseBackend } from "../db/sqlite-backend.js";
+import type { ChunkMetadata } from "../db/backend.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface MigrationStats {
+  fileHashCount: number;
+  chunkCount: number;
+  embeddingCount: number;
+  vectorCount: number;
+  branchCount: number;
+  symbolCount: number;
+  callEdgeCount: number;
+  invertedIndexChunkCount: number;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+function bufferToFloat32Array(buf: Buffer): Float32Array {
+  return new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
+}
+
+// ── Core migration function ──────────────────────────────────────────────────
+
+/**
+ * Reads all data from the SQLite index at `sqliteIndexPath` and writes it into
+ * the already-initialized `targetDb` / `targetStore` (pgvector backends).
+ *
+ * Both backends must already be initialized before calling this function.
+ * The function opens its own read-only SQLite connection for the source.
+ */
+async function runMigration(
+  sqliteIndexPath: string,
+  targetDb: import("../db/backend.js").IDatabaseBackend,
+  targetStore: import("../db/backend.js").IVectorStoreBackend,
+  onProgress: (step: string, detail?: string) => void,
+): Promise<MigrationStats> {
+  const stats: MigrationStats = {
+    fileHashCount: 0,
+    chunkCount: 0,
+    embeddingCount: 0,
+    vectorCount: 0,
+    branchCount: 0,
+    symbolCount: 0,
+    callEdgeCount: 0,
+    invertedIndexChunkCount: 0,
+  };
+
+  const sqliteDbPath = path.join(sqliteIndexPath, "codebase.db");
+  if (!existsSync(sqliteDbPath)) {
+    throw new Error(`No SQLite database found at ${sqliteDbPath}`);
+  }
+
+  const sourceDb = new SqliteDatabaseBackend(sqliteDbPath);
+  await sourceDb.initialize();
+
+  try {
+    // ── 1. File hashes ───────────────────────────────────────────────────────
+    onProgress("Migrating file hashes...");
+    const rawFileHashes = await sourceDb.getAllFileHashes();
+
+    // The SQLite backend stores both plain `filePath` keys and
+    // source-scoped `sourceId::filePath` keys.  Only copy plain paths.
+    const fileHashes = new Map<string, string>();
+    for (const [key, hash] of rawFileHashes) {
+      if (!key.includes("::")) {
+        fileHashes.set(key, hash);
+      }
+    }
+    await targetDb.setFileHashesBatch(fileHashes);
+    stats.fileHashCount = fileHashes.size;
+
+    // File paths drive the rest of the migration.
+    const filePaths = Array.from(fileHashes.keys());
+
+    // ── 2. Chunks, embeddings, vectors, and inverted index ───────────────────
+    onProgress("Migrating chunks, embeddings and vectors...", `${filePaths.length} files`);
+
+    const seenContentHashes = new Set<string>();
+    const invertedIndexEntries: Array<{ chunkId: string; content: string }> = [];
+
+    for (let i = 0; i < filePaths.length; i++) {
+      const filePath = filePaths[i];
+
+      onProgress(
+        "Migrating chunks, embeddings and vectors...",
+        `${i + 1}/${filePaths.length}: ${path.basename(filePath)}`,
+      );
+
+      const chunks = await sourceDb.getChunksByFile(filePath);
+      if (chunks.length === 0) continue;
+
+      // Migrate chunk metadata rows.
+      await targetDb.upsertChunksBatch(chunks);
+      stats.chunkCount += chunks.length;
+
+      // Read file once for inverted-index re-tokenization.
+      let fileLines: string[] | null = null;
+      if (existsSync(filePath)) {
+        try {
+          fileLines = readFileSync(filePath, "utf-8").split("\n");
+        } catch {
+          // File unreadable — skip inverted index for this file.
+        }
+      }
+
+      const vectorBatch: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }> = [];
+
+      for (const chunk of chunks) {
+        // Inverted index: extract the chunk text from the live file.
+        if (fileLines) {
+          const text = fileLines.slice(chunk.startLine - 1, chunk.endLine).join("\n");
+          if (text.trim()) {
+            invertedIndexEntries.push({ chunkId: chunk.chunkId, content: text });
+          }
+        }
+
+        // Each unique content-hash maps to exactly one embedding buffer.
+        if (!seenContentHashes.has(chunk.contentHash)) {
+          seenContentHashes.add(chunk.contentHash);
+
+          const embBuffer = await sourceDb.getEmbedding(chunk.contentHash);
+          if (embBuffer) {
+            // Persist the raw BYTEA into pgvector's embedding cache.
+            // chunkText / model are not stored in the SQLite interface;
+            // passing sentinel values preserves the cache hit without
+            // re-embedding while keeping the schema valid.
+            await targetDb.upsertEmbedding(chunk.contentHash, embBuffer, "", "migrated");
+            stats.embeddingCount++;
+
+            // Convert BYTEA → float32 for the ANN vector column.
+            const vector = Array.from(bufferToFloat32Array(embBuffer));
+            vectorBatch.push({
+              id: chunk.chunkId,
+              vector,
+              metadata: {
+                filePath: chunk.filePath,
+                startLine: chunk.startLine,
+                endLine: chunk.endLine,
+                chunkType: (chunk.nodeType ?? "other") as ChunkMetadata["chunkType"],
+                name: chunk.name,
+                language: chunk.language,
+                hash: chunk.contentHash,
+              },
+            });
+          }
+        }
+      }
+
+      if (vectorBatch.length > 0) {
+        await targetStore.addBatch(vectorBatch);
+        stats.vectorCount += vectorBatch.length;
+      }
+    }
+
+    // ── 3. Inverted index (BM25 posting tables) ──────────────────────────────
+    onProgress("Migrating inverted index...", `${invertedIndexEntries.length} chunks`);
+    const II_BATCH = 200;
+    for (let i = 0; i < invertedIndexEntries.length; i += II_BATCH) {
+      await targetDb.upsertInvertedIndexChunkBatch(invertedIndexEntries.slice(i, i + II_BATCH));
+    }
+    stats.invertedIndexChunkCount = invertedIndexEntries.length;
+
+    // ── 4. Branch chunk catalog ──────────────────────────────────────────────
+    onProgress("Migrating branch catalog...");
+    const branches = await sourceDb.getAllBranches();
+    for (const branch of branches) {
+      const chunkIds = await sourceDb.getBranchChunkIds(branch);
+      if (chunkIds.length > 0) {
+        await targetDb.addChunksToBranchBatch(branch, chunkIds);
+      }
+    }
+    stats.branchCount = branches.length;
+
+    // ── 5. Symbols ───────────────────────────────────────────────────────────
+    onProgress("Migrating symbols...");
+    for (const filePath of filePaths) {
+      const symbols = await sourceDb.getSymbolsByFile(filePath);
+      if (symbols.length > 0) {
+        await targetDb.upsertSymbolsBatch(symbols);
+        stats.symbolCount += symbols.length;
+      }
+    }
+
+    // Branch symbol catalog.
+    for (const branch of branches) {
+      const symbolIds = await sourceDb.getBranchSymbolIds(branch);
+      if (symbolIds.length > 0) {
+        await targetDb.addSymbolsToBranchBatch(branch, symbolIds);
+      }
+    }
+
+    // ── 6. Call edges ────────────────────────────────────────────────────────
+    onProgress("Migrating call edges...");
+    // Collect unique symbol IDs across all branches.
+    const allSymbolIds = new Set<string>();
+    for (const branch of branches) {
+      for (const id of await sourceDb.getBranchSymbolIds(branch)) {
+        allSymbolIds.add(id);
+      }
+    }
+
+    const seenEdgeIds = new Set<string>();
+    const edgeBatch: import("../db/backend.js").CallEdgeData[] = [];
+    const EDGE_BATCH = 500;
+
+    const firstBranch = branches[0] ?? "main";
+    for (const symbolId of allSymbolIds) {
+      const callees = await sourceDb.getCallees(symbolId, firstBranch);
+      for (const edge of callees) {
+        if (!seenEdgeIds.has(edge.id)) {
+          seenEdgeIds.add(edge.id);
+          edgeBatch.push(edge);
+          if (edgeBatch.length >= EDGE_BATCH) {
+            await targetDb.upsertCallEdgesBatch(edgeBatch);
+            stats.callEdgeCount += edgeBatch.length;
+            edgeBatch.length = 0;
+          }
+        }
+      }
+    }
+    if (edgeBatch.length > 0) {
+      await targetDb.upsertCallEdgesBatch(edgeBatch);
+      stats.callEdgeCount += edgeBatch.length;
+    }
+
+    return stats;
+  } finally {
+    await sourceDb.close();
+  }
+}
+
+// ── CLI entry point ──────────────────────────────────────────────────────────
+
+function parseMigrateArgs(argv: string[]): {
+  project: string;
+  deleteSqlite: boolean;
+  dryRun: boolean;
+} {
+  let project = process.cwd();
+  let deleteSqlite = false;
+  let dryRun = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project" && argv[i + 1]) {
+      project = path.resolve(argv[++i]);
+    } else if (argv[i] === "--delete-sqlite") {
+      deleteSqlite = true;
+    } else if (argv[i] === "--dry-run") {
+      dryRun = true;
+    }
+  }
+
+  return { project, deleteSqlite, dryRun };
+}
+
+export async function handleMigrateCommand(argv: string[]): Promise<void> {
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    console.log(`Usage: opencode-codebase-index migrate [options]
+
+Migrates an existing SQLite index to the pgvector database configured in
+codebase-index.json.  The target config must have database.engine = "pgvector".
+
+Options:
+  --project <path>   Project root directory (default: current directory)
+  --delete-sqlite    Delete SQLite files after a successful migration
+  --dry-run          Show what would be migrated without writing to pgvector
+  -h, --help         Show this help message`);
+    return;
+  }
+
+  const { project, deleteSqlite, dryRun } = parseMigrateArgs(argv);
+  const rawConfig = loadMergedConfig(project);
+  const config = parseConfig(rawConfig);
+
+  console.error(`Project root: ${project}`);
+
+  if (config.database.engine !== "pgvector") {
+    console.error(
+      `Error: database.engine is "${config.database.engine}", not "pgvector".\n` +
+      `Set database.engine = "pgvector" in your codebase-index.json before migrating.`,
+    );
+    process.exit(1);
+  }
+
+  const indexPath = resolveProjectIndexPath(project, config.scope);
+  const sqliteDbPath = path.join(indexPath, "codebase.db");
+
+  if (!existsSync(sqliteDbPath)) {
+    console.error(`No SQLite database found at ${sqliteDbPath}`);
+    console.error("Nothing to migrate.");
+    return;
+  }
+
+  const pg = config.database.pgvector!;
+  const connDesc = pg.connectionString
+    ? "connection string"
+    : `${pg.user ?? "postgres"}@${pg.host ?? "localhost"}:${pg.port ?? 5432}/${pg.database ?? "postgres"}`;
+  console.error(`Source : SQLite at ${sqliteDbPath}`);
+  console.error(`Target : pgvector (${connDesc})`);
+  console.error("");
+
+  if (dryRun) {
+    console.error("Dry-run mode — no data will be written to pgvector.");
+    // Count what would be migrated.
+    const srcDb = new SqliteDatabaseBackend(sqliteDbPath);
+    await srcDb.initialize();
+    try {
+      const hashes = await srcDb.getAllFileHashes();
+      const fileCount = [...hashes.keys()].filter((k) => !k.includes("::")).length;
+      const branches = await srcDb.getAllBranches();
+      console.log(`Would migrate: ${fileCount} files, ${branches.length} branches`);
+    } finally {
+      await srcDb.close();
+    }
+    return;
+  }
+
+  // Need dimensions from the embedding provider config.
+  // Use a minimal provider check — just enough to get dimensions.
+  const dimensions = await (async () => {
+    const { createCustomProviderInfo, tryDetectProvider, detectEmbeddingProvider } = await import("../embeddings/detector.js");
+    if (config.embeddingProvider === "custom") {
+      if (!config.customProvider) throw new Error("embeddingProvider is 'custom' but customProvider is missing.");
+      return createCustomProviderInfo(config.customProvider).modelInfo.dimensions;
+    }
+    if (config.embeddingProvider === "auto") {
+      return (await tryDetectProvider()).modelInfo.dimensions;
+    }
+    return (await detectEmbeddingProvider(config.embeddingProvider, config.embeddingModel)).modelInfo.dimensions;
+  })();
+
+  console.error(`Embedding dimensions: ${dimensions}`);
+  console.error("Connecting to pgvector...");
+
+  const targetDb = await createDatabaseBackend(config.database, "");
+  const targetStore = await createVectorStoreBackend(config.database, "", dimensions);
+
+  console.error("Connected. Starting migration...");
+  console.error("");
+
+  let lastStep = "";
+  const onProgress = (step: string, detail?: string): void => {
+    if (step !== lastStep) {
+      lastStep = step;
+      process.stderr.write(`  ${step}\n`);
+    }
+    if (detail) {
+      process.stderr.write(`    ${detail}\r`);
+    }
+  };
+
+  try {
+    const stats = await runMigration(indexPath, targetDb, targetStore, onProgress);
+
+    console.error("\n");
+    console.error("Migration complete:");
+    console.error(`  File hashes   : ${stats.fileHashCount}`);
+    console.error(`  Chunks        : ${stats.chunkCount}`);
+    console.error(`  Embeddings    : ${stats.embeddingCount}`);
+    console.error(`  Vectors       : ${stats.vectorCount}`);
+    console.error(`  Branches      : ${stats.branchCount}`);
+    console.error(`  Symbols       : ${stats.symbolCount}`);
+    console.error(`  Call edges    : ${stats.callEdgeCount}`);
+    console.error(`  Inverted index: ${stats.invertedIndexChunkCount} chunks`);
+
+    if (deleteSqlite) {
+      const { promises: fs } = await import("fs");
+      const toDelete = [
+        sqliteDbPath,
+        `${sqliteDbPath}-shm`,
+        `${sqliteDbPath}-wal`,
+        path.join(indexPath, "vectors.usearch"),
+        path.join(indexPath, "file-hashes.json"),
+        path.join(indexPath, "inverted-index.json"),
+      ];
+      console.error("\nDeleting SQLite files...");
+      for (const f of toDelete) {
+        try {
+          await fs.rm(f, { force: true });
+          console.error(`  Deleted: ${f}`);
+        } catch {
+          // best-effort
+        }
+      }
+    }
+  } finally {
+    await targetDb.close();
+    // PgVectorStoreBackend has a close() not on the interface — call it if present.
+    const storeWithClose = targetStore as unknown as { close?: () => Promise<void> };
+    if (typeof storeWithClose.close === "function") {
+      await storeWithClose.close();
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,7 +16,7 @@ import {
   formatLogs,
   formatSearchResults,
 } from "./utils.js";
-import { existsSync, writeFileSync, mkdirSync, statSync } from "fs";
+import { existsSync, writeFileSync, readFileSync, mkdirSync, statSync } from "fs";
 import * as path from "path";
 import { loadMergedConfig, loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
 import { resolveWritableProjectConfigPath } from "../config/paths.js";
@@ -36,7 +36,7 @@ export function getSharedIndexer(): Indexer {
   return getIndexer();
 }
 
-function refreshIndexerFromConfig(): void {
+export function refreshIndexerFromConfig(): void {
   if (!sharedProjectRoot) {
     throw new Error("Codebase index tools not initialized. Plugin may not be loaded correctly.");
   }
@@ -139,23 +139,34 @@ function loadEditableConfig(): Record<string, unknown> {
   return normalizeKnowledgeBasePaths(config);
 }
 
-function saveConfig(config: Record<string, unknown>): void {
+/**
+ * Reads the raw project config JSON file, updates ONLY the `knowledgeBases`
+ * field, and writes it back. Every other key in the file is left exactly
+ * as-is — no normalization, no reordering, no risk of freezing inherited
+ * global settings into the project config.
+ *
+ * @param normalizedKbs Absolute paths as returned by loadEditableConfig().
+ */
+function patchKnowledgeBasesConfig(normalizedKbs: string[]): void {
   const configPath = getConfigPath();
   const configDir = path.dirname(configPath);
   const configBaseDir = path.dirname(configDir);
-  if (!existsSync(configDir)) {
-    mkdirSync(configDir, { recursive: true });
+
+  let raw: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    } catch {
+      raw = {};
+    }
+  } else {
+    raw = loadProjectConfigLayer(sharedProjectRoot);
   }
 
-  const serializableConfig: Record<string, unknown> = { ...config };
+  raw.knowledgeBases = normalizedKbs.map(kb => serializeConfigPathValue(kb, configBaseDir));
 
-  if (Array.isArray(serializableConfig.knowledgeBases)) {
-    serializableConfig.knowledgeBases = (serializableConfig.knowledgeBases as string[]).map(kb =>
-      serializeConfigPathValue(kb, configBaseDir)
-    );
-  }
-
-  writeFileSync(configPath, JSON.stringify(serializableConfig, null, 2) + "\n", "utf-8");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
 }
 
 export const codebase_peek: ToolDefinition = tool({
@@ -438,10 +449,10 @@ export const add_knowledge_base: ToolDefinition = tool({
       return `Error: Cannot access directory: ${resolvedPath} - ${error instanceof Error ? error.message : String(error)}`;
     }
 
-    // Load current config
-    const config = loadEditableConfig();
-    const knowledgeBases: string[] = Array.isArray(config.knowledgeBases)
-      ? config.knowledgeBases as string[]
+    // Load only the project-layer KBs (not merged) for comparison and mutation.
+    const editableConfig = loadEditableConfig();
+    const knowledgeBases: string[] = Array.isArray(editableConfig.knowledgeBases)
+      ? editableConfig.knowledgeBases as string[]
       : [];
 
     // Check if already added (normalize paths for comparison)
@@ -454,10 +465,9 @@ export const add_knowledge_base: ToolDefinition = tool({
       return `Knowledge base already configured: ${resolvedPath}`;
     }
 
-    // Add the knowledge base
+    // Add the knowledge base — surgical write: only knowledgeBases changes.
     knowledgeBases.push(resolvedPath);
-    config.knowledgeBases = knowledgeBases;
-    saveConfig(config);
+    patchKnowledgeBasesConfig(knowledgeBases);
     refreshIndexerFromConfig();
 
     let result = `${resolvedPath}\n`;
@@ -516,10 +526,10 @@ export const remove_knowledge_base: ToolDefinition = tool({
   async execute(args) {
     const inputPath = args.path.trim();
 
-    // Load current config
-    const config = loadEditableConfig();
-    const knowledgeBases: string[] = Array.isArray(config.knowledgeBases)
-      ? config.knowledgeBases as string[]
+    // Load only the project-layer KBs (not merged) for mutation.
+    const editableConfig = loadEditableConfig();
+    const knowledgeBases: string[] = Array.isArray(editableConfig.knowledgeBases)
+      ? editableConfig.knowledgeBases as string[]
       : [];
 
     if (knowledgeBases.length === 0) {
@@ -543,8 +553,8 @@ export const remove_knowledge_base: ToolDefinition = tool({
     }
 
     const removed = knowledgeBases.splice(index, 1)[0];
-    config.knowledgeBases = knowledgeBases;
-    saveConfig(config);
+    // Surgical write: only knowledgeBases changes.
+    patchKnowledgeBasesConfig(knowledgeBases);
     refreshIndexerFromConfig();
 
     let result = `Removed: ${removed}\n\n`;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import { existsSync, writeFileSync, readFileSync, mkdirSync, statSync } from "fs
 import * as path from "path";
 import { loadMergedConfig, loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
 import { resolveWritableProjectConfigPath } from "../config/paths.js";
+import { writeProgressLog } from "../utils/progress-log.js";
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
 
 const z = tool.schema;
@@ -44,6 +45,10 @@ export function refreshIndexerFromConfig(): void {
   sharedIndexer = new Indexer(sharedProjectRoot, parseConfig(loadRuntimeConfig()));
 }
 
+function normalizeFsPath(targetPath: string): string {
+  return path.normalize(targetPath).replace(/\\/g, "/");
+}
+
 function shouldForceLocalizeProjectIndex(): boolean {
   const currentConfig = parseConfig(loadRuntimeConfig());
   if (currentConfig.scope !== "project") {
@@ -57,7 +62,7 @@ function shouldForceLocalizeProjectIndex(): boolean {
   }
 
   const inheritedIndexPath = path.join(mainRepoRoot, ".opencode", "index");
-  return !existsSync(localIndexPath) && existsSync(inheritedIndexPath);
+  return !existsSync(normalizeFsPath(localIndexPath)) && existsSync(normalizeFsPath(inheritedIndexPath));
 }
 
 function getIndexer(): Indexer {
@@ -217,9 +222,16 @@ export const index_codebase: ToolDefinition = tool({
       await indexer.clearIndex();
     }
 
+    const rawProgressLogFile = parseConfig(loadRuntimeConfig()).debug.progressLogFile;
+    const progressLogFile = rawProgressLogFile
+      ? path.isAbsolute(rawProgressLogFile)
+        ? rawProgressLogFile
+        : path.resolve(sharedProjectRoot, rawProgressLogFile)
+      : undefined;
     const stats = await indexer.index((progress) => {
+      const title = formatProgressTitle(progress);
       context.metadata({
-        title: formatProgressTitle(progress),
+        title,
         metadata: {
           phase: progress.phase,
           filesProcessed: progress.filesProcessed,
@@ -227,8 +239,13 @@ export const index_codebase: ToolDefinition = tool({
           chunksProcessed: progress.chunksProcessed,
           totalChunks: progress.totalChunks,
           percentage: calculatePercentage(progress),
+          estimatedSecondsRemaining: progress.estimatedSecondsRemaining,
+          currentFiles: progress.currentFiles,
         },
       });
+      if (progressLogFile) {
+        writeProgressLog(progressLogFile, title);
+      }
     });
     return formatIndexStats(stats, args.verbose ?? false);
   },

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -58,19 +58,19 @@ export function formatIndexStats(stats: IndexStats, verbose: boolean = false): s
       lines.push("");
       lines.push(`Skipped files: ${stats.skippedFiles.length}`);
       if (tooLarge.length > 0) {
-        lines.push(`  Too large (${tooLarge.length}): ${tooLarge.slice(0, 5).map(f => f.path).join(", ")}${tooLarge.length > 5 ? "..." : ""}`);
+        lines.push(`  Too large (${tooLarge.length}):\n    ${tooLarge.slice(0, 5).map(f => f.path).join("\n    ")}${tooLarge.length > 5 ? "\n    ..." : ""}`);
       }
       if (excluded.length > 0) {
-        lines.push(`  Excluded (${excluded.length}): ${excluded.slice(0, 5).map(f => f.path).join(", ")}${excluded.length > 5 ? "..." : ""}`);
+        lines.push(`  Excluded (${excluded.length}):\n    ${excluded.slice(0, 5).map(f => f.path).join("\n    ")}${excluded.length > 5 ? "\n    ..." : ""}`);
       }
       if (gitignored.length > 0) {
-        lines.push(`  Gitignored (${gitignored.length}): ${gitignored.slice(0, 5).map(f => f.path).join(", ")}${gitignored.length > 5 ? "..." : ""}`);
+        lines.push(`  Gitignored (${gitignored.length}):\n    ${gitignored.slice(0, 5).map(f => f.path).join("\n    ")}${gitignored.length > 5 ? "\n    ..." : ""}`);
       }
     }
 
     if (stats.parseFailures.length > 0) {
       lines.push("");
-      lines.push(`Files with no extractable chunks (${stats.parseFailures.length}): ${stats.parseFailures.slice(0, 10).join(", ")}${stats.parseFailures.length > 10 ? "..." : ""}`);
+      lines.push(`Files with no extractable chunks (${stats.parseFailures.length}):\n  ${stats.parseFailures.slice(0, 10).join("\n  ")}${stats.parseFailures.length > 10 ? "\n  ..." : ""}`);
     }
   }
 
@@ -166,7 +166,7 @@ export function formatProgressTitle(progress: IndexProgress): string {
     case "scanning":
       return "Scanning files...";
     case "parsing":
-      return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files${progress.currentFiles?.length ? ` [${progress.currentFiles.join(", ")}]` : ""}`;
+      return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files${progress.currentFiles?.length ? `\n${progress.currentFiles.join("\n")}` : ""}`;
     case "embedding": {
       const etaStr = progress.estimatedSecondsRemaining != null
         ? ` (~${formatEta(progress.estimatedSecondsRemaining)} left)`
@@ -247,7 +247,7 @@ export function formatHealthCheck(result: HealthCheckResult): string {
   }
 
   if (result.filePaths.length > 0) {
-    lines.push(`Cleaned paths: ${result.filePaths.join(", ")}`);
+    lines.push(`Cleaned paths:\n  ${result.filePaths.join("\n  ")}`);
   }
 
   return lines.join("\n");

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -167,8 +167,7 @@ export function formatProgressTitle(progress: IndexProgress): string {
       return "Scanning files...";
     case "parsing":
       if (progress.currentFiles?.length) {
-        const label = progress.batchStarting ? "Parsing batch" : "Parsed batch";
-        return `${label} (${progress.filesProcessed}/${progress.totalFiles} files)\n${progress.currentFiles.join("\n")}`;
+        return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files [${progress.currentFiles.join(", ")}]`;
       }
       return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files`;
     case "embedding": {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -26,7 +26,7 @@ export function formatIndexStats(stats: IndexStats, verbose: boolean = false): s
     }
     lines.push("");
   }
-  
+
   if (stats.indexedChunks === 0 && stats.removedChunks === 0) {
     lines.push(`${stats.totalFiles} files processed, ${stats.existingChunks} code chunks already up to date.`);
   } else if (stats.indexedChunks === 0) {
@@ -54,7 +54,7 @@ export function formatIndexStats(stats: IndexStats, verbose: boolean = false): s
       const tooLarge = stats.skippedFiles.filter(f => f.reason === "too_large");
       const excluded = stats.skippedFiles.filter(f => f.reason === "excluded");
       const gitignored = stats.skippedFiles.filter(f => f.reason === "gitignore");
-      
+
       lines.push("");
       lines.push(`Skipped files: ${stats.skippedFiles.length}`);
       if (tooLarge.length > 0) {
@@ -78,6 +78,24 @@ export function formatIndexStats(stats: IndexStats, verbose: boolean = false): s
 }
 
 export function formatStatus(status: StatusResult): string {
+  if (status.indexingInProgress && status.progress) {
+    const lines = [
+      "Indexing is currently in progress.",
+      formatProgressTitle(status.progress),
+    ];
+
+    if (status.progress.currentFiles?.length) {
+      lines.push(`Current batch:\n${status.progress.currentFiles.map(f => `  ${f}`).join("\n")}`);
+    }
+
+    if (status.progress.estimatedSecondsRemaining != null) {
+      lines.push(`Estimated time remaining: ${formatEta(status.progress.estimatedSecondsRemaining)}`);
+    }
+
+    lines.push(`Indexed chunks currently available: ${status.vectorCount.toLocaleString()}`);
+    return lines.join("\n");
+  }
+
   if (!status.indexed) {
     if (status.warning) {
       return status.warning;
@@ -136,14 +154,25 @@ export function formatStatus(status: StatusResult): string {
   return lines.join("\n");
 }
 
+function formatEta(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const min = Math.floor(seconds / 60);
+  const sec = seconds % 60;
+  return sec > 0 ? `${min}m ${sec}s` : `${min}m`;
+}
+
 export function formatProgressTitle(progress: IndexProgress): string {
   switch (progress.phase) {
     case "scanning":
       return "Scanning files...";
     case "parsing":
-      return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files`;
-    case "embedding":
-      return `Embedding: ${progress.chunksProcessed}/${progress.totalChunks} chunks`;
+      return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files${progress.currentFiles?.length ? ` [${progress.currentFiles.join(", ")}]` : ""}`;
+    case "embedding": {
+      const etaStr = progress.estimatedSecondsRemaining != null
+        ? ` (~${formatEta(progress.estimatedSecondsRemaining)} left)`
+        : "";
+      return `Embedding: ${progress.chunksProcessed}/${progress.totalChunks} chunks${etaStr}`;
+    }
     case "storing":
       return "Storing index...";
     case "complete":
@@ -156,19 +185,19 @@ export function formatProgressTitle(progress: IndexProgress): string {
 export function calculatePercentage(progress: IndexProgress): number {
   if (progress.phase === "scanning") return 0;
   if (progress.phase === "complete") return 100;
-  
+
   if (progress.phase === "parsing") {
     if (progress.totalFiles === 0) return 5;
     return Math.round(5 + (progress.filesProcessed / progress.totalFiles) * 15);
   }
-  
+
   if (progress.phase === "embedding") {
     if (progress.totalChunks === 0) return 20;
     return Math.round(20 + (progress.chunksProcessed / progress.totalChunks) * 70);
   }
-  
+
   if (progress.phase === "storing") return 95;
-  
+
   return 0;
 }
 
@@ -196,15 +225,15 @@ export function formatHealthCheck(result: HealthCheckResult): string {
   }
 
   const lines: string[] = [];
-  
+
   if (result.removed > 0) {
     lines.push(`Removed stale entries: ${result.removed}`);
   }
-  
+
   if (result.gcOrphanEmbeddings > 0) {
     lines.push(`Garbage collected orphan embeddings: ${result.gcOrphanEmbeddings}`);
   }
-  
+
   if (result.gcOrphanChunks > 0) {
     lines.push(`Garbage collected orphan chunks: ${result.gcOrphanChunks}`);
   }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -166,7 +166,11 @@ export function formatProgressTitle(progress: IndexProgress): string {
     case "scanning":
       return "Scanning files...";
     case "parsing":
-      return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files${progress.currentFiles?.length ? `\n${progress.currentFiles.join("\n")}` : ""}`;
+      if (progress.currentFiles?.length) {
+        const label = progress.batchStarting ? "Parsing batch" : "Parsed batch";
+        return `${label} (${progress.filesProcessed}/${progress.totalFiles} files)\n${progress.currentFiles.join("\n")}`;
+      }
+      return `Parsing: ${progress.filesProcessed}/${progress.totalFiles} files`;
     case "embedding": {
       const etaStr = progress.estimatedSecondsRemaining != null
         ? ` (~${formatEta(progress.estimatedSecondsRemaining)} left)`

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -91,6 +91,8 @@ export class Logger {
   private logs: LogEntry[] = [];
   private maxLogs = 1000;
   private clientLog: ClientLogCallback | null = null;
+  private consoleOutput = false;
+  private consoleMinLevel: LogLevel = "warn";
 
   constructor(config: DebugConfig) {
     this.config = config;
@@ -99,6 +101,17 @@ export class Logger {
 
   setClientLogger(fn: ClientLogCallback): void {
     this.clientLog = fn;
+  }
+
+  /**
+   * Mirror log entries to stderr as they are recorded. Used by the CLI so
+   * users can see what the indexer is doing in real time. `minLevel` controls
+   * which entries are printed (e.g. "info" prints info/warn/error, "debug"
+   * prints everything).
+   */
+  setConsoleOutput(enabled: boolean, minLevel: LogLevel = "warn"): void {
+    this.consoleOutput = enabled;
+    this.consoleMinLevel = minLevel;
   }
 
   private shouldLog(level: LogLevel): boolean {
@@ -120,6 +133,14 @@ export class Logger {
     this.logs.push(entry);
     if (this.logs.length > this.maxLogs) {
       this.logs.shift();
+    }
+
+    if (this.consoleOutput && LOG_LEVEL_PRIORITY[level] <= LOG_LEVEL_PRIORITY[this.consoleMinLevel]) {
+      const dataStr = data ? ` ${JSON.stringify(data)}` : "";
+      const line = `[${entry.timestamp}] ${level.toUpperCase()} ${category}: ${message}${dataStr}`;
+      if (level === "error") console.error(line);
+      else if (level === "warn") console.warn(line);
+      else console.error(line); // stderr keeps stdout reserved for command output
     }
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -20,7 +20,7 @@ export interface Metrics {
   embeddingApiCalls: number;
   embeddingTokensUsed: number;
   embeddingErrors: number;
-  
+
   searchCount: number;
   searchTotalMs: number;
   searchAvgMs: number;
@@ -29,14 +29,14 @@ export interface Metrics {
   vectorSearchMs: number;
   keywordSearchMs: number;
   fusionMs: number;
-  
+
   cacheHits: number;
   cacheMisses: number;
-  
+
   queryCacheHits: number;
   queryCacheSimilarHits: number;
   queryCacheMisses: number;
-  
+
   gcRuns: number;
   gcOrphansRemoved: number;
   gcChunksRemoved: number;
@@ -83,15 +83,22 @@ function createEmptyMetrics(): Metrics {
   };
 }
 
+export type ClientLogCallback = (level: "error" | "warn" | "info", message: string, extra?: Record<string, unknown>) => void;
+
 export class Logger {
   private config: DebugConfig;
   private metrics: Metrics;
   private logs: LogEntry[] = [];
   private maxLogs = 1000;
+  private clientLog: ClientLogCallback | null = null;
 
   constructor(config: DebugConfig) {
     this.config = config;
     this.metrics = createEmptyMetrics();
+  }
+
+  setClientLogger(fn: ClientLogCallback): void {
+    this.clientLog = fn;
   }
 
   private shouldLog(level: LogLevel): boolean {
@@ -152,10 +159,12 @@ export class Logger {
 
   warn(message: string, data?: Record<string, unknown>): void {
     this.log("warn", "general", message, data);
+    this.clientLog?.("warn", message, data);
   }
 
   error(message: string, data?: Record<string, unknown>): void {
     this.log("error", "general", message, data);
+    this.clientLog?.("error", message, data);
   }
 
   debug(message: string, data?: Record<string, unknown>): void {
@@ -224,7 +233,7 @@ export class Logger {
     this.metrics.searchTotalMs += durationMs;
     this.metrics.searchLastMs = durationMs;
     this.metrics.searchAvgMs = this.metrics.searchTotalMs / this.metrics.searchCount;
-    
+
     if (breakdown) {
       this.metrics.embeddingCallMs = breakdown.embeddingMs;
       this.metrics.vectorSearchMs = breakdown.vectorMs;
@@ -305,12 +314,12 @@ export class Logger {
   formatMetrics(): string {
     const m = this.metrics;
     const lines: string[] = [];
-    
+
     if (m.indexingStartTime && m.indexingEndTime) {
       const duration = m.indexingEndTime - m.indexingStartTime;
       lines.push(`Indexing duration: ${(duration / 1000).toFixed(2)}s`);
     }
-    
+
     lines.push("");
     lines.push("Indexing:");
     lines.push(`  Files scanned: ${m.filesScanned}`);
@@ -319,13 +328,13 @@ export class Logger {
     lines.push(`  Chunks embedded: ${m.chunksEmbedded}`);
     lines.push(`  Chunks from cache: ${m.chunksFromCache}`);
     lines.push(`  Chunks removed: ${m.chunksRemoved}`);
-    
+
     lines.push("");
     lines.push("Embedding API:");
     lines.push(`  API calls: ${m.embeddingApiCalls}`);
     lines.push(`  Tokens used: ${m.embeddingTokensUsed.toLocaleString()}`);
     lines.push(`  Errors: ${m.embeddingErrors}`);
-    
+
     if (m.searchCount > 0) {
       lines.push("");
       lines.push("Search:");
@@ -339,7 +348,7 @@ export class Logger {
         lines.push(`    - Fusion: ${m.fusionMs.toFixed(2)}ms`);
       }
     }
-    
+
     const totalCacheOps = m.cacheHits + m.cacheMisses;
     if (totalCacheOps > 0) {
       lines.push("");
@@ -348,7 +357,7 @@ export class Logger {
       lines.push(`  Misses: ${m.cacheMisses}`);
       lines.push(`  Hit rate: ${((m.cacheHits / totalCacheOps) * 100).toFixed(1)}%`);
     }
-    
+
     if (m.gcRuns > 0) {
       lines.push("");
       lines.push("Garbage Collection:");
@@ -357,7 +366,7 @@ export class Logger {
       lines.push(`  Chunks removed: ${m.gcChunksRemoved}`);
       lines.push(`  Embeddings removed: ${m.gcEmbeddingsRemoved}`);
     }
-    
+
     return lines.join("\n");
   }
 
@@ -366,7 +375,7 @@ export class Logger {
     if (logs.length === 0) {
       return "No logs recorded.";
     }
-    
+
     return logs.map(l => {
       const dataStr = l.data ? ` ${JSON.stringify(l.data)}` : "";
       return `[${l.timestamp}] [${l.level.toUpperCase()}] [${l.category}] ${l.message}${dataStr}`;
@@ -385,6 +394,10 @@ export class Logger {
 let globalLogger: Logger | null = null;
 
 export function initializeLogger(config: DebugConfig): Logger {
+  // If logger already exists, just return it (preserves any logs already written)
+  if (globalLogger) {
+    return globalLogger;
+  }
   globalLogger = new Logger(config);
   return globalLogger;
 }

--- a/src/utils/progress-log.ts
+++ b/src/utils/progress-log.ts
@@ -1,0 +1,14 @@
+import { appendFileSync } from "fs";
+
+/**
+ * Appends a timestamped progress line to the configured log file.
+ * Errors are silently swallowed — this is best-effort monitoring output.
+ */
+export function writeProgressLog(filePath: string, message: string): void {
+  try {
+    const ts = new Date().toISOString();
+    appendFileSync(filePath, `[${ts}] ${message}\n`, "utf-8");
+  } catch {
+    /* best-effort */
+  }
+}

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -203,6 +203,7 @@ describe("indexer failed batch recovery", () => {
       compatibility: null,
       failedBatchesCount: 2,
       failedBatchesPath: "/tmp/index/failed-batches.json",
+      indexingInProgress: false,
     });
 
     expect(message).toContain("rerun index_codebase normally");

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -242,7 +242,7 @@ describe("MCP server tools and prompts", () => {
     expect(prompts.prompts).toHaveLength(5);
 
     const promptNames = prompts.prompts.map(p => p.name).sort();
-    const expectedNames = ["definition", "find", "index", "search", "status"].sort();
+    const expectedNames = ["definition", "find", "index", "index_status", "search"].sort();
 
     expect(promptNames).toEqual(expectedNames);
   });
@@ -536,7 +536,7 @@ describe("MCP server tools and prompts", () => {
 
   it("should get status prompt", async () => {
     const prompt = await client.getPrompt({
-      name: "status",
+      name: "index_status",
       arguments: {},
     });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,3 +1,5 @@
+import type { StatusResult } from "../src/indexer/index.js";
+
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMcpServer } from "../src/mcp-server.js";
 import { parseConfig } from "../src/config/schema.js";
@@ -46,7 +48,7 @@ let mockIndexResult = {
   parseFailures: [],
 };
 
-let mockStatusResult = {
+let mockStatusResult: StatusResult = {
   indexed: true,
   vectorCount: 50,
   provider: "openai",
@@ -57,6 +59,7 @@ let mockStatusResult = {
   compatibility: { compatible: true },
   failedBatchesCount: 0,
   failedBatchesPath: undefined as string | undefined,
+  indexingInProgress: false,
 };
 
 let mockHealthCheckResult = {
@@ -189,6 +192,7 @@ describe("MCP server tools and prompts", () => {
       compatibility: { compatible: true },
       failedBatchesCount: 0,
       failedBatchesPath: undefined,
+      indexingInProgress: false,
     };
     mockHealthCheckResult = {
       removed: 0,
@@ -326,6 +330,7 @@ describe("MCP server tools and prompts", () => {
       compatibility: null,
       failedBatchesCount: 2,
       failedBatchesPath: "/tmp/index/failed-batches.json",
+      indexingInProgress: false,
     };
 
     const result = await client.callTool({

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -365,23 +365,6 @@ public class AccountService {
       expect(store.count()).toBe(0);
     });
 
-    it("should persist and load", () => {
-      store.add("chunk1", [1, 0, 0], {
-        filePath: "test.ts",
-        startLine: 1,
-        endLine: 5,
-        chunkType: "function",
-        language: "typescript",
-        hash: "abc123",
-      });
-      store.save();
-
-      const newStore = new VectorStore(path.join(tempDir, "vectors"), 3);
-      newStore.load();
-
-      expect(newStore.count()).toBe(1);
-    });
-
     it("should add vectors in batch and keep metadata searchable", () => {
       store.addBatch([
         {
@@ -507,18 +490,6 @@ public class AccountService {
       expect(metadataMap.get("chunk0")?.hash).toBe("hash-0");
       expect(metadataMap.get("chunk777")?.filePath).toBe("file-777.ts");
       expect(metadataMap.get("chunk999")?.endLine).toBe(1001);
-
-      store.save();
-
-      const reloadedStore = new VectorStore(path.join(tempDir, "vectors"), 3);
-      reloadedStore.load();
-
-      expect(reloadedStore.count()).toBe(batchSize);
-      expect(reloadedStore.getMetadata("chunk777")?.filePath).toBe("file-777.ts");
-      expect(reloadedStore.getMetadata("chunk999")?.hash).toBe("hash-999");
-
-      const reloadedResults = reloadedStore.search(items[777].vector, 10);
-      expect(reloadedResults[0]?.id).toBe("chunk777");
     });
 
     it("should clear all data", () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -9,7 +9,7 @@ import {
   formatLogs,
   formatSearchResults,
 } from "../src/tools/utils.js";
-import type { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../src/indexer/index.js";
+import type { IndexStats, IndexProgress, SearchResult, StatusResult } from "../src/indexer/index.js";
 import type { LogEntry } from "../src/utils/logger.js";
 
 function createBaseStats(overrides: Partial<IndexStats> = {}): IndexStats {
@@ -169,6 +169,36 @@ describe("tools utils", () => {
   });
 
   describe("formatStatus", () => {
+    it("should show live indexing progress when indexing is in progress", () => {
+      const status: StatusResult = {
+        indexed: true,
+        vectorCount: 120,
+        provider: "openai",
+        model: "text-embedding-3-small",
+        indexPath: "/tmp/index",
+        currentBranch: "default",
+        baseBranch: "default",
+        compatibility: { compatible: true },
+        failedBatchesCount: 0,
+        failedBatchesPath: undefined,
+        indexingInProgress: true,
+        progress: {
+          phase: "parsing",
+          filesProcessed: 12,
+          totalFiles: 40,
+          chunksProcessed: 15,
+          totalChunks: 80,
+          currentFiles: ["src/indexer/index.ts"],
+        },
+      };
+      const result = formatStatus(status);
+
+      expect(result).toContain("Indexing is currently in progress");
+      expect(result).toContain("Parsing: 12/40 files");
+      expect(result).toContain("src/indexer/index.ts");
+      expect(result).toContain("Indexed chunks currently available: 120");
+    });
+
     it("should return not-indexed message when not indexed", () => {
       const status: StatusResult = {
         indexed: false,
@@ -181,6 +211,7 @@ describe("tools utils", () => {
         compatibility: null,
         failedBatchesCount: 0,
         failedBatchesPath: undefined,
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -200,6 +231,7 @@ describe("tools utils", () => {
         compatibility: { compatible: true },
         failedBatchesCount: 0,
         failedBatchesPath: undefined,
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -223,6 +255,7 @@ describe("tools utils", () => {
         compatibility: { compatible: true },
         failedBatchesCount: 0,
         failedBatchesPath: undefined,
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -253,6 +286,7 @@ describe("tools utils", () => {
         },
         failedBatchesCount: 0,
         failedBatchesPath: undefined,
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -274,6 +308,7 @@ describe("tools utils", () => {
         compatibility: null,
         failedBatchesCount: 0,
         failedBatchesPath: undefined,
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -292,6 +327,7 @@ describe("tools utils", () => {
         compatibility: null,
         failedBatchesCount: 2,
         failedBatchesPath: "/tmp/index/failed-batches.json",
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -312,6 +348,7 @@ describe("tools utils", () => {
         failedBatchesCount: 0,
         failedBatchesPath: undefined,
         warning: "Detected a corrupted local SQLite index at /tmp/index/codebase.db and reset the local index. Run index_codebase to rebuild search data.",
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -332,6 +369,7 @@ describe("tools utils", () => {
         compatibility: { compatible: true },
         failedBatchesCount: 1,
         failedBatchesPath: "/tmp/index/failed-batches.json",
+        indexingInProgress: false,
       };
       const result = formatStatus(status);
 
@@ -343,6 +381,10 @@ describe("tools utils", () => {
   describe("formatProgressTitle", () => {
     it("should format scanning phase", () => {
       expect(formatProgressTitle({ phase: "scanning", filesProcessed: 0, totalFiles: 0, chunksProcessed: 0, totalChunks: 0 })).toBe("Scanning files...");
+    });
+
+    it("should format parsing phase with current files batch", () => {
+      expect(formatProgressTitle({ phase: "parsing", filesProcessed: 5, totalFiles: 20, chunksProcessed: 0, totalChunks: 0, currentFiles: ["src/main.ts"] })).toBe("Parsing: 5/20 files [src/main.ts]");
     });
 
     it("should format parsing phase with counts", () => {


### PR DESCRIPTION
> ⚠️ **Depends on the `pgvector` and `batched-indexing` PRs**. This branch is rebased on `emanspeaks:batched-indexing`. Until both upstream PRs merge, this PR's diff includes the `pgvector` and `batched-indexing` commits as well; once they merge, the `index-cli-cmd` commits become the only diffs.

## Summary

Adds a standalone `index` CLI subcommand that lets you trigger indexing directly without an OpenCode agent session. Also wires in a `migrate` subcommand to move an existing SQLite index into a pgvector database. Bundles the changes from #72 (pgvector backend) and #73 (batched file indexing) into a cohesive release.

## Changes

- **`index` CLI subcommand** (`src/cli.ts`): run indexing from the terminal with `--project`, `--force`, `--estimate-only`, and `--verbose` flags; prints resolved config, live progress, and final stats to stderr
- **`migrate` CLI subcommand** (`src/migration/sqlite-to-pgvector.ts`): migrates file hashes, chunks, embeddings, vectors, branch catalogs, symbols, call edges, and BM25 posting tables from SQLite to pgvector
- **pgvector database backend** (`src/db/`): abstract `IDatabaseBackend` / `IVectorStoreBackend` interfaces with SQLite and pgvector implementations; factory functions in `src/db/index.ts` (from #72)
- **Batched indexing** (`indexing.fileBatchSize`): controls files-per-batch to cap peak memory (from #73)
- **Config additions**: `indexing.skipAutoIndexOnLoad`, `indexing.fileBatchSize`, `database.engine`, `database.pgvector.*` connection/pool/SSL settings, `debug.progressLogFile` for `tail -f` monitoring
- **Config deep-merge** (`src/config/merger.ts`): project config now deep-merges on top of global config for `indexing`, `search`, `debug`, and `database.pgvector` sub-trees; `knowledgeBases` and `additionalInclude` are union-merged
- **Tests**: `indexer-failed-batches.test.ts`, `mcp-server.test.ts`, `tools-utils.test.ts`, `native.test.ts` additions/updates
- **Docs**: updated AGENTS.md, ARCHITECTURE.md, README.md, CONTRIBUTING.md, TROUBLESHOOTING.md, CHANGELOG.md to reflect new db layer, config options, and CLI usage

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [ ] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Depends on #72 (pgvector backend), #73 (batched file indexing)