### PR TITLE
fix: prevent watcher from recursing into OS-restricted directories

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from "@opencode-ai/plugin";
+import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
 
@@ -89,9 +90,15 @@ const plugin: Plugin = async ({ directory, worktree }) => {
       ? new RoutingHintController(() => getProjectIndexer().getStatus())
       : null;
 
-    const isValidProject = !config.indexing.requireProjectMarker || hasProjectMarker(projectRoot);
+    const isHomeDir = path.resolve(projectRoot) === path.resolve(os.homedir());
+    const isValidProject = !isHomeDir && (!config.indexing.requireProjectMarker || hasProjectMarker(projectRoot));
 
-    if (!isValidProject) {
+    if (isHomeDir) {
+      console.warn(
+        `[codebase-index] Refusing to watch or index home directory "${projectRoot}". ` +
+        `Open a specific project directory instead.`
+      );
+    } else if (!isValidProject) {
       console.warn(
         `[codebase-index] Skipping file watching and auto-indexing: no project marker found in "${projectRoot}". ` +
         `Set "indexing.requireProjectMarker": false in config to override.`

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -17,3 +17,44 @@ export function hasFilteredPathSegment(relativePath: string, separator: string =
     (part) => isHiddenPathSegment(part) || isBuildPathSegment(part)
   );
 }
+
+/**
+ * Directories that should never be watched when they appear as a top-level
+ * segment of a relative path. These are OS-level directories that are either
+ * permission-restricted or irrelevant to source code projects.
+ *
+ * macOS: Library, Applications, System, Volumes, private, cores
+ * Linux: proc, sys, dev, run, snap
+ * Windows: Windows, ProgramData, Program Files, $Recycle.Bin
+ */
+const RESTRICTED_DIRECTORIES = new Set([
+  // macOS
+  "library",
+  "applications",
+  "system",
+  "volumes",
+  "private",
+  "cores",
+  // Linux
+  "proc",
+  "sys",
+  "dev",
+  "run",
+  "snap",
+  // Windows
+  "windows",
+  "programdata",
+  "program files",
+  "program files (x86)",
+  "$recycle.bin",
+]);
+
+/**
+ * Returns true if the first path segment is a known OS-restricted directory.
+ * This prevents the watcher from descending into paths like ~/Library/ on macOS.
+ */
+export function isRestrictedDirectory(relativePath: string, separator: string = path.sep): boolean {
+  const firstSegment = relativePath.split(separator)[0];
+  if (!firstSegment) return false;
+  return RESTRICTED_DIRECTORIES.has(firstSegment.toLowerCase());
+}

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 import type { CodebaseIndexConfig } from "../config/schema.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
-import { hasFilteredPathSegment } from "../utils/paths.js";
+import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
 export type FileChangeType = "add" | "change" | "unlink";
 
@@ -45,6 +45,10 @@ export class FileWatcher {
           return true;
         }
 
+        if (isRestrictedDirectory(relativePath, path.sep)) {
+          return true;
+        }
+
         if (ignoreFilter.ignores(relativePath)) {
           return true;
         }
@@ -57,6 +61,15 @@ export class FileWatcher {
         stabilityThreshold: 300,
         pollInterval: 100,
       },
+    });
+
+    this.watcher.on("error", (error: unknown) => {
+      const err = error instanceof Error ? (error as NodeJS.ErrnoException) : null;
+      if (err?.code === "EPERM" || err?.code === "EACCES") {
+        // Silently ignore permission errors — common on macOS restricted paths
+        return;
+      }
+      console.error("[codebase-index] Watcher error:", err?.message ?? error);
     });
 
     this.watcher.on("add", (filePath) => this.handleChange("add", filePath));

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -6,6 +6,7 @@ import {
   hasFilteredPathSegment,
   isBuildPathSegment,
   isHiddenPathSegment,
+  isRestrictedDirectory,
   normalizePathSeparators,
 } from "../src/utils/paths.js";
 
@@ -31,5 +32,26 @@ describe("path helpers", () => {
     expect(hasFilteredPathSegment(`src${path.sep}.git${path.sep}config`)).toBe(true);
     expect(hasFilteredPathSegment(`src${path.sep}cmake-build-debug${path.sep}index.ts`)).toBe(true);
     expect(hasFilteredPathSegment(`src${path.sep}watcher${path.sep}index.ts`)).toBe(false);
+  });
+
+  it("detects restricted OS directories in first path segment", () => {
+    expect(isRestrictedDirectory("Library/Containers/uuid", "/")).toBe(true);
+    expect(isRestrictedDirectory("library/Preferences", "/")).toBe(true);
+    expect(isRestrictedDirectory("Applications/App.app", "/")).toBe(true);
+    expect(isRestrictedDirectory("System/Library", "/")).toBe(true);
+    expect(isRestrictedDirectory("Volumes/Disk", "/")).toBe(true);
+    expect(isRestrictedDirectory("private/var", "/")).toBe(true);
+    expect(isRestrictedDirectory("cores/core.1234", "/")).toBe(true);
+    // Linux
+    expect(isRestrictedDirectory("proc/1/status", "/")).toBe(true);
+    expect(isRestrictedDirectory("sys/class", "/")).toBe(true);
+    // Windows
+    expect(isRestrictedDirectory("Windows\\System32", "\\")).toBe(true);
+    expect(isRestrictedDirectory("ProgramData\\App", "\\")).toBe(true);
+    // Non-restricted paths
+    expect(isRestrictedDirectory("src/Library/thing", "/")).toBe(false);
+    expect(isRestrictedDirectory("node_modules/lib", "/")).toBe(false);
+    expect(isRestrictedDirectory("dist/index.js", "/")).toBe(false);
+    expect(isRestrictedDirectory("", "/")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Prevent the file watcher from recursing into OS-restricted directories (e.g. `~/Library/` on macOS) when the plugin receives a home directory as `projectRoot`. This fixes the Desktop app getting stuck on the splash screen due to hundreds of EPERM unhandled promise rejections.

## Changes

- Refuse to watch or auto-index when `projectRoot` resolves to `os.homedir()` — prints a warning instead
- Add `isRestrictedDirectory()` utility that blocks known OS-level directories (`Library`, `Applications`, `System`, `Volumes`, `private`, `cores`, `proc`, `sys`, `dev`, `run`, `snap`, `Windows`, `ProgramData`, `Program Files`) when they appear as the first path segment
- Wire `isRestrictedDirectory` into chokidar `ignored` callback so the watcher never descends into these paths
- Add `.on("error")` handler to chokidar instance that gracefully swallows `EPERM`/`EACCES` errors instead of causing unhandled promise rejections

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`bug`)
- [x] Added at most one semver label (`semver:patch`)

## Related Issues

Fixes #107