### PR TITLE
fix: restore semantic search identifier fallback

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -716,13 +716,26 @@ function classifyExternalRerankBand(
   return "other";
 }
 
-function classifyQueryIntent(tokens: string[]): "source" | "doc_test" {
+function classifyQueryIntent(tokens: string[]): "source" | "doc_test" | "neutral" {
   const sourceIntentHits = tokens.filter((t) => SOURCE_INTENT_HINTS.has(t)).length;
   const docTestIntentHits = tokens.filter((t) => DOC_TEST_INTENT_HINTS.has(t)).length;
-  return sourceIntentHits >= docTestIntentHits ? "source" : "doc_test";
+
+  if (sourceIntentHits === 0 && docTestIntentHits === 0) {
+    return "neutral";
+  }
+
+  if (sourceIntentHits > docTestIntentHits) {
+    return "source";
+  }
+
+  if (docTestIntentHits > sourceIntentHits) {
+    return "doc_test";
+  }
+
+  return "neutral";
 }
 
-function classifyQueryIntentRaw(query: string): "source" | "doc_test" {
+function classifyQueryIntentRaw(query: string): "source" | "doc_test" | "neutral" {
   const lowerQuery = query.toLowerCase();
   const docTestRawHits = Array.from(DOC_TEST_INTENT_HINTS).filter((hint) =>
     new RegExp(`\\b${hint}\\b`).test(lowerQuery)
@@ -744,7 +757,7 @@ function classifyQueryIntentRaw(query: string): "source" | "doc_test" {
     return "doc_test";
   }
 
-  if (sourceRawHits > docTestRawHits) {
+  if (sourceRawHits > docTestRawHits && sourceRawHits > 0) {
     return "source";
   }
 
@@ -1714,6 +1727,35 @@ export function mergeTieredResults(
   }
 
   return out;
+}
+
+function matchesSearchFilters(
+  candidate: RankedCandidate,
+  options: {
+    fileType?: string;
+    directory?: string;
+    chunkType?: string;
+  } | undefined,
+  minScore: number
+): boolean {
+  if (candidate.score < minScore) return false;
+
+  if (options?.fileType) {
+    const ext = candidate.metadata.filePath.split(".").pop()?.toLowerCase();
+    if (ext !== options.fileType.toLowerCase().replace(/^\./, "")) return false;
+  }
+
+  if (options?.directory) {
+    const normalizedDir = options.directory.replace(/^\/|\/$/g, "");
+    if (!candidate.metadata.filePath.includes(`/${normalizedDir}/`) &&
+      !candidate.metadata.filePath.includes(`${normalizedDir}/`)) return false;
+  }
+
+  if (options?.chunkType && candidate.metadata.chunkType !== options.chunkType) {
+    return false;
+  }
+
+  return true;
 }
 
 function unionCandidates(
@@ -3959,26 +4001,7 @@ export class Indexer {
     const tiered = mergeTieredResults(primaryLane, rescued, maxResults * 4);
     const hasCodeHints = extractCodeTermHints(query).length > 0 || identifierHints.length > 0;
 
-    const baseFiltered = tiered.filter((r) => {
-      if (r.score < this.config.search.minScore) return false;
-
-      if (options?.fileType) {
-        const ext = r.metadata.filePath.split(".").pop()?.toLowerCase();
-        if (ext !== options.fileType.toLowerCase().replace(/^\./, "")) return false;
-      }
-
-      if (options?.directory) {
-        const normalizedDir = options.directory.replace(/^\/|\/$/g, "");
-        if (!r.metadata.filePath.includes(`/${normalizedDir}/`) &&
-          !r.metadata.filePath.includes(`${normalizedDir}/`)) return false;
-      }
-
-      if (options?.chunkType) {
-        if (r.metadata.chunkType !== options.chunkType) return false;
-      }
-
-      return true;
-    });
+    const baseFiltered = tiered.filter((r) => matchesSearchFilters(r, options, this.config.search.minScore));
 
     const implementationOnly = baseFiltered.filter((r) =>
       isLikelyImplementationPath(r.metadata.filePath) &&
@@ -3990,7 +4013,13 @@ export class Indexer {
       : baseFiltered
     ).slice(0, maxResults);
 
-    const finalResults = filtered;
+    const identifierFallback = (!options?.definitionIntent && filtered.length === 0 && identifierHints.length > 0)
+      ? buildSymbolDefinitionLane(query, database, branchChunkIds, maxResults, union, true)
+        .filter((r) => matchesSearchFilters(r, options, this.config.search.minScore))
+        .slice(0, maxResults)
+      : [];
+
+    const finalResults = filtered.length > 0 ? filtered : identifierFallback;
 
     const totalSearchMs = performance.now() - searchStartTime;
     this.logger.recordSearch(totalSearchMs, {

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -689,7 +689,9 @@ export class Database {
   }
 
   close(): void {
-    this.inner.close();
+    if (typeof this.inner.close === "function") {
+      this.inner.close();
+    }
   }
 
   embeddingExists(contentHash: string): boolean {

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -178,6 +178,39 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(topPaths[0]).toContain(path.join("app", "indexer", "index.ts"));
   });
 
+  it("keeps plain identifier queries discoverable without definitionIntent", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("rankHybridResults", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    const topPaths = results.slice(0, 3).map((r) => r.filePath);
+    expect(topPaths[0]).toContain(path.join("app", "indexer", "index.ts"));
+  });
+
   it("forces definition lanes for doc-leaning queries when definitionIntent is true", async () => {
     const config = parseConfig({
       embeddingProvider: "custom",


### PR DESCRIPTION
## Summary

Fix issue #76 where `codebase_search` / `codebase_peek` could return no matches for known identifiers while `implementation_lookup` still worked.

## Changes

- stop treating neutral identifier queries as source-definition intent by default in `src/indexer/index.ts`
- add an exact-symbol fallback for ordinary identifier queries when semantic search returns no results, and cover it with a regression in `tests/search-integration.test.ts`
- guard `Database.close()` in `src/native/index.ts` so focused integration tests do not crash when the native binding lacks a `close` method

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [ ] Tests pass (`npm run test:run`)
- [ ] Lint passes (`npm run lint`)

Additional focused validation:
- [x] `npm test -- --run tests/search-integration.test.ts`

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #76