### PR TITLE
feat: add peek and reindex slash commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,8 @@ This document explains the architecture of opencode-codebase-index, including da
 │         index_codebase, index_status, index_health_check, index_metrics,    │
 │         index_logs, add_knowledge_base, list_knowledge_bases,               │
 │         remove_knowledge_base                                               │
-│  Commands: /peek, /search, /find, /call-graph, /index, /reindex, /status   │
+│  Commands: /definition, /peek, /search, /find, /call-graph, /index,        │
+│            /reindex, /status                                                │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ This document explains the architecture of opencode-codebase-index, including da
 │         index_codebase, index_status, index_health_check, index_metrics,    │
 │         index_logs, add_knowledge_base, list_knowledge_bases,               │
 │         remove_knowledge_base                                               │
-│  Commands: /search, /find, /call-graph, /index, /status                     │
+│  Commands: /peek, /search, /find, /call-graph, /index, /reindex, /status   │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼

--- a/README.md
+++ b/README.md
@@ -379,10 +379,12 @@ The plugin automatically registers these slash commands:
 
 | Command | Description |
 | ------- | ----------- |
+| `/peek <query>` | **Quick Semantic Lookup**. Returns likely locations only, without full code content. |
+| `/reindex` | **Full Rebuild**. Rebuilds the codebase index from scratch. |
 | `/search <query>` | **Pure Semantic Search**. Best for "How does X work?" |
 | `/find <query>` | **Hybrid Search**. Combines semantic search + grep. Best for "Find usage of X". |
 | `/call-graph <query>` | **Call Graph Trace**. Find callers/callees to understand execution flow. |
-| `/index` | **Update Index**. Forces a refresh of the codebase index. |
+| `/index` | **Update Index**. Runs incremental indexing by default; use `/index force` for a full rebuild. |
 | `/status` | **Check Status**. Shows if indexed, chunk count, and provider info. |
 
 ## 📚 Knowledge Base

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ The plugin automatically registers these slash commands:
 
 | Command | Description |
 | ------- | ----------- |
+| `/definition <query>` | **Definition Lookup**. Finds the authoritative implementation site for a symbol or concept. |
 | `/peek <query>` | **Quick Semantic Lookup**. Returns likely locations only, without full code content. |
 | `/reindex` | **Full Rebuild**. Rebuilds the codebase index from scratch. |
 | `/search <query>` | **Pure Semantic Search**. Best for "How does X work?" |

--- a/commands/peek.md
+++ b/commands/peek.md
@@ -1,0 +1,24 @@
+---
+description: Quickly find likely code locations without returning full code
+---
+
+Search the codebase using `codebase_peek`.
+
+User input: $ARGUMENTS
+
+The first part is the search query. Look for optional parameters:
+- `limit=N` or "top N" or "first N" → set limit
+- `type=X` or mentions "functions"/"classes"/"methods" → set chunkType
+- `dir=X` or "in folder X" → set directory filter
+- File extensions like ".ts", "typescript", ".py" → set fileType
+
+Call `codebase_peek` with the parsed arguments.
+
+Examples:
+- `/peek authentication logic` → query="authentication logic"
+- `/peek error handling limit=5` → query="error handling", limit=5
+- `/peek validation functions` → query="validation", chunkType="function"
+
+If the index doesn't exist, run `index_codebase` first.
+
+Return results as concise locations with file paths and line numbers. Suggest reading the returned files or using `codebase_search` when the user needs full code context.

--- a/commands/reindex.md
+++ b/commands/reindex.md
@@ -1,0 +1,25 @@
+---
+description: Fully rebuild the codebase index from scratch
+---
+
+Run the `index_codebase` tool with `force=true` to rebuild the index from scratch.
+
+User input: $ARGUMENTS
+
+Parse the input and set tool arguments:
+- force=true always
+- estimateOnly=false always
+- verbose=false (default, for token efficiency)
+- verbose=true if input contains "verbose" (for detailed output)
+
+Examples:
+- `/reindex` → force=true, estimateOnly=false, verbose=false
+- `/reindex verbose` → force=true, estimateOnly=false, verbose=true
+
+IMPORTANT: You MUST call `index_codebase` with `force=true`.
+
+Show final statistics including files processed, chunks indexed, tokens used, and duration.
+
+If indexing completes but the codebase still is not ready, tell the user to run `/status` next.
+- If `/status` reports failed embedding batches, fix the provider/auth issue and rerun `/index` normally.
+- If `/status` reports provider/model incompatibility again after a rebuild, surface that clearly as an unexpected issue.

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -176,12 +176,15 @@ Final line.`;
 
       const commands = loadCommandsFromDirectory(commandsDir);
 
-      expect(commands.size).toBeGreaterThanOrEqual(3);
+      expect(commands.size).toBeGreaterThanOrEqual(7);
       expect(commands.has("definition")).toBe(true);
+      expect(commands.has("peek")).toBe(true);
       expect(commands.has("search")).toBe(true);
       expect(commands.has("index")).toBe(true);
+      expect(commands.has("reindex")).toBe(true);
       expect(commands.has("find")).toBe(true);
       expect(commands.has("call-graph")).toBe(true);
+      expect(commands.has("status")).toBe(true);
 
       const definitionCmd = commands.get("definition")!;
       expect(definitionCmd.description).toBe("Find where a symbol is defined in the codebase");
@@ -191,6 +194,14 @@ Final line.`;
       const indexCmd = commands.get("index")!;
       expect(indexCmd.description).toBe("Index the codebase for semantic search");
       expect(indexCmd.template).toContain("index_codebase");
+
+      const peekCmd = commands.get("peek")!;
+      expect(peekCmd.description).toBe("Quickly find likely code locations without returning full code");
+      expect(peekCmd.template).toContain("codebase_peek");
+
+      const reindexCmd = commands.get("reindex")!;
+      expect(reindexCmd.description).toBe("Fully rebuild the codebase index from scratch");
+      expect(reindexCmd.template).toContain("force=true");
 
       const callGraphCmd = commands.get("call-graph")!;
       expect(callGraphCmd.description).toBe("Trace callers or callees using the call graph");


### PR DESCRIPTION
## Summary

Add two curated slash commands that improve discoverability for common codebase-index workflows.

## Changes

- add `/peek` as a lightweight location-first command backed by `codebase_peek`
- add `/reindex` as a friendly alias for a full `index_codebase(force=true)` rebuild
- update command docs and command-loading coverage to reflect the expanded slash-command surface

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [ ] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #71