### PR TITLE
fix: avoid native remove during index cleanup

### DIFF
--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -557,6 +557,24 @@ pub fn delete_chunks_by_file(conn: &Connection, file_path: &str) -> DbResult<usi
     Ok(count)
 }
 
+/// Delete chunks by their IDs.
+pub fn delete_chunks_by_ids(conn: &Connection, chunk_ids: &[String]) -> DbResult<usize> {
+    if chunk_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let mut deleted = 0;
+    for chunk_batch in chunk_ids.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk_batch.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("DELETE FROM chunks WHERE chunk_id IN ({})", placeholders);
+        deleted += conn.execute(&sql, rusqlite::params_from_iter(chunk_batch.iter()))?;
+    }
+
+    Ok(deleted)
+}
+
 #[derive(Debug, Clone)]
 pub struct ChunkRow {
     pub chunk_id: String,

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -558,6 +558,17 @@ impl Database {
     }
 
     #[napi]
+    pub fn delete_chunks_by_ids(&self, chunk_ids: Vec<String>) -> Result<u32> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        let count = db::delete_chunks_by_ids(&conn, &chunk_ids)
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(count as u32)
+    }
+
+    #[napi]
     pub fn add_chunks_to_branch(&self, branch: String, chunk_ids: Vec<String>) -> Result<()> {
         let conn = self
             .conn

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2174,9 +2174,11 @@ export class Indexer {
     const sharedChunkIds = new Set(database.getReferencedChunkIds(removedChunkIdList));
     const removableChunkIds = removedChunkIdList.filter((chunkId) => !sharedChunkIds.has(chunkId));
 
-    for (const chunkId of removableChunkIds) {
-      store.remove(chunkId);
-      invertedIndex.removeChunk(chunkId);
+    if (removableChunkIds.length > 0) {
+      this.rebuildVectorStoreExcludingChunkIds(store, database, removableChunkIds);
+      for (const chunkId of removableChunkIds) {
+        invertedIndex.removeChunk(chunkId);
+      }
     }
 
     for (const branchKey of this.getProjectScopedBranchCatalogCleanupKeys(Array.from(projectLocalChunkIds), Array.from(projectLocalSymbolIds))) {
@@ -2724,6 +2726,111 @@ export class Indexer {
     }
 
     return null;
+  }
+
+  private rebuildVectorStoreExcludingChunkIds(
+    store: VectorStore,
+    database: Database,
+    excludedChunkIds: Iterable<string>
+  ): void {
+    const excludedSet = new Set(excludedChunkIds);
+    if (excludedSet.size === 0) {
+      return;
+    }
+
+    const retainedEntries = store
+      .getAllMetadata()
+      .filter(({ key }) => !excludedSet.has(key));
+
+    const storeBasePath = path.join(this.indexPath, "vectors");
+    const storeIndexPath = `${storeBasePath}.usearch`;
+    const storeMetadataPath = `${storeBasePath}.meta.json`;
+    const backupIndexPath = `${storeIndexPath}.bak`;
+    const backupMetadataPath = `${storeMetadataPath}.bak`;
+
+    let backedUpIndex = false;
+    let backedUpMetadata = false;
+    let rebuiltCount = 0;
+    let skippedCount = 0;
+
+    if (existsSync(backupIndexPath)) {
+      unlinkSync(backupIndexPath);
+    }
+    if (existsSync(backupMetadataPath)) {
+      unlinkSync(backupMetadataPath);
+    }
+
+    try {
+      if (existsSync(storeIndexPath)) {
+        renameSync(storeIndexPath, backupIndexPath);
+        backedUpIndex = true;
+      }
+      if (existsSync(storeMetadataPath)) {
+        renameSync(storeMetadataPath, backupMetadataPath);
+        backedUpMetadata = true;
+      }
+
+      store.clear();
+
+      for (const { key, metadata } of retainedEntries) {
+        const chunk = database.getChunk(key);
+        if (!chunk) {
+          skippedCount += 1;
+          continue;
+        }
+
+        const embeddingBuffer = database.getEmbedding(chunk.contentHash);
+        if (!embeddingBuffer) {
+          skippedCount += 1;
+          continue;
+        }
+
+        const vector = bufferToFloat32Array(embeddingBuffer);
+        store.add(key, Array.from(vector), metadata);
+        rebuiltCount += 1;
+      }
+
+      store.save();
+
+      if (backedUpIndex && existsSync(backupIndexPath)) {
+        unlinkSync(backupIndexPath);
+      }
+      if (backedUpMetadata && existsSync(backupMetadataPath)) {
+        unlinkSync(backupMetadataPath);
+      }
+
+      this.logger.gc("info", "Rebuilt vector store to avoid native remove", {
+        excludedChunks: excludedSet.size,
+        rebuiltChunks: rebuiltCount,
+        skippedChunks: skippedCount,
+      });
+    } catch (error) {
+      try {
+        store.clear();
+      } catch {
+        // Ignore best-effort cleanup before restore.
+      }
+
+      if (existsSync(storeIndexPath)) {
+        unlinkSync(storeIndexPath);
+      }
+      if (existsSync(storeMetadataPath)) {
+        unlinkSync(storeMetadataPath);
+      }
+
+      if (backedUpIndex && existsSync(backupIndexPath)) {
+        renameSync(backupIndexPath, storeIndexPath);
+      }
+      if (backedUpMetadata && existsSync(backupMetadataPath)) {
+        renameSync(backupMetadataPath, storeMetadataPath);
+      }
+
+      if (backedUpIndex || backedUpMetadata) {
+        store.load();
+      }
+
+      throw error;
+    }
   }
 
   private getCorruptedIndexWarning(dbPath: string): string {
@@ -3303,14 +3410,22 @@ export class Indexer {
       }
     }
 
-    let removedCount = 0;
+    const removedChunkIds: string[] = [];
     for (const [chunkId] of existingChunks) {
       if (!currentChunkIds.has(chunkId)) {
-        store.remove(chunkId);
-        invertedIndex.removeChunk(chunkId);
-        removedCount++;
+        removedChunkIds.push(chunkId);
       }
     }
+
+    if (removedChunkIds.length > 0) {
+      this.rebuildVectorStoreExcludingChunkIds(store, database, removedChunkIds);
+      for (const chunkId of removedChunkIds) {
+        invertedIndex.removeChunk(chunkId);
+      }
+      database.deleteChunksByIds(removedChunkIds);
+    }
+
+    const removedCount = removedChunkIds.length;
 
     stats.totalChunks = pendingChunks.length;
     stats.existingChunks = currentChunkIds.size - pendingChunks.length;
@@ -3537,10 +3652,11 @@ export class Indexer {
             try {
               database.upsertEmbeddingsBatch(embeddingBatchItems);
             } catch (dbError) {
-              // Rollback vectors added to store if DB write fails
-              for (const { chunk } of pooledResults) {
-                store.remove(chunk.id);
-              }
+              this.rebuildVectorStoreExcludingChunkIds(
+                store,
+                database,
+                pooledResults.map(({ chunk }) => chunk.id)
+              );
               throw dbError;
             }
 
@@ -4219,21 +4335,36 @@ export class Indexer {
     }
 
     const removedFilePaths: string[] = [];
-    let removedCount = 0;
+    const removedChunkKeys: string[] = [];
+    const chunkKeysByRemovedFile = new Map<string, string[]>();
 
     for (const [filePath, chunkKeys] of filePathsToChunkKeys) {
       if (!existsSync(filePath)) {
+        chunkKeysByRemovedFile.set(filePath, chunkKeys);
         for (const key of chunkKeys) {
-          store.remove(key);
-          invertedIndex.removeChunk(key);
-          removedCount++;
+          removedChunkKeys.push(key);
         }
-        database.deleteChunksByFile(filePath);
-        database.deleteCallEdgesByFile(filePath);
-        database.deleteSymbolsByFile(filePath);
         removedFilePaths.push(filePath);
       }
     }
+
+    if (removedChunkKeys.length > 0) {
+      this.rebuildVectorStoreExcludingChunkIds(store, database, removedChunkKeys);
+      for (const key of removedChunkKeys) {
+        invertedIndex.removeChunk(key);
+      }
+    }
+
+    for (const filePath of removedFilePaths) {
+      const fileChunkKeys = chunkKeysByRemovedFile.get(filePath) ?? [];
+      if (fileChunkKeys.length > 0) {
+        database.deleteChunksByIds(fileChunkKeys);
+      }
+      database.deleteCallEdgesByFile(filePath);
+      database.deleteSymbolsByFile(filePath);
+    }
+
+    const removedCount = removedChunkKeys.length;
 
     if (removedCount > 0) {
       store.save();
@@ -4418,10 +4549,11 @@ export class Indexer {
               }))
             );
           } catch (dbError) {
-            // Rollback vectors added to store if DB write fails
-            for (const { chunk } of successfulResults) {
-              store.remove(chunk.id);
-            }
+            this.rebuildVectorStoreExcludingChunkIds(
+              store,
+              database,
+              successfulResults.map(({ chunk }) => chunk.id)
+            );
             throw dbError;
           }
         }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -754,6 +754,11 @@ export class Database {
     return this.inner.deleteChunksByFile(filePath);
   }
 
+  deleteChunksByIds(chunkIds: string[]): number {
+    if (chunkIds.length === 0) return 0;
+    return this.inner.deleteChunksByIds(chunkIds);
+  }
+
   addChunksToBranch(branch: string, chunkIds: string[]): void {
     this.inner.addChunksToBranch(branch, chunkIds);
   }

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -112,6 +112,20 @@ describe("Database", () => {
       expect(deleted).toBe(2);
       expect(db.getChunk("chunk_abc123")).toBeNull();
     });
+
+    it("should delete chunks by ids", () => {
+      db.upsertChunk(testChunk);
+      db.upsertChunk({
+        ...testChunk,
+        chunkId: "chunk_def456",
+      });
+
+      const deleted = db.deleteChunksByIds(["chunk_abc123"]);
+
+      expect(deleted).toBe(1);
+      expect(db.getChunk("chunk_abc123")).toBeNull();
+      expect(db.getChunk("chunk_def456")).not.toBeNull();
+    });
   });
 
   describe("branch_chunks", () => {

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadMergedConfig } from "../src/config/merger.js";
 import { parseConfig } from "../src/config/schema.js";
 import { Indexer } from "../src/indexer/index.js";
-import { Database } from "../src/native/index.js";
+import { Database, VectorStore } from "../src/native/index.js";
 import { hashContent } from "../src/native/index.js";
 
 describe("indexer clearIndex force rebuild", () => {
@@ -221,7 +221,14 @@ describe("indexer clearIndex force rebuild", () => {
     await indexerA.index();
     await indexerB.index();
 
+    const removeSpy = vi.spyOn(VectorStore.prototype, "remove").mockImplementation(() => {
+      throw new Error("native remove should not be called during clearIndex");
+    });
+
     await indexerA.clearIndex();
+
+    expect(removeSpy).not.toHaveBeenCalled();
+    removeSpy.mockRestore();
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
@@ -238,6 +245,40 @@ describe("indexer clearIndex force rebuild", () => {
     const fileHashCache = JSON.parse(fs.readFileSync(fileHashCachePath, "utf-8")) as Record<string, string>;
     expect(fileHashCache[projectAFile]).toBeUndefined();
     expect(typeof fileHashCache[projectBFile]).toBe("string");
+  });
+
+  it("rebuilds the vector store during incremental removals without calling native remove", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+
+    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+    const dbBefore = trackDb(new Database(dbPath));
+    const chunkIdsBefore = dbBefore.getChunksByFile(sourceFile).map((chunk) => chunk.chunkId);
+
+    fs.writeFileSync(
+      sourceFile,
+      [
+        "export function alpha() {",
+        "  return 'alpha';",
+        "}",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const removeSpy = vi.spyOn(VectorStore.prototype, "remove").mockImplementation(() => {
+      throw new Error("native remove should not be called during incremental indexing");
+    });
+
+    const stats = await indexer.index();
+
+    expect(stats.removedChunks).toBeGreaterThan(0);
+    expect(stats.failedChunks).toBe(0);
+    expect(removeSpy).not.toHaveBeenCalled();
+    removeSpy.mockRestore();
+
+    const dbAfter = trackDb(new Database(dbPath));
+    const chunkIdsAfter = new Set(dbAfter.getChunksByFile(sourceFile).map((chunk) => chunk.chunkId));
+    expect(chunkIdsBefore.some((chunkId) => !chunkIdsAfter.has(chunkId))).toBe(true);
   });
 
   it("rejects an incompatible global force reset when the shared index contains other projects", async () => {
@@ -789,6 +830,34 @@ describe("indexer clearIndex force rebuild", () => {
     const status = await indexer.getStatus();
     expect(status.indexed).toBe(false);
     expect(status.vectorCount).toBe(0);
+  });
+
+  it("rebuilds the vector store during health check cleanup without calling native remove", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+
+    const retainedFile = path.join(tempDir, "src", "retained.ts");
+    fs.writeFileSync(retainedFile, "export function gamma() { return 'g'; }\n", "utf-8");
+    await indexer.index();
+
+    fs.rmSync(sourceFile, { force: true });
+
+    const removeSpy = vi.spyOn(VectorStore.prototype, "remove").mockImplementation(() => {
+      throw new Error("native remove should not be called during health check");
+    });
+
+    const result = await indexer.healthCheck();
+
+    expect(result.removed).toBeGreaterThan(0);
+    expect(removeSpy).not.toHaveBeenCalled();
+    removeSpy.mockRestore();
+
+    const status = await indexer.getStatus();
+    expect(status.vectorCount).toBeGreaterThan(0);
+
+    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+    const db = trackDb(new Database(dbPath));
+    expect(db.getChunksByFile(retainedFile).length).toBeGreaterThan(0);
   });
 
   it("refuses to auto-reset a corrupted shared global sqlite index", async () => {

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1418,46 +1418,54 @@ describe("indexer failed batch recovery", () => {
   it("rolls back vectors and excludes failed chunks from branch when database upsert fails during index()", async () => {
     const originalUpsert = Database.prototype.upsertEmbeddingsBatch;
     let callCount = 0;
+    const removeSpy = vi.spyOn(VectorStore.prototype, "remove").mockImplementation(() => {
+      throw new Error("native remove should not be called during index rollback");
+    });
 
-    vi.spyOn(Database.prototype, "upsertEmbeddingsBatch").mockImplementation(
-      function (
-        this: Database,
-        items: Array<{ contentHash: string; embedding: Buffer; chunkText: string; model: string }>
-      ) {
-        callCount += 1;
-        if (callCount === 1) {
-          throw new Error("database write failed");
+    try {
+      vi.spyOn(Database.prototype, "upsertEmbeddingsBatch").mockImplementation(
+        function (
+          this: Database,
+          items: Array<{ contentHash: string; embedding: Buffer; chunkText: string; model: string }>
+        ) {
+          callCount += 1;
+          if (callCount === 1) {
+            throw new Error("database write failed");
+          }
+          return originalUpsert.call(this, items);
         }
-        return originalUpsert.call(this, items);
+      );
+
+      const indexer = createIndexer();
+      const stats = await indexer.index();
+
+      expect(stats.failedChunks).toBeGreaterThan(0);
+      expect(stats.indexedChunks).toBe(0);
+      expect(removeSpy).not.toHaveBeenCalled();
+
+      const status = await indexer.getStatus();
+      expect(status.indexed).toBe(false);
+      expect(status.failedBatchesCount).toBeGreaterThan(0);
+
+      const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+      const dbAfter = trackDb(new Database(dbPath));
+      const branches = dbAfter.getAllBranches();
+      const branchKey = branches.find((b) => b.includes("default")) || branches[0];
+      if (branchKey) {
+        const branchChunks = dbAfter.getBranchChunkIds(branchKey);
+        expect(branchChunks.length).toBe(0);
       }
-    );
 
-    const indexer = createIndexer();
-    const stats = await indexer.index();
-
-    expect(stats.failedChunks).toBeGreaterThan(0);
-    expect(stats.indexedChunks).toBe(0);
-
-    const status = await indexer.getStatus();
-    expect(status.indexed).toBe(false);
-    expect(status.failedBatchesCount).toBeGreaterThan(0);
-
-    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
-    const dbAfter = trackDb(new Database(dbPath));
-    const branches = dbAfter.getAllBranches();
-    const branchKey = branches.find((b) => b.includes("default")) || branches[0];
-    if (branchKey) {
-      const branchChunks = dbAfter.getBranchChunkIds(branchKey);
-      expect(branchChunks.length).toBe(0);
-    }
-
-    const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
-    if (fs.existsSync(failedBatchesPath)) {
-      const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
-        error: string;
-      }>;
-      expect(failedBatches.length).toBeGreaterThan(0);
-      expect(failedBatches[0]?.error).toContain("database write failed");
+      const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
+      if (fs.existsSync(failedBatchesPath)) {
+        const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+          error: string;
+        }>;
+        expect(failedBatches.length).toBeGreaterThan(0);
+        expect(failedBatches[0]?.error).toContain("database write failed");
+      }
+    } finally {
+      removeSpy.mockRestore();
     }
   });
 
@@ -1471,44 +1479,52 @@ describe("indexer failed batch recovery", () => {
 
     const originalUpsert = Database.prototype.upsertEmbeddingsBatch;
     let callCount = 0;
+    const removeSpy = vi.spyOn(VectorStore.prototype, "remove").mockImplementation(() => {
+      throw new Error("native remove should not be called during retry rollback");
+    });
 
-    vi.spyOn(Database.prototype, "upsertEmbeddingsBatch").mockImplementation(
-      function (
-        this: Database,
-        items: Array<{ contentHash: string; embedding: Buffer; chunkText: string; model: string }>
-      ) {
-        callCount += 1;
-        if (callCount === 1) {
-          throw new Error("database write failed during retry");
+    try {
+      vi.spyOn(Database.prototype, "upsertEmbeddingsBatch").mockImplementation(
+        function (
+          this: Database,
+          items: Array<{ contentHash: string; embedding: Buffer; chunkText: string; model: string }>
+        ) {
+          callCount += 1;
+          if (callCount === 1) {
+            throw new Error("database write failed during retry");
+          }
+          return originalUpsert.call(this, items);
         }
-        return originalUpsert.call(this, items);
+      );
+
+      const retry = await indexer.retryFailedBatches();
+
+      expect(retry.succeeded).toBe(0);
+      expect(retry.failed).toBeGreaterThan(0);
+      expect(removeSpy).not.toHaveBeenCalled();
+
+      const status = await indexer.getStatus();
+      expect(status.failedBatchesCount).toBeGreaterThan(0);
+
+      const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+      const dbAfter = trackDb(new Database(dbPath));
+      const branches = dbAfter.getAllBranches();
+      const branchKey = branches.find((b) => b.includes("default")) || branches[0];
+      if (branchKey) {
+        const branchChunks = dbAfter.getBranchChunkIds(branchKey);
+        expect(branchChunks.length).toBe(0);
       }
-    );
 
-    const retry = await indexer.retryFailedBatches();
-
-    expect(retry.succeeded).toBe(0);
-    expect(retry.failed).toBeGreaterThan(0);
-
-    const status = await indexer.getStatus();
-    expect(status.failedBatchesCount).toBeGreaterThan(0);
-
-    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
-    const dbAfter = trackDb(new Database(dbPath));
-    const branches = dbAfter.getAllBranches();
-    const branchKey = branches.find((b) => b.includes("default")) || branches[0];
-    if (branchKey) {
-      const branchChunks = dbAfter.getBranchChunkIds(branchKey);
-      expect(branchChunks.length).toBe(0);
+      const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
+      if (fs.existsSync(failedBatchesPath)) {
+        const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+          error: string;
+        }>;
+        expect(failedBatches.length).toBeGreaterThan(0);
+        expect(failedBatches[0]?.error).toContain("database write failed during retry");
+      }
+    } finally {
+      removeSpy.mockRestore();
     }
-
-     const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
-     if (fs.existsSync(failedBatchesPath)) {
-       const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
-         error: string;
-       }>;
-       expect(failedBatches.length).toBeGreaterThan(0);
-       expect(failedBatches[0]?.error).toContain("database write failed during retry");
-     }
-   });
+  });
 });


### PR DESCRIPTION
## Summary

Avoid the synchronous native `VectorStore.remove()` cleanup path during normal index maintenance, and harden the rebuild workaround so SQLite and vector-store state stay in sync.

## Changes

- rebuild vector-store cleanup paths from SQLite-backed chunk and embedding state instead of calling native `remove()` during clear-index, incremental cleanup, health checks, and rollback flows
- add native `deleteChunksByIds()` support so incremental stale-chunk cleanup removes SQLite rows immediately instead of relying on later orphan GC
- expand regression coverage for database deletion-by-id, retained-file health-check behavior, incremental cleanup, and rollback paths that must not call native `remove()`

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [ ] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #79