### PR TITLE
docs: fix v0.8.0 changelog scope

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -67,6 +67,7 @@ template: |
 
   ## Release checks
 
+  - [ ] Draft notes reconciled against the full previous release tag diff (for example `git log --oneline <previous-tag>..HEAD`)
   - [ ] `CHANGELOG.md` updated
   - [ ] `package.json` version bumped
   - [ ] `npm run build && npm run typecheck && npm run lint && npm run test:run` passed

--- a/.github/workflows/release-label-check.yml
+++ b/.github/workflows/release-label-check.yml
@@ -21,7 +21,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = (context.payload.pull_request?.labels || []).map((l) => l.name);
+            const pullRequestNumber = context.payload.pull_request?.number;
+
+            if (!pullRequestNumber) {
+              core.setFailed('Could not determine pull request number from event payload.');
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+
+            const labels = (pullRequest.labels || [])
+              .map((label) => label.name)
+              .filter((label) => typeof label === 'string');
 
             const categoryLabels = new Set([
               'feature',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,13 +254,14 @@ npm run build && npm run typecheck && npm run lint && npm run test:run
 When creating a new release:
 
 1. **Update `CHANGELOG.md`** - Add new version section with Added/Changed/Fixed entries
-2. **Bump version in `package.json`** - Follow semver (patch for fixes, minor for features)
-3. **Commit changes** - `git commit -m "chore: bump version to X.Y.Z"`
-4. **Push the release branch** - `git push -u origin release/vX.Y.Z`
-5. **Open and merge a PR into `main`**
-6. **Create git tag** - `git tag vX.Y.Z`
-7. **Push tag** - `git push origin vX.Y.Z`
-8. **Create GitHub release** - `gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."`
+2. **Reconcile the full previous-tag delta** - Compare `git log --oneline <previous-tag>..HEAD` with the Release Drafter draft so `CHANGELOG.md` and release notes reflect everything shipped since the last release, not only the current `Unreleased` bullets
+3. **Bump version in `package.json`** - Follow semver (patch for fixes, minor for features)
+4. **Commit changes** - `git commit -m "chore: bump version to X.Y.Z"`
+5. **Push the release branch** - `git push -u origin release/vX.Y.Z`
+6. **Open and merge a PR into `main`**
+7. **Create git tag** - `git tag vX.Y.Z`
+8. **Push tag** - `git push origin vX.Y.Z`
+9. **Create GitHub release** - `gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."`
 
 Follow the repository workflow: prepare the release on a `release/vX.Y.Z` branch, open a PR into `main`, merge the PR, then tag and publish from the merged commit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2026-05-14
 
 ### Added
+- **Git worktree fallback and reuse**: Fresh git worktrees now inherit the main repository's project-scoped `.opencode` config and index when no local worktree state exists, including matching eval-path and knowledge-base handling.
 - **Apex semantic parsing**: Added tree-sitter-based semantic chunking for Salesforce Apex source files (`.cls` and `.trigger`) via the [`tree-sitter-sfapex`](https://github.com/aheber/tree-sitter-sfapex) grammar. Recognizes class, interface, enum, method, constructor, and trigger declarations with leading JavaDoc-style block comments attached to their target chunks. Anonymous Apex (`.apex`), SOQL, and SOSL standalone files are out of scope.
 - **Apex call graph extraction**: Method invocations, constructor calls (`new MyClass(...)`), and instance/static method calls are extracted for the `call_graph` tool. Apex is case-insensitive at the language level, so callee names are normalized to lowercase during extraction (matching the existing PHP behavior). Apex has no imports — namespaces are referenced via fully qualified names — so no `Import` edges are produced.
+- **Zig language support**: Added tree-sitter semantic parsing, file discovery, and call-graph extraction for `.zig` files.
+- **New slash commands**: Added `/peek` for lightweight location-first discovery and `/reindex` as a full rebuild shortcut.
+
+### Changed
+- **Ollama oversized-input handling**: Built-in Ollama embeddings now use pooled multi-part requests, broader context-length detection, and progressive retry/backoff behavior for oversized inputs.
+- **Release documentation and support guidance**: Aligned maintainer guidance, support policy, and release workflow docs with the protected-branch release process used for `v0.8.0`.
+
+### Fixed
+- **Index reset and cleanup hardening**: Fixed shared/global rebuild flows, SQLite corruption recovery, stale chunk ownership cleanup, and related rebuild-state edge cases across project and worktree setups.
+- **Windows build and test reliability**: Fixed Windows-native build/test failures with explicit database/indexer cleanup, portable path handling, and cross-platform native pretest scripting.
+- **Database close lifecycle**: Hardened `Database.close()` so use-after-close fails fast instead of silently swapping to an in-memory SQLite connection.
+- **Semantic search and rebuild cleanup**: Restored identifier fallback in semantic search and rebuilt cleanup paths from SQLite-backed state without relying on unsafe native remove flows.
 
 ## [0.7.0] - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ To ensure release notes reflect all merged work, this repo uses a draft-release 
    - PRs are validated by CI (`Release Label Check`) and fail if no release category label is present
 2. **Let Release Drafter build the draft notes** automatically from merged PRs on `main`.
 3. **Before publishing**:
+   - compare `git log --oneline vX.Y.Z..HEAD` (or the previous release tag range) against the draft release notes so the release summary covers the full shipped delta, not just the current `CHANGELOG.md` `Unreleased` section
    - copy/finalize relevant highlights into `CHANGELOG.md`
    - bump `package.json` version
    - run: `npm run build && npm run typecheck && npm run lint && npm run test:run`


### PR DESCRIPTION
## Summary

Correct the checked-in `v0.8.0` changelog entry so it matches the actual `v0.7.0...v0.8.0` release scope, and add a maintainer guardrail so future releases reconcile the full previous-tag delta before publishing notes.

## Changes

- expand `CHANGELOG.md` `## [0.8.0] - 2026-05-14` to cover the shipped worktree fallback/reuse, Zig support, new `/peek` and `/reindex` commands, Ollama oversized-input handling, Windows reliability fixes, cleanup/corruption-recovery hardening, and Database.close lifecycle fixes
- tighten `README.md` release instructions so maintainers compare the previous release tag range against the draft notes before publishing
- update `AGENTS.md` and `.github/release-drafter.yml` so the same previous-tag reconciliation step is part of the maintainer checklist and draft-release checklist

## Testing

How were these changes tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Build passes (`npm run build`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Tests pass (`npm run test:run`)
- [ ] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

- N/A (follow-up changelog/process correction after publishing `v0.8.0`)