### PR TITLE
chore: prepare v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-31
+
 ### Added
 - **GDScript language support**: Added tree-sitter semantic parsing, file discovery (`.gd`), and call-graph extraction for GDScript (#94).
 - **MATLAB indexing support**: Added tree-sitter semantic parsing and file discovery for MATLAB (`.m`). MATLAB is opt-in via `additionalInclude` because `.m` conflicts with Objective-C on Apple codebases (#91).
@@ -308,7 +310,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.6.1...v0.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "~1.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump version to 0.9.0 and finalize the changelog for release.

## Changes

- `package.json` version: 0.8.1 → 0.9.0
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.0] - 2026-05-31`
- Updated comparison links at bottom of changelog

## What's in v0.9.0

### Added
- GDScript language support (parser + call graph) (#94)
- MATLAB indexing support (parser, opt-in via additionalInclude) (#91)
- MATLAB call graph support (#91)

### Changed
- Subsystem module splits (#92)
- AI slop removal (#93)
- Remove SiliconFlow default from reranker

### Fixed
- SSRF protection for custom embedding provider (#95)
- Knowledge base path restrictions (#95)
- Google API key moved to header (#95)
- Error response truncation (#95)
- Config and eval loading hardening (#92)
- Command and indexer diagnostics (#92)
- `additionalInclude` dedup filter removal (#91)
- npm audit vulnerabilities (#99)