### PR TITLE
feat(config): support developer role for routing hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,8 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "rrfK": 60,                               // RRF smoothing constant
     "rerankTopN": 20,                         // Deterministic rerank depth
     "contextLines": 0,                        // Extra lines before/after match
-    "routingHints": true                      // Runtime nudges for local discovery/definition queries
+    "routingHints": true,                     // Runtime nudges for local discovery/definition queries
+    "routingHintRole": "system"              // system | developer (message role used for hints)
   },
   "reranker": {
     "enabled": false,
@@ -646,6 +647,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `rerankTopN` | `20` | Deterministic rerank depth cap. Applies lightweight name/path/chunk-type rerank to top-N only |
 | `contextLines` | `0` | Extra lines to include before/after each match |
 | `routingHints` | `true` | Inject lightweight runtime hints for local conceptual discovery and definition lookups. Set to `false` to disable plugin-side routing nudges. |
+| `routingHintRole` | `"system"` | Message role used when injecting routing hints: `"system"` (default) or `"developer"`. |
 | **reranker** | | Optional second-stage model reranker for the top candidate pool |
 | `enabled` | `false` | Turn external reranking on/off |
 | `provider` | `"custom"` | Hosted shortcuts: `cohere`, `jina`, or `custom` |
@@ -676,7 +678,7 @@ These warnings improve observability but do **not** change the recovery behavior
 ### Retrieval ranking behavior
 
 - `codebase_search` and `codebase_peek` use the hybrid path: semantic + keyword retrieval → fusion (`fusionStrategy`) → deterministic rerank (`rerankTopN`) → optional external reranker (`reranker`) → filtering.
-- When `search.routingHints` is enabled (default), the plugin adds tiny per-turn runtime hints for local conceptual discovery and definition queries. Conceptual discovery is nudged toward `codebase_peek` / `codebase_search`, while definition questions are nudged toward `implementation_lookup`. Exact identifier and unrelated operational tasks are left alone.
+- When `search.routingHints` is enabled (default), the plugin adds tiny per-turn runtime hints for local conceptual discovery and definition queries. Conceptual discovery is nudged toward `codebase_peek` / `codebase_search`, while definition questions are nudged toward `implementation_lookup`. Exact identifier and unrelated operational tasks are left alone. Set `search.routingHintRole` to `"developer"` if your client/runtime expects developer-role guidance instead of system-role guidance.
 - `find_similar` stays semantic-only: semantic retrieval + deterministic rerank only (no keyword retrieval, no RRF).
 - For compatibility rollbacks, set `search.fusionStrategy` to `"weighted"` to use the legacy weighted fusion path.
 - When enabled, the external reranker sees path metadata plus a bounded on-disk code snippet for each candidate so it can distinguish real implementations from docs/tests more reliably.

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -35,6 +35,7 @@ export function getDefaultSearchConfig(): SearchConfig {
     rerankTopN: 20,
     contextLines: 0,
     routingHints: true,
+    routingHintRole: "system",
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -66,6 +66,7 @@ export interface SearchConfig {
   rerankTopN: number;
   contextLines: number;
   routingHints: boolean;
+  routingHintRole: "system" | "developer";
 }
 
 export type RerankerProvider = "cohere" | "jina" | "custom";
@@ -191,6 +192,9 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     rerankTopN: typeof rawSearch.rerankTopN === "number" ? Math.min(200, Math.max(0, Math.floor(rawSearch.rerankTopN))) : defaultSearch.rerankTopN,
     contextLines: typeof rawSearch.contextLines === "number" ? Math.min(50, Math.max(0, rawSearch.contextLines)) : defaultSearch.contextLines,
     routingHints: typeof rawSearch.routingHints === "boolean" ? rawSearch.routingHints : defaultSearch.routingHints,
+    routingHintRole: rawSearch.routingHintRole === "developer" || rawSearch.routingHintRole === "system"
+      ? rawSearch.routingHintRole
+      : defaultSearch.routingHintRole,
   };
 
   const rawDebug = (input.debug && typeof input.debug === "object" ? input.debug : {}) as Record<string, unknown>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,32 @@ function getCommandsDir(): string {
   return path.join(currentDir, "..", "commands");
 }
 
+function appendRoutingHints(
+  output: { system?: string[]; developer?: string[] },
+  hints: string[],
+  preferredRole: "system" | "developer",
+): void {
+  const preferredBucket = preferredRole === "developer" ? output.developer : output.system;
+  if (Array.isArray(preferredBucket)) {
+    preferredBucket.push(...hints);
+    return;
+  }
+
+  // Compatibility fallback for runtimes that do not expose a developer channel yet.
+  if (Array.isArray(output.system)) {
+    output.system.push(...hints);
+  }
+}
+
+interface ChatTransformInput {
+  sessionID?: string;
+}
+
+interface ChatTransformOutput {
+  system?: string[];
+  developer?: string[];
+}
+
 const plugin: Plugin = async ({ directory }) => {
   try {
     const projectRoot = directory;
@@ -99,9 +125,22 @@ const plugin: Plugin = async ({ directory }) => {
         routingHints?.observeUserMessage(input.sessionID, output.parts);
       },
 
-      async "experimental.chat.system.transform"(input, output) {
+      async "experimental.chat.system.transform"(input: ChatTransformInput, output: ChatTransformOutput) {
+        if (config.search.routingHintRole !== "system") {
+          return;
+        }
+
         const hints = await routingHints?.getSystemHints(input.sessionID) ?? [];
-        output.system.push(...hints);
+        appendRoutingHints(output, hints, "system");
+      },
+
+      async "experimental.chat.developer.transform"(input: ChatTransformInput, output: ChatTransformOutput) {
+        if (config.search.routingHintRole !== "developer") {
+          return;
+        }
+
+        const hints = await routingHints?.getSystemHints(input.sessionID) ?? [];
+        appendRoutingHints(output, hints, "developer");
       },
 
       async "tool.execute.after"(input) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -292,6 +292,7 @@ describe("config schema", () => {
         expect(config.search.rrfK).toBe(60);
         expect(config.search.rerankTopN).toBe(20);
         expect(config.search.routingHints).toBe(true);
+        expect(config.search.routingHintRole).toBe("system");
       });
 
       it("should parse routingHints boolean", () => {
@@ -301,6 +302,15 @@ describe("config schema", () => {
 
       it("should fallback routingHints to default for invalid values", () => {
         expect(parseConfig({ search: { routingHints: "nope" } }).search.routingHints).toBe(true);
+      });
+
+      it("should parse routingHintRole values", () => {
+        expect(parseConfig({ search: { routingHintRole: "system" } }).search.routingHintRole).toBe("system");
+        expect(parseConfig({ search: { routingHintRole: "developer" } }).search.routingHintRole).toBe("developer");
+      });
+
+      it("should fallback routingHintRole to default for invalid values", () => {
+        expect(parseConfig({ search: { routingHintRole: "nope" } }).search.routingHintRole).toBe("system");
       });
 
       it("should fallback fusionStrategy to default for invalid values", () => {

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+  config: {
+    search: {
+      routingHints: true,
+      routingHintRole: "system" as "system" | "developer",
+    },
+    indexing: {
+      autoIndex: false,
+      watchFiles: false,
+      requireProjectMarker: true,
+    },
+  },
+  hints: ["runtime-routing-hint"],
+  routingControllers: [] as Array<{
+    getSystemHints: ReturnType<typeof vi.fn>;
+    observeUserMessage: ReturnType<typeof vi.fn>;
+    markToolUsed: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock("../src/config/merger.js", () => ({
+  loadMergedConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("../src/config/schema.js", () => ({
+  parseConfig: vi.fn(() => mockState.config),
+}));
+
+vi.mock("../src/utils/files.js", () => ({
+  hasProjectMarker: vi.fn(() => true),
+}));
+
+vi.mock("../src/watcher/index.js", () => ({
+  createWatcherWithIndexer: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
+vi.mock("../src/commands/loader.js", () => ({
+  loadCommandsFromDirectory: vi.fn(() => new Map()),
+}));
+
+vi.mock("../src/tools/index.js", () => {
+  const toolStub = {};
+  const indexerStub = {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    index: vi.fn().mockResolvedValue(undefined),
+    getStatus: vi.fn().mockResolvedValue({ indexed: true, compatibility: { compatible: true } }),
+  };
+
+  return {
+    codebase_search: toolStub,
+    codebase_peek: toolStub,
+    index_codebase: toolStub,
+    index_status: toolStub,
+    index_health_check: toolStub,
+    index_metrics: toolStub,
+    index_logs: toolStub,
+    find_similar: toolStub,
+    call_graph: toolStub,
+    implementation_lookup: toolStub,
+    add_knowledge_base: toolStub,
+    list_knowledge_bases: toolStub,
+    remove_knowledge_base: toolStub,
+    initializeTools: vi.fn(),
+    getSharedIndexer: vi.fn(() => indexerStub),
+  };
+});
+
+vi.mock("../src/routing-hints.js", () => {
+  class MockRoutingHintController {
+    observeUserMessage = vi.fn();
+    getSystemHints = vi.fn(async () => mockState.hints);
+    markToolUsed = vi.fn();
+
+    constructor() {
+      mockState.routingControllers.push({
+        getSystemHints: this.getSystemHints,
+        observeUserMessage: this.observeUserMessage,
+        markToolUsed: this.markToolUsed,
+      });
+    }
+  }
+
+  return {
+    RoutingHintController: MockRoutingHintController,
+  };
+});
+
+import plugin from "../src/index.js";
+
+describe("plugin routing hint hook selection", () => {
+  beforeEach(() => {
+    mockState.config = {
+      search: {
+        routingHints: true,
+        routingHintRole: "system",
+      },
+      indexing: {
+        autoIndex: false,
+        watchFiles: false,
+        requireProjectMarker: true,
+      },
+    };
+    mockState.hints = ["runtime-routing-hint"];
+    mockState.routingControllers.length = 0;
+  });
+
+  it("injects hints through system transform when role is system", async () => {
+    const runtime = await plugin({ directory: "/tmp/project" } as Parameters<typeof plugin>[0]);
+
+    const systemTransform = runtime["experimental.chat.system.transform"] as
+      ((input: { sessionID?: string }, output: { system?: string[]; developer?: string[] }) => Promise<void>)
+      | undefined;
+    const developerTransform = runtime["experimental.chat.developer.transform"] as
+      ((input: { sessionID?: string }, output: { system?: string[]; developer?: string[] }) => Promise<void>)
+      | undefined;
+
+    expect(systemTransform).toBeTypeOf("function");
+    expect(developerTransform).toBeTypeOf("function");
+
+    const systemOutput: { system: string[]; developer: string[] } = { system: [], developer: [] };
+    await systemTransform?.({ sessionID: "s1" }, systemOutput);
+    expect(systemOutput.system).toEqual(["runtime-routing-hint"]);
+    expect(systemOutput.developer).toEqual([]);
+
+    const developerOutput: { system: string[]; developer: string[] } = { system: [], developer: [] };
+    await developerTransform?.({ sessionID: "s1" }, developerOutput);
+    expect(developerOutput.system).toEqual([]);
+    expect(developerOutput.developer).toEqual([]);
+  });
+
+  it("injects hints through developer transform when role is developer", async () => {
+    mockState.config.search.routingHintRole = "developer";
+    const runtime = await plugin({ directory: "/tmp/project" } as Parameters<typeof plugin>[0]);
+
+    const systemTransform = runtime["experimental.chat.system.transform"] as
+      ((input: { sessionID?: string }, output: { system?: string[]; developer?: string[] }) => Promise<void>)
+      | undefined;
+    const developerTransform = runtime["experimental.chat.developer.transform"] as
+      ((input: { sessionID?: string }, output: { system?: string[]; developer?: string[] }) => Promise<void>)
+      | undefined;
+
+    const systemOutput: { system: string[]; developer: string[] } = { system: [], developer: [] };
+    await systemTransform?.({ sessionID: "s2" }, systemOutput);
+    expect(systemOutput.system).toEqual([]);
+    expect(systemOutput.developer).toEqual([]);
+
+    const developerOutput: { system: string[]; developer: string[] } = { system: [], developer: [] };
+    await developerTransform?.({ sessionID: "s2" }, developerOutput);
+    expect(developerOutput.developer).toEqual(["runtime-routing-hint"]);
+    expect(developerOutput.system).toEqual([]);
+  });
+
+  it("falls back to system output when developer output channel is unavailable", async () => {
+    mockState.config.search.routingHintRole = "developer";
+    const runtime = await plugin({ directory: "/tmp/project" } as Parameters<typeof plugin>[0]);
+
+    const developerTransform = runtime["experimental.chat.developer.transform"] as
+      ((input: { sessionID?: string }, output: { system?: string[]; developer?: string[] }) => Promise<void>)
+      | undefined;
+
+    const output: { system: string[] } = { system: [] };
+    await developerTransform?.({ sessionID: "s3" }, output);
+
+    expect(output.system).toEqual(["runtime-routing-hint"]);
+  });
+});


### PR DESCRIPTION
## Summary

Per-turn guidance is injected as a system message after the initial system prompt. Qwen3.5 models use a strict Jinja chat template that requires the system role to appear only as the first message in the conversation. When the plugin injected an additional system message later in the message list, llama.cpp failed template parsing with:

`Jinja Exception: System message must be at the beginning.`

This caused all requests to fail for Qwen3.5-based models when semantic indexing/context injection was enabled.

The fix allows the routingHintRole to be changed to developer.

## Changes

- Add config option routingHintRole
- Modify code to handle routingHint
- Tests

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [ ] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [ ] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

I don't have permission to add labels in this repo.