### PR TITLE
chore: prepare v0.8.0 release metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - AI Agent Guidelines for opencode-codebase-index
 
-**Generated:** 2025-01-16 | **Commit:** 9f94822 | **Branch:** main
+**Generated:** 2026-05-14 | **Commit:** 929083b | **Branch:** release/v0.8.0
 
 Semantic codebase indexing plugin for OpenCode. Hybrid TypeScript/Rust architecture:
 - **TypeScript** (`src/`): Plugin logic, embedding providers, OpenCode tools
@@ -49,11 +49,11 @@ src/
 
 native/src/
 ├── lib.rs                # NAPI exports: parse_file, VectorStore, Database, InvertedIndex
-├── parser.rs             # Tree-sitter parsing (14 languages: TS, JS, Python, Rust, Go, Java, C#, Ruby, Bash, C, C++, JSON, TOML, YAML)
+├── parser.rs             # Tree-sitter parsing (17 languages: TS, JS, Python, Rust, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, JSON, TOML, YAML, Zig)
 ├── chunker.rs            # Semantic chunking with overlap
 ├── store.rs              # usearch vector store (F16 quantization)
 ├── db.rs                 # SQLite: embeddings, chunks, branch catalog, symbols, call edges
-├── call_extractor.rs     # Tree-sitter query-based call extraction (TS/JS, Python, Go, Rust)
+├── call_extractor.rs     # Tree-sitter query-based call extraction (TS/JS, Python, Go, Rust, PHP, Zig, Apex)
 ├── inverted_index.rs     # BM25 keyword search
 ├── hasher.rs             # xxhash content hashing
 └── types.rs              # Shared types (Language enum with from_string)
@@ -256,20 +256,25 @@ When creating a new release:
 1. **Update `CHANGELOG.md`** - Add new version section with Added/Changed/Fixed entries
 2. **Bump version in `package.json`** - Follow semver (patch for fixes, minor for features)
 3. **Commit changes** - `git commit -m "chore: bump version to X.Y.Z"`
-4. **Push to origin** - `git push origin main`
-5. **Create git tag** - `git tag vX.Y.Z`
-6. **Push tag** - `git push origin vX.Y.Z`
-7. **Create GitHub release** - `gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."`
+4. **Push the release branch** - `git push -u origin release/vX.Y.Z`
+5. **Open and merge a PR into `main`**
+6. **Create git tag** - `git tag vX.Y.Z`
+7. **Push tag** - `git push origin vX.Y.Z`
+8. **Create GitHub release** - `gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."`
+
+Follow the repository workflow: prepare the release on a `release/vX.Y.Z` branch, open a PR into `main`, merge the PR, then tag and publish from the merged commit.
 
 Example:
 ```bash
-# After updating CHANGELOG.md and package.json
-git add CHANGELOG.md package.json
-git commit -m "chore: bump version to 0.3.1"
-git push origin main
-git tag v0.3.1
-git push origin v0.3.1
-gh release create v0.3.1 --title "v0.3.1 - Search Performance Optimizations" --notes "$(cat <<'EOF'
+# After updating CHANGELOG.md, package.json, and package-lock.json on release/v0.8.0
+git checkout -b release/v0.8.0
+git add CHANGELOG.md package.json package-lock.json
+git commit -m "chore: prepare v0.8.0 release metadata"
+git push -u origin release/v0.8.0
+# Open and merge the PR into main, then tag the merged commit on main
+git tag v0.8.0
+git push origin v0.8.0
+gh release create v0.8.0 --title "v0.8.0 - Apex semantic parsing" --notes "$(cat <<'EOF'
 ## What's New
 ...
 EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-14
+
 ### Added
 - **Apex semantic parsing**: Added tree-sitter-based semantic chunking for Salesforce Apex source files (`.cls` and `.trigger`) via the [`tree-sitter-sfapex`](https://github.com/aheber/tree-sitter-sfapex) grammar. Recognizes class, interface, enum, method, constructor, and trigger declarations with leading JavaDoc-style block comments attached to their target chunks. Anonymous Apex (`.apex`), SOQL, and SOSL standalone files are out of scope.
 - **Apex call graph extraction**: Method invocations, constructor calls (`new MyClass(...)`), and instance/static method calls are extracted for the `call_graph` tool. Apex is case-insensitive at the language level, so callee names are normalized to lowercase during extraction (matching the existing PHP behavior). Apex has no imports — namespaces are referenced via fully qualified names — so no `Import` edges are produced.
@@ -265,7 +267,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.5.2...v0.6.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
-| < 0.5.0 | :x:                |
+| 0.8.x   | :white_check_mark: |
+| < 0.8.0 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "~1.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Prepare the `v0.8.0` release branch by cutting the Apex release notes into the changelog, bumping package metadata to `0.8.0`, and aligning contributor/support docs with the current protected-branch release workflow.

## Changes

- bump `package.json` and `package-lock.json` from `0.7.0` to `0.8.0`
- cut the existing Apex semantic parsing and Apex call-graph entries into `CHANGELOG.md` as `## [0.8.0] - 2026-05-14` and advance compare links
- update `AGENTS.md` and `SECURITY.md` so release guidance, language/support coverage, and protected-branch workflow match the current repo state

## Testing

How were these changes tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

- N/A (release preparation PR)