### PR TITLE
chore: prepare v0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-05
+
+### Added
+- **Developer role for routing hints**: Support `developer` role for routing hint messages via `search.routingHintRole` config option (#102).
+
+### Fixed
+- **Multi-project index collision**: Resolved index collisions when multiple projects are open by using per-directory Indexer map keyed by worktree root (#108).
+- **Watcher EPERM flood**: Prevent watcher from recursing into OS-restricted directories that cause permission error storms (#109).
+- **CodeQL security findings**: Fully break taint chains from `apiKey` to error logs and resolve 6 GitHub CodeQL security findings (#105).
+
 ## [0.9.0] - 2026-05-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "~1.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Prepare v0.10.0 release with 1 feature and 3 bug fixes shipped since v0.9.0.

## Changes

- Bump version to 0.10.0 in package.json and package-lock.json
- Add v0.10.0 changelog section covering the full v0.9.0..HEAD delta:
  - **feat**: Developer role support for routing hints (#102)
  - **fix**: Multi-project index collision via per-directory Indexer map (#108)
  - **fix**: Watcher EPERM flood from OS-restricted directories (#109)
  - **fix**: CodeQL security findings — taint chain breakage (#105)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Includes #102, #105, #108, #109