### PR TITLE
docs(AGENTS): add MATLAB to language lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,11 @@ src/
 
 native/src/
 ├── lib.rs                # NAPI exports: parse_file, VectorStore, Database, InvertedIndex
-├── parser.rs             # Tree-sitter parsing (17 languages: TS, JS, Python, Rust, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, JSON, TOML, YAML, Zig)
+├── parser.rs             # Tree-sitter parsing (18 languages: TS, JS, Python, Rust, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, JSON, TOML, YAML, Zig, MATLAB)
 ├── chunker.rs            # Semantic chunking with overlap
 ├── store.rs              # usearch vector store (F16 quantization)
 ├── db.rs                 # SQLite: embeddings, chunks, branch catalog, symbols, call edges
-├── call_extractor.rs     # Tree-sitter query-based call extraction (TS/JS, Python, Go, Rust, PHP, Zig, Apex)
+├── call_extractor.rs     # Tree-sitter query-based call extraction (TS/JS, Python, Go, Rust, PHP, Zig, Apex, MATLAB)
 ├── inverted_index.rs     # BM25 keyword search
 ├── hasher.rs             # xxhash content hashing
 └── types.rs              # Shared types (Language enum with from_string)


### PR DESCRIPTION
## Summary

Updates `AGENTS.md` to reflect MATLAB support added in #91.

## Changes

- `parser.rs` comment: 17 → 18 languages, added MATLAB to the list
- `call_extractor.rs` comment: added MATLAB to the call extraction language list

## Context

PR #91 added MATLAB indexing and call graph support but didn't update the `AGENTS.md` language counts/lists. This was the only place that needed updating — all runtime code (`CALL_GRAPH_LANGUAGES`, `CALL_GRAPH_SYMBOL_CHUNK_TYPES`, tool descriptions, MCP server) was correctly handled by the PR itself.

## Release Labels

- [x] `chore`
- [x] `skip-changelog`