### PR TITLE
feat: improve definition-first retrieval routing

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2616,6 +2616,7 @@ export class Indexer {
     options?: {
       definitionIntent?: boolean;
       hasIdentifierHints?: boolean;
+      hasExplicitLookupHint?: boolean;
     }
   ): Promise<RankedCandidate[]> {
     const reranker = this.config.reranker;
@@ -2631,7 +2632,11 @@ export class Indexer {
       return candidates;
     }
 
-    if (options?.hasIdentifierHints === true && preferSourcePaths && !docIntent) {
+    if (
+      preferSourcePaths &&
+      !docIntent &&
+      (options?.hasIdentifierHints === true || options?.hasExplicitLookupHint === true)
+    ) {
       return candidates;
     }
 
@@ -4277,9 +4282,14 @@ export class Indexer {
       hybridWeight,
       prioritizeSourcePaths: sourceIntent,
     });
+    const primaryIdentifierHint = extractPrimaryIdentifierQueryHint(query);
+    const hasSpecificPrimaryLookupHint = primaryIdentifierHint !== null && !GENERIC_LOOKUP_TERMS.has(primaryIdentifierHint);
+    const hasExplicitLookupPhrase = hasPatternMatch(query.toLowerCase(), STRONG_DEFINITION_PATTERNS) ||
+      hasPatternMatch(query.toLowerCase(), IMPLEMENTATION_LOOKUP_PATTERNS);
     const rerankedCombined = await this.rerankCandidatesWithApi(query, combined, {
       definitionIntent: options?.definitionIntent === true,
       hasIdentifierHints: identifierHints.length > 0,
+      hasExplicitLookupHint: hasSpecificPrimaryLookupHint && hasExplicitLookupPhrase,
     });
     const fusionMs = performance.now() - fusionStartTime;
 
@@ -4318,10 +4328,6 @@ export class Indexer {
       sourceIntent
     );
 
-    const primaryIdentifierHint = extractPrimaryIdentifierQueryHint(query);
-    const hasSpecificPrimaryLookupHint = primaryIdentifierHint !== null && !GENERIC_LOOKUP_TERMS.has(primaryIdentifierHint);
-    const hasExplicitLookupPhrase = hasPatternMatch(query.toLowerCase(), STRONG_DEFINITION_PATTERNS) ||
-      hasPatternMatch(query.toLowerCase(), IMPLEMENTATION_LOOKUP_PATTERNS);
     const prePrimaryLane = mergeTieredResults(deterministicIdentifierLane, identifierLane, maxResults * 4);
     const primaryLane = hasSpecificPrimaryLookupHint
       ? mergeTieredResults(symbolLane, prePrimaryLane, maxResults * 4)

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -547,6 +547,17 @@ const SOURCE_INTENT_HINTS = new Set([
   "where",
 ]);
 
+const GENERIC_LOOKUP_TERMS = new Set([
+  ...SOURCE_INTENT_HINTS,
+  "code",
+  "source",
+  "actual",
+  "defined",
+  "definition",
+  "located",
+  "path",
+]);
+
 const DOC_TEST_INTENT_HINTS = new Set([
   "test",
   "tests",
@@ -565,6 +576,37 @@ const DOC_INTENT_HINTS = new Set([
   "guide",
   "usage",
 ]);
+
+type QueryIntentKind = "definition" | "implementation" | "doc_test" | "exploratory" | "neutral";
+
+interface QueryIntentProfile {
+  kind: QueryIntentKind;
+  preferSourcePaths: boolean;
+  definitionFirst: boolean;
+  hasIdentifierHints: boolean;
+  hasCodeHints: boolean;
+  docIntent: "docs" | "test" | "mixed" | "none";
+}
+
+const STRONG_DEFINITION_PATTERNS = [
+  /\bwhere\s+is\b/,
+  /\bwhere\s+does\b/,
+  /\bdefinition\s+of\b/,
+  /\bdefined\s+in\b/,
+  /\bimplementation\s+of\b/,
+  /\bsource\s+(?:for|of)\b/,
+  /\bpath\s+to\b/,
+  /\blocated?\s+in\b/,
+];
+
+const IMPLEMENTATION_LOOKUP_PATTERNS = [
+  /\bimplement(?:ation|ed|s)?\b/,
+  /\bsource\s+code\b/,
+  /\bactual\s+code\b/,
+  /\bfunction\b/,
+  /\bmethod\b/,
+  /\bclass\b/,
+];
 
 function setBoundedCache(
   cache: Map<string, Set<string>>,
@@ -735,8 +777,18 @@ function classifyQueryIntent(tokens: string[]): "source" | "doc_test" | "neutral
   return "neutral";
 }
 
-function classifyQueryIntentRaw(query: string): "source" | "doc_test" | "neutral" {
+function hasPatternMatch(text: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function classifyQueryIntentProfile(query: string, forceDefinitionIntent: boolean = false): QueryIntentProfile {
   const lowerQuery = query.toLowerCase();
+  const identifierHints = extractIdentifierHints(query);
+  const codeTermHints = extractCodeTermHints(query);
+  const filePathHint = extractFilePathHint(query);
+  const queryTokens = Array.from(tokenizeTextForRanking(query));
+  const docIntent = classifyDocIntent(queryTokens);
+  const tokenIntent = classifyQueryIntent(queryTokens);
   const docTestRawHits = Array.from(DOC_TEST_INTENT_HINTS).filter((hint) =>
     new RegExp(`\\b${hint}\\b`).test(lowerQuery)
   ).length;
@@ -752,23 +804,65 @@ function classifyQueryIntentRaw(query: string): "source" | "doc_test" | "neutral
     "pipeline",
     "indexer",
   ].filter((hint) => new RegExp(`\\b${hint}\\b`).test(lowerQuery)).length;
+  const shortMixedTestLookupBonus = hasPatternMatch(lowerQuery, STRONG_DEFINITION_PATTERNS) &&
+    /\btests?\b/.test(lowerQuery) &&
+    !/\b(?:benchmark|benchmarks|fixture|fixtures|readme|docs|documentation)\b/.test(lowerQuery)
+      ? 1
+      : 0;
+  const hasStrongDefinitionPhrase = hasPatternMatch(lowerQuery, STRONG_DEFINITION_PATTERNS);
+  const hasImplementationLookupPhrase = hasPatternMatch(lowerQuery, IMPLEMENTATION_LOOKUP_PATTERNS);
+  const hasExactLookupTarget = identifierHints.length > 0 || filePathHint !== null;
+  const hasStrongLookupTarget = hasExactLookupTarget;
+  const hasCodeHints = identifierHints.length > 0 || codeTermHints.length > 0;
 
-  if (docTestRawHits > sourceRawHits) {
+  const docTestDominant = !forceDefinitionIntent && docIntent !== "none" && docTestRawHits > (sourceRawHits + shortMixedTestLookupBonus);
+  const preferSourcePaths = forceDefinitionIntent || (
+    !docTestDominant && (
+      ((docIntent === "none" || docIntent === "test" || docIntent === "mixed") && hasImplementationLookupPhrase && hasCodeHints) ||
+      ((docIntent === "none" || docIntent === "test" || docIntent === "mixed") && hasStrongDefinitionPhrase && hasStrongLookupTarget) ||
+      ((docIntent === "none" || docIntent === "test" || docIntent === "mixed") && tokenIntent === "source" && hasCodeHints)
+    )
+  );
+  const definitionFirst = forceDefinitionIntent || (
+    preferSourcePaths &&
+    !docTestDominant &&
+    hasStrongLookupTarget &&
+    ((docIntent === "none" && hasStrongDefinitionPhrase) ||
+      (docIntent === "none" && hasImplementationLookupPhrase))
+  );
+
+  let kind: QueryIntentKind = "neutral";
+  if (docTestDominant || tokenIntent === "doc_test") {
+    kind = "doc_test";
+  } else if (definitionFirst) {
+    kind = "definition";
+  } else if (preferSourcePaths) {
+    kind = "implementation";
+  } else if (hasCodeHints) {
+    kind = "exploratory";
+  }
+
+  return {
+    kind,
+    preferSourcePaths,
+    definitionFirst,
+    hasIdentifierHints: identifierHints.length > 0,
+    hasCodeHints,
+    docIntent,
+  };
+}
+
+function classifyQueryIntentRaw(query: string): "source" | "doc_test" | "neutral" {
+  const intent = classifyQueryIntentProfile(query);
+  if (intent.kind === "doc_test") {
     return "doc_test";
   }
 
-  if (sourceRawHits > docTestRawHits && sourceRawHits > 0) {
+  if (intent.preferSourcePaths) {
     return "source";
   }
 
-  const hasWhereIsPattern = /\bwhere\s+is\b/.test(lowerQuery);
-  const hasIdentifierHints = extractIdentifierHints(query).length > 0;
-  if (hasWhereIsPattern && hasIdentifierHints && docTestRawHits === 0) {
-    return "source";
-  }
-
-  const queryTokens = Array.from(tokenizeTextForRanking(query));
-  return classifyQueryIntent(queryTokens);
+  return "neutral";
 }
 
 function classifyDocIntent(tokens: string[]): "docs" | "test" | "mixed" | "none" {
@@ -1081,10 +1175,19 @@ export function rerankResults(
     return candidates;
   }
 
+  const intentProfile = classifyQueryIntentProfile(query);
   const queryTokenList = Array.from(queryTokens);
-  const docIntent = classifyDocIntent(queryTokenList);
-  const preferSourcePaths = options?.prioritizeSourcePaths ?? classifyQueryIntentRaw(query) === "source";
+  const docIntent = intentProfile.docIntent;
+  const preferSourcePaths = options?.prioritizeSourcePaths ?? intentProfile.preferSourcePaths;
+  const definitionFirst = preferSourcePaths && intentProfile.definitionFirst;
   const identifierHints = extractIdentifierHints(query);
+  const primaryHint = extractPrimaryIdentifierQueryHint(query);
+  const primaryVariants = primaryHint ? normalizeIdentifierVariants(primaryHint) : [];
+  const hasRealImplementationCandidate = candidates.some((candidate) =>
+    isLikelyImplementationPath(candidate.metadata.filePath) &&
+    isImplementationChunkType(candidate.metadata.chunkType) &&
+    !isTestOrDocPath(candidate.metadata.filePath)
+  );
 
   const head = candidates.slice(0, topN).map((candidate, idx) => {
     const pathTokens = splitPathTokens(candidate.metadata.filePath);
@@ -1119,12 +1222,57 @@ export function rerankResults(
     const lowerPath = candidate.metadata.filePath.toLowerCase();
     const lowerName = (candidate.metadata.name ?? "").toLowerCase();
     const hasIdentifierMatch = identifierHints.some((id) => lowerPath.includes(id) || lowerName.includes(id));
+    const identifierMatchScore = identifierHints.length > 0
+      ? scoreIdentifierMatch(candidate.metadata.name, candidate.metadata.filePath, identifierHints)
+      : 0;
+    const compactName = lowerName.replace(/[^a-z0-9]/g, "");
+    const exactPrimaryNameMatch = primaryVariants.some((variant) =>
+      lowerName === variant || compactName === variant.replace(/[^a-z0-9]/g, "")
+    );
+    const isDocumentationCandidate = isDocumentationPath(candidate.metadata.filePath);
+    const isFixtureOrExamplePath = lowerPath.includes("fixture") || lowerPath.includes("example");
+    const isBenchmarkPath = lowerPath.includes("benchmark");
+    const implementationChunk = isImplementationChunkType(candidate.metadata.chunkType);
+    const likelyImplementationPath = isLikelyImplementationPath(candidate.metadata.filePath);
+    const exactNameTokenMatch = queryTokenList.some((token) => lowerName === token);
 
-    const implementationPathBoost = preferSourcePaths && isLikelyImplementationPath(candidate.metadata.filePath) ? 0.08 : 0;
+    const implementationPathBoost = preferSourcePaths && likelyImplementationPath
+      ? (definitionFirst ? 0.14 : 0.08)
+      : likelyImplementationPath
+        ? 0.02
+        : 0;
+    const implementationChunkBoost = preferSourcePaths && implementationChunk
+      ? (definitionFirst ? 0.12 : 0.06)
+      : implementationChunk
+        ? 0.04
+        : 0;
     const isReadmePath = candidate.metadata.filePath.toLowerCase().includes("readme");
-    const testDocPenalty = preferSourcePaths && likelyTestOrDoc ? 0.12 : 0;
+    const sourcePenalty = preferSourcePaths && hasRealImplementationCandidate
+      ? isBenchmarkPath
+        ? 0.28
+        : isFixtureOrExamplePath
+          ? 0.24
+          : isDocumentationCandidate
+            ? (docIntent === "test" || docIntent === "mixed" ? 0.08 : 0.2)
+            : likelyTestOrDoc
+              ? (docIntent === "test" || docIntent === "mixed" ? 0.04 : 0.18)
+              : 0
+      : 0;
     const readmeDocBoost = !preferSourcePaths && isReadmePath ? 0.08 : 0;
-    const identifierBoost = hasIdentifierMatch ? 0.12 : 0;
+    const exactNameBoost = exactNameTokenMatch
+      ? implementationChunk
+        ? 0.12
+        : 0.03
+      : 0;
+    const identifierBoost = exactPrimaryNameMatch
+      ? (definitionFirst ? 0.3 : 0.18)
+      : identifierMatchScore >= 1
+        ? (definitionFirst ? 0.26 : 0.16)
+        : identifierMatchScore >= 0.8
+          ? (definitionFirst ? 0.18 : 0.12)
+          : hasIdentifierMatch
+            ? 0.08
+            : 0;
     const tokenCoverage = queryTokenList.length > 0
       ? (exactOrPrefixNameHits + pathOverlap + chunkTypeHits) / queryTokenList.length
       : 0;
@@ -1135,10 +1283,12 @@ export function rerankResults(
       pathOverlap * 0.03 +
       chunkTypeHits * 0.02 +
       coverageBoost +
+      exactNameBoost +
       identifierBoost +
       implementationPathBoost -
-      testDocPenalty +
+      sourcePenalty +
       readmeDocBoost +
+      implementationChunkBoost +
       chunkTypeBoost(candidate.metadata.chunkType);
 
     return {
@@ -1146,9 +1296,14 @@ export function rerankResults(
       boostedScore: candidate.score + deterministicBoost,
       originalIndex: idx,
       hasIdentifierMatch,
-      implementationChunk: isImplementationChunkType(candidate.metadata.chunkType),
-      isLikelyImplementationPath: isLikelyImplementationPath(candidate.metadata.filePath),
+      identifierMatchScore,
+      exactPrimaryNameMatch,
+      implementationChunk,
+      isLikelyImplementationPath: likelyImplementationPath,
       isTestOrDocPath: likelyTestOrDoc,
+      isDocumentationCandidate,
+      isBenchmarkPath,
+      isFixtureOrExamplePath,
       isReadmePath,
     };
   });
@@ -1162,6 +1317,12 @@ export function rerankResults(
 
   if (preferSourcePaths) {
     head.sort((a, b) => {
+      const aExactPrimary = a.exactPrimaryNameMatch ? 1 : 0;
+      const bExactPrimary = b.exactPrimaryNameMatch ? 1 : 0;
+      if (aExactPrimary !== bExactPrimary) return bExactPrimary - aExactPrimary;
+
+      if (b.identifierMatchScore !== a.identifierMatchScore) return b.identifierMatchScore - a.identifierMatchScore;
+
       const aId = a.hasIdentifierMatch ? 1 : 0;
       const bId = b.hasIdentifierMatch ? 1 : 0;
       if (aId !== bId) return bId - aId;
@@ -1174,9 +1335,23 @@ export function rerankResults(
       const bImplementationPath = b.isLikelyImplementationPath ? 1 : 0;
       if (aImplementationPath !== bImplementationPath) return bImplementationPath - aImplementationPath;
 
-      const aTestDoc = a.isTestOrDocPath ? 1 : 0;
-      const bTestDoc = b.isTestOrDocPath ? 1 : 0;
-      if (aTestDoc !== bTestDoc) return aTestDoc - bTestDoc;
+      if (docIntent !== "test" && docIntent !== "mixed") {
+        const aTestDoc = a.isTestOrDocPath ? 1 : 0;
+        const bTestDoc = b.isTestOrDocPath ? 1 : 0;
+        if (aTestDoc !== bTestDoc) return aTestDoc - bTestDoc;
+      }
+
+      const aBenchmark = a.isBenchmarkPath ? 1 : 0;
+      const bBenchmark = b.isBenchmarkPath ? 1 : 0;
+      if (aBenchmark !== bBenchmark) return aBenchmark - bBenchmark;
+
+      const aFixture = a.isFixtureOrExamplePath ? 1 : 0;
+      const bFixture = b.isFixtureOrExamplePath ? 1 : 0;
+      if (aFixture !== bFixture) return aFixture - bFixture;
+
+      const aDocs = a.isDocumentationCandidate ? 1 : 0;
+      const bDocs = b.isDocumentationCandidate ? 1 : 0;
+      if (aDocs !== bDocs) return aDocs - bDocs;
 
       return 0;
     });
@@ -1185,6 +1360,22 @@ export function rerankResults(
       const aReadme = a.isReadmePath ? 1 : 0;
       const bReadme = b.isReadmePath ? 1 : 0;
       if (aReadme !== bReadme) return bReadme - aReadme;
+      return 0;
+    });
+  } else if (docIntent === "test" || docIntent === "mixed") {
+    head.sort((a, b) => {
+      const aDocTest = a.isTestOrDocPath ? 1 : 0;
+      const bDocTest = b.isTestOrDocPath ? 1 : 0;
+      if (aDocTest !== bDocTest) return bDocTest - aDocTest;
+
+      const aDocs = a.isDocumentationCandidate ? 1 : 0;
+      const bDocs = b.isDocumentationCandidate ? 1 : 0;
+      if (aDocs !== bDocs) return bDocs - aDocs;
+
+      const aReadme = a.isReadmePath ? 1 : 0;
+      const bReadme = b.isReadmePath ? 1 : 0;
+      if (aReadme !== bReadme) return bReadme - aReadme;
+
       return 0;
     });
   }
@@ -1285,7 +1476,8 @@ export function rankHybridResults(
   keywordResults: RankedCandidate[],
   options: HybridRankOptions & { prioritizeSourcePaths?: boolean }
 ): RankedCandidate[] {
-  const prioritizeSourcePaths = options.prioritizeSourcePaths ?? classifyQueryIntentRaw(query) === "source";
+  const intentProfile = classifyQueryIntentProfile(query);
+  const prioritizeSourcePaths = options.prioritizeSourcePaths ?? intentProfile.preferSourcePaths;
   const cacheKey = `${query}\u0001${options.fusionStrategy}|${options.rrfK}|${options.hybridWeight}|${options.rerankTopN}|${options.limit}|${prioritizeSourcePaths ? 1 : 0}`;
 
   let byKeyword = rankHybridResultsCache.get(semanticResults);
@@ -1305,12 +1497,16 @@ export function rankHybridResults(
     }
   }
 
-  const overfetchLimit = Math.max(options.limit * 4, options.limit);
+  const overfetchLimit = prioritizeSourcePaths
+    ? Math.max(options.limit * 6, options.limit)
+    : Math.max(options.limit * 4, options.limit);
   const fused = options.fusionStrategy === "rrf"
     ? fuseResultsRrf(semanticResults, keywordResults, options.rrfK, overfetchLimit)
     : fuseResultsWeighted(semanticResults, keywordResults, options.hybridWeight, overfetchLimit);
 
-  const rerankPoolLimit = Math.max(overfetchLimit, options.rerankTopN * 3, options.limit * 6);
+  const rerankPoolLimit = prioritizeSourcePaths
+    ? Math.max(overfetchLimit, options.rerankTopN * 4, options.limit * 8)
+    : Math.max(overfetchLimit, options.rerankTopN * 3, options.limit * 6);
   const rerankPool = fused.slice(0, rerankPoolLimit);
   const ranked = rerankResults(query, rerankPool, options.rerankTopN, {
     prioritizeSourcePaths,
@@ -1533,8 +1729,16 @@ function buildSymbolDefinitionLane(
     ])
     .filter((hint, idx, arr) => hint.length >= 3 && arr.indexOf(hint) === idx)
     .slice(0, 6);
+  const lookupHints = primaryHint && !GENERIC_LOOKUP_TERMS.has(primaryHint)
+    ? Array.from(new Set([
+      primaryHint,
+      primaryHint.replace(/_/g, ""),
+      primaryHint.replace(/_/g, "-"),
+      ...normalizedHints,
+    ])).slice(0, 6)
+    : normalizedHints;
 
-  for (const identifier of normalizedHints) {
+  for (const identifier of lookupHints) {
     const symbols = [
       ...database.getSymbolsByName(identifier),
       ...database.getSymbolsByNameCi(identifier),
@@ -1603,7 +1807,7 @@ function buildSymbolDefinitionLane(
       const nameLower = (candidate.metadata.name ?? "").toLowerCase();
       const pathLower = candidate.metadata.filePath.toLowerCase();
 
-      const exactHintMatch = normalizedHints.some((hint) => nameLower === hint || nameLower.replace(/_/g, "") === hint.replace(/_/g, ""));
+      const exactHintMatch = lookupHints.some((hint) => nameLower === hint || nameLower.replace(/_/g, "") === hint.replace(/_/g, ""));
       const tokenizedName = tokenizeTextForRanking(nameLower);
       const tokenHits = codeTermHints.filter((term) => tokenizedName.has(term) || pathLower.includes(term)).length;
 
@@ -3993,7 +4197,9 @@ export class Indexer {
     const rrfK = this.config.search.rrfK;
     const rerankTopN = this.config.search.rerankTopN;
     const filterByBranch = options?.filterByBranch ?? true;
-    const sourceIntent = options?.definitionIntent === true || classifyQueryIntentRaw(query) === "source";
+    const intentProfile = classifyQueryIntentProfile(query, options?.definitionIntent === true);
+    const sourceIntent = intentProfile.preferSourcePaths;
+    const definitionFirst = intentProfile.definitionFirst;
     const identifierHints = extractIdentifierHints(query);
 
     this.logger.search("debug", "Starting search", {
@@ -4112,10 +4318,27 @@ export class Indexer {
       sourceIntent
     );
 
+    const primaryIdentifierHint = extractPrimaryIdentifierQueryHint(query);
+    const hasSpecificPrimaryLookupHint = primaryIdentifierHint !== null && !GENERIC_LOOKUP_TERMS.has(primaryIdentifierHint);
+    const hasExplicitLookupPhrase = hasPatternMatch(query.toLowerCase(), STRONG_DEFINITION_PATTERNS) ||
+      hasPatternMatch(query.toLowerCase(), IMPLEMENTATION_LOOKUP_PATTERNS);
     const prePrimaryLane = mergeTieredResults(deterministicIdentifierLane, identifierLane, maxResults * 4);
-    const primaryLane = mergeTieredResults(prePrimaryLane, symbolLane, maxResults * 4);
-    const tiered = mergeTieredResults(primaryLane, rescued, maxResults * 4);
-    const hasCodeHints = extractCodeTermHints(query).length > 0 || identifierHints.length > 0;
+    const primaryLane = hasSpecificPrimaryLookupHint
+      ? mergeTieredResults(symbolLane, prePrimaryLane, maxResults * 4)
+      : mergeTieredResults(prePrimaryLane, symbolLane, maxResults * 4);
+    const usePrimaryLane = definitionFirst || (
+      sourceIntent &&
+      intentProfile.docIntent !== "docs" &&
+      (identifierHints.length > 0 || (
+        hasSpecificPrimaryLookupHint &&
+        hasExplicitLookupPhrase
+      ))
+    );
+    const tiered = usePrimaryLane
+      ? mergeTieredResults(primaryLane, rescued, maxResults * 4)
+      : rescued;
+    const hasCodeHints = intentProfile.hasCodeHints;
+    const testIntentSupport = sourceIntent && !definitionFirst && (intentProfile.docIntent === "test" || intentProfile.docIntent === "mixed");
 
     const baseFiltered = tiered.filter((r) => matchesSearchFilters(r, options, this.config.search.minScore));
 
@@ -4123,10 +4346,117 @@ export class Indexer {
       isLikelyImplementationPath(r.metadata.filePath) &&
       isImplementationChunkType(r.metadata.chunkType)
     );
+    const explicitPrimarySourceMatches = sourceIntent && intentProfile.docIntent === "none" && hasSpecificPrimaryLookupHint && hasExplicitLookupPhrase
+      ? baseFiltered.filter((candidate) =>
+        isLikelyImplementationPath(candidate.metadata.filePath) &&
+        scoreIdentifierMatch(
+          candidate.metadata.name,
+          candidate.metadata.filePath,
+          [primaryIdentifierHint]
+        ) >= 0.6
+      )
+      : [];
 
-    const filtered = (sourceIntent && hasCodeHints && implementationOnly.length > 0
+    const supportingTestResults = (() => {
+      if (!testIntentSupport) {
+        return [];
+      }
+
+      const candidateById = new Map<string, RankedCandidate>();
+      for (const candidate of baseFiltered) {
+        if (isTestOrDocPath(candidate.metadata.filePath)) {
+          candidateById.set(candidate.id, candidate);
+        }
+      }
+
+      for (const candidate of union) {
+        if (candidateById.has(candidate.id)) {
+          continue;
+        }
+        candidateById.set(candidate.id, candidate);
+      }
+
+      for (const identifier of identifierHints) {
+        const chunks = [
+          ...database.getChunksByName(identifier),
+          ...database.getChunksByNameCi(identifier),
+        ];
+
+        for (const chunk of chunks) {
+          if (branchChunkIds && !branchChunkIds.has(chunk.chunkId)) {
+            continue;
+          }
+
+          const metadata: ChunkMetadata = {
+            filePath: chunk.filePath,
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            chunkType: (chunk.nodeType ?? "other") as ChunkMetadata["chunkType"],
+            name: chunk.name ?? undefined,
+            language: chunk.language,
+            hash: chunk.contentHash,
+          };
+
+          if (!isTestOrDocPath(metadata.filePath)) {
+            continue;
+          }
+
+          const existing = candidateById.get(chunk.chunkId);
+          candidateById.set(chunk.chunkId, {
+            id: chunk.chunkId,
+            score: existing?.score ?? 0.65,
+            metadata: existing?.metadata ?? metadata,
+          });
+        }
+      }
+
+      return Array.from(candidateById.values())
+        .filter((candidate) => matchesSearchFilters(candidate, options, this.config.search.minScore))
+        .filter((candidate) => isTestOrDocPath(candidate.metadata.filePath))
+        .map((candidate) => ({
+          candidate,
+          identifierMatchScore: identifierHints.length > 0
+            ? scoreIdentifierMatch(candidate.metadata.name, candidate.metadata.filePath, identifierHints)
+            : 0,
+          tokenOverlap: (() => {
+            const nameTokens = splitNameTokens(candidate.metadata.name ?? "");
+            const pathTokens = splitPathTokens(candidate.metadata.filePath);
+            const queryTokens = tokenizeTextForRanking(query);
+            let overlap = 0;
+            for (const token of queryTokens) {
+              if (nameTokens.has(token) || pathTokens.has(token)) {
+                overlap += 1;
+              }
+            }
+            return overlap;
+          })(),
+        }))
+        .filter((entry) => entry.identifierMatchScore > 0 || entry.tokenOverlap > 0)
+        .sort((a, b) => {
+          if (b.identifierMatchScore !== a.identifierMatchScore) return b.identifierMatchScore - a.identifierMatchScore;
+          if (b.tokenOverlap !== a.tokenOverlap) return b.tokenOverlap - a.tokenOverlap;
+          if (b.candidate.score !== a.candidate.score) return b.candidate.score - a.candidate.score;
+          return a.candidate.id.localeCompare(b.candidate.id);
+        })
+        .map((entry) => ({
+          id: entry.candidate.id,
+          score: Math.min(1, Math.max(entry.candidate.score, 0.7 + entry.identifierMatchScore * 0.15 + entry.tokenOverlap * 0.03)),
+          metadata: entry.candidate.metadata,
+        }));
+    })();
+
+    const filteredBase = definitionFirst && sourceIntent && hasCodeHints && implementationOnly.length > 0
       ? implementationOnly
-      : baseFiltered
+      : explicitPrimarySourceMatches.length > 0
+        ? mergeTieredResults(explicitPrimarySourceMatches, baseFiltered, maxResults * 4)
+        : baseFiltered;
+    const filtered = (testIntentSupport && implementationOnly.length > 0 && supportingTestResults.length > 0
+      ? mergeTieredResults(
+        implementationOnly.slice(0, 1),
+        mergeTieredResults(supportingTestResults, baseFiltered, maxResults * 4),
+        maxResults * 4
+      )
+      : filteredBase
     ).slice(0, maxResults);
 
     const identifierFallback = (!options?.definitionIntent && filtered.length === 0 && identifierHints.length > 0)

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -708,6 +708,52 @@ function isTestOrDocPath(filePath: string): boolean {
   return TEST_PATH_SEGMENTS.some((segment) => filePath.includes(segment));
 }
 
+function normalizeSupportPath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").toLowerCase();
+}
+
+function isFixturePath(filePath: string): boolean {
+  return normalizeSupportPath(filePath).includes("fixtures/");
+}
+
+function isBenchmarkPath(filePath: string): boolean {
+  const normalized = normalizeSupportPath(filePath);
+  return normalized.includes("/benchmarks/") ||
+    normalized.startsWith("benchmarks/") ||
+    normalized.includes("/benchmark/") ||
+    normalized.startsWith("benchmark/") ||
+    /(?:^|\/)[^/]*\.bench\.[^/]+$/i.test(normalized);
+}
+
+function isActualTestPath(filePath: string): boolean {
+  const lowered = normalizeSupportPath(filePath);
+  if (isFixturePath(lowered) || isBenchmarkPath(lowered) || isDocumentationPath(lowered)) {
+    return false;
+  }
+
+  return lowered.includes("tests/") ||
+    lowered.includes("__tests__/") ||
+    lowered.includes("/test/") ||
+    /\.(?:test|spec)\.[a-z0-9]+$/i.test(lowered);
+}
+
+function matchesSupportingTestIntentPath(filePath: string, query: string): boolean {
+  if (isActualTestPath(filePath)) {
+    return true;
+  }
+
+  const loweredQuery = query.toLowerCase();
+  if (/\bfixtures?\b/.test(loweredQuery) && isFixturePath(filePath)) {
+    return true;
+  }
+
+  if (/\bbenchmarks?\b/.test(loweredQuery) && isBenchmarkPath(filePath)) {
+    return true;
+  }
+
+  return false;
+}
+
 function isLikelyImplementationPath(filePath: string): boolean {
   const lowered = filePath.toLowerCase();
   if (IMPLEMENTATION_EXCLUDE_PATH_SEGMENTS.some((segment) => lowered.includes(segment))) {
@@ -4370,7 +4416,7 @@ export class Indexer {
 
       const candidateById = new Map<string, RankedCandidate>();
       for (const candidate of baseFiltered) {
-        if (isTestOrDocPath(candidate.metadata.filePath)) {
+        if (matchesSupportingTestIntentPath(candidate.metadata.filePath, query)) {
           candidateById.set(candidate.id, candidate);
         }
       }
@@ -4403,7 +4449,7 @@ export class Indexer {
             hash: chunk.contentHash,
           };
 
-          if (!isTestOrDocPath(metadata.filePath)) {
+          if (!matchesSupportingTestIntentPath(metadata.filePath, query)) {
             continue;
           }
 
@@ -4418,7 +4464,7 @@ export class Indexer {
 
       return Array.from(candidateById.values())
         .filter((candidate) => matchesSearchFilters(candidate, options, this.config.search.minScore))
-        .filter((candidate) => isTestOrDocPath(candidate.metadata.filePath))
+        .filter((candidate) => matchesSupportingTestIntentPath(candidate.metadata.filePath, query))
         .map((candidate) => ({
           candidate,
           identifierMatchScore: identifierHints.length > 0

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -367,6 +367,17 @@ describe("retrieval ranking", () => {
     }
   });
 
+  it("keeps lowercase explicit implementation lookups source-first", () => {
+    const candidates: Candidate[] = [
+      { id: "docs", score: 0.92, metadata: meta({ filePath: "/repo/README.md", name: "validate docs", chunkType: "other" }) },
+      { id: "tests", score: 0.91, metadata: meta({ filePath: "/repo/tests/validate.test.ts", name: "validate", chunkType: "function" }) },
+      { id: "impl", score: 0.85, metadata: meta({ filePath: "/repo/src/validation.ts", name: "validate", chunkType: "function" }) },
+    ];
+
+    const reranked = rerankResults("where is validate implementation", candidates, 10);
+    expect(reranked[0]?.id).toBe("impl");
+  });
+
   it("does not over-route doc phrasing with 'where is ... documentation' to source intent", () => {
     const candidates: Candidate[] = [
       { id: "impl", score: 0.91, metadata: meta({ filePath: "/repo/src/indexer/index.ts", name: "rankHybridResults", chunkType: "function" }) },
@@ -376,6 +387,77 @@ describe("retrieval ranking", () => {
 
     const reranked = rerankResults("where is rankHybridResults documentation", candidates, 10);
     expect(reranked[0]?.id).toBe("docs");
+  });
+
+  it("keeps coherent mixed implementation and test ordering for where-is test queries", () => {
+    const candidates: Candidate[] = [
+      { id: "impl", score: 0.9, metadata: meta({ filePath: "/repo/src/payments/handler.ts", name: "paymentFunction", chunkType: "function" }) },
+      { id: "test", score: 0.89, metadata: meta({ filePath: "/repo/tests/paymentFunction.test.ts", name: "paymentFunction", chunkType: "function" }) },
+      { id: "noise", score: 0.91, metadata: meta({ filePath: "/repo/docs/payments.md", name: "payment docs", chunkType: "other" }) },
+    ];
+
+    const reranked = rerankResults("where is paymentFunction function test", candidates, 10);
+    expect(reranked[0]?.id).toBe("impl");
+    expect(reranked[1]?.id).toBe("test");
+  });
+
+  it("keeps short where-is test queries source-first", () => {
+    const candidates: Candidate[] = [
+      { id: "impl", score: 0.89, metadata: meta({ filePath: "/repo/src/payments/handler.ts", name: "paymentFunction", chunkType: "function" }) },
+      { id: "test", score: 0.9, metadata: meta({ filePath: "/repo/tests/paymentFunction.test.ts", name: "paymentFunction", chunkType: "function" }) },
+      { id: "docs", score: 0.88, metadata: meta({ filePath: "/repo/docs/payments.md", name: "payment docs", chunkType: "other" }) },
+    ];
+
+    const reranked = rerankResults("where is paymentFunction test", candidates, 10);
+    expect(reranked[0]?.id).toBe("impl");
+    expect(reranked[1]?.id).toBe("test");
+  });
+
+  it("penalizes benchmark, fixture, and example paths when a real implementation exists", () => {
+    const candidates: Candidate[] = [
+      { id: "benchmark", score: 0.94, metadata: meta({ filePath: "/repo/benchmarks/run.ts", name: "rankHybridResults benchmark", chunkType: "function" }) },
+      { id: "fixture", score: 0.93, metadata: meta({ filePath: "/repo/tests/fixtures/rankHybridResults.ts", name: "entryPoint", chunkType: "function" }) },
+      { id: "example", score: 0.92, metadata: meta({ filePath: "/repo/examples/rankHybridResults.ts", name: "exampleUsage", chunkType: "function" }) },
+      { id: "impl", score: 0.81, metadata: meta({ filePath: "/repo/src/indexer/index.ts", name: "rankHybridResults", chunkType: "function" }) },
+    ];
+
+    const reranked = rerankResults("where is rankHybridResults implementation", candidates, 10);
+    expect(reranked[0]?.id).toBe("impl");
+    expect(reranked.slice(1).every((candidate) => candidate.id !== "impl")).toBe(true);
+  });
+
+  it("keeps exploratory queries broad instead of forcing definition-first routing", () => {
+    const candidates: Candidate[] = [
+      { id: "impl", score: 0.95, metadata: meta({ filePath: "/repo/src/indexer/index.ts", name: "rankHybridResults", chunkType: "function" }) },
+      { id: "helper", score: 0.94, metadata: meta({ filePath: "/repo/src/ranking/helpers.ts", name: "buildRankingReport", chunkType: "function" }) },
+      { id: "docs", score: 0.93, metadata: meta({ filePath: "/repo/docs/ranking-guide.md", name: "ranking guide", chunkType: "other" }) },
+    ];
+
+    const reranked = rerankResults("ranking report flow", candidates, 10);
+    expect(reranked[0]?.id).toBe("helper");
+    expect(reranked.slice(0, 3).map((candidate) => candidate.id)).toContain("docs");
+  });
+
+  it("keeps source preference for mixed test and implementation phrasing when signals tie", () => {
+    const candidates: Candidate[] = [
+      { id: "testCase", score: 0.92, metadata: meta({ filePath: "/repo/tests/payment.test.ts", name: "payment test", chunkType: "function" }) },
+      { id: "impl", score: 0.89, metadata: meta({ filePath: "/repo/src/payments/handler.ts", name: "paymentFunction", chunkType: "function" }) },
+    ];
+
+    const reranked = rerankResults("test the payment function", candidates, 10);
+    expect(reranked[0]?.id).toBe("impl");
+  });
+
+  it("keeps broad discovery phrasing from over-prioritizing a synthetic exact lookup target", () => {
+    const candidates: Candidate[] = [
+      { id: "impl", score: 0.95, metadata: meta({ filePath: "/repo/src/ranking/flow.ts", name: "buildRankingFlow", chunkType: "function" }) },
+      { id: "docs", score: 0.94, metadata: meta({ filePath: "/repo/docs/ranking-flow.md", name: "ranking flow guide", chunkType: "other" }) },
+      { id: "helper", score: 0.93, metadata: meta({ filePath: "/repo/src/ranking/report.ts", name: "buildRankingReport", chunkType: "function" }) },
+    ];
+
+    const reranked = rerankResults("where does ranking flow happen", candidates, 10);
+    expect(reranked.slice(0, 3).map((candidate) => candidate.id)).toContain("docs");
+    expect(reranked[0]?.id).toBe("impl");
   });
 
   it("extracts file path hint from path-constrained implementation query", () => {

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -629,6 +629,61 @@ describe("retrieval ranking", () => {
     globalThis.fetch = fetchSpy;
   });
 
+  it("skips external reranker for lowercase explicit implementation lookups with primary hints", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embed",
+        dimensions: 8,
+      },
+      reranker: {
+        enabled: true,
+        provider: "custom",
+        model: "mock-reranker",
+        baseUrl: "https://rerank.example/v1",
+        topN: 3,
+      },
+    });
+    const indexer = new Indexer("/repo", config);
+
+    const fetchSpy = globalThis.fetch;
+    let rerankCalled = false;
+    globalThis.fetch = (async (input) => {
+      if (String(input).includes("/rerank")) {
+        rerankCalled = true;
+        return new Response(JSON.stringify({
+          results: [
+            { index: 2, relevance_score: 0.99 },
+            { index: 0, relevance_score: 0.72 },
+            { index: 1, relevance_score: 0.4 },
+          ],
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ data: [{ embedding: Array.from({ length: 8 }, () => 0.1) }], usage: { total_tokens: 1 } }), { status: 200 });
+    }) as typeof fetch;
+
+    const candidates: Candidate[] = [
+      { id: "docs", score: 0.92, metadata: meta({ filePath: "/repo/README.md", name: "validate docs", chunkType: "other", startLine: 1, endLine: 3 }) },
+      { id: "tests", score: 0.91, metadata: meta({ filePath: "/repo/tests/validate.test.ts", name: "validate", chunkType: "function", startLine: 1, endLine: 3 }) },
+      { id: "impl", score: 0.85, metadata: meta({ filePath: "/repo/src/validation.ts", name: "validate", chunkType: "function", startLine: 1, endLine: 3 }) },
+    ];
+
+    const reranked = await (indexer as unknown as {
+      rerankCandidatesWithApi(
+        query: string,
+        items: Candidate[],
+        options?: { definitionIntent?: boolean; hasIdentifierHints?: boolean; hasExplicitLookupHint?: boolean }
+      ): Promise<Candidate[]>;
+    }).rerankCandidatesWithApi("where is validate implementation", candidates, {
+      hasExplicitLookupHint: true,
+    });
+
+    expect(rerankCalled).toBe(false);
+    expect(reranked.map((candidate) => candidate.id)).toEqual(["docs", "tests", "impl"]);
+    globalThis.fetch = fetchSpy;
+  });
+
   it("allows external reranker for documentation intent even when identifier hints are present", async () => {
     const config = parseConfig({
       embeddingProvider: "custom",

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -495,6 +495,657 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(results[1]?.filePath).toContain(path.join("tests", "paymentFunction.test.ts"));
   });
 
+  it("keeps real tests ahead of benchmark and docs in the mixed support lane", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const implPath = path.join(tempDir, "src", "payments", "handler.ts");
+    const testPath = path.join(tempDir, "tests", "paymentFunction.test.ts");
+    const benchmarkPath = path.join(tempDir, "benchmarks", "paymentFunction.ts");
+    const fixturePath = path.join(tempDir, "tests", "fixtures", "paymentFunction.ts");
+    const readmePath = path.join(tempDir, "README.md");
+
+    fs.mkdirSync(path.dirname(implPath), { recursive: true });
+    fs.mkdirSync(path.dirname(testPath), { recursive: true });
+    fs.mkdirSync(path.dirname(benchmarkPath), { recursive: true });
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(implPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(testPath, `import { paymentFunction } from "../src/payments/handler";\n\ntest("paymentFunction", () => { expect(paymentFunction()).toBe(true); });\n`, "utf-8");
+    fs.writeFileSync(benchmarkPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(fixturePath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(readmePath, `# Payment docs\n\nThis documents paymentFunction.\n`, "utf-8");
+
+    const mocked = indexer as unknown as {
+      ensureInitialized: () => Promise<{
+        store: { count(): number; search(): Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }> };
+        provider: { embedQuery(query: string): Promise<{ embedding: number[]; tokensUsed: number }> };
+        invertedIndex: unknown;
+        configuredProviderInfo: unknown;
+        database: {
+          getBranchChunkIds(_key: string): string[];
+          getSymbolsByName(_name: string): unknown[];
+          getSymbolsByNameCi(_name: string): unknown[];
+          getChunksByFile(_filePath: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByName(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByNameCi(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+        };
+      }>;
+      checkCompatibility: () => { compatible: boolean; reason?: string };
+      getQueryEmbedding: (_query: string, _provider: unknown) => Promise<number[]>;
+      keywordSearch: (_query: string, _limit: number) => Promise<Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }>>;
+      currentBranch: string;
+      config: typeof config;
+    };
+
+    mocked.currentBranch = "default";
+    mocked.checkCompatibility = () => ({ compatible: true });
+    mocked.getQueryEmbedding = async () => [0.1, 0.2, 0.3];
+    mocked.keywordSearch = async () => [];
+    mocked.ensureInitialized = async () => ({
+      store: {
+        count: () => 1,
+        search: () => [
+          {
+            id: "impl",
+            score: 0.95,
+            metadata: {
+              filePath: implPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "impl-hash",
+              name: "paymentFunction",
+            },
+          },
+          {
+            id: "docs",
+            score: 0.93,
+            metadata: {
+              filePath: readmePath,
+              startLine: 1,
+              endLine: 3,
+              chunkType: "other",
+              language: "markdown",
+              hash: "docs-hash",
+              name: "paymentFunction docs",
+            },
+          },
+          {
+            id: "benchmark",
+            score: 0.92,
+            metadata: {
+              filePath: benchmarkPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "benchmark-hash",
+              name: "paymentFunction",
+            },
+          },
+          {
+            id: "fixture",
+            score: 0.91,
+            metadata: {
+              filePath: fixturePath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "fixture-hash",
+              name: "paymentFunction",
+            },
+          },
+        ],
+      },
+      provider: {
+        embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      },
+      invertedIndex: {},
+      configuredProviderInfo: {},
+      database: {
+        getBranchChunkIds: () => [],
+        getSymbolsByName: () => [],
+        getSymbolsByNameCi: () => [],
+        getChunksByFile: () => [],
+        getChunksByName: () => [],
+        getChunksByNameCi: () => [
+          {
+            chunkId: "test",
+            filePath: testPath,
+            startLine: 1,
+            endLine: 3,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "test-hash",
+          },
+          {
+            chunkId: "benchmark",
+            filePath: benchmarkPath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "benchmark-hash",
+          },
+          {
+            chunkId: "fixture",
+            filePath: fixturePath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "fixture-hash",
+          },
+        ],
+      },
+    });
+
+    const results = await indexer.search("where is paymentFunction function test", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    const resultPaths = results.map((result) => result.filePath);
+    const testIndex = resultPaths.indexOf(testPath);
+    const benchmarkIndex = resultPaths.indexOf(benchmarkPath);
+    const fixtureIndex = resultPaths.indexOf(fixturePath);
+    const readmeIndex = resultPaths.indexOf(readmePath);
+
+    expect(results[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+    expect(results[1]?.filePath).toContain(path.join("tests", "paymentFunction.test.ts"));
+    expect(testIndex).toBeGreaterThanOrEqual(0);
+    expect(benchmarkIndex === -1 || benchmarkIndex > testIndex).toBe(true);
+    expect(fixtureIndex === -1 || fixtureIndex > testIndex).toBe(true);
+    expect(readmeIndex === -1 || readmeIndex > testIndex).toBe(true);
+  });
+
+  it("rescues benchmark matches for explicit benchmark intent", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const implPath = path.join(tempDir, "src", "payments", "handler.ts");
+    const benchmarkPath = path.join(tempDir, "benchmarks", "paymentFunction.ts");
+
+    fs.mkdirSync(path.dirname(implPath), { recursive: true });
+    fs.mkdirSync(path.dirname(benchmarkPath), { recursive: true });
+    fs.writeFileSync(implPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(benchmarkPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+
+    const mocked = indexer as unknown as {
+      ensureInitialized: () => Promise<{
+        store: { count(): number; search(): Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }> };
+        provider: { embedQuery(query: string): Promise<{ embedding: number[]; tokensUsed: number }> };
+        invertedIndex: unknown;
+        configuredProviderInfo: unknown;
+        database: {
+          getBranchChunkIds(_key: string): string[];
+          getSymbolsByName(_name: string): unknown[];
+          getSymbolsByNameCi(_name: string): unknown[];
+          getChunksByFile(_filePath: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByName(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByNameCi(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+        };
+      }>;
+      checkCompatibility: () => { compatible: boolean; reason?: string };
+      getQueryEmbedding: (_query: string, _provider: unknown) => Promise<number[]>;
+      keywordSearch: (_query: string, _limit: number) => Promise<Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }>>;
+      currentBranch: string;
+      config: typeof config;
+    };
+
+    mocked.currentBranch = "default";
+    mocked.checkCompatibility = () => ({ compatible: true });
+    mocked.getQueryEmbedding = async () => [0.1, 0.2, 0.3];
+    mocked.keywordSearch = async () => [];
+    mocked.ensureInitialized = async () => ({
+      store: {
+        count: () => 1,
+        search: () => [
+          {
+            id: "impl",
+            score: 0.95,
+            metadata: {
+              filePath: implPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "impl-hash",
+              name: "paymentFunction",
+            },
+          },
+        ],
+      },
+      provider: {
+        embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      },
+      invertedIndex: {},
+      configuredProviderInfo: {},
+      database: {
+        getBranchChunkIds: () => [],
+        getSymbolsByName: () => [],
+        getSymbolsByNameCi: () => [],
+        getChunksByFile: () => [],
+        getChunksByName: () => [],
+        getChunksByNameCi: () => [
+          {
+            chunkId: "benchmark",
+            filePath: benchmarkPath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "benchmark-hash",
+          },
+        ],
+      },
+    });
+
+    const results = await indexer.search("where is paymentFunction function benchmark", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+    expect(results.some((result) => result.filePath === benchmarkPath)).toBe(true);
+  });
+
+  it("rescues fixture matches for explicit fixture intent", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const implPath = path.join(tempDir, "src", "payments", "handler.ts");
+    const fixturePath = path.join(tempDir, "tests", "fixtures", "paymentFunction.ts");
+
+    fs.mkdirSync(path.dirname(implPath), { recursive: true });
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+    fs.writeFileSync(implPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(fixturePath, `export function paymentFunction() { return true; }\n`, "utf-8");
+
+    const mocked = indexer as unknown as {
+      ensureInitialized: () => Promise<{
+        store: { count(): number; search(): Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }> };
+        provider: { embedQuery(query: string): Promise<{ embedding: number[]; tokensUsed: number }> };
+        invertedIndex: unknown;
+        configuredProviderInfo: unknown;
+        database: {
+          getBranchChunkIds(_key: string): string[];
+          getSymbolsByName(_name: string): unknown[];
+          getSymbolsByNameCi(_name: string): unknown[];
+          getChunksByFile(_filePath: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByName(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByNameCi(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+        };
+      }>;
+      checkCompatibility: () => { compatible: boolean; reason?: string };
+      getQueryEmbedding: (_query: string, _provider: unknown) => Promise<number[]>;
+      keywordSearch: (_query: string, _limit: number) => Promise<Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }>>;
+      currentBranch: string;
+      config: typeof config;
+    };
+
+    mocked.currentBranch = "default";
+    mocked.checkCompatibility = () => ({ compatible: true });
+    mocked.getQueryEmbedding = async () => [0.1, 0.2, 0.3];
+    mocked.keywordSearch = async () => [];
+    mocked.ensureInitialized = async () => ({
+      store: {
+        count: () => 1,
+        search: () => [
+          {
+            id: "impl",
+            score: 0.95,
+            metadata: {
+              filePath: implPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "impl-hash",
+              name: "paymentFunction",
+            },
+          },
+        ],
+      },
+      provider: {
+        embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      },
+      invertedIndex: {},
+      configuredProviderInfo: {},
+      database: {
+        getBranchChunkIds: () => [],
+        getSymbolsByName: () => [],
+        getSymbolsByNameCi: () => [],
+        getChunksByFile: () => [],
+        getChunksByName: () => [],
+        getChunksByNameCi: () => [
+          {
+            chunkId: "fixture",
+            filePath: fixturePath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "fixture-hash",
+          },
+        ],
+      },
+    });
+
+    const results = await indexer.search("where is paymentFunction function fixture", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results.some((result) => result.filePath === fixturePath)).toBe(true);
+    expect(results.some((result) => result.filePath === implPath)).toBe(true);
+  });
+
+  it("rescues Windows-style fixture paths for explicit fixture intent", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const implPath = path.join(tempDir, "src", "payments", "handler.ts");
+    const fixturePath = "C:\\repo\\tests\\fixtures\\paymentFunction.ts";
+
+    fs.mkdirSync(path.dirname(implPath), { recursive: true });
+    fs.writeFileSync(implPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+
+    const mocked = indexer as unknown as {
+      ensureInitialized: () => Promise<{
+        store: { count(): number; search(): Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }> };
+        provider: { embedQuery(query: string): Promise<{ embedding: number[]; tokensUsed: number }> };
+        invertedIndex: unknown;
+        configuredProviderInfo: unknown;
+        database: {
+          getBranchChunkIds(_key: string): string[];
+          getSymbolsByName(_name: string): unknown[];
+          getSymbolsByNameCi(_name: string): unknown[];
+          getChunksByFile(_filePath: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByName(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByNameCi(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+        };
+      }>;
+      checkCompatibility: () => { compatible: boolean; reason?: string };
+      getQueryEmbedding: (_query: string, _provider: unknown) => Promise<number[]>;
+      keywordSearch: (_query: string, _limit: number) => Promise<Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }>>;
+      currentBranch: string;
+      config: typeof config;
+    };
+
+    mocked.currentBranch = "default";
+    mocked.checkCompatibility = () => ({ compatible: true });
+    mocked.getQueryEmbedding = async () => [0.1, 0.2, 0.3];
+    mocked.keywordSearch = async () => [];
+    mocked.ensureInitialized = async () => ({
+      store: {
+        count: () => 1,
+        search: () => [
+          {
+            id: "impl",
+            score: 0.95,
+            metadata: {
+              filePath: implPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "impl-hash",
+              name: "paymentFunction",
+            },
+          },
+        ],
+      },
+      provider: {
+        embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      },
+      invertedIndex: {},
+      configuredProviderInfo: {},
+      database: {
+        getBranchChunkIds: () => [],
+        getSymbolsByName: () => [],
+        getSymbolsByNameCi: () => [],
+        getChunksByFile: () => [],
+        getChunksByName: () => [],
+        getChunksByNameCi: () => [
+          {
+            chunkId: "fixture-win",
+            filePath: fixturePath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "fixture-win-hash",
+          },
+        ],
+      },
+    });
+
+    const results = await indexer.search("where is paymentFunction function fixture", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results.some((result) => result.filePath === fixturePath)).toBe(true);
+    expect(results.some((result) => result.filePath === implPath)).toBe(true);
+  });
+
+  it("keeps benchmark-named test files in the real-test lane for generic test queries", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const implPath = path.join(tempDir, "src", "payments", "handler.ts");
+    const benchmarkNamedTestPath = path.join(tempDir, "tests", "benchmarking", "payment.test.ts");
+    const benchmarkPath = path.join(tempDir, "benchmarks", "paymentFunction.ts");
+
+    fs.mkdirSync(path.dirname(implPath), { recursive: true });
+    fs.mkdirSync(path.dirname(benchmarkNamedTestPath), { recursive: true });
+    fs.mkdirSync(path.dirname(benchmarkPath), { recursive: true });
+    fs.writeFileSync(implPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(benchmarkNamedTestPath, `import { paymentFunction } from "../../src/payments/handler";\n\ntest("paymentFunction benchmark helper", () => { expect(paymentFunction()).toBe(true); });\n`, "utf-8");
+    fs.writeFileSync(benchmarkPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+
+    const mocked = indexer as unknown as {
+      ensureInitialized: () => Promise<{
+        store: { count(): number; search(): Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }> };
+        provider: { embedQuery(query: string): Promise<{ embedding: number[]; tokensUsed: number }> };
+        invertedIndex: unknown;
+        configuredProviderInfo: unknown;
+        database: {
+          getBranchChunkIds(_key: string): string[];
+          getSymbolsByName(_name: string): unknown[];
+          getSymbolsByNameCi(_name: string): unknown[];
+          getChunksByFile(_filePath: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByName(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByNameCi(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+        };
+      }>;
+      checkCompatibility: () => { compatible: boolean; reason?: string };
+      getQueryEmbedding: (_query: string, _provider: unknown) => Promise<number[]>;
+      keywordSearch: (_query: string, _limit: number) => Promise<Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }>>;
+      currentBranch: string;
+      config: typeof config;
+    };
+
+    mocked.currentBranch = "default";
+    mocked.checkCompatibility = () => ({ compatible: true });
+    mocked.getQueryEmbedding = async () => [0.1, 0.2, 0.3];
+    mocked.keywordSearch = async () => [];
+    mocked.ensureInitialized = async () => ({
+      store: {
+        count: () => 1,
+        search: () => [
+          {
+            id: "impl",
+            score: 0.95,
+            metadata: {
+              filePath: implPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "impl-hash",
+              name: "paymentFunction",
+            },
+          },
+          {
+            id: "bench-noise",
+            score: 0.92,
+            metadata: {
+              filePath: benchmarkPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "benchmark-hash",
+              name: "paymentFunction",
+            },
+          },
+        ],
+      },
+      provider: {
+        embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      },
+      invertedIndex: {},
+      configuredProviderInfo: {},
+      database: {
+        getBranchChunkIds: () => [],
+        getSymbolsByName: () => [],
+        getSymbolsByNameCi: () => [],
+        getChunksByFile: () => [],
+        getChunksByName: () => [],
+        getChunksByNameCi: () => [
+          {
+            chunkId: "benchmark-test",
+            filePath: benchmarkNamedTestPath,
+            startLine: 1,
+            endLine: 3,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "benchmark-test-hash",
+          },
+          {
+            chunkId: "bench-noise",
+            filePath: benchmarkPath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "benchmark-hash",
+          },
+        ],
+      },
+    });
+
+    const results = await indexer.search("where is paymentFunction function test", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    const resultPaths = results.map((result) => result.filePath);
+    const testIndex = resultPaths.indexOf(benchmarkNamedTestPath);
+    const benchmarkIndex = resultPaths.indexOf(benchmarkPath);
+
+    expect(results[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+    expect(testIndex).toBeGreaterThanOrEqual(0);
+    expect(benchmarkIndex === -1 || benchmarkIndex > testIndex).toBe(true);
+  });
+
   it("keeps short mixed 'where is ... test' queries source-first", async () => {
     const config = parseConfig({
       embeddingProvider: "custom",

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -251,6 +251,441 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(withOverride[0]?.filePath).not.toContain("README.md");
   });
 
+  it("keeps exploratory queries broad instead of forcing definition lanes", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("query length flow", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.slice(0, 3).some((result) => result.filePath.includes(path.join("app", "indexer", "index.ts")))).toBe(true);
+    expect(results.slice(0, 5).some((result) => result.filePath.includes("README.md"))).toBe(true);
+  });
+
+  it("keeps matching test results in mixed test and implementation queries", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const implPath = path.join(tempDir, "src", "payments", "handler.ts");
+    const testPath = path.join(tempDir, "tests", "paymentFunction.test.ts");
+
+    fs.mkdirSync(path.dirname(implPath), { recursive: true });
+    fs.mkdirSync(path.dirname(testPath), { recursive: true });
+    fs.writeFileSync(implPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+    fs.writeFileSync(testPath, `export function paymentFunction() { return true; }\n`, "utf-8");
+
+    const mocked = indexer as unknown as {
+      ensureInitialized: () => Promise<{
+        store: { count(): number; search(): Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }> };
+        provider: { embedQuery(query: string): Promise<{ embedding: number[]; tokensUsed: number }> };
+        invertedIndex: unknown;
+        configuredProviderInfo: unknown;
+        database: {
+          getBranchChunkIds(_key: string): string[];
+          getSymbolsByName(_name: string): unknown[];
+          getSymbolsByNameCi(_name: string): unknown[];
+          getChunksByFile(_filePath: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByName(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+          getChunksByNameCi(_name: string): Array<{ chunkId: string; filePath: string; startLine: number; endLine: number; nodeType: string; name?: string; language: string; contentHash: string }>;
+        };
+      }>;
+      checkCompatibility: () => { compatible: boolean; reason?: string };
+      getQueryEmbedding: (_query: string, _provider: unknown) => Promise<number[]>;
+      keywordSearch: (_query: string, _limit: number) => Promise<Array<{ id: string; score: number; metadata: { filePath: string; startLine: number; endLine: number; chunkType: string; language: string; hash: string; name?: string } }>>;
+      currentBranch: string;
+      config: typeof config;
+    };
+
+    mocked.currentBranch = "default";
+    mocked.checkCompatibility = () => ({ compatible: true });
+    mocked.getQueryEmbedding = async () => [0.1, 0.2, 0.3];
+    mocked.keywordSearch = async () => [];
+    mocked.ensureInitialized = async () => ({
+      store: {
+        count: () => 1,
+        search: () => [
+          {
+            id: "impl",
+            score: 0.95,
+            metadata: {
+              filePath: implPath,
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "impl-hash",
+              name: "paymentFunction",
+            },
+          },
+          {
+            id: "other",
+            score: 0.7,
+            metadata: {
+              filePath: path.join(tempDir, "app", "indexer", "index.ts"),
+              startLine: 1,
+              endLine: 1,
+              chunkType: "function",
+              language: "typescript",
+              hash: "other-hash",
+              name: "rankHybridResults",
+            },
+          },
+        ],
+      },
+      provider: {
+        embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      },
+      invertedIndex: {},
+      configuredProviderInfo: {},
+      database: {
+        getBranchChunkIds: () => [],
+        getSymbolsByName: () => [],
+        getSymbolsByNameCi: () => [],
+        getChunksByFile: () => [],
+        getChunksByName: () => [],
+        getChunksByNameCi: () => [
+          {
+            chunkId: "test",
+            filePath: testPath,
+            startLine: 1,
+            endLine: 1,
+            nodeType: "function",
+            name: "paymentFunction",
+            language: "typescript",
+            contentHash: "test-hash",
+          },
+        ],
+      },
+    });
+
+    const results = await indexer.search("test the paymentFunction function", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+    expect(results.some((result) => result.filePath.includes(path.join("tests", "paymentFunction.test.ts")))).toBe(true);
+  });
+
+  it("keeps documentation-oriented symbol queries on the docs path", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    fs.mkdirSync(path.join(tempDir, "src", "payments"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "src", "payments", "handler.ts"),
+      `export function paymentFunction() { return true; }\n`,
+      "utf-8"
+    );
+    fs.writeFileSync(
+      path.join(tempDir, "README.md"),
+      "# Payment docs\n\nDocumentation for paymentFunction function.\n",
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("documentation for the paymentFunction function", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]?.filePath).toContain("README.md");
+    expect(results.some((result) => result.filePath.includes(path.join("src", "payments", "handler.ts")))).toBe(true);
+  });
+
+  it("keeps matching tests visible for mixed 'where is ... test' queries", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    fs.mkdirSync(path.join(tempDir, "src", "payments"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "src", "payments", "handler.ts"),
+      `export function paymentFunction() { return true; }\n`,
+      "utf-8"
+    );
+    fs.mkdirSync(path.join(tempDir, "tests"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "tests", "paymentFunction.test.ts"),
+      `import { paymentFunction } from "../src/payments/handler";\n\ntest("paymentFunction", () => { expect(paymentFunction()).toBe(true); });\n`,
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("where is paymentFunction function test", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+    expect(results[1]?.filePath).toContain(path.join("tests", "paymentFunction.test.ts"));
+  });
+
+  it("keeps short mixed 'where is ... test' queries source-first", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    fs.mkdirSync(path.join(tempDir, "src", "payments"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "src", "payments", "handler.ts"),
+      `export function paymentFunction() { return true; }\n`,
+      "utf-8"
+    );
+    fs.mkdirSync(path.join(tempDir, "tests"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "tests", "paymentFunction.test.ts"),
+      `import { paymentFunction } from "../src/payments/handler";\n\ntest("paymentFunction", () => { expect(paymentFunction()).toBe(true); });\n`,
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("where is paymentFunction test", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+    expect(results[1]?.filePath).toContain(path.join("tests", "paymentFunction.test.ts"));
+  });
+
+  it("keeps 'where is ... documentation' queries on docs unless definition intent is forced", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    fs.mkdirSync(path.join(tempDir, "src", "payments"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "src", "payments", "handler.ts"),
+      `export function paymentFunction() { return true; }\n`,
+      "utf-8"
+    );
+    fs.writeFileSync(
+      path.join(tempDir, "README.md"),
+      "# Payment docs\n\nWhere is paymentFunction function documentation? Right here.\n",
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const withoutOverride = await indexer.search("where is paymentFunction function documentation", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+    expect(withoutOverride[0]?.filePath).toContain("README.md");
+
+    const withOverride = await indexer.search("where is paymentFunction function documentation", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+      definitionIntent: true,
+    });
+    expect(withOverride[0]?.filePath).toContain(path.join("src", "payments", "handler.ts"));
+  });
+
+  it("rescues lowercase explicit implementation lookups through the primary lane", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "src", "validate.ts"),
+      `export function validate() { return true; }\n`,
+      "utf-8"
+    );
+    fs.writeFileSync(
+      path.join(tempDir, "README.md"),
+      "# Validation docs\n\nwhere is validate implementation guide\n",
+      "utf-8"
+    );
+    fs.mkdirSync(path.join(tempDir, "tests"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "tests", "validate.test.ts"),
+      `export function validate() { return true; }\n`,
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("where is validate implementation", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    const topPaths = results.slice(0, 3).map((result) => result.filePath);
+    expect(topPaths).toContain(path.join(tempDir, "src", "validate.ts"));
+    expect(topPaths.indexOf(path.join(tempDir, "src", "validate.ts"))).toBeLessThan(topPaths.indexOf(path.join(tempDir, "README.md")) === -1 ? topPaths.length : topPaths.indexOf(path.join(tempDir, "README.md")));
+    expect(topPaths.indexOf(path.join(tempDir, "src", "validate.ts"))).toBeLessThan(topPaths.indexOf(path.join(tempDir, "tests", "validate.test.ts")) === -1 ? topPaths.length : topPaths.indexOf(path.join(tempDir, "tests", "validate.test.ts")));
+  });
+
+  it("keeps broad discovery queries out of definition-first collapse", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+        fusionStrategy: "rrf",
+        rrfK: 60,
+        rerankTopN: 20,
+      },
+    });
+
+    fs.mkdirSync(path.join(tempDir, "src", "ranking"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "src", "ranking", "flow.ts"),
+      `export function buildRankingFlow() { return "flow"; }\n`,
+      "utf-8"
+    );
+    fs.mkdirSync(path.join(tempDir, "docs"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, "docs", "ranking-flow.md"),
+      "# Ranking Flow\n\nThis document explains where the ranking flow happens.\n",
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("where does ranking flow happen", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results.some((result) => result.filePath.includes(path.join("src", "ranking", "flow.ts")))).toBe(true);
+    expect(results.some((result) => result.filePath.includes(path.join("docs", "ranking-flow.md")))).toBe(true);
+  });
+
   it("keeps implementation results ahead of docs even when external reranker prefers docs for implementation intent", async () => {
     fetchSpy.mockImplementation(async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
       if (String(url).includes("/rerank")) {


### PR DESCRIPTION
## Summary

Improve Phase 1 retrieval quality for definition and implementation-intent queries by making source definitions more authoritative while preserving doc/test and exploratory behavior.

## Changes

- tighten query-intent classification for definition-first vs implementation-first vs doc/test vs exploratory searches
- strengthen deterministic reranking and source-intent routing so implementation results outrank docs/tests/benchmarks/fixtures when appropriate
- add extensive ranking and integration regressions for doc-intent queries, mixed source+test queries, lowercase explicit lookups, and exploratory queries

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #76
