### PR TITLE
Fix MCP server to work via npx without pre-installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
      "mcpServers": {
        "codebase-index": {
          "command": "npx",
-         "args": ["opencode-codebase-index-mcp", "--project", "/path/to/your/project"]
+         "args": ["opencode-codebase-index", "--mcp", "--project", "/path/to/your/project"]
        }
      }
    }
@@ -111,7 +111,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
      "mcpServers": {
        "codebase-index": {
          "command": "npx",
-         "args": ["opencode-codebase-index-mcp", "--project", "/path/to/your/project"]
+         "args": ["opencode-codebase-index", "--mcp", "--project", "/path/to/your/project"]
        }
      }
    }
@@ -119,9 +119,9 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
 
 3. **CLI options**
    ```bash
-   npx opencode-codebase-index-mcp --project /path/to/repo    # specify project root
-   npx opencode-codebase-index-mcp --config /path/to/config   # custom config file
-   npx opencode-codebase-index-mcp                            # uses current directory
+   npx opencode-codebase-index --mcp --project /path/to/repo    # specify project root
+   npx opencode-codebase-index --mcp --config /path/to/config   # custom config file
+   npx opencode-codebase-index --mcp                            # uses current directory
    ```
 
 The MCP server exposes all 9 tools (`codebase_search`, `codebase_peek`, `find_similar`, `call_graph`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 4 prompts (`search`, `find`, `index`, `status`).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     }
   },
   "bin": {
-    "opencode-codebase-index-mcp": "dist/cli.js"
+    "opencode-codebase-index-mcp": "dist/cli.js",
+    "opencode-codebase-index": "dist/cli.js"
   },
   "license": "MIT",
   "author": "Kenneth",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,19 +7,25 @@ import { handleEvalCommand } from "./eval/cli.js";
 import { createMcpServer } from "./mcp-server.js";
 import { loadMergedConfig } from "./config/merger.js";
 
-function parseArgs(argv: string[]): { project: string; config?: string } {
+function parseArgs(argv: string[]): { help: boolean; mcp: boolean; project: string; config?: string } {
+  let help = false;
+  let mcp = false;
   let project = process.cwd();
   let config: string | undefined;
 
   for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === "--project" && argv[i + 1]) {
+    if (argv[i] === "--help" || argv[i] === "-h") {
+      help = true;
+    } else if (argv[i] === "--mcp") {
+      mcp = true;
+    } else if (argv[i] === "--project" && argv[i + 1]) {
       project = path.resolve(argv[++i]);
     } else if (argv[i] === "--config" && argv[i + 1]) {
       config = path.resolve(argv[++i]);
     }
   }
 
-  return { project, config };
+  return { help, mcp, project, config };
 }
 
 async function main(): Promise<void> {
@@ -29,6 +35,33 @@ async function main(): Promise<void> {
   }
 
   const args = parseArgs(process.argv);
+
+  // Show help and exit early (before trying to load native module)
+  if (args.help) {
+    console.log(`Usage:
+  npx opencode-codebase-index --mcp --project PATH    Start MCP server
+  npx opencode-codebase-index --help                   Show this help
+  npx opencode-codebase-index eval ...                 Run evaluation
+
+Aliases:
+  npx opencode-codebase-index-mcp  (equivalent to --mcp)
+`);
+    process.exit(0);
+  }
+
+  // --mcp flag required when using opencode-codebase-index bin
+  // (opencode-codebase-index-mcp bin defaults to MCP mode for backwards compatibility)
+  const isMcpBin = process.argv[0]?.endsWith("codebase-index-mcp") || process.execPath.includes("codebase-index-mcp");
+  const shouldRunMcp = args.mcp || isMcpBin;
+
+  if (!shouldRunMcp) {
+    console.error("Usage: npx opencode-codebase-index --mcp --project PATH");
+    console.error("       npx opencode-codebase-index eval ...");
+    console.error("\nNote: Use '--mcp' flag to start the MCP server.");
+    console.error("Or use 'npx opencode-codebase-index-mcp' for backwards compatibility.");
+    process.exit(1);
+  }
+
   const rawConfig = loadMergedConfig(args.project);
   const config = parseConfig(rawConfig);
 


### PR DESCRIPTION
The README currently tells users to run `npx opencode-codebase-index-mcp`, but that package does not exist on npm. The `opencode-codebase-index-mcp` binary is only available after installing the main `opencode-codebase-index` package locally, which defeats the purpose of using `npx` in the first place.

This fixes it by adding `opencode-codebase-index` as a second bin entry in package.json (pointing to the same `dist/cli.js`). Since the bin name now matches the npm package name, `npx opencode-codebase-index --mcp` resolves and runs in one step.

Changes:
- **package.json**: Added `"opencode-codebase-index": "dist/cli.js"` bin alias alongside the existing `opencode-codebase-index-mcp` entry
- **src/cli.ts**: Added `--mcp` flag (required for the new bin) and `--help` flag. The old `opencode-codebase-index-mcp` bin still works without `--mcp` for backwards compatibility.
- **README.md**: Updated all MCP examples to use the new command format

The old `opencode-codebase-index-mcp` bin and its existing behavior are unchanged.