### PR TITLE
chore: remove SiliconFlow default from reranker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Subsystem module splits**: Split large config, embeddings, eval, MCP, watcher, git, tools, routing, and utility modules into smaller focused files while preserving public entrypoints (#92).
 - **AI slop removal**: Trimmed redundant comments and small wrapper noise across config, eval, runtime, indexer, tools, and utils with behavior-neutral refactors (#93).
 
+- **Remove SiliconFlow default**: The custom reranker no longer falls back to a Chinese endpoint (`api.siliconflow.cn`). A `baseUrl` is now required for the `custom` reranker provider. README examples updated to use Cohere and generic env-var placeholders.
 ### Fixed
 - **SSRF protection for custom embedding provider**: Custom provider URLs are now validated against cloud metadata endpoints (169.254.x.x, metadata.google.internal) and non-HTTP protocols to prevent server-side request forgery via malicious config files.
 - **Knowledge base path restrictions**: `add_knowledge_base` now blocks sensitive system directories (`/etc`, `/proc`, `/sys`, `/dev`, `/boot`, `/root`, `/var/run`, `/var/log`) and home dotdirs (`.ssh`, `.gnupg`, `.aws`, `.config/gcloud`, `.docker`, `.kube`). Symlinks are resolved before checking.

--- a/README.md
+++ b/README.md
@@ -433,10 +433,10 @@ Global-level config (`~/.config/opencode/codebase-index.json`):
 {
   "embeddingProvider": "custom",
   "customProvider": {
-    "baseUrl": "https://api.siliconflow.cn/v1",
+    "baseUrl": "{env:EMBED_BASE_URL}",
     "model": "BAAI/bge-m3",
     "dimensions": 1024,
-    "apiKey": "{env:SILICONFLOW_API_KEY}"
+    "apiKey": "{env:EMBED_API_KEY}"
   }
 }
 ```
@@ -460,9 +460,9 @@ Add to your config (`.opencode/codebase-index.json` or global config):
 {
   "reranker": {
     "enabled": true,
-    "baseUrl": "https://api.siliconflow.cn/v1",
-    "model": "BAAI/bge-reranker-v2-m3",
-    "apiKey": "{env:SILICONFLOW_API_KEY}",
+    "baseUrl": "https://api.cohere.ai/v1",
+    "model": "rerank-v3.5",
+    "apiKey": "{env:RERANK_API_KEY}",
     "topN": 20
   }
 }
@@ -512,10 +512,10 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
 
   // === Custom Embedding API (when embeddingProvider is "custom") ===
   "customProvider": {
-    "baseUrl": "https://api.siliconflow.cn/v1",
+    "baseUrl": "{env:EMBED_BASE_URL}",
     "model": "BAAI/bge-m3",
     "dimensions": 1024,
-    "apiKey": "{env:SILICONFLOW_API_KEY}",
+    "apiKey": "{env:EMBED_API_KEY}",
     "maxTokens": 8192,                        // Max tokens per input text
     "timeoutMs": 30000,                       // Request timeout (ms)
     "concurrency": 3,                         // Max concurrent requests

--- a/src/rerank/index.ts
+++ b/src/rerank/index.ts
@@ -58,7 +58,10 @@ class SiliconFlowReranker implements RerankerInterface {
       headers["Authorization"] = `Bearer ${this.config.apiKey}`;
     }
 
-    const baseUrl = this.config.baseUrl ?? "https://api.siliconflow.cn/v1";
+    const baseUrl = this.config.baseUrl;
+    if (!baseUrl) {
+      throw new Error("Reranker baseUrl is required. Configure reranker.baseUrl in your codebase-index.json.");
+    }
     const timeoutMs = this.config.timeoutMs ?? 30000;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);


### PR DESCRIPTION
## Summary

Remove the hardcoded Chinese endpoint (`api.siliconflow.cn`) from the custom reranker and all README references.

## Changes

- **src/rerank/index.ts**: Remove SiliconFlow fallback URL. Now throws a clear error if `baseUrl` is missing (config validation already prevents this path).
- **README.md**: Replace all SiliconFlow examples with Cohere (reranker) and generic `{env:EMBED_BASE_URL}` / `{env:EMBED_API_KEY}` placeholders (embeddings).
- **CHANGELOG.md**: Add entry under Unreleased.

## Testing

- `lsp_diagnostics` clean on changed files
- No functional behavior change for users who configure `baseUrl` explicitly (which is already required by config validation)