### PR TITLE
feat(visualize): temporal call graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,13 +404,24 @@ Analyzes a PR's changed files to determine impact scope within the codebase.
 - **Parameters**: `checkConflicts` (optional, default `false`) — when `true`, detects overlapping concurrent PRs sharing affected symbols and returns `conflictingPRs`.
 
 ### `index_visualize`
-Generate a self-contained HTML call graph view for browser-based exploration.
+Generate a self-contained temporal call graph view for browser-based exploration.
 
-- **Use for**: Onboarding, architecture walkthroughs, and drilling from module-level structure into symbol relationships.
-- **What it shows**: A module overview by default, a clustered symbol exploration view, and a focus view with callers/callees for a selected module or symbol.
+- **Use for**: Onboarding, architecture walkthroughs, and understanding what moved recently before drilling into call relationships.
+- **What it shows**: Recent change lenses, module overview, symbol exploration, hotspots, and cycles.
+- **Concepts**: Modules are path-based code areas such as `src/tools` or `native`; symbols are indexed functions, classes, methods, or similar named code units; edges are caller/callee relationships.
 - **Parameters**: `directory` (optional folder filter), `maxNodes` (default `5000`), `includeOrphans` (include disconnected symbols).
 - **Output**: Writes a temporary HTML file you can open in any browser.
 - **Example**: `index_visualize(directory="src/tools", maxNodes=1500)`
+
+CLI shortcut after building locally:
+
+```bash
+npm run build
+npm run visualize
+npm run visualize -- native
+npm run visualize -- src/tools max=1000
+npm run visualize -- src/indexer orphans
+```
 
 
 ### `add_knowledge_base`
@@ -441,7 +452,7 @@ The plugin automatically registers these slash commands:
 | `/find <query>` | **Hybrid Search**. Combines semantic search + grep. Best for "Find usage of X". |
 | `/call-graph <query>` | **Call Graph Trace**. Find callers/callees to understand execution flow. |
 | `/pr-impact <PR number or branch>` | **PR Impact Analysis**. Analyze changed files, affected symbols, communities, hub nodes, and risk. |
-| `/visualize [directory|max=N|orphans]` | **Call Graph Visualization**. Open a module overview and symbol exploration view in a browser-ready HTML file. |
+| `/visualize [directory|max=N|orphans]` | **Temporal Call Graph Visualization**. Open recent changes, module overview, symbol exploration, hotspots, and cycles in a browser-ready HTML file. |
 | `/index` | **Update Index**. Runs incremental indexing by default; use `/index force` for a full rebuild. |
 | `/status` | **Check Status**. Shows if indexed, chunk count, and provider info. |
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,17 @@ Find the shortest known call-graph path between two symbols. Use it after `codeb
 Analyzes a PR's changed files to determine impact scope within the codebase.
 - **Use for**: Understanding which symbols are affected by a PR, their call-graph reach, risk level, and community/cluster detection.
 - **Parameters**: `checkConflicts` (optional, default `false`) — when `true`, detects overlapping concurrent PRs sharing affected symbols and returns `conflictingPRs`.
+
+### `index_visualize`
+Generate a self-contained HTML call graph view for browser-based exploration.
+
+- **Use for**: Onboarding, architecture walkthroughs, and drilling from module-level structure into symbol relationships.
+- **What it shows**: A module overview by default, a clustered symbol exploration view, and a focus view with callers/callees for a selected module or symbol.
+- **Parameters**: `directory` (optional folder filter), `maxNodes` (default `5000`), `includeOrphans` (include disconnected symbols).
+- **Output**: Writes a temporary HTML file you can open in any browser.
+- **Example**: `index_visualize(directory="src/tools", maxNodes=1500)`
+
+
 ### `add_knowledge_base`
 Add a folder as a knowledge base to be indexed alongside project code.
 - **Use for**: Indexing external documentation, API references, example programs.
@@ -430,6 +441,7 @@ The plugin automatically registers these slash commands:
 | `/find <query>` | **Hybrid Search**. Combines semantic search + grep. Best for "Find usage of X". |
 | `/call-graph <query>` | **Call Graph Trace**. Find callers/callees to understand execution flow. |
 | `/pr-impact <PR number or branch>` | **PR Impact Analysis**. Analyze changed files, affected symbols, communities, hub nodes, and risk. |
+| `/visualize [directory|max=N|orphans]` | **Call Graph Visualization**. Open a module overview and symbol exploration view in a browser-ready HTML file. |
 | `/index` | **Update Index**. Runs incremental indexing by default; use `/index force` for a full rebuild. |
 | `/status` | **Check Status**. Shows if indexed, chunk count, and provider info. |
 

--- a/commands/visualize.md
+++ b/commands/visualize.md
@@ -2,7 +2,7 @@
 description: Generate interactive HTML call graph visualization
 ---
 
-Generate an interactive force-directed visualization of the call graph.
+Generate an interactive call graph visualization with a module overview by default and a clustered symbol exploration mode.
 
 User input: $ARGUMENTS
 
@@ -15,7 +15,7 @@ Parse input for optional parameters:
 Call `index_visualize` with parsed parameters.
 
 Examples:
-- `/visualize` → full call graph
+- `/visualize` → full call graph with module overview + symbol exploration views
 - `/visualize src/tools` → only symbols in src/tools/
 - `/visualize max=1000` → limit to 1000 nodes
 - `/visualize src/indexer orphans` → include disconnected nodes

--- a/commands/visualize.md
+++ b/commands/visualize.md
@@ -1,8 +1,8 @@
 ---
-description: Generate interactive HTML call graph visualization
+description: Generate temporal HTML call graph visualization
 ---
 
-Generate an interactive call graph visualization with a module overview by default and a clustered symbol exploration mode.
+Generate an interactive temporal call graph visualization that starts with recent movement/onboarding context, then supports module overview, symbol exploration, hotspots, and cycles.
 
 User input: $ARGUMENTS
 
@@ -10,12 +10,12 @@ Parse input for optional parameters:
 - Plain text → directory filter (e.g., `/visualize src/services`)
 - `max=N` or "limit N" → sets maxNodes
 - `orphans` or `include-orphans` → sets includeOrphans=true
-- No input → visualize entire call graph
+- No input → visualize recent code movement plus entire call graph
 
 Call `index_visualize` with parsed parameters.
 
 Examples:
-- `/visualize` → full call graph with module overview + symbol exploration views
+- `/visualize` → temporal onboarding view with changes, modules, symbols, hotspots, and cycles
 - `/visualize src/tools` → only symbols in src/tools/
 - `/visualize max=1000` → limit to 1000 nodes
 - `/visualize src/indexer orphans` → include disconnected nodes
@@ -23,3 +23,8 @@ Examples:
 If the index doesn't exist, run `index_codebase` first.
 
 Return the generated file path and open instructions.
+
+Terminology:
+- Modules are path-based code areas, such as `src/tools` or `native`.
+- Symbols are indexed named code units, such as functions, methods, classes, or Rust modules.
+- Cycles are loops where code can eventually call or depend back on itself.

--- a/commands/visualize.md
+++ b/commands/visualize.md
@@ -1,0 +1,25 @@
+---
+description: Generate interactive HTML call graph visualization
+---
+
+Generate an interactive force-directed visualization of the call graph.
+
+User input: $ARGUMENTS
+
+Parse input for optional parameters:
+- Plain text → directory filter (e.g., `/visualize src/services`)
+- `max=N` or "limit N" → sets maxNodes
+- `orphans` or `include-orphans` → sets includeOrphans=true
+- No input → visualize entire call graph
+
+Call `index_visualize` with parsed parameters.
+
+Examples:
+- `/visualize` → full call graph
+- `/visualize src/tools` → only symbols in src/tools/
+- `/visualize max=1000` → limit to 1000 nodes
+- `/visualize src/indexer orphans` → include disconnected nodes
+
+If the index doesn't exist, run `index_codebase` first.
+
+Return the generated file path and open instructions.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build:ts": "tsup",
     "build:native": "cd native && cargo build --release && napi build --release --platform",
     "build:native:all": "cd native && napi build --release --platform --target x86_64-apple-darwin --target aarch64-apple-darwin --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu --target x86_64-pc-windows-msvc",
+    "visualize": "node dist/cli.js visualize",
     "dev": "tsup --watch",
     "eval": "npx tsx src/cli.ts eval run",
     "eval:smoke": "npx tsx src/cli.ts eval run --config .github/eval-config.json --reindex --dataset benchmarks/golden/small.json",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,6 @@ async function handleVisualizeCommand(argv: string[], cwd: string): Promise<numb
     const indexer = new Indexer(args.project, config);
     const rawData = await indexer.getVisualizationData({
       directory: args.directory,
-      maxNodes: args.maxNodes,
     });
 
     if (rawData.symbols.length === 0) {
@@ -79,6 +78,8 @@ async function handleVisualizeCommand(argv: string[], cwd: string): Promise<numb
 
     const vizData = attachRecentActivity(transformForVisualization(rawData.symbols, rawData.edges, {
       includeOrphans: args.includeOrphans,
+      directory: args.directory,
+      maxNodes: args.maxNodes,
     }), args.project);
 
     if (vizData.nodes.length === 0) {
@@ -91,7 +92,7 @@ async function handleVisualizeCommand(argv: string[], cwd: string): Promise<numb
     console.log(`Temporal call graph visualization generated: ${outputPath}`);
     console.log(`Nodes: ${vizData.nodes.length} | Edges: ${vizData.edges.length}`);
     console.log(`Recent change lenses: ${vizData.changes?.length ?? 0}`);
-    if (rawData.truncated) {
+    if (vizData.metadata.truncated) {
       console.log(`Graph truncated to ${args.maxNodes} most-connected nodes.`);
     }
     return 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,8 +95,8 @@ async function handleVisualizeCommand(argv: string[], cwd: string): Promise<numb
       console.log(`Graph truncated to ${args.maxNodes} most-connected nodes.`);
     }
     return 0;
-  } catch (error: unknown) {
-    console.error(error instanceof Error ? error.message : String(error));
+  } catch {
+    console.error("Failed to generate visualization. Check the project, config, and arguments, then retry.");
     return 1;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,23 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { writeFileSync } from "fs";
+import * as os from "os";
 import * as path from "path";
 
 import { parseConfig } from "./config/schema.js";
 import { handleEvalCommand } from "./eval/cli.js";
+import { Indexer } from "./indexer/index.js";
 import { createMcpServer } from "./mcp-server.js";
 import { loadMergedConfig } from "./config/merger.js";
+import { attachRecentActivity } from "./tools/visualize/activity.js";
+import { generateVisualizationHtml, transformForVisualization } from "./tools/visualize/index.js";
+
+interface VisualizeArgs {
+  directory?: string;
+  includeOrphans: boolean;
+  maxNodes: number;
+  project: string;
+}
 
 function parseArgs(argv: string[]): { project: string; config?: string } {
   let project = process.cwd();
@@ -22,9 +34,80 @@ function parseArgs(argv: string[]): { project: string; config?: string } {
   return { project, config };
 }
 
+function parseVisualizeArgs(argv: string[], cwd: string): VisualizeArgs {
+  let project = cwd;
+  let directory: string | undefined;
+  let includeOrphans = false;
+  let maxNodes = 5000;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--project" && argv[i + 1]) {
+      project = path.resolve(argv[++i]);
+    } else if (arg === "--max" && argv[i + 1]) {
+      maxNodes = Number(argv[++i]);
+    } else if (arg.startsWith("--max=") || arg.startsWith("max=")) {
+      maxNodes = Number(arg.split("=")[1]);
+    } else if (arg === "--orphans" || arg === "orphans" || arg === "--include-orphans" || arg === "include-orphans") {
+      includeOrphans = true;
+    } else if (!arg.startsWith("-") && directory === undefined) {
+      directory = arg;
+    }
+  }
+
+  if (!Number.isFinite(maxNodes) || maxNodes < 1) {
+    throw new Error("max must be a positive number");
+  }
+
+  return { directory, includeOrphans, maxNodes, project };
+}
+
+async function handleVisualizeCommand(argv: string[], cwd: string): Promise<number> {
+  try {
+    const args = parseVisualizeArgs(argv, cwd);
+    const config = parseConfig(loadMergedConfig(args.project));
+    const indexer = new Indexer(args.project, config);
+    const rawData = await indexer.getVisualizationData({
+      directory: args.directory,
+      maxNodes: args.maxNodes,
+    });
+
+    if (rawData.symbols.length === 0) {
+      console.error("No call graph data found. Run /index in OpenCode first, then retry npm run visualize.");
+      return 1;
+    }
+
+    const vizData = attachRecentActivity(transformForVisualization(rawData.symbols, rawData.edges, {
+      includeOrphans: args.includeOrphans,
+    }), args.project);
+
+    if (vizData.nodes.length === 0) {
+      console.error("No connected symbols found. Retry with: npm run visualize -- orphans");
+      return 1;
+    }
+
+    const outputPath = path.join(os.tmpdir(), `call-graph-${Date.now()}.html`);
+    writeFileSync(outputPath, generateVisualizationHtml(vizData), "utf-8");
+    console.log(`Temporal call graph visualization generated: ${outputPath}`);
+    console.log(`Nodes: ${vizData.nodes.length} | Edges: ${vizData.edges.length}`);
+    console.log(`Recent change lenses: ${vizData.changes?.length ?? 0}`);
+    if (rawData.truncated) {
+      console.log(`Graph truncated to ${args.maxNodes} most-connected nodes.`);
+    }
+    return 0;
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
 async function main(): Promise<void> {
   if (process.argv[2] === "eval") {
     const exitCode = await handleEvalCommand(process.argv.slice(3), process.cwd());
+    process.exit(exitCode);
+  }
+  if (process.argv[2] === "visualize") {
+    const exitCode = await handleVisualizeCommand(process.argv.slice(3), process.cwd());
     process.exit(exitCode);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   add_knowledge_base,
   list_knowledge_bases,
   remove_knowledge_base,
+  index_visualize,
   getIndexerForProject,
   initializeTools,
   pr_impact,
@@ -137,6 +138,7 @@ const plugin: Plugin = async ({ directory, worktree }) => {
         list_knowledge_bases,
         remove_knowledge_base,
         pr_impact,
+        index_visualize,
       },
 
       async "chat.message"(input, output) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5124,10 +5124,9 @@ export class Indexer {
     };
   }
 
-  async getVisualizationData(options?: { directory?: string; maxNodes?: number }): Promise<{
+  async getVisualizationData(options?: { directory?: string }): Promise<{
     symbols: SymbolData[];
     edges: CallEdgeData[];
-    truncated: boolean;
   }> {
     const { database, store } = await this.ensureInitialized();
     const seenSymbols = new Map<string, SymbolData>();
@@ -5180,12 +5179,7 @@ export class Indexer {
       }
     }
 
-    const symbols = [...seenSymbols.values()];
-    const edges = [...seenEdges.values()];
-    const maxNodes = options?.maxNodes ?? 5000;
-    const truncated = symbols.length > maxNodes;
-
-    return { symbols, edges, truncated };
+    return { symbols: [...seenSymbols.values()], edges: [...seenEdges.values()] };
   }
 
   async close(): Promise<void> {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4903,7 +4903,6 @@ export class Indexer {
     return shortest;
   }
 
-
   async getSymbolsForBranch(branch?: string): Promise<SymbolData[]> {
     const { database } = await this.ensureInitialized();
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
@@ -5123,6 +5122,70 @@ export class Indexer {
       direction,
       conflictingPRs,
     };
+  }
+
+  async getVisualizationData(options?: { directory?: string; maxNodes?: number }): Promise<{
+    symbols: SymbolData[];
+    edges: CallEdgeData[];
+    truncated: boolean;
+  }> {
+    const { database, store } = await this.ensureInitialized();
+    const seenSymbols = new Map<string, SymbolData>();
+    const seenEdges = new Map<string, CallEdgeData>();
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      // Get all symbol IDs on this branch
+      const symbolIds = database.getBranchSymbolIds(branchKey);
+      const symbolIdSet = new Set(symbolIds);
+
+      // Get unique file paths from branch chunks' metadata
+      const chunkIds = database.getBranchChunkIds(branchKey);
+      const metadataMap = chunkIds.length > 0 ? store.getMetadataBatch(chunkIds) : new Map<string, import("../native/index.js").ChunkMetadata>();
+      const filePaths = new Set<string>();
+      for (const [, meta] of metadataMap) {
+        if (meta.filePath) filePaths.add(meta.filePath);
+      }
+
+      const directory = options?.directory?.replace(/\/$/, "");
+      const absoluteDirectoryFilter = directory
+        ? path.resolve(this.projectRoot, directory)
+        : undefined;
+
+      // Gather symbols from each file
+      for (const filePath of filePaths) {
+        if (directory) {
+          const absoluteFilePath = path.resolve(filePath);
+          const matchesRelative = filePath === directory || filePath.startsWith(directory + "/");
+          const matchesProjectRelative = absoluteDirectoryFilter !== undefined && (
+            absoluteFilePath === absoluteDirectoryFilter || absoluteFilePath.startsWith(absoluteDirectoryFilter + path.sep)
+          );
+          if (!matchesRelative && !matchesProjectRelative) {
+            continue;
+          }
+        }
+        for (const sym of database.getSymbolsByFile(filePath)) {
+          if (symbolIdSet.has(sym.id) && !seenSymbols.has(sym.id)) {
+            seenSymbols.set(sym.id, sym);
+          }
+        }
+      }
+
+      // Gather edges from each symbol
+      for (const symbolId of seenSymbols.keys()) {
+        for (const edge of database.getCallees(symbolId, branchKey)) {
+          if (!seenEdges.has(edge.id)) {
+            seenEdges.set(edge.id, edge);
+          }
+        }
+      }
+    }
+
+    const symbols = [...seenSymbols.values()];
+    const edges = [...seenEdges.values()];
+    const maxNodes = options?.maxNodes ?? 5000;
+    const truncated = symbols.length > maxNodes;
+
+    return { symbols, edges, truncated };
   }
 
   async close(): Promise<void> {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -538,8 +538,9 @@ export { pr_impact };
 
 export const index_visualize: ToolDefinition = tool({
   description:
-    "Generate a self-contained HTML call graph view for browser-based exploration. " +
-    "Shows a module overview by default, clustered symbol exploration, and a focus view for selected modules.",
+    "Generate an interactive HTML visualization of the call graph. " +
+    "Starts with a module overview and includes a clustered symbol exploration view. " +
+    "Clickable modules and symbols show relationship details. Supports search and drill-down.",
   args: {
     directory: z.string().optional().describe("Filter to symbols in this directory (e.g., 'src/services')"),
     maxNodes: z.number().optional().default(5000).describe("Maximum nodes to include (default 5000)"),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -23,11 +23,13 @@ import {
   resolveKnowledgeBasePath,
 } from "./knowledge-base-paths.js";
 import { existsSync, realpathSync, statSync } from "fs";
+import { writeFileSync } from "fs";
 import * as path from "path";
 import { loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
 import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from "./config-state.js";
 import * as os from "os";
+import { generateVisualizationHtml, transformForVisualization } from "./visualize/index.js";
 
 function ensureStringArray(value: unknown): string[] {
   return Array.isArray(value) ? (value as string[]) : [];
@@ -533,3 +535,49 @@ export const remove_knowledge_base: ToolDefinition = tool({
   },
 });
 export { pr_impact };
+
+export const index_visualize: ToolDefinition = tool({
+  description:
+    "Generate a self-contained HTML call graph view for browser-based exploration. " +
+    "Shows a module overview by default, clustered symbol exploration, and a focus view for selected modules.",
+  args: {
+    directory: z.string().optional().describe("Filter to symbols in this directory (e.g., 'src/services')"),
+    maxNodes: z.number().optional().default(5000).describe("Maximum nodes to include (default 5000)"),
+    includeOrphans: z.boolean().optional().default(false).describe("Include symbols with no call relationships"),
+  },
+  async execute(args, context) {
+    const indexer = getIndexerForProject(context?.worktree);
+    const rawData = await indexer.getVisualizationData({
+      directory: args.directory,
+      maxNodes: args.maxNodes,
+    });
+
+    if (rawData.symbols.length === 0) {
+      return "No call graph data found. Run index_codebase first to build the call graph.";
+    }
+
+    const vizData = transformForVisualization(rawData.symbols, rawData.edges, {
+      includeOrphans: args.includeOrphans,
+      directory: args.directory,
+      maxNodes: args.maxNodes,
+    });
+
+    if (vizData.nodes.length === 0) {
+      return "No connected symbols found for visualization. Try including orphans with includeOrphans=true, or check that the call graph has resolved edges.";
+    }
+
+    const html = generateVisualizationHtml(vizData);
+    const outputPath = path.join(os.tmpdir(), `call-graph-${Date.now()}.html`);
+    writeFileSync(outputPath, html, "utf-8");
+
+    let result = `Visualization generated: ${outputPath}\n\n`;
+    result += `Nodes: ${vizData.nodes.length} | Edges: ${vizData.edges.length}\n`;
+    result += `Files: ${new Set(vizData.nodes.map(n => n.filePath)).size}\n`;
+    result += `Directories: ${new Set(vizData.nodes.map(n => n.directory)).size}`;
+    if (rawData.truncated) {
+      result += `\n\n\u26a0\ufe0f Graph truncated to ${args.maxNodes} most-connected nodes (total: ${rawData.symbols.length}).`;
+    }
+
+    return result;
+  },
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -550,7 +550,6 @@ export const index_visualize: ToolDefinition = tool({
     const indexer = getIndexerForProject(context?.worktree);
     const rawData = await indexer.getVisualizationData({
       directory: args.directory,
-      maxNodes: args.maxNodes,
     });
 
     if (rawData.symbols.length === 0) {
@@ -576,7 +575,7 @@ export const index_visualize: ToolDefinition = tool({
     result += `Recent change lenses: ${vizData.changes?.length ?? 0}\n`;
     result += `Files: ${new Set(vizData.nodes.map(n => n.filePath)).size}\n`;
     result += `Directories: ${new Set(vizData.nodes.map(n => n.directory)).size}`;
-    if (rawData.truncated) {
+    if (vizData.metadata.truncated) {
       result += `\n\n\u26a0\ufe0f Graph truncated to ${args.maxNodes} most-connected nodes (total: ${rawData.symbols.length}).`;
     }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,6 +29,7 @@ import { loadProjectConfigLayer, materializeLocalProjectConfig } from "../config
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
 import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from "./config-state.js";
 import * as os from "os";
+import { attachRecentActivity } from "./visualize/activity.js";
 import { generateVisualizationHtml, transformForVisualization } from "./visualize/index.js";
 
 function ensureStringArray(value: unknown): string[] {
@@ -538,9 +539,8 @@ export { pr_impact };
 
 export const index_visualize: ToolDefinition = tool({
   description:
-    "Generate an interactive HTML visualization of the call graph. " +
-    "Starts with a module overview and includes a clustered symbol exploration view. " +
-    "Clickable modules and symbols show relationship details. Supports search and drill-down.",
+    "Generate an interactive HTML visualization of recent code movement and the call graph. " +
+    "Starts with temporal onboarding context from Git history, then supports module, symbol, hotspot, and cycle drill-down.",
   args: {
     directory: z.string().optional().describe("Filter to symbols in this directory (e.g., 'src/services')"),
     maxNodes: z.number().optional().default(5000).describe("Maximum nodes to include (default 5000)"),
@@ -557,11 +557,11 @@ export const index_visualize: ToolDefinition = tool({
       return "No call graph data found. Run index_codebase first to build the call graph.";
     }
 
-    const vizData = transformForVisualization(rawData.symbols, rawData.edges, {
+    const vizData = attachRecentActivity(transformForVisualization(rawData.symbols, rawData.edges, {
       includeOrphans: args.includeOrphans,
       directory: args.directory,
       maxNodes: args.maxNodes,
-    });
+    }), context?.worktree ?? defaultProjectRoot);
 
     if (vizData.nodes.length === 0) {
       return "No connected symbols found for visualization. Try including orphans with includeOrphans=true, or check that the call graph has resolved edges.";
@@ -571,8 +571,9 @@ export const index_visualize: ToolDefinition = tool({
     const outputPath = path.join(os.tmpdir(), `call-graph-${Date.now()}.html`);
     writeFileSync(outputPath, html, "utf-8");
 
-    let result = `Visualization generated: ${outputPath}\n\n`;
+    let result = `Temporal call graph visualization generated: ${outputPath}\n\n`;
     result += `Nodes: ${vizData.nodes.length} | Edges: ${vizData.edges.length}\n`;
+    result += `Recent change lenses: ${vizData.changes?.length ?? 0}\n`;
     result += `Files: ${new Set(vizData.nodes.map(n => n.filePath)).size}\n`;
     result += `Directories: ${new Set(vizData.nodes.map(n => n.directory)).size}`;
     if (rawData.truncated) {

--- a/src/tools/visualize/activity.ts
+++ b/src/tools/visualize/activity.ts
@@ -1,0 +1,223 @@
+import { execFileSync } from "child_process";
+import * as path from "path";
+
+import type { VisualizationChange, VisualizationData, VisualizationNode } from "./types.js";
+
+interface FileActivity {
+  churn: number;
+  commits: number;
+  latestDate: string;
+  latestHash: string;
+  latestSubject: string;
+}
+
+interface ModuleActivity {
+  moduleId: string;
+  filePaths: Set<string>;
+  churn: number;
+  commits: number;
+  latestDate: string;
+  latestHash: string;
+  latestSubject: string;
+}
+
+export function attachRecentActivity(data: VisualizationData, projectRoot: string): VisualizationData {
+  const activity = readGitActivity(projectRoot);
+  const changes = activity.size > 0
+    ? buildGitChanges(data, activity, projectRoot)
+    : buildGraphChanges(data);
+
+  return {
+    ...data,
+    changes,
+  };
+}
+
+function readGitActivity(projectRoot: string): Map<string, FileActivity> {
+  try {
+    const output = execFileSync(
+      "git",
+      ["-C", projectRoot, "log", "--since=90.days", "--numstat", "--date=short", "--pretty=format:__COMMIT__%x09%h%x09%ad%x09%s"],
+      { encoding: "utf8", maxBuffer: 8 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return parseGitActivity(output);
+  } catch {
+    return new Map();
+  }
+}
+
+function parseGitActivity(output: string): Map<string, FileActivity> {
+  const activity = new Map<string, FileActivity>();
+  let latestHash = "";
+  let latestDate = "";
+  let latestSubject = "";
+
+  for (const line of output.split(/\r?\n/)) {
+    if (!line) continue;
+    if (line.startsWith("__COMMIT__\t")) {
+      const [, hash = "", date = "", subject = ""] = line.split("\t");
+      latestHash = hash;
+      latestDate = date;
+      latestSubject = subject;
+      continue;
+    }
+
+    const [addedRaw, deletedRaw, filePath] = line.split("\t");
+    if (!filePath || addedRaw === "-" || deletedRaw === "-") continue;
+
+    const churn = Number(addedRaw) + Number(deletedRaw);
+    if (!Number.isFinite(churn) || churn <= 0) continue;
+
+    const normalizedPath = normalizePath(filePath);
+    const previous = activity.get(normalizedPath);
+    activity.set(normalizedPath, {
+      churn: (previous?.churn ?? 0) + churn,
+      commits: (previous?.commits ?? 0) + 1,
+      latestDate: previous?.latestDate ?? latestDate,
+      latestHash: previous?.latestHash ?? latestHash,
+      latestSubject: previous?.latestSubject ?? latestSubject,
+    });
+  }
+
+  return activity;
+}
+
+function buildGitChanges(data: VisualizationData, activity: Map<string, FileActivity>, projectRoot: string): VisualizationChange[] {
+  const byModule = new Map<string, ModuleActivity>();
+
+  for (const node of data.nodes) {
+    const fileActivity = activity.get(toGitRelativePath(projectRoot, node.filePath));
+    if (!fileActivity) continue;
+
+    const current = byModule.get(node.moduleId) ?? {
+      moduleId: node.moduleId,
+      filePaths: new Set<string>(),
+      churn: 0,
+      commits: 0,
+      latestDate: fileActivity.latestDate,
+      latestHash: fileActivity.latestHash,
+      latestSubject: fileActivity.latestSubject,
+    };
+    if (!current.filePaths.has(node.filePath)) {
+      current.filePaths.add(node.filePath);
+      current.churn += fileActivity.churn;
+      current.commits += fileActivity.commits;
+    }
+    if (fileActivity.latestDate > current.latestDate) {
+      current.latestDate = fileActivity.latestDate;
+      current.latestHash = fileActivity.latestHash;
+      current.latestSubject = fileActivity.latestSubject;
+    }
+    byModule.set(node.moduleId, current);
+  }
+
+  return [...byModule.values()]
+    .sort((a, b) => scoreModule(data, b.moduleId, b.churn) - scoreModule(data, a.moduleId, a.churn))
+    .slice(0, 12)
+    .map((item, index) => toGitChange(data, item, index));
+}
+
+function buildGraphChanges(data: VisualizationData): VisualizationChange[] {
+  return data.modules
+    .map((module) => {
+      const calls = moduleCallCount(data, module.id);
+      const focusNode = strongestNode(data, module.id);
+      const risk = riskFor(calls, module.symbolCount);
+      return {
+        id: `graph-${module.id}`,
+        title: `${module.label} is structurally important`,
+        kind: risk === "high" ? "risk" : "hot",
+        when: "graph-derived",
+        source: "call graph",
+        intent: "load-bearing path",
+        summary: `${module.symbolCount} symbols with ${calls} cross-module calls in this slice.`,
+        why: "No recent Git history was available, so this highlights modules whose call relationships make them expensive to misunderstand during onboarding.",
+        calls,
+        churn: 0,
+        risk,
+        moduleId: module.id,
+        focusNodeId: focusNode?.id,
+        filePaths: [...new Set(data.nodes.filter((node) => node.moduleId === module.id).map((node) => node.filePath))].slice(0, 6),
+      } satisfies VisualizationChange;
+    })
+    .sort((a, b) => b.calls - a.calls)
+    .slice(0, 8);
+}
+
+function toGitChange(data: VisualizationData, item: ModuleActivity, index: number): VisualizationChange {
+  const module = data.modules.find((candidate) => candidate.id === item.moduleId);
+  const label = module?.label ?? item.moduleId;
+  const calls = moduleCallCount(data, item.moduleId);
+  const focusNode = strongestNode(data, item.moduleId);
+  const risk = riskFor(calls, item.churn);
+  const intent = inferIntent(item.latestSubject);
+
+  return {
+    id: `git-${item.moduleId}-${index}`,
+    title: `${label} moved recently`,
+    kind: risk === "high" ? "risk" : "hot",
+    when: item.latestDate || "recently",
+    source: item.latestHash ? `commit ${item.latestHash}` : "git history",
+    intent,
+    summary: `${item.churn} changed lines across ${item.filePaths.size} indexed files. Latest: ${item.latestSubject || "no commit subject"}.`,
+    why: `${label} is both changing and connected to ${calls} call edges. Start here to understand whether the current graph is new work, load-bearing behavior, or legacy surface area.`,
+    calls,
+    churn: item.churn,
+    risk,
+    moduleId: item.moduleId,
+    focusNodeId: focusNode?.id,
+    filePaths: [...item.filePaths].slice(0, 8),
+  };
+}
+
+function scoreModule(data: VisualizationData, moduleId: string, churn: number): number {
+  return churn + moduleCallCount(data, moduleId) * 4;
+}
+
+function moduleCallCount(data: VisualizationData, moduleId: string): number {
+  const moduleEdgeCount = data.moduleEdges
+    .filter((edge) => edge.source === moduleId || edge.target === moduleId)
+    .reduce((total, edge) => total + edge.weight, 0);
+  if (moduleEdgeCount > 0) return moduleEdgeCount;
+
+  const nodeModules = new Map(data.nodes.map((node) => [node.id, node.moduleId]));
+  return data.edges.filter((edge) => nodeModules.get(edge.source) === moduleId || nodeModules.get(edge.target) === moduleId).length;
+}
+
+function strongestNode(data: VisualizationData, moduleId: string): VisualizationNode | undefined {
+  const degree = new Map<string, number>();
+  for (const edge of data.edges) {
+    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1);
+    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1);
+  }
+
+  return data.nodes
+    .filter((node) => node.moduleId === moduleId)
+    .sort((a, b) => (degree.get(b.id) ?? 0) - (degree.get(a.id) ?? 0))[0];
+}
+
+function riskFor(calls: number, churnOrSymbols: number): "low" | "medium" | "high" {
+  if (calls >= 20 || churnOrSymbols >= 250) return "high";
+  if (calls >= 8 || churnOrSymbols >= 80) return "medium";
+  return "low";
+}
+
+function inferIntent(subject: string): string {
+  const normalized = subject.toLowerCase();
+  if (normalized.includes("fix")) return "stability";
+  if (normalized.includes("test")) return "verification";
+  if (normalized.includes("refactor")) return "refactor";
+  if (normalized.includes("visual")) return "visualization";
+  if (normalized.includes("call") || normalized.includes("graph")) return "call graph";
+  if (normalized.includes("config")) return "configuration";
+  return "recent work";
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}
+
+function toGitRelativePath(projectRoot: string, filePath: string): string {
+  const relativePath = path.isAbsolute(filePath) ? path.relative(projectRoot, filePath) : filePath;
+  return normalizePath(relativePath);
+}

--- a/src/tools/visualize/index.ts
+++ b/src/tools/visualize/index.ts
@@ -1,4 +1,10 @@
 export { generateVisualizationHtml } from "./template.js";
 export { transformForVisualization } from "./transform.js";
-export type { VisualizationData, VisualizationNode, VisualizationEdge } from "./types.js";
+export type {
+  VisualizationData,
+  VisualizationNode,
+  VisualizationEdge,
+  VisualizationModule,
+  VisualizationModuleEdge,
+} from "./types.js";
 export type { TransformOptions } from "./transform.js";

--- a/src/tools/visualize/index.ts
+++ b/src/tools/visualize/index.ts
@@ -1,0 +1,4 @@
+export { generateVisualizationHtml } from "./template.js";
+export { transformForVisualization } from "./transform.js";
+export type { VisualizationData, VisualizationNode, VisualizationEdge } from "./types.js";
+export type { TransformOptions } from "./transform.js";

--- a/src/tools/visualize/modules.ts
+++ b/src/tools/visualize/modules.ts
@@ -1,0 +1,199 @@
+import type {
+  VisualizationModule,
+  VisualizationModuleEdge,
+  VisualizationNode,
+} from "./types.js";
+import type { VisualizationEdge } from "./types.js";
+
+const MAX_MODULES = 18;
+const KNOWN_ROOTS = ["src", "native", "tests", "commands", "scripts", "docs", "benchmarks"];
+
+function normalizeSlashes(input: string): string {
+  return input.replace(/\\/g, "/");
+}
+
+function stripToProjectRelative(filePath: string): string {
+  const normalized = normalizeSlashes(filePath);
+  let bestIndex = Number.POSITIVE_INFINITY;
+  let bestRoot: string | null = null;
+  for (const root of KNOWN_ROOTS) {
+    const marker = `/${root}/`;
+    const rootIndex = normalized.indexOf(marker);
+    if (rootIndex !== -1 && rootIndex < bestIndex) {
+      bestIndex = rootIndex;
+      bestRoot = root;
+    }
+    if (normalized.endsWith(`/${root}`)) {
+      return root;
+    }
+  }
+  if (bestRoot !== null && Number.isFinite(bestIndex)) {
+    return normalized.slice(bestIndex + 1);
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.slice(-3).join("/") || normalized;
+}
+
+function modulePrefixFromRelativePath(relativeFilePath: string): string {
+  const parts = relativeFilePath.split("/").filter(Boolean);
+  if (parts.length === 0) return ".";
+
+  const [root, second, third] = parts;
+
+  if (root === "src") {
+    if (!second) return "src";
+    const broadBuckets = new Set([
+      "config",
+      "embeddings",
+      "eval",
+      "git",
+      "indexer",
+      "native",
+      "rerank",
+      "tools",
+      "utils",
+      "watcher",
+    ]);
+    if (broadBuckets.has(second)) return `src/${second}`;
+    return second ? `src/${second}` : "src";
+  }
+
+  if (root === "tests") {
+    if (second === "fixtures" && third) return `tests/fixtures/${third}`;
+    return second ? `tests/${second}` : "tests";
+  }
+
+  if (root === "native") {
+    if (second === "src") return "native";
+    return second ? `native/${second}` : "native";
+  }
+
+  if (root === "commands") return "commands";
+  if (root === "scripts") return "scripts";
+  if (root === "docs") return second ? `docs/${second}` : "docs";
+  if (root === "benchmarks") return second ? `benchmarks/${second}` : "benchmarks";
+
+  return root;
+}
+
+function parentModulePrefix(prefix: string): string | null {
+  const parts = prefix.split("/");
+  if (parts.length <= 1) return null;
+  return parts.slice(0, -1).join("/");
+}
+
+function shortLabel(prefix: string, allPrefixes: Set<string>): string {
+  const parts = prefix.split("/");
+  for (let i = 1; i <= parts.length; i++) {
+    const suffix = parts.slice(parts.length - i).join("/");
+    const ambiguous = [...allPrefixes].some((candidate) => {
+      if (candidate === prefix) return false;
+      return candidate.endsWith(`/${suffix}`) || candidate === suffix;
+    });
+    if (!ambiguous) return suffix;
+  }
+  return prefix;
+}
+
+function compactModules(prefixToNodes: Map<string, VisualizationNode[]>): Map<string, VisualizationNode[]> {
+  const grouped = new Map(prefixToNodes);
+  while (grouped.size > MAX_MODULES) {
+    const smallest = [...grouped.entries()].sort((a, b) => a[1].length - b[1].length)[0];
+    if (!smallest) break;
+    const [prefix, members] = smallest;
+    const parent = parentModulePrefix(prefix);
+    if (!parent) break;
+    grouped.delete(prefix);
+    if (!grouped.has(parent)) grouped.set(parent, []);
+    grouped.get(parent)?.push(...members);
+  }
+  return grouped;
+}
+
+export function deriveModules(nodes: VisualizationNode[]): VisualizationModule[] {
+  const initial = new Map<string, VisualizationNode[]>();
+
+  for (const node of nodes) {
+    const relative = stripToProjectRelative(node.filePath);
+    const prefix = modulePrefixFromRelativePath(relative);
+    if (!initial.has(prefix)) initial.set(prefix, []);
+    initial.get(prefix)?.push(node);
+  }
+
+  const nonFixturePrefixes = [...initial.keys()].filter((prefix) => !prefix.startsWith("tests/fixtures/"));
+  if (nonFixturePrefixes.length > 0) {
+    const fixtureEntries = [...initial.entries()].filter(([prefix]) => prefix.startsWith("tests/fixtures/"));
+    if (fixtureEntries.length > 1) {
+      const mergedFixtureNodes = fixtureEntries.flatMap(([, members]) => members);
+      for (const [prefix] of fixtureEntries) {
+        initial.delete(prefix);
+      }
+      initial.set("tests/fixtures", mergedFixtureNodes);
+    }
+  }
+
+  const grouped = compactModules(initial);
+  const allPrefixes = new Set(grouped.keys());
+
+  const modules: VisualizationModule[] = [...grouped.entries()]
+    .map(([prefix, members]) => {
+      const kinds: Record<string, number> = {};
+      for (const node of members) {
+        kinds[node.kind] = (kinds[node.kind] ?? 0) + 1;
+      }
+
+      const label = shortLabel(prefix, allPrefixes);
+      const id = `module-${prefix.replace(/[^a-zA-Z0-9]+/g, "-")}`;
+
+      for (const node of members) {
+        node.moduleId = id;
+        node.moduleLabel = label;
+      }
+
+      return {
+        id,
+        label,
+        pathPrefix: prefix,
+        symbolCount: members.length,
+        symbols: members.map((node) => node.id),
+        kinds,
+      };
+    })
+    .sort((a, b) => b.symbolCount - a.symbolCount || a.label.localeCompare(b.label));
+
+  return modules;
+}
+
+export function deriveModuleEdges(
+  nodes: VisualizationNode[],
+  edges: VisualizationEdge[],
+): VisualizationModuleEdge[] {
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  const aggregate = new Map<string, VisualizationModuleEdge>();
+
+  for (const edge of edges) {
+    const source = nodeMap.get(edge.source);
+    if (!source || !source.moduleId) continue;
+
+    const target = nodeMap.get(edge.target);
+    const targetModuleId = target?.moduleId;
+
+    if (!targetModuleId) continue;
+    if (source.moduleId === targetModuleId) continue;
+
+    const key = `${source.moduleId}__${targetModuleId}`;
+    if (!aggregate.has(key)) {
+      aggregate.set(key, {
+        source: source.moduleId,
+        target: targetModuleId,
+        weight: 0,
+        callTypes: {},
+      });
+    }
+    const moduleEdge = aggregate.get(key)!;
+    moduleEdge.weight += 1;
+    moduleEdge.callTypes[edge.callType] = (moduleEdge.callTypes[edge.callType] ?? 0) + 1;
+  }
+
+  return [...aggregate.values()].sort((a, b) => b.weight - a.weight);
+}

--- a/src/tools/visualize/modules.ts
+++ b/src/tools/visualize/modules.ts
@@ -17,6 +17,10 @@ function stripToProjectRelative(filePath: string): string {
   let bestIndex = Number.POSITIVE_INFINITY;
   let bestRoot: string | null = null;
   for (const root of KNOWN_ROOTS) {
+    if (normalized === root || normalized.startsWith(`${root}/`)) {
+      return normalized;
+    }
+
     const marker = `/${root}/`;
     const rootIndex = normalized.indexOf(marker);
     if (rootIndex !== -1 && rootIndex < bestIndex) {
@@ -95,6 +99,46 @@ function shortLabel(prefix: string, allPrefixes: Set<string>): string {
   return prefix;
 }
 
+function classifyModulePrefix(prefix: string): VisualizationModule["category"] {
+  if (prefix.startsWith("tests/fixtures")) return "fixture";
+  if (prefix.startsWith("tests")) return "test";
+  if (prefix === "native" || prefix.startsWith("native/")) return "native";
+  if (prefix === "commands" || prefix.startsWith("commands/")) return "command";
+  if (prefix === "scripts" || prefix.startsWith("scripts/")) return "script";
+  if (prefix === "docs" || prefix.startsWith("docs/")) return "doc";
+  if (prefix === "benchmarks" || prefix.startsWith("benchmarks/")) return "benchmark";
+  if (prefix === "src" || prefix.startsWith("src/")) return "source";
+  return "other";
+}
+
+function displayLabelForPrefix(prefix: string, allPrefixes: Set<string>): string {
+  const short = shortLabel(prefix, allPrefixes);
+
+  if (prefix.startsWith("tests/fixtures/")) {
+    const fixtureName = prefix.slice("tests/fixtures/".length);
+    return `fixture: ${fixtureName}`;
+  }
+
+  if (prefix === "tests/fixtures") {
+    return "fixtures";
+  }
+
+  if (prefix.startsWith("tests/")) {
+    const testArea = prefix.slice("tests/".length);
+    return `tests: ${testArea}`;
+  }
+
+  if (prefix === "tests") {
+    return "tests";
+  }
+
+  if (prefix === "native") {
+    return "native";
+  }
+
+  return short;
+}
+
 function compactModules(prefixToNodes: Map<string, VisualizationNode[]>): Map<string, VisualizationNode[]> {
   const grouped = new Map(prefixToNodes);
   while (grouped.size > MAX_MODULES) {
@@ -142,7 +186,8 @@ export function deriveModules(nodes: VisualizationNode[]): VisualizationModule[]
         kinds[node.kind] = (kinds[node.kind] ?? 0) + 1;
       }
 
-      const label = shortLabel(prefix, allPrefixes);
+      const label = displayLabelForPrefix(prefix, allPrefixes);
+      const category = classifyModulePrefix(prefix);
       const id = `module-${prefix.replace(/[^a-zA-Z0-9]+/g, "-")}`;
 
       for (const node of members) {
@@ -154,6 +199,7 @@ export function deriveModules(nodes: VisualizationNode[]): VisualizationModule[]
         id,
         label,
         pathPrefix: prefix,
+        category,
         symbolCount: members.length,
         symbols: members.map((node) => node.id),
         kinds,

--- a/src/tools/visualize/template.ts
+++ b/src/tools/visualize/template.ts
@@ -1,18 +1,17 @@
 import type { VisualizationData } from "./types.js";
 
 /**
- * Generate a self-contained HTML file with an interactive stratified cluster graph visualization.
- * Layout algorithm:
- * 1. Compute topological depth via DAG traversal (cycle-breaking with DFS)
- * 2. Group nodes into directory clusters
- * 3. Position clusters vertically by median node depth (orchestrators top, utilities bottom)
- * 4. Position clusters horizontally using barycenter ordering to minimize edge crossings
- * 5. Intra-cluster layout: compact grid
- * 6. Edge rendering with directional arrows
+ * Generate a self-contained HTML file with a module-first architecture map.
+ *
+ * Interaction model:
+ * - Overview mode: modules/directories as the primary graph
+ * - Focus mode: selected module centered, callers on the left, callees on the right
+ * - Symbol detail appears only inside the focused module
  */
 export function generateVisualizationHtml(data: VisualizationData): string {
-  // Escape < and > in JSON to prevent script injection in HTML context
-  const jsonData = JSON.stringify(data).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+  const jsonData = JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e");
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -23,345 +22,612 @@ export function generateVisualizationHtml(data: VisualizationData): string {
 <title>Call Graph Visualization</title>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f1a; color: #e0e0e0; overflow: hidden; }
+body {
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #0d0f1a;
+  color: #e6e8ef;
+  overflow: hidden;
+}
 #container { width: 100vw; height: 100vh; position: relative; }
 canvas { display: block; }
+.interaction-hint {
+  position: absolute;
+  left: 50%;
+  bottom: 12px;
+  transform: translateX(-50%);
+  z-index: 20;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(23,27,45,0.92);
+  border: 1px solid #2a3050;
+  color: #aeb7d4;
+  font-size: 11px;
+  display: none;
+  pointer-events: none;
+}
 
-#controls { position: absolute; top: 12px; left: 12px; display: flex; gap: 8px; align-items: center; z-index: 10; flex-wrap: wrap; max-width: 500px; }
-#search { padding: 8px 12px; border-radius: 6px; border: 1px solid #2a2a4a; background: #1a1a2e; color: #e0e0e0; font-size: 13px; width: 220px; outline: none; }
-#search:focus { border-color: #4a4a8a; box-shadow: 0 0 0 2px rgba(74,74,138,0.3); }
-.ctrl-btn { padding: 6px 10px; border-radius: 6px; border: 1px solid #2a2a4a; background: #1a1a2e; color: #b0b0c0; font-size: 11px; cursor: pointer; transition: all 0.15s; }
-.ctrl-btn:hover { background: #252545; border-color: #4a4a8a; color: #e0e0e0; }
-.ctrl-btn.active { background: #2a2a5a; border-color: #6a6aaa; color: #fff; }
+#controls {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  z-index: 20;
+  flex-wrap: wrap;
+  max-width: 620px;
+}
+#search {
+  padding: 9px 12px;
+  border-radius: 8px;
+  border: 1px solid #2a3050;
+  background: #171b2d;
+  color: #e6e8ef;
+  font-size: 13px;
+  width: 220px;
+  outline: none;
+}
+#search:focus {
+  border-color: #5574ff;
+  box-shadow: 0 0 0 2px rgba(85,116,255,0.22);
+}
+.button {
+  padding: 8px 11px;
+  border-radius: 8px;
+  border: 1px solid #2a3050;
+  background: #171b2d;
+  color: #c4c9da;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.button:hover {
+  background: #202744;
+  color: #fff;
+}
+.button.active {
+  background: #26305c;
+  border-color: #5a74ff;
+  color: #fff;
+}
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
-#stats { position: absolute; top: 12px; right: 12px; background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 12px 16px; font-size: 11px; z-index: 10; line-height: 1.7; }
-#stats .stat-label { color: #666; }
+#stats {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 20;
+  background: rgba(23,27,45,0.92);
+  border: 1px solid #2a3050;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 11px;
+  line-height: 1.65;
+  min-width: 120px;
+}
+#stats .label { color: #7f88a8; }
 
-#detail { position: absolute; bottom: 12px; left: 12px; background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 16px; font-size: 12px; z-index: 10; max-width: 380px; display: none; box-shadow: 0 4px 20px rgba(0,0,0,0.4); }
-#detail h3 { margin-bottom: 10px; color: #7eb8ff; font-size: 14px; font-weight: 600; letter-spacing: -0.3px; }
-#detail .field { margin-bottom: 5px; display: flex; gap: 6px; }
-#detail .label { color: #666; min-width: 80px; }
-#detail .value { color: #ccc; word-break: break-all; }
+#legend {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 20;
+  background: rgba(23,27,45,0.94);
+  border: 1px solid #2a3050;
+  border-radius: 10px;
+  padding: 12px 14px;
+  width: 260px;
+  max-height: 260px;
+  overflow-y: auto;
+}
+#legend h4 {
+  font-size: 11px;
+  color: #8f97b3;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.legend-item:hover { background: #202744; }
+.legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: 0 0 auto;
+}
+.legend-text {
+  color: #c6cce0;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-#legend { position: absolute; bottom: 12px; right: 12px; background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 12px 16px; font-size: 10px; z-index: 10; max-height: 240px; overflow-y: auto; min-width: 160px; }
-#legend h4 { margin-bottom: 8px; color: #888; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
-.legend-item { display: flex; align-items: center; margin-bottom: 4px; cursor: pointer; padding: 2px 4px; border-radius: 3px; }
-.legend-item:hover { background: #252545; }
-.legend-swatch { width: 10px; height: 10px; border-radius: 3px; margin-right: 8px; flex-shrink: 0; }
-.legend-label { color: #aaa; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#detail {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  z-index: 20;
+  max-width: 520px;
+  background: rgba(23,27,45,0.94);
+  border: 1px solid #2a3050;
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: none;
+  box-shadow: 0 8px 28px rgba(0,0,0,0.35);
+}
+#detail h3 {
+  font-size: 14px;
+  margin-bottom: 10px;
+  color: #ffffff;
+}
+#detail .row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+#detail .k {
+  min-width: 92px;
+  color: #7f88a8;
+}
+#detail .v {
+  color: #dbe1f1;
+  word-break: break-word;
+}
+#detail .section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+}
 
-#edge-legend { position: absolute; top: 12px; left: 50%; transform: translateX(-50%); background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 8px 16px; font-size: 10px; z-index: 10; display: flex; gap: 14px; align-items: center; }
-.edge-type { display: flex; align-items: center; gap: 4px; }
-.edge-line { width: 16px; height: 2px; border-radius: 1px; }
+#mode-badge {
+  position: absolute;
+  top: 58px;
+  left: 12px;
+  z-index: 20;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(34,41,70,0.92);
+  border: 1px solid #36406a;
+  color: #dbe1f1;
+  font-size: 11px;
+  display: none;
+}
 
-#truncation-warning { position: absolute; top: 50px; left: 12px; background: #2a2000; border: 1px solid #8a6800; border-radius: 6px; padding: 8px 12px; font-size: 11px; color: #ffd700; z-index: 10; display: none; }
-
-#minimap { position: absolute; bottom: 12px; left: 50%; transform: translateX(-50%); background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; width: 180px; height: 100px; z-index: 9; overflow: hidden; display: none; }
+#truncation-warning {
+  position: absolute;
+  top: 58px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(70,50,10,0.94);
+  border: 1px solid #8a6d15;
+  color: #ffd86a;
+  font-size: 11px;
+  display: none;
+}
 </style>
 </head>
 <body>
 <div id="container">
   <canvas id="graph"></canvas>
   <div id="controls">
-    <input type="text" id="search" placeholder="Search symbols..." autocomplete="off">
-    <button class="ctrl-btn" id="btn-reset" title="Reset view">Reset</button>
-    <button class="ctrl-btn" id="btn-labels" title="Toggle labels">Labels</button>
-    <button class="ctrl-btn" id="btn-edges" title="Toggle edge type colors">Edges</button>
+    <input id="search" type="text" placeholder="Search symbols or modules..." autocomplete="off">
+    <button class="button" id="btn-overview">Overview</button>
+    <button class="button active" id="btn-labels">Labels</button>
+    <button class="button active" id="btn-weights">Weights</button>
+    <button class="button" id="btn-blast">Blast Radius</button>
+    <button class="button" id="btn-fit" title="Recompute the overview layout for the current window size">Reset Overview Layout</button>
   </div>
-  <div id="edge-legend">
-    <div class="edge-type"><div class="edge-line" style="background:#5c7cfa"></div><span>Call</span></div>
-    <div class="edge-type"><div class="edge-line" style="background:#20c997"></div><span>Method</span></div>
-    <div class="edge-type"><div class="edge-line" style="background:#ff6b6b"></div><span>Constructor</span></div>
-    <div class="edge-type"><div class="edge-line" style="background:#fcc419"></div><span>Import</span></div>
-    <div class="edge-type"><div class="edge-line" style="background:#cc5de8"></div><span>Inherits</span></div>
-    <div class="edge-type"><div class="edge-line" style="background:#51cf66"></div><span>Implements</span></div>
-  </div>
+  <div id="mode-badge"></div>
+  <div id="truncation-warning"></div>
+  <div id="interaction-hint" class="interaction-hint"></div>
   <div id="stats"></div>
   <div id="detail">
-    <h3 id="detail-name"></h3>
-    <div class="field"><span class="label">File</span><span class="value" id="detail-file"></span></div>
-    <div class="field"><span class="label">Kind</span><span class="value" id="detail-kind"></span></div>
-    <div class="field"><span class="label">Line</span><span class="value" id="detail-line"></span></div>
-    <div class="field"><span class="label">Connections</span><span class="value" id="detail-connections"></span></div>
-    <div class="field"><span class="label">Callers</span><span class="value" id="detail-callers"></span></div>
-    <div class="field"><span class="label">Callees</span><span class="value" id="detail-callees"></span></div>
+    <h3 id="detail-title"></h3>
+    <div class="row"><div class="k">Type</div><div class="v" id="detail-type"></div></div>
+    <div class="row"><div class="k">Location</div><div class="v" id="detail-location"></div></div>
+    <div class="row"><div class="k">Connections</div><div class="v" id="detail-connections"></div></div>
+    <div class="row"><div class="k">Notes</div><div class="v" id="detail-notes"></div></div>
+    <div class="section">
+      <div class="row"><div class="k">Callers</div><div class="v" id="detail-callers"></div></div>
+      <div class="row"><div class="k">Callees</div><div class="v" id="detail-callees"></div></div>
+      <div class="row"><div class="k">Edge types</div><div class="v" id="detail-edge-types"></div></div>
+      <div class="row"><div class="k">Blast radius</div><div class="v" id="detail-blast"></div></div>
+    </div>
   </div>
   <div id="legend"><h4>Modules</h4><div id="legend-items"></div></div>
-  <div id="truncation-warning"></div>
 </div>
 <script>
-(function() {
+(function () {
 "use strict";
 
 const DATA = ${jsonData};
-const nodes = DATA.nodes;
-const edges = DATA.edges;
+const allNodes = DATA.nodes;
+const allEdges = DATA.edges;
+const allModules = DATA.modules || [];
+const allModuleEdges = DATA.moduleEdges || [];
 const meta = DATA.metadata;
 
-// ═══════════════════════════════════════════════════
-// GRAPH ANALYSIS
-// ═══════════════════════════════════════════════════
+// ────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────
+function shortPath(path) {
+  return path.length > 36 ? "..." + path.slice(-33) : path;
+}
 
-const nodeMap = new Map();
-nodes.forEach(n => nodeMap.set(n.id, n));
+function hashColor(index) {
+  const palette = [
+    "#5c7cfa", "#20c997", "#ff6b6b", "#fcc419", "#cc5de8", "#51cf66",
+    "#339af0", "#f06595", "#ff922b", "#66d9e8", "#845ef7", "#94d82d",
+    "#748ffc", "#3bc9db", "#ffa94d", "#69db7c", "#e64980", "#f76707"
+  ];
+  return palette[index % palette.length];
+}
 
-// Build adjacency lists
-const outEdges = new Map(); // id -> [{target, edge}]
-const inEdges = new Map();  // id -> [{source, edge}]
-nodes.forEach(n => { outEdges.set(n.id, []); inEdges.set(n.id, []); });
+function roundRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.arcTo(x + w, y, x + w, y + r, r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+  ctx.lineTo(x + r, y + h);
+  ctx.arcTo(x, y + h, x, y + h - r, r);
+  ctx.lineTo(x, y + r);
+  ctx.arcTo(x, y, x + r, y, r);
+  ctx.closePath();
+}
 
-const resolvedEdges = [];
-for (const e of edges) {
-  const src = nodeMap.get(e.source);
-  const tgt = nodeMap.get(e.target);
-  if (src && tgt) {
-    resolvedEdges.push({ source: src, target: tgt, callType: e.callType, confidence: e.confidence });
-    outEdges.get(e.source).push({ node: tgt, edge: e });
-    inEdges.get(e.target).push({ node: src, edge: e });
+function kindColor(kind, moduleColor) {
+  if (!kind) return moduleColor;
+  const k = kind.toLowerCase();
+  if (k.includes("class") || k.includes("struct")) return "#ffd166";
+  if (k.includes("interface") || k.includes("type")) return "#7bdff2";
+  if (k.includes("const") || k.includes("variable") || k.includes("let")) return "#ff99c8";
+  if (k.includes("enum")) return "#cdb4db";
+  return moduleColor;
+}
+
+function drawSymbolGlyph(ctx, node, x, y, size, color) {
+  const kind = (node.kind || "").toLowerCase();
+  ctx.beginPath();
+  if (kind.includes("class") || kind.includes("struct")) {
+    ctx.rect(x - size, y - size, size * 2, size * 2);
+  } else if (kind.includes("interface") || kind.includes("type")) {
+    ctx.moveTo(x, y - size - 1);
+    ctx.lineTo(x + size + 1, y);
+    ctx.lineTo(x, y + size + 1);
+    ctx.lineTo(x - size - 1, y);
+    ctx.closePath();
+  } else if (kind.includes("const") || kind.includes("variable") || kind.includes("let")) {
+    ctx.moveTo(x, y - size - 1);
+    ctx.lineTo(x + size + 1, y + size + 1);
+    ctx.lineTo(x - size - 1, y + size + 1);
+    ctx.closePath();
+  } else {
+    ctx.arc(x, y, size, 0, Math.PI * 2);
+  }
+  ctx.fillStyle = color;
+  ctx.fill();
+}
+
+function shortNodeLabel(name) {
+  return name.length > 18 ? name.slice(0, 15) + "…" : name;
+}
+
+// ────────────────────────────────────────────────────────────
+// Build graph models
+// ────────────────────────────────────────────────────────────
+const nodeById = new Map(allNodes.map((n) => [n.id, n]));
+allNodes.forEach((n) => { n.module = n.moduleId; });
+
+const resolvedEdges = allEdges
+  .filter((e) => nodeById.has(e.source) && nodeById.has(e.target))
+  .map((e) => ({ ...e, sourceNode: nodeById.get(e.source), targetNode: nodeById.get(e.target) }));
+
+const modules = new Map((DATA.modules || []).map((module) => [module.id, {
+  ...module,
+  color: null,
+  nodes: [],
+  files: new Set(),
+  incoming: new Map(),
+  outgoing: new Map(),
+  internalEdgeCount: 0,
+  totalWeight: 0,
+}]));
+
+for (const node of allNodes) {
+  const mod = modules.get(node.moduleId);
+  if (!mod) continue;
+  mod.nodes.push(node);
+  mod.files.add(node.filePath);
+}
+
+const moduleList = [...modules.values()].sort((a, b) => b.symbolCount - a.symbolCount || a.label.localeCompare(b.label));
+moduleList.forEach((m, i) => { m.color = hashColor(i); });
+
+for (const edge of resolvedEdges) {
+  const src = edge.sourceNode.moduleId;
+  const tgt = edge.targetNode.moduleId;
+  if (src && tgt && src === tgt && modules.has(src)) {
+    modules.get(src).internalEdgeCount += 1;
   }
 }
 
-// ═══════════════════════════════════════════════════
-// LAYER ASSIGNMENT (Topological depth with cycle breaking)
-// ═══════════════════════════════════════════════════
+const moduleEdges = (DATA.moduleEdges || []).map((edge) => ({
+  ...edge,
+  callTypes: edge.callTypes || {},
+}));
 
-function computeDepths() {
-  const depth = new Map();
-  const visited = new Set();
-  const inStack = new Set();
+for (const edge of moduleEdges) {
+  if (modules.has(edge.source) && modules.has(edge.target)) {
+    modules.get(edge.source).outgoing.set(edge.target, edge.weight);
+    modules.get(edge.target).incoming.set(edge.source, edge.weight);
+  }
+}
 
-  function dfs(id, d) {
-    if (inStack.has(id)) return; // cycle - skip
-    if (visited.has(id) && depth.get(id) >= d) return;
-    visited.add(id);
-    inStack.add(id);
-    depth.set(id, Math.max(depth.get(id) || 0, d));
-    for (const { node } of outEdges.get(id) || []) {
-      dfs(node.id, d + 1);
+for (const mod of moduleList) {
+  mod.totalWeight = [...mod.incoming.values(), ...mod.outgoing.values()].reduce((a, b) => a + b, 0) + mod.internalEdgeCount;
+}
+
+// ────────────────────────────────────────────────────────────
+// Overview layout: module dependency map
+// ────────────────────────────────────────────────────────────
+const moduleBounds = new Map();
+
+function computeModuleDepths() {
+  const indegree = new Map(moduleList.map((m) => [m.id, 0]));
+  const outgoing = new Map(moduleList.map((m) => [m.id, []]));
+  for (const e of moduleEdges) {
+    indegree.set(e.target, (indegree.get(e.target) || 0) + 1);
+    outgoing.get(e.source).push(e.target);
+  }
+
+  const queue = [];
+  indegree.forEach((v, k) => { if (v === 0) queue.push(k); });
+  const depth = new Map(moduleList.map((m) => [m.id, 0]));
+  const seen = new Set();
+
+  while (queue.length) {
+    const current = queue.shift();
+    seen.add(current);
+    for (const next of outgoing.get(current) || []) {
+      depth.set(next, Math.max(depth.get(next) || 0, (depth.get(current) || 0) + 1));
+      indegree.set(next, indegree.get(next) - 1);
+      if (indegree.get(next) === 0) queue.push(next);
     }
-    inStack.delete(id);
   }
 
-  // Start from roots (nodes with no incoming edges)
-  const roots = nodes.filter(n => (inEdges.get(n.id) || []).length === 0);
-  if (roots.length === 0) {
-    // All nodes in cycles - pick highest out-degree nodes as roots
-    const sorted = [...nodes].sort((a, b) => (outEdges.get(b.id) || []).length - (outEdges.get(a.id) || []).length);
-    sorted.slice(0, Math.max(3, Math.floor(nodes.length * 0.1))).forEach(n => dfs(n.id, 0));
-  } else {
-    roots.forEach(n => dfs(n.id, 0));
+  // cycles / disconnected: fallback by fan-out - fan-in bias
+  for (const mod of moduleList) {
+    if (!seen.has(mod.id)) {
+      const out = mod.outgoing.size;
+      const inc = mod.incoming.size;
+      depth.set(mod.id, Math.max(0, 2 + out - inc));
+    }
   }
-
-  // Handle disconnected nodes
-  nodes.forEach(n => { if (!depth.has(n.id)) depth.set(n.id, 0); });
-
   return depth;
 }
 
-const nodeDepth = computeDepths();
+const moduleDepth = computeModuleDepths();
 
-// ═══════════════════════════════════════════════════
-// DIRECTORY CLUSTERING
-// ═══════════════════════════════════════════════════
+function layoutOverview() {
+  moduleBounds.clear();
+  const sparseModuleGraph = moduleEdges.length < Math.max(2, Math.floor(moduleList.length / 3));
 
-const clusters = new Map(); // directory -> [nodes]
-nodes.forEach(n => {
-  if (!clusters.has(n.directory)) clusters.set(n.directory, []);
-  clusters.get(n.directory).push(n);
-});
+  if (sparseModuleGraph) {
+    const cols = Math.max(2, Math.min(4, Math.ceil(Math.sqrt(moduleList.length))));
+    const cardW = 240;
+    const cardHBase = 92;
+    const gapX = 28;
+    const gapY = 26;
+    const totalWidth = cols * cardW + (cols - 1) * gapX;
+    const startX = Math.max(48, (window.innerWidth - totalWidth) / 2);
+    let currentX = startX;
+    let currentY = 120;
+    let rowMaxHeight = cardHBase;
 
-// Compute cluster median depth for vertical ordering
-const clusterDepth = new Map();
-for (const [dir, members] of clusters) {
-  const depths = members.map(n => nodeDepth.get(n.id) || 0).sort((a, b) => a - b);
-  clusterDepth.set(dir, depths[Math.floor(depths.length / 2)]);
-}
-
-// Sort clusters into layers
-const maxDepth = Math.max(...nodeDepth.values(), 0);
-const layerCount = Math.min(maxDepth + 1, 8); // Cap at 8 layers for readability
-const layerSize = (maxDepth + 1) / layerCount;
-
-const clusterLayer = new Map();
-for (const [dir, depth] of clusterDepth) {
-  clusterLayer.set(dir, Math.min(Math.floor(depth / layerSize), layerCount - 1));
-}
-
-// Group clusters by layer
-const layers = Array.from({ length: layerCount }, () => []);
-for (const [dir] of clusters) {
-  layers[clusterLayer.get(dir)].push(dir);
-}
-
-// Order clusters within each layer by barycenter (average position of connected clusters in adjacent layers)
-function orderByBarycenter() {
-  // Build inter-cluster edges
-  const interCluster = new Map(); // dir -> Set of connected dirs
-  for (const e of resolvedEdges) {
-    const srcDir = e.source.directory;
-    const tgtDir = e.target.directory;
-    if (srcDir !== tgtDir) {
-      if (!interCluster.has(srcDir)) interCluster.set(srcDir, new Map());
-      const m = interCluster.get(srcDir);
-      m.set(tgtDir, (m.get(tgtDir) || 0) + 1);
-    }
-  }
-
-  // Multiple sweep passes
-  for (let pass = 0; pass < 4; pass++) {
-    for (let l = 1; l < layerCount; l++) {
-      const layer = layers[l];
-      const prevLayer = layers[l - 1];
-      const prevPos = new Map();
-      prevLayer.forEach((d, i) => prevPos.set(d, i));
-
-      layer.sort((a, b) => {
-        const aConns = interCluster.get(a);
-        const bConns = interCluster.get(b);
-        let aSum = 0, aCount = 0, bSum = 0, bCount = 0;
-        if (aConns) for (const [d, w] of aConns) { if (prevPos.has(d)) { aSum += prevPos.get(d) * w; aCount += w; } }
-        if (bConns) for (const [d, w] of bConns) { if (prevPos.has(d)) { bSum += prevPos.get(d) * w; bCount += w; } }
-        const aBar = aCount ? aSum / aCount : Infinity;
-        const bBar = bCount ? bSum / bCount : Infinity;
-        return aBar - bBar;
-      });
-    }
-  }
-}
-orderByBarycenter();
-
-// ═══════════════════════════════════════════════════
-// LAYOUT COMPUTATION
-// ═══════════════════════════════════════════════════
-
-const CLUSTER_PAD_X = 30;
-const CLUSTER_PAD_Y = 28;
-const NODE_SPACING = 28;
-const CLUSTER_GAP_X = 50;
-const CLUSTER_GAP_Y = 70;
-const LAYER_GAP = 100;
-
-const clusterBounds = new Map(); // dir -> {x, y, w, h}
-const nodePositions = new Map(); // id -> {x, y}
-
-function computeLayout() {
-  let currentY = 60;
-
-  for (let l = 0; l < layerCount; l++) {
-    const layerDirs = layers[l];
-    if (layerDirs.length === 0) continue;
-
-    // Compute cluster sizes
-    const clusterSizes = layerDirs.map(dir => {
-      const members = clusters.get(dir);
-      const cols = Math.ceil(Math.sqrt(members.length * 1.5));
-      const rows = Math.ceil(members.length / cols);
-      const w = cols * NODE_SPACING + CLUSTER_PAD_X * 2;
-      const h = rows * NODE_SPACING + CLUSTER_PAD_Y * 2;
-      return { dir, members, cols, rows, w, h };
+    moduleList.forEach((mod, index) => {
+      const cardH = Math.max(cardHBase, 58 + Math.ceil(mod.nodes.length / 8) * 14);
+      moduleBounds.set(mod.id, { x: currentX, y: currentY, w: cardW, h: cardH });
+      rowMaxHeight = Math.max(rowMaxHeight, cardH);
+      if ((index + 1) % cols === 0) {
+        currentX = startX;
+        currentY += rowMaxHeight + gapY + 24;
+        rowMaxHeight = cardHBase;
+      } else {
+        currentX += cardW + gapX;
+      }
     });
 
-    const maxH = Math.max(...clusterSizes.map(c => c.h));
-    let currentX = 40;
+    return { maxDepth: 0, sortedDepths: [0], sparse: true };
+  }
 
-    for (const cs of clusterSizes) {
-      const cx = currentX;
-      const cy = currentY;
+  const levels = new Map();
+  let maxDepth = 0;
+  for (const mod of moduleList) {
+    const d = moduleDepth.get(mod.id) || 0;
+    maxDepth = Math.max(maxDepth, d);
+    if (!levels.has(d)) levels.set(d, []);
+    levels.get(d).push(mod);
+  }
 
-      clusterBounds.set(cs.dir, { x: cx, y: cy, w: cs.w, h: cs.h });
+  // barycenter-like ordering by average target/source level positions
+  const sortedDepths = [...levels.keys()].sort((a, b) => a - b);
+  for (const depth of sortedDepths) {
+    const row = levels.get(depth);
+    row.sort((a, b) => {
+      const aScore = [...a.incoming.entries(), ...a.outgoing.entries()].reduce((sum, [k, w]) => sum + (moduleDepth.get(k) || 0) * w, 0) / Math.max(1, a.totalWeight);
+      const bScore = [...b.incoming.entries(), ...b.outgoing.entries()].reduce((sum, [k, w]) => sum + (moduleDepth.get(k) || 0) * w, 0) / Math.max(1, b.totalWeight);
+      return aScore - bScore || b.totalWeight - a.totalWeight;
+    });
+  }
 
-      // Position nodes in grid within cluster
-      cs.members.forEach((node, i) => {
-        const col = i % cs.cols;
-        const row = Math.floor(i / cs.cols);
-        const nx = cx + CLUSTER_PAD_X + col * NODE_SPACING + NODE_SPACING / 2;
-        const ny = cy + CLUSTER_PAD_Y + row * NODE_SPACING + NODE_SPACING / 2;
-        nodePositions.set(node.id, { x: nx, y: ny });
-        node._x = nx;
-        node._y = ny;
-      });
+  const leftPad = 70;
+  const rightPad = 90;
+  const topPad = 120;
+  const laneGap = 170;
+  const rowGap = 70;
+  const baseW = 150;
+  const baseH = 76;
 
-      currentX += cs.w + CLUSTER_GAP_X;
+  for (const depth of sortedDepths) {
+    const row = levels.get(depth);
+    const x = leftPad + depth * laneGap;
+    const totalHeight = row.reduce((sum, mod) => {
+      const h = Math.max(baseH, 42 + Math.ceil(mod.nodes.length / 6) * 11);
+      return sum + h;
+    }, 0) + Math.max(0, row.length - 1) * rowGap;
+
+    let y = Math.max(topPad, (window.innerHeight - totalHeight) / 2);
+    for (const mod of row) {
+      const h = Math.max(baseH, 42 + Math.ceil(mod.nodes.length / 6) * 11);
+      const w = Math.min(240, Math.max(baseW, 120 + Math.min(mod.totalWeight, 20) * 4));
+      moduleBounds.set(mod.id, { x, y, w, h });
+      y += h + rowGap;
+    }
+  }
+
+  return { maxDepth, sortedDepths, sparse: false };
+}
+
+let overviewLayout = layoutOverview();
+
+// ────────────────────────────────────────────────────────────
+// Focus layout: selected module centered, callers left, callees right
+// ────────────────────────────────────────────────────────────
+function buildFocusState(moduleId) {
+  const center = modules.get(moduleId);
+  if (!center) return null;
+
+  function traverse(direction) {
+    const queue = [...(direction === "incoming" ? center.incoming.entries() : center.outgoing.entries())]
+      .map(([id, weight]) => ({ id, weight, hop: 1 }));
+    const visited = new Set();
+    const results = [];
+
+    while (queue.length) {
+      const current = queue.shift();
+      if (visited.has(current.id) || current.hop > 3) continue;
+      visited.add(current.id);
+      const mod = modules.get(current.id);
+      if (!mod) continue;
+      results.push({ mod, weight: current.weight, hop: current.hop });
+      if (blastRadiusMode) {
+        const nextEntries = direction === "incoming" ? mod.incoming.entries() : mod.outgoing.entries();
+        for (const [nextId, nextWeight] of nextEntries) {
+          if (!visited.has(nextId)) queue.push({ id: nextId, weight: nextWeight, hop: current.hop + 1 });
+        }
+      }
     }
 
-    currentY += maxH + LAYER_GAP;
+    return results.sort((a, b) => a.hop - b.hop || b.weight - a.weight);
   }
-}
-computeLayout();
 
-// ═══════════════════════════════════════════════════
-// COLOR SCHEME
-// ═══════════════════════════════════════════════════
+  const callers = traverse("incoming");
+  const callees = traverse("outgoing");
 
-const directories = [...clusters.keys()].sort();
-const dirColorMap = new Map();
-// Use a perceptually uniform palette
-const PALETTE = [
-  "#5c7cfa", "#20c997", "#ff6b6b", "#fcc419", "#cc5de8",
-  "#51cf66", "#339af0", "#f06595", "#ff922b", "#66d9e8",
-  "#845ef7", "#94d82d", "#e599f7", "#3bc9db", "#ffa94d",
-  "#69db7c", "#748ffc", "#e64980", "#f76707", "#22b8cf",
-];
-directories.forEach((dir, i) => {
-  dirColorMap.set(dir, PALETTE[i % PALETTE.length]);
-});
-
-const EDGE_COLORS = {
-  Call: "#5c7cfa",
-  MethodCall: "#20c997",
-  Constructor: "#ff6b6b",
-  Import: "#fcc419",
-  Inherits: "#cc5de8",
-  Implements: "#51cf66",
-};
-
-// ═══════════════════════════════════════════════════
-// STATS
-// ═══════════════════════════════════════════════════
-
-const fileCount = new Set(nodes.map(n => n.filePath)).size;
-document.getElementById("stats").innerHTML =
-  '<span class="stat-label">Nodes</span> ' + nodes.length +
-  '<br><span class="stat-label">Edges</span> ' + resolvedEdges.length +
-  '<br><span class="stat-label">Files</span> ' + fileCount +
-  '<br><span class="stat-label">Modules</span> ' + clusters.size +
-  '<br><span class="stat-label">Layers</span> ' + layerCount;
-
-if (meta.truncated) {
-  const w = document.getElementById("truncation-warning");
-  w.style.display = "block";
-  w.textContent = "\\u26a0\\ufe0f Graph truncated to " + nodes.length + " most-connected nodes (total: " + meta.totalSymbols + ")";
+  return { center, callers, callees };
 }
 
-// Legend
-const legendEl = document.getElementById("legend-items");
-directories.forEach(dir => {
-  const item = document.createElement("div");
-  item.className = "legend-item";
-  item.dataset.dir = dir;
-  const swatch = document.createElement("div");
-  swatch.className = "legend-swatch";
-  swatch.style.background = dirColorMap.get(dir);
-  const label = document.createElement("span");
-  label.className = "legend-label";
-  const shortDir = dir.length > 28 ? "..." + dir.slice(-25) : dir;
-  label.textContent = shortDir + " (" + clusters.get(dir).length + ")";
-  label.title = dir;
-  item.appendChild(swatch);
-  item.appendChild(label);
-  item.addEventListener("click", () => focusCluster(dir));
-  legendEl.appendChild(item);
-});
+function layoutFocus(moduleId) {
+  const focus = buildFocusState(moduleId);
+  if (!focus) return null;
 
-// ═══════════════════════════════════════════════════
-// CANVAS SETUP
-// ═══════════════════════════════════════════════════
+  const centerBox = {
+    x: window.innerWidth * 0.28,
+    y: 120,
+    w: window.innerWidth * 0.44,
+    h: Math.max(280, 140 + Math.ceil(focus.center.nodes.length / 5) * 26),
+  };
 
+  const leftBoxes = [];
+  const rightBoxes = [];
+
+  function stackSide(items, side) {
+    const startX = side === "left" ? 36 : window.innerWidth - 36 - 190;
+    let y = 150;
+    return items.map(({ mod, weight, hop }) => {
+      const h = Math.max(64, 46 + Math.ceil(mod.nodes.length / 10) * 10);
+      const box = { x: startX, y, w: 190, h, weight, hop, mod };
+      y += h + 24;
+      return box;
+    });
+  }
+
+  leftBoxes.push(...stackSide(focus.callers, "left"));
+  rightBoxes.push(...stackSide(focus.callees, "right"));
+
+  const symbolPositions = new Map();
+  const fileBoxes = [];
+  const fileGroups = new Map();
+  for (const node of focus.center.nodes) {
+    if (!fileGroups.has(node.filePath)) fileGroups.set(node.filePath, []);
+    fileGroups.get(node.filePath).push(node);
+  }
+
+  const files = [...fileGroups.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const laneGap = 12;
+  const innerX = centerBox.x + 16;
+  const innerY = centerBox.y + 58;
+  const laneW = centerBox.w - 32;
+  let laneY = innerY;
+
+  files.forEach(([filePath, nodesInFile]) => {
+    const sortedNodes = [...nodesInFile].sort((a, b) => a.name.localeCompare(b.name));
+    const estimatedChipWidth = Math.max(
+      90,
+      ...sortedNodes.map((node) => shortNodeLabel(node.name).length * 7 + 18),
+    );
+    const maxPerRow = Math.max(1, Math.min(3, Math.floor((laneW - 145) / Math.min(180, estimatedChipWidth))));
+    const rows = Math.max(1, Math.ceil(sortedNodes.length / maxPerRow));
+    const laneH = Math.max(68, 36 + rows * 34);
+    fileBoxes.push({ filePath, x: innerX, y: laneY, w: laneW, h: laneH, nodes: sortedNodes });
+
+    const contentStartX = innerX + 130;
+    const contentW = laneW - 145;
+    const cols = Math.max(1, Math.min(maxPerRow, Math.ceil(sortedNodes.length / rows)));
+    const stepX = contentW / Math.max(cols, 1);
+    const stepY = rows > 1 ? 30 : 0;
+
+    sortedNodes.forEach((node, index) => {
+      const col = index % cols;
+      const row = Math.floor(index / cols);
+      symbolPositions.set(node.id, {
+        x: contentStartX + col * stepX + stepX / 2,
+        y: laneY + 20 + row * stepY + 12,
+      });
+    });
+
+    laneY += laneH + laneGap;
+  });
+
+  centerBox.h = Math.max(centerBox.h, laneY - centerBox.y + 12);
+
+  return { focus, centerBox, leftBoxes, rightBoxes, symbolPositions, fileBoxes };
+}
+
+// ────────────────────────────────────────────────────────────
+// Canvas / interaction state
+// ────────────────────────────────────────────────────────────
 const canvas = document.getElementById("graph");
 const ctx = canvas.getContext("2d");
 let width = window.innerWidth;
 let height = window.innerHeight;
-
 function resizeCanvas() {
   width = window.innerWidth;
   height = window.innerHeight;
@@ -373,355 +639,699 @@ function resizeCanvas() {
 }
 resizeCanvas();
 
-// ═══════════════════════════════════════════════════
-// ZOOM & PAN
-// ═══════════════════════════════════════════════════
+let mode = "overview";
+let focusedModuleId = null;
+let focusedSymbolId = null;
+let blastRadiusMode = false;
+let searchValue = "";
+let showLabels = true;
+let showWeights = true;
+let hoverTarget = null;
+let focusPanY = 0;
 
-let transform = { x: 40, y: 40, k: 1 };
+const legendItemsEl = document.getElementById("legend-items");
+const statsEl = document.getElementById("stats");
+const detailEl = document.getElementById("detail");
+const modeBadgeEl = document.getElementById("mode-badge");
+const overviewButton = document.getElementById("btn-overview");
+const fitButton = document.getElementById("btn-fit");
+const interactionHintEl = document.getElementById("interaction-hint");
 
-// Auto-fit on load
-function fitView() {
-  if (nodes.length === 0) return;
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  for (const [, b] of clusterBounds) {
-    minX = Math.min(minX, b.x);
-    minY = Math.min(minY, b.y);
-    maxX = Math.max(maxX, b.x + b.w);
-    maxY = Math.max(maxY, b.y + b.h);
+if (meta.truncated) {
+  const warning = document.getElementById("truncation-warning");
+  warning.style.display = "block";
+  warning.textContent = "⚠ Graph truncated to " + allNodes.length + " nodes (source total: " + meta.totalSymbols + ")";
+}
+
+for (const mod of moduleList) {
+  const item = document.createElement("div");
+  item.className = "legend-item";
+  item.innerHTML = '<div class="legend-swatch" style="background:' + mod.color + '"></div>' +
+    '<div class="legend-text" title="' + mod.pathPrefix + '">' + mod.label + ' (' + mod.nodes.length + ')</div>';
+  item.addEventListener("click", () => enterFocus(mod.id));
+  legendItemsEl.appendChild(item);
+}
+
+function updateStats() {
+  if (mode === "overview") {
+    statsEl.innerHTML =
+      '<span class="label">Mode</span> overview' +
+      '<br><span class="label">Modules</span> ' + moduleList.length +
+      '<br><span class="label">Module edges</span> ' + moduleEdges.length +
+      '<br><span class="label">Symbols</span> ' + allNodes.length +
+      '<br><span class="label">Files</span> ' + new Set(allNodes.map((n) => n.filePath)).size;
+      modeBadgeEl.style.display = "none";
+  } else {
+    const focus = modules.get(focusedModuleId);
+    statsEl.innerHTML =
+      '<span class="label">Mode</span> focus' +
+      '<br><span class="label">Module</span> ' + focus.label +
+      '<br><span class="label">Symbols</span> ' + focus.nodes.length +
+      '<br><span class="label">Incoming</span> ' + [...focus.incoming.values()].reduce((a, b) => a + b, 0) +
+      '<br><span class="label">Outgoing</span> ' + [...focus.outgoing.values()].reduce((a, b) => a + b, 0);
+    modeBadgeEl.style.display = "block";
+    modeBadgeEl.textContent = "Focus mode: " + focus.label;
   }
-  const graphW = maxX - minX;
-  const graphH = maxY - minY;
-  const padW = width * 0.08;
-  const padH = height * 0.08;
-  const scaleX = (width - padW * 2) / graphW;
-  const scaleY = (height - padH * 2) / graphH;
-  transform.k = Math.min(scaleX, scaleY, 2.5);
-  transform.x = (width - graphW * transform.k) / 2 - minX * transform.k;
-  transform.y = (height - graphH * transform.k) / 2 - minY * transform.k;
-}
-fitView();
-
-function screenToWorld(sx, sy) {
-  return { x: (sx - transform.x) / transform.k, y: (sy - transform.y) / transform.k };
 }
 
-canvas.addEventListener("wheel", (e) => {
-  e.preventDefault();
-  const scale = e.deltaY > 0 ? 0.92 : 1.08;
-  const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-  const my = e.clientY - rect.top;
-  transform.x = mx - (mx - transform.x) * scale;
-  transform.y = my - (my - transform.y) * scale;
-  transform.k *= scale;
+function updateControls() {
+  overviewButton.textContent = mode === "overview" ? "Overview Map" : "Back to Overview";
+  overviewButton.title = mode === "overview"
+    ? "You are viewing the top-level architecture map"
+    : "Return to the top-level architecture map";
+  overviewButton.classList.toggle("active", mode === "overview");
+  overviewButton.disabled = mode === "overview";
+
+  fitButton.textContent = mode === "overview" ? "Reset Overview Layout" : "Overview Layout Only";
+  fitButton.title = mode === "overview"
+    ? "Recompute the overview layout for the current window size"
+    : "This control only affects the overview map. Click Overview to return there first.";
+  fitButton.disabled = mode !== "overview";
+
+  interactionHintEl.style.display = mode === "focus" ? "block" : "none";
+  interactionHintEl.textContent = mode === "focus"
+    ? "Scroll to pan vertically inside focus mode"
+    : "";
+}
+
+function getFocusPanBounds() {
+  if (mode !== "focus" || !focusedModuleId) return { min: 0, max: 0 };
+  const state = layoutFocus(focusedModuleId);
+  if (!state) return { min: 0, max: 0 };
+  const contentBottom = Math.max(
+    state.centerBox.y + state.centerBox.h,
+    ...state.leftBoxes.map((box) => box.y + box.h),
+    ...state.rightBoxes.map((box) => box.y + box.h),
+  );
+  const overflow = Math.max(0, contentBottom - (height - 32));
+  return { min: -overflow, max: 0 };
+}
+
+function clampFocusPan() {
+  const bounds = getFocusPanBounds();
+  focusPanY = Math.min(bounds.max, Math.max(bounds.min, focusPanY));
+}
+
+function setDetailForModule(mod, note) {
+  detailEl.style.display = "block";
+  document.getElementById("detail-title").textContent = mod.label;
+  document.getElementById("detail-type").textContent = "Module";
+  document.getElementById("detail-location").textContent = mod.pathPrefix + (mod.files.size ? " • " + [...mod.files].slice(0, 2).map(shortPath).join(", ") + ([...mod.files].length > 2 ? " …" : "") : "");
+  document.getElementById("detail-connections").textContent =
+    "incoming " + [...mod.incoming.values()].reduce((a, b) => a + b, 0) +
+    ", outgoing " + [...mod.outgoing.values()].reduce((a, b) => a + b, 0) +
+    ", internal " + mod.internalEdgeCount;
+  document.getElementById("detail-notes").textContent = note;
+  document.getElementById("detail-callers").textContent = [...mod.incoming.keys()].map((id) => modules.get(id)?.label).filter(Boolean).join(", ") || "none";
+  document.getElementById("detail-callees").textContent = [...mod.outgoing.keys()].map((id) => modules.get(id)?.label).filter(Boolean).join(", ") || "none";
+  document.getElementById("detail-edge-types").textContent = mod.internalEdgeCount > 0 ? ("internal " + mod.internalEdgeCount) : "n/a";
+  document.getElementById("detail-blast").textContent = blastRadiusMode ? "blast mode active" : "toggle Blast Radius to inspect affected neighbors";
+}
+
+function setDetailForSymbol(node) {
+  const incoming = resolvedEdges.filter((e) => e.target === node.id).length;
+  const outgoing = resolvedEdges.filter((e) => e.source === node.id).length;
+  const callers = resolvedEdges.filter((e) => e.target === node.id).map((e) => nodeById.get(e.source)?.name).filter(Boolean);
+  const callees = resolvedEdges.filter((e) => e.source === node.id).map((e) => nodeById.get(e.target)?.name).filter(Boolean);
+  const edgeTypes = new Map();
+  for (const edge of resolvedEdges) {
+    if (edge.source === node.id || edge.target === node.id) {
+      edgeTypes.set(edge.callType, (edgeTypes.get(edge.callType) || 0) + 1);
+    }
+  }
+  const visited = new Set([node.id]);
+  const queue = [{ id: node.id, depth: 0 }];
+  while (queue.length) {
+    const current = queue.shift();
+    if (current.depth >= 2) continue;
+    for (const edge of resolvedEdges) {
+      if (edge.source === current.id && !visited.has(edge.target)) {
+        visited.add(edge.target);
+        queue.push({ id: edge.target, depth: current.depth + 1 });
+      }
+      if (edge.target === current.id && !visited.has(edge.source)) {
+        visited.add(edge.source);
+        queue.push({ id: edge.source, depth: current.depth + 1 });
+      }
+    }
+  }
+  const blastModules = new Set([...visited].map((id) => nodeById.get(id)?.moduleLabel).filter(Boolean));
+  detailEl.style.display = "block";
+  document.getElementById("detail-title").textContent = node.name;
+  document.getElementById("detail-type").textContent = node.kind;
+  document.getElementById("detail-location").textContent = shortPath(node.filePath) + ':' + node.line;
+  document.getElementById("detail-connections").textContent = "incoming " + incoming + ", outgoing " + outgoing;
+  document.getElementById("detail-notes").textContent = "Module: " + node.moduleLabel;
+  document.getElementById("detail-callers").textContent = callers.length ? callers.slice(0, 6).join(", ") + (callers.length > 6 ? " …" : "") : "none";
+  document.getElementById("detail-callees").textContent = callees.length ? callees.slice(0, 6).join(", ") + (callees.length > 6 ? " …" : "") : "none";
+  document.getElementById("detail-edge-types").textContent = [...edgeTypes.entries()].map(([type, count]) => type + "×" + count).join(", ") || "none";
+  document.getElementById("detail-blast").textContent = (visited.size - 1) + " symbols, " + Math.max(0, blastModules.size - 1) + " modules within 2 hops";
+}
+
+function clearDetail() {
+  detailEl.style.display = "none";
+}
+
+function enterFocus(moduleId) {
+  mode = "focus";
+  focusedModuleId = moduleId;
+  focusedSymbolId = null;
+  focusPanY = 0;
+  updateStats();
+  updateControls();
   draw();
-}, { passive: false });
+}
 
-let isPanning = false;
-let isDragging = false;
-let dragNode = null;
-let lastMouse = { x: 0, y: 0 };
+function backToOverview() {
+  mode = "overview";
+  focusedModuleId = null;
+  focusedSymbolId = null;
+  focusPanY = 0;
+  clearDetail();
+  updateStats();
+  updateControls();
+  draw();
+}
 
-canvas.addEventListener("mousedown", (e) => {
-  const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-  const my = e.clientY - rect.top;
-  const world = screenToWorld(mx, my);
-
-  const hitNode = findNodeAt(world.x, world.y);
-  if (hitNode) {
-    isDragging = true;
-    dragNode = hitNode;
-    selectNode(hitNode);
-  } else {
-    isPanning = true;
-    selectNode(null);
+function getSearchMatches() {
+  const q = searchValue.trim().toLowerCase();
+  if (!q) return { modules: new Set(), nodes: new Set() };
+  const modulesSet = new Set();
+  const nodesSet = new Set();
+  for (const mod of moduleList) {
+    if (mod.label.toLowerCase().includes(q) || mod.pathPrefix.toLowerCase().includes(q)) modulesSet.add(mod.id);
+    for (const node of mod.nodes) {
+      if (node.name.toLowerCase().includes(q) || node.filePath.toLowerCase().includes(q)) {
+        modulesSet.add(mod.id);
+        nodesSet.add(node.id);
+      }
+    }
   }
-  lastMouse = { x: mx, y: my };
-});
+  return { modules: modulesSet, nodes: nodesSet };
+}
 
-canvas.addEventListener("mousemove", (e) => {
-  const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-  const my = e.clientY - rect.top;
+function computeBlastRadius() {
+  if (!blastRadiusMode) return { modules: new Set(), nodes: new Set() };
 
-  if (isPanning) {
-    transform.x += mx - lastMouse.x;
-    transform.y += my - lastMouse.y;
-    lastMouse = { x: mx, y: my };
-    draw();
-  } else if (isDragging && dragNode) {
-    const world = screenToWorld(mx, my);
-    dragNode._x = world.x;
-    dragNode._y = world.y;
-    nodePositions.set(dragNode.id, { x: world.x, y: world.y });
-    draw();
-  } else {
-    const world = screenToWorld(mx, my);
-    const hover = findNodeAt(world.x, world.y);
-    canvas.style.cursor = hover ? "pointer" : "grab";
+  if (focusedSymbolId) {
+    const visited = new Set([focusedSymbolId]);
+    const queue = [{ id: focusedSymbolId, depth: 0 }];
+    while (queue.length) {
+      const current = queue.shift();
+      if (current.depth >= 2) continue;
+      for (const edge of resolvedEdges) {
+        if (edge.source === current.id && !visited.has(edge.target)) {
+          visited.add(edge.target);
+          queue.push({ id: edge.target, depth: current.depth + 1 });
+        }
+        if (edge.target === current.id && !visited.has(edge.source)) {
+          visited.add(edge.source);
+          queue.push({ id: edge.source, depth: current.depth + 1 });
+        }
+      }
+    }
+    const moduleIds = new Set([...visited].map((id) => nodeById.get(id)?.moduleId).filter(Boolean));
+    return { nodes: visited, modules: moduleIds };
   }
-});
 
-canvas.addEventListener("mouseup", () => {
-  isPanning = false;
-  isDragging = false;
-  dragNode = null;
-});
+  if (focusedModuleId) {
+    const moduleIds = new Set([focusedModuleId]);
+    const nodeIds = new Set((modules.get(focusedModuleId)?.nodes || []).map((node) => node.id));
+    const queue = [{ id: focusedModuleId, depth: 0 }];
+    while (queue.length) {
+      const current = queue.shift();
+      if (current.depth >= 3) continue;
+      for (const edge of moduleEdges) {
+        if (edge.source === current.id && !moduleIds.has(edge.target)) {
+          moduleIds.add(edge.target);
+          queue.push({ id: edge.target, depth: current.depth + 1 });
+        }
+        if (edge.target === current.id && !moduleIds.has(edge.source)) {
+          moduleIds.add(edge.source);
+          queue.push({ id: edge.source, depth: current.depth + 1 });
+        }
+      }
+    }
+    for (const modId of moduleIds) {
+      for (const node of modules.get(modId)?.nodes || []) nodeIds.add(node.id);
+    }
+    return { modules: moduleIds, nodes: nodeIds };
+  }
 
-function findNodeAt(wx, wy) {
-  const radius = Math.max(6, 10 / transform.k);
-  for (let i = nodes.length - 1; i >= 0; i--) {
-    const n = nodes[i];
-    const dx = n._x - wx;
-    const dy = n._y - wy;
-    if (dx * dx + dy * dy < radius * radius) return n;
+  return { modules: new Set(), nodes: new Set() };
+}
+
+// ────────────────────────────────────────────────────────────
+// Drawing
+// ────────────────────────────────────────────────────────────
+function drawOverview() {
+  const matches = getSearchMatches();
+  const blast = computeBlastRadius();
+
+  if (!overviewLayout.sparse) {
+    // background flow lanes
+    for (let d = 0; d <= overviewLayout.maxDepth; d++) {
+      const x = 52 + d * 170;
+      ctx.fillStyle = "rgba(255,255,255,0.02)";
+      roundRect(ctx, x - 18, 94, 130, height - 170, 12);
+      ctx.fill();
+      if (showLabels) {
+        ctx.fillStyle = "#647095";
+        ctx.font = "11px sans-serif";
+        ctx.textAlign = "center";
+        ctx.fillText(d === 0 ? "entry" : "layer " + d, x + 47, 82);
+      }
+    }
+  } else if (showLabels) {
+    ctx.fillStyle = "#647095";
+    ctx.font = "11px sans-serif";
+    ctx.textAlign = "left";
+    ctx.fillText("module atlas", 48, 82);
+  }
+
+  const drawOverviewEdges = () => {
+  const atlasBusY = Math.max(40, Math.min(...moduleList.map((mod) => (moduleBounds.get(mod.id)?.y ?? 120) - 18)));
+  for (const edge of moduleEdges) {
+    const s = moduleBounds.get(edge.source);
+    const t = moduleBounds.get(edge.target);
+    if (!s || !t) continue;
+    const sMid = { x: s.x + s.w, y: s.y + s.h / 2 };
+    const tMid = { x: t.x, y: t.y + t.h / 2 };
+    const searched = !matches.modules.size || matches.modules.has(edge.source) || matches.modules.has(edge.target);
+    const inBlast = !blast.modules.size || blast.modules.has(edge.source) || blast.modules.has(edge.target);
+    ctx.strokeStyle = searched && inBlast ? "rgba(123,145,255," + Math.min(0.82, 0.18 + edge.weight * 0.06) + ")" : "rgba(70,78,110,0.12)";
+    ctx.lineWidth = Math.max(1, Math.min(8, edge.weight * 0.85));
+    ctx.beginPath();
+    if (overviewLayout.sparse) {
+      const sourcePoint = s.x < t.x
+        ? { x: s.x + s.w, y: s.y + s.h / 2 }
+        : { x: s.x, y: s.y + s.h / 2 };
+      const targetPoint = s.x < t.x
+        ? { x: t.x, y: t.y + t.h / 2 }
+        : { x: t.x + t.w, y: t.y + t.h / 2 };
+      const corridorX = (sourcePoint.x + targetPoint.x) / 2;
+      ctx.moveTo(sourcePoint.x, sourcePoint.y);
+      ctx.lineTo(corridorX, sourcePoint.y);
+      ctx.lineTo(corridorX, targetPoint.y);
+      ctx.lineTo(targetPoint.x, targetPoint.y);
+    } else {
+      const dx = Math.max(50, (tMid.x - sMid.x) * 0.45);
+      ctx.moveTo(sMid.x, sMid.y);
+      ctx.bezierCurveTo(sMid.x + dx, sMid.y, tMid.x - dx, tMid.y, tMid.x, tMid.y);
+    }
+    ctx.stroke();
+
+    if (showWeights) {
+      const mx = (sMid.x + tMid.x) / 2;
+      const my = (sMid.y + tMid.y) / 2;
+      ctx.fillStyle = "rgba(13,15,26,0.95)";
+      roundRect(ctx, mx - 10, my - 8, 20, 16, 5);
+      ctx.fill();
+      ctx.fillStyle = "#cfd6ef";
+      ctx.font = "10px sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillText(String(edge.weight), mx, my + 3);
+    }
+  }
+  };
+
+  if (!overviewLayout.sparse) drawOverviewEdges();
+
+  for (const mod of moduleList) {
+    const b = moduleBounds.get(mod.id);
+    const searched = !matches.modules.size || matches.modules.has(mod.id);
+    const inBlast = !blast.modules.size || blast.modules.has(mod.id);
+    const fill = searched && inBlast ? mod.color + "18" : "rgba(24,28,44,0.46)";
+    const stroke = searched && inBlast ? mod.color : "#2f3659";
+
+    ctx.fillStyle = fill;
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1.5;
+    ctx.shadowColor = searched && inBlast ? mod.color + "33" : "rgba(0,0,0,0)";
+    ctx.shadowBlur = searched && inBlast ? 18 : 0;
+    ctx.shadowOffsetY = 6;
+    roundRect(ctx, b.x, b.y, b.w, b.h, 14);
+    ctx.fill();
+    ctx.shadowBlur = 0;
+    ctx.shadowOffsetY = 0;
+    ctx.stroke();
+
+    // header glow / accent
+    ctx.fillStyle = mod.color + "22";
+    roundRect(ctx, b.x + 10, b.y + 10, b.w - 20, 16, 8);
+    ctx.fill();
+
+    // module title
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "700 14px sans-serif";
+    ctx.textAlign = "left";
+    ctx.fillText(mod.label, b.x + 14, b.y + 23);
+
+    // summary
+    ctx.fillStyle = "#b0b8d4";
+    ctx.font = "12px sans-serif";
+    ctx.fillText(mod.nodes.length + " symbols", b.x + 14, b.y + 46);
+    ctx.fillText(mod.files.size + " files", b.x + 14, b.y + 63);
+
+    // density bars
+    const barY = b.y + b.h - 18;
+    const outgoing = [...mod.outgoing.values()].reduce((a, c) => a + c, 0);
+    const incoming = [...mod.incoming.values()].reduce((a, c) => a + c, 0);
+    ctx.fillStyle = "rgba(255,255,255,0.08)";
+    roundRect(ctx, b.x + 14, barY, b.w - 28, 7, 3);
+    ctx.fill();
+    const total = Math.max(1, outgoing + incoming + mod.internalEdgeCount);
+    const outW = (b.w - 28) * (outgoing / total);
+    const intW = (b.w - 28) * (mod.internalEdgeCount / total);
+    ctx.fillStyle = "#7b91ff";
+    roundRect(ctx, b.x + 14, barY, outW, 7, 3);
+    ctx.fill();
+    ctx.fillStyle = "#4ad7a6";
+    roundRect(ctx, b.x + 14 + outW, barY, intW, 7, 3);
+    ctx.fill();
+  }
+
+  if (overviewLayout.sparse) drawOverviewEdges();
+}
+
+function drawFocus() {
+  const state = layoutFocus(focusedModuleId);
+  if (!state) return;
+  clampFocusPan();
+  const matches = getSearchMatches();
+  const blast = computeBlastRadius();
+  ctx.save();
+  ctx.translate(0, focusPanY);
+
+  // left callers
+  for (const box of state.leftBoxes) {
+    drawSideModuleBox(box, "caller", (!matches.modules.size || matches.modules.has(box.mod.id)) && (!blast.modules.size || blast.modules.has(box.mod.id)));
+  }
+  // right callees
+  for (const box of state.rightBoxes) {
+    drawSideModuleBox(box, "callee", (!matches.modules.size || matches.modules.has(box.mod.id)) && (!blast.modules.size || blast.modules.has(box.mod.id)));
+  }
+
+  // center panel
+  ctx.fillStyle = state.focus.center.color + "18";
+  ctx.strokeStyle = state.focus.center.color;
+  ctx.lineWidth = 2;
+  roundRect(ctx, state.centerBox.x, state.centerBox.y, state.centerBox.w, state.centerBox.h, 16);
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "700 16px sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillText(state.focus.center.label, state.centerBox.x + 16, state.centerBox.y + 24);
+  ctx.fillStyle = "#9aa6cb";
+  ctx.font = "12px sans-serif";
+  ctx.fillText(
+    state.focus.center.nodes.length + " symbols • " + state.focus.center.files.size + " files • internal edges " + state.focus.center.internalEdgeCount,
+    state.centerBox.x + 16,
+    state.centerBox.y + 44,
+  );
+
+  for (const fileBox of state.fileBoxes) {
+    ctx.fillStyle = "rgba(255,255,255,0.03)";
+    ctx.strokeStyle = "rgba(255,255,255,0.08)";
+    ctx.lineWidth = 1;
+    roundRect(ctx, fileBox.x, fileBox.y, fileBox.w, fileBox.h, 10);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = "rgba(255,255,255,0.06)";
+    roundRect(ctx, fileBox.x + 6, fileBox.y + 6, 112, fileBox.h - 12, 8);
+    ctx.fill();
+
+    ctx.fillStyle = "#bfc8e8";
+    ctx.font = "10px sans-serif";
+    ctx.textAlign = "left";
+    const shortFile = fileBox.filePath.split("/").pop();
+    ctx.fillText(shortFile, fileBox.x + 14, fileBox.y + 20);
+    ctx.fillStyle = "#8290b8";
+    ctx.font = "9px sans-serif";
+    ctx.fillText(fileBox.nodes.length + " symbols", fileBox.x + 14, fileBox.y + 34);
+  }
+
+  // internal symbol edges
+  const centerIds = new Set(state.focus.center.nodes.map((n) => n.id));
+  const internalEdges = resolvedEdges.filter((e) => centerIds.has(e.source) && centerIds.has(e.target));
+  for (const edge of internalEdges) {
+    const s = state.symbolPositions.get(edge.source);
+    const t = state.symbolPositions.get(edge.target);
+    const searched = !matches.nodes.size || matches.nodes.has(edge.source) || matches.nodes.has(edge.target);
+    ctx.strokeStyle = searched ? "rgba(123,145,255,0.5)" : "rgba(74,82,118,0.22)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(s.x, s.y);
+    ctx.lineTo(t.x, t.y);
+    ctx.stroke();
+  }
+
+  // symbol nodes
+  for (const node of state.focus.center.nodes) {
+    const pos = state.symbolPositions.get(node.id);
+    const match = (!matches.nodes.size || matches.nodes.has(node.id)) && (!blast.nodes.size || blast.nodes.has(node.id));
+    const selected = focusedSymbolId === node.id;
+    const degree = resolvedEdges.filter((e) => e.source === node.id || e.target === node.id).length;
+    const radius = selected ? 8 : Math.min(7, 4 + degree * 0.45);
+    const color = match ? kindColor(node.kind, state.focus.center.color) : "#525a7e";
+    drawSymbolGlyph(ctx, node, pos.x, pos.y, radius, color);
+    if (selected) {
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    } else if (hoverTarget && hoverTarget.type === "symbol" && hoverTarget.node.id === node.id) {
+      ctx.strokeStyle = "rgba(255,255,255,0.8)";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+    if (showLabels) {
+      const label = shortNodeLabel(node.name);
+      ctx.font = selected ? "600 10px sans-serif" : "9px sans-serif";
+      ctx.textAlign = "center";
+      const textWidth = ctx.measureText(label).width;
+      const chipW = textWidth + 10;
+      const chipH = 16;
+      const chipX = pos.x - chipW / 2;
+      const chipY = pos.y - (radius + 20);
+      const hovered = hoverTarget && hoverTarget.type === "symbol" && hoverTarget.node.id === node.id;
+      ctx.fillStyle = selected ? "rgba(255,255,255,0.16)" : (hovered ? "rgba(33,38,60,0.96)" : "rgba(18,22,36,0.88)");
+      roundRect(ctx, chipX, chipY, chipW, chipH, 6);
+      ctx.fill();
+      ctx.strokeStyle = selected ? "rgba(255,255,255,0.28)" : (hovered ? "rgba(123,145,255,0.35)" : "rgba(255,255,255,0.08)");
+      ctx.lineWidth = 1;
+      ctx.stroke();
+      ctx.fillStyle = selected ? "#fff" : (hovered ? "#eef3ff" : "#dce2f4");
+      ctx.fillText(label, pos.x, chipY + 11);
+    }
+  }
+
+  // aggregated side edges
+  for (const box of state.leftBoxes) {
+    const targetY = box.y + box.h / 2;
+    const sourceY = state.centerBox.y + state.centerBox.h / 2;
+    const weight = box.weight;
+    drawAggregateConnector(box.x + box.w, targetY, state.centerBox.x, sourceY, weight, box.mod.color, true);
+  }
+  for (const box of state.rightBoxes) {
+    const sourceY = state.centerBox.y + state.centerBox.h / 2;
+    const targetY = box.y + box.h / 2;
+    const weight = box.weight;
+    drawAggregateConnector(state.centerBox.x + state.centerBox.w, sourceY, box.x, targetY, weight, box.mod.color, false);
+  }
+  ctx.restore();
+}
+
+function drawSideModuleBox(box, kind, searched) {
+  ctx.fillStyle = searched ? box.mod.color + "20" : "rgba(28,31,49,0.76)";
+  ctx.strokeStyle = searched ? box.mod.color : "#2f3659";
+  ctx.lineWidth = 1.4;
+  ctx.shadowColor = searched ? box.mod.color + "22" : "rgba(0,0,0,0)";
+  ctx.shadowBlur = searched ? 10 : 0;
+  ctx.shadowOffsetY = 4;
+  roundRect(ctx, box.x, box.y, box.w, box.h, 12);
+  ctx.fill();
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetY = 0;
+  ctx.stroke();
+
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "600 12px sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillText(box.mod.label, box.x + 12, box.y + 20);
+  ctx.fillStyle = "#95a0c5";
+  ctx.font = "11px sans-serif";
+  ctx.fillText((box.hop > 1 ? String(box.hop) + " hops away" : (kind === "caller" ? "calls selected module" : "called by selected module")), box.x + 12, box.y + 38);
+  ctx.fillText(box.weight + " cross-module calls", box.x + 12, box.y + 54);
+}
+
+function drawAggregateConnector(x1, y1, x2, y2, weight, color, leftToCenter) {
+  const dx = Math.abs(x2 - x1) * 0.45;
+  ctx.strokeStyle = color + (showWeights ? "cc" : "88");
+  ctx.lineWidth = Math.max(2, Math.min(10, weight * 0.8));
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  if (leftToCenter) {
+    ctx.bezierCurveTo(x1 + dx, y1, x2 - dx, y2, x2, y2);
+  } else {
+    ctx.bezierCurveTo(x1 + dx, y1, x2 - dx, y2, x2, y2);
+  }
+  ctx.stroke();
+
+  if (showWeights) {
+    const mx = (x1 + x2) / 2;
+    const my = (y1 + y2) / 2;
+    ctx.fillStyle = "rgba(13,15,26,0.96)";
+    roundRect(ctx, mx - 12, my - 9, 24, 18, 6);
+    ctx.fill();
+    ctx.fillStyle = "#fff";
+    ctx.font = "10px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText(String(weight), mx, my + 3);
+  }
+}
+
+function draw() {
+  ctx.clearRect(0, 0, width, height);
+  if (mode === "overview") drawOverview();
+  else drawFocus();
+}
+
+// ────────────────────────────────────────────────────────────
+// Hit testing
+// ────────────────────────────────────────────────────────────
+function hitTestOverview(x, y) {
+  for (const mod of moduleList) {
+    const b = moduleBounds.get(mod.id);
+    if (x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h) return { type: "module", moduleId: mod.id };
   }
   return null;
 }
 
-// ═══════════════════════════════════════════════════
-// SELECTION & INTERACTION
-// ═══════════════════════════════════════════════════
+function hitTestFocus(x, y) {
+  const state = layoutFocus(focusedModuleId);
+  if (!state) return null;
+  const adjustedY = y - focusPanY;
 
-let selectedNode = null;
-let highlightedIds = new Set();
-let focusedDir = null;
+  if (x >= state.centerBox.x && x <= state.centerBox.x + state.centerBox.w && adjustedY >= state.centerBox.y && adjustedY <= state.centerBox.y + state.centerBox.h) {
+    for (const node of state.focus.center.nodes) {
+      const pos = state.symbolPositions.get(node.id);
+      const dx = x - pos.x;
+      const dy = adjustedY - pos.y;
+      if (dx * dx + dy * dy <= 64) return { type: "symbol", node };
+    }
+    return { type: "module", moduleId: focusedModuleId };
+  }
 
-function selectNode(node) {
-  selectedNode = node;
-  const detail = document.getElementById("detail");
-  if (!node) {
-    detail.style.display = "none";
-    highlightedIds.clear();
+  for (const box of [...state.leftBoxes, ...state.rightBoxes]) {
+    if (x >= box.x && x <= box.x + box.w && adjustedY >= box.y && adjustedY <= box.y + box.h) {
+      return { type: "module", moduleId: box.mod.id };
+    }
+  }
+  return null;
+}
+
+canvas.addEventListener("wheel", (event) => {
+  if (mode !== "focus") return;
+  const bounds = getFocusPanBounds();
+  if (bounds.min === 0 && bounds.max === 0) return;
+  event.preventDefault();
+  focusPanY -= event.deltaY;
+  clampFocusPan();
+  draw();
+}, { passive: false });
+
+canvas.addEventListener("mousemove", (event) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const previousHover = hoverTarget;
+  hoverTarget = mode === "overview" ? hitTestOverview(x, y) : hitTestFocus(x, y);
+  canvas.style.cursor = hoverTarget ? "pointer" : "default";
+  if ((previousHover?.type || null) !== (hoverTarget?.type || null)
+    || (previousHover?.node?.id || null) !== (hoverTarget?.node?.id || null)
+    || (previousHover?.moduleId || null) !== (hoverTarget?.moduleId || null)) {
     draw();
+  }
+});
+
+canvas.addEventListener("click", (event) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const hit = mode === "overview" ? hitTestOverview(x, y) : hitTestFocus(x, y);
+  if (!hit) return;
+
+  if (hit.type === "module") {
+    if (mode === "focus" && hit.moduleId === focusedModuleId) {
+      setDetailForModule(modules.get(hit.moduleId), "Selected module overview");
+      draw();
+      return;
+    }
+    if (mode === "focus" && hit.moduleId !== focusedModuleId) {
+      enterFocus(hit.moduleId);
+      setDetailForModule(modules.get(hit.moduleId), "Drilled into connected module");
+      return;
+    }
+    enterFocus(hit.moduleId);
+    setDetailForModule(modules.get(hit.moduleId), "Click Overview to return to the architecture map");
     return;
   }
 
-  detail.style.display = "block";
-  document.getElementById("detail-name").textContent = node.name;
-  document.getElementById("detail-file").textContent = node.filePath;
-  document.getElementById("detail-kind").textContent = node.kind;
-  document.getElementById("detail-line").textContent = String(node.line);
-
-  const callerList = (inEdges.get(node.id) || []).map(e => e.node.name);
-  const calleeList = (outEdges.get(node.id) || []).map(e => e.node.name);
-  document.getElementById("detail-connections").textContent = String(callerList.length + calleeList.length);
-  document.getElementById("detail-callers").textContent = callerList.length ? callerList.join(", ") : "none";
-  document.getElementById("detail-callees").textContent = calleeList.length ? calleeList.join(", ") : "none";
-
-  highlightedIds = new Set([node.id]);
-  for (const e of inEdges.get(node.id) || []) highlightedIds.add(e.node.id);
-  for (const e of outEdges.get(node.id) || []) highlightedIds.add(e.node.id);
-  draw();
-}
-
-function focusCluster(dir) {
-  if (focusedDir === dir) { focusedDir = null; draw(); return; }
-  focusedDir = dir;
-
-  // Pan to cluster
-  const bounds = clusterBounds.get(dir);
-  if (bounds) {
-    const cx = bounds.x + bounds.w / 2;
-    const cy = bounds.y + bounds.h / 2;
-    transform.x = width / 2 - cx * transform.k;
-    transform.y = height / 2 - cy * transform.k;
+  if (hit.type === "symbol") {
+    focusedSymbolId = hit.node.id;
+    setDetailForSymbol(hit.node);
+    draw();
   }
-  draw();
-}
+});
 
-// Search
+// controls
 const searchInput = document.getElementById("search");
-let searchMatches = new Set();
-
 searchInput.addEventListener("input", () => {
-  const q = searchInput.value.toLowerCase().trim();
-  if (!q) {
-    searchMatches.clear();
-  } else {
-    searchMatches = new Set(nodes.filter(n => n.name.toLowerCase().includes(q) || n.filePath.toLowerCase().includes(q)).map(n => n.id));
-  }
+  searchValue = searchInput.value;
   draw();
 });
 
-// Controls
-let showLabels = true;
-let showEdgeColors = true;
-
-document.getElementById("btn-reset").addEventListener("click", () => {
-  selectedNode = null;
-  highlightedIds.clear();
-  searchMatches.clear();
-  focusedDir = null;
-  searchInput.value = "";
-  document.getElementById("detail").style.display = "none";
-  fitView();
-  draw();
+document.getElementById("btn-overview").addEventListener("click", () => {
+  backToOverview();
 });
 
-document.getElementById("btn-labels").addEventListener("click", function() {
+document.getElementById("btn-labels").addEventListener("click", function () {
   showLabels = !showLabels;
   this.classList.toggle("active", showLabels);
   draw();
 });
-document.getElementById("btn-labels").classList.add("active");
 
-document.getElementById("btn-edges").addEventListener("click", function() {
-  showEdgeColors = !showEdgeColors;
-  this.classList.toggle("active", showEdgeColors);
+document.getElementById("btn-weights").addEventListener("click", function () {
+  showWeights = !showWeights;
+  this.classList.toggle("active", showWeights);
   draw();
 });
-document.getElementById("btn-edges").classList.add("active");
 
-// ═══════════════════════════════════════════════════
-// DRAWING
-// ═══════════════════════════════════════════════════
+document.getElementById("btn-blast").addEventListener("click", function () {
+  blastRadiusMode = !blastRadiusMode;
+  this.classList.toggle("active", blastRadiusMode);
+  draw();
+});
 
-function draw() {
-  ctx.save();
-  ctx.clearRect(0, 0, width, height);
-  ctx.translate(transform.x, transform.y);
-  ctx.scale(transform.k, transform.k);
+document.getElementById("btn-fit").addEventListener("click", () => {
+  if (mode !== "overview") return;
+  overviewLayout = layoutOverview();
+  clearDetail();
+  draw();
+});
 
-  const hasHighlight = highlightedIds.size > 0;
-  const hasSearch = searchMatches.size > 0;
-  const hasFocus = focusedDir !== null;
+window.addEventListener("resize", () => {
+  resizeCanvas();
+  overviewLayout = layoutOverview();
+  draw();
+});
 
-  // Draw cluster backgrounds
-  for (const [dir, bounds] of clusterBounds) {
-    const dimmed = hasFocus && dir !== focusedDir;
-    ctx.fillStyle = dimmed ? "rgba(20,20,40,0.3)" : "rgba(30,30,55,0.6)";
-    ctx.strokeStyle = dimmed ? "rgba(40,40,70,0.3)" : dirColorMap.get(dir) + "44";
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    roundRect(ctx, bounds.x, bounds.y, bounds.w, bounds.h, 8);
-    ctx.fill();
-    ctx.stroke();
-
-    // Cluster label
-    if (transform.k > 0.4) {
-      ctx.font = "bold " + (10 / Math.max(transform.k, 0.8)) + "px sans-serif";
-      ctx.fillStyle = dimmed ? "rgba(100,100,130,0.3)" : dirColorMap.get(dir) + "aa";
-      ctx.textAlign = "left";
-      const shortLabel = dir.split("/").pop() || dir;
-      ctx.fillText(shortLabel, bounds.x + 8, bounds.y + 14);
-    }
-  }
-
-  // Draw edges
-  for (const e of resolvedEdges) {
-    const srcDimmed = hasFocus && e.source.directory !== focusedDir && e.target.directory !== focusedDir;
-    const highlighted = hasHighlight && (highlightedIds.has(e.source.id) && highlightedIds.has(e.target.id));
-    const searched = hasSearch && (searchMatches.has(e.source.id) || searchMatches.has(e.target.id));
-    const dimmed = srcDimmed || (hasHighlight && !highlighted) || (hasSearch && !searched);
-
-    ctx.beginPath();
-    // Curved edges for inter-cluster, straight for intra-cluster
-    if (e.source.directory !== e.target.directory) {
-      const mx = (e.source._x + e.target._x) / 2;
-      const my = (e.source._y + e.target._y) / 2;
-      const dx = e.target._x - e.source._x;
-      const dy = e.target._y - e.source._y;
-      const offsetX = -dy * 0.1;
-      const offsetY = dx * 0.1;
-      ctx.moveTo(e.source._x, e.source._y);
-      ctx.quadraticCurveTo(mx + offsetX, my + offsetY, e.target._x, e.target._y);
-    } else {
-      ctx.moveTo(e.source._x, e.source._y);
-      ctx.lineTo(e.target._x, e.target._y);
-    }
-
-    const baseColor = showEdgeColors ? (EDGE_COLORS[e.callType] || "#5c7cfa") : "#4a4a7a";
-    ctx.strokeStyle = dimmed ? "rgba(50,50,70,0.2)" : baseColor;
-    ctx.lineWidth = highlighted ? 1.8 : (dimmed ? 0.3 : 0.8);
-    ctx.globalAlpha = dimmed ? 0.2 : (highlighted ? 0.9 : 0.5);
-    ctx.stroke();
-
-    // Arrow
-    if (!dimmed && transform.k > 0.5) {
-      const angle = Math.atan2(e.target._y - e.source._y, e.target._x - e.source._x);
-      const arrowLen = 5;
-      const ax = e.target._x - Math.cos(angle) * 7;
-      const ay = e.target._y - Math.sin(angle) * 7;
-      ctx.beginPath();
-      ctx.moveTo(ax, ay);
-      ctx.lineTo(ax - arrowLen * Math.cos(angle - 0.4), ay - arrowLen * Math.sin(angle - 0.4));
-      ctx.lineTo(ax - arrowLen * Math.cos(angle + 0.4), ay - arrowLen * Math.sin(angle + 0.4));
-      ctx.closePath();
-      ctx.globalAlpha = highlighted ? 0.9 : 0.6;
-      ctx.fillStyle = baseColor;
-      ctx.fill();
-    }
-  }
-
-  ctx.globalAlpha = 1;
-
-  // Draw nodes
-  const baseRadius = Math.max(3, Math.min(5, 600 / Math.sqrt(nodes.length)));
-  for (const n of nodes) {
-    const inFocus = !hasFocus || n.directory === focusedDir;
-    const dimmed = (hasFocus && !inFocus) ||
-      (hasHighlight && !highlightedIds.has(n.id)) ||
-      (hasSearch && !searchMatches.has(n.id));
-
-    const isSelected = selectedNode && n.id === selectedNode.id;
-    const isSearchMatch = searchMatches.has(n.id);
-    const isHighlighted = highlightedIds.has(n.id);
-
-    let r = baseRadius;
-    if (isSelected) r *= 2;
-    else if (isSearchMatch || isHighlighted) r *= 1.4;
-
-    ctx.beginPath();
-    ctx.arc(n._x, n._y, r, 0, Math.PI * 2);
-    ctx.fillStyle = dimmed ? "rgba(50,50,70,0.3)" : dirColorMap.get(n.directory) || "#888";
-    ctx.fill();
-
-    if (isSelected) {
-      ctx.strokeStyle = "#fff";
-      ctx.lineWidth = 2;
-      ctx.stroke();
-    } else if (isSearchMatch) {
-      ctx.strokeStyle = "#ffd700";
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
-    } else if (isHighlighted) {
-      ctx.strokeStyle = "#7eb8ff";
-      ctx.lineWidth = 1;
-      ctx.stroke();
-    }
-
-    // Labels
-    if (!dimmed && showLabels && (isSelected || isSearchMatch || isHighlighted || transform.k > 1.8)) {
-      ctx.font = Math.max(8, 10 / Math.max(transform.k, 1)) + "px sans-serif";
-      ctx.fillStyle = isSelected ? "#fff" : (dimmed ? "rgba(100,100,130,0.3)" : "#c8c8d8");
-      ctx.textAlign = "center";
-      ctx.fillText(n.name, n._x, n._y - r - 3);
-    }
-  }
-
-  ctx.restore();
-}
-
-function roundRect(ctx, x, y, w, h, r) {
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.arcTo(x + w, y, x + w, y + r, r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
-  ctx.lineTo(x + r, y + h);
-  ctx.arcTo(x, y + h, x, y + h - r, r);
-  ctx.lineTo(x, y + r);
-  ctx.arcTo(x, y, x + r, y, r);
-}
-
-// Initial draw
+updateStats();
+updateControls();
 draw();
-
-// Resize handler
-window.addEventListener("resize", () => { resizeCanvas(); draw(); });
-
 })();
 </script>
 </body>

--- a/src/tools/visualize/template.ts
+++ b/src/tools/visualize/template.ts
@@ -25,7 +25,6 @@ export function generateVisualizationHtml(data: VisualizationData): string {
 .details{display:grid;gap:8px}.kv{display:flex;justify-content:space-between;gap:12px;border-bottom:1px solid #17243a;padding-bottom:7px;color:#6f83a4;font-size:12px}.kv span:first-child{color:#334966;text-transform:uppercase;font-size:10px;letter-spacing:.08em}.mini{display:flex;align-items:center;gap:8px;color:#6f83a4;font-size:12px}.dot{width:8px;height:8px;border-radius:50%;flex:0 0 auto}.empty{height:100%;display:grid;place-items:center;color:#334966;font-size:12px;text-align:center;line-height:1.5}.guide{border:1px solid #203149;border-radius:7px;background:#101722;padding:10px;color:#6f83a4;font-size:12px;line-height:1.45}.guide b{display:block;color:#e0e6f7;margin-bottom:4px}.guide span{display:block}
 .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:10px;align-content:start}.rank{font-size:20px;color:#8b6cf6;font-variant-numeric:tabular-nums}.change-grid{display:grid;grid-template-columns:minmax(280px,.95fr) minmax(320px,1.2fr);gap:12px;height:100%;min-height:0}.change-list,.why{display:flex;flex-direction:column;gap:9px;min-height:0;overflow:auto;overflow-x:hidden}.change-top{display:flex;align-items:center;gap:8px;margin-bottom:7px;min-width:0}.pill{font-size:10px;text-transform:uppercase;letter-spacing:.08em;border:1px solid #203149;border-radius:999px;padding:3px 7px;color:#6f83a4;flex:0 0 auto}.pill.hot{color:#d5c9ff;border-color:#634bc2}.pill.risk{color:#ffbab7;border-color:#8d3d3a}.pill.legacy{color:#c5d1df;border-color:#41536c}.why-card{min-width:0;border:1px solid #203149;background:rgba(16,23,34,.65);border-radius:8px;padding:14px;overflow:hidden}.why-card h3{margin:0 0 8px;font-size:13px}.why-card p{margin:0;color:#6f83a4;font-size:13px;line-height:1.55}.impact{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:10px}.impact div{border:1px solid #17243a;border-radius:7px;padding:8px}.impact b{display:block;font-size:16px;color:#e0e6f7}.impact span{font-size:10px;color:#334966;text-transform:uppercase;letter-spacing:.08em}
 .hint{position:absolute;left:50%;bottom:12px;transform:translateX(-50%);font-size:11px;color:#334966;border:1px solid #203149;background:rgba(13,17,24,.9);border-radius:6px;padding:6px 12px;white-space:nowrap}
-#legacy-canvas{display:none}
 @media(max-width:1500px){body{overflow:auto}#app{height:auto;min-height:100vh;grid-template-columns:1fr;grid-template-rows:auto auto auto auto}.top{flex-wrap:wrap}.tabs{flex-wrap:wrap;overflow:visible}.search{width:100%;max-width:none}.stats{margin-left:0;width:100%}.main{order:1;min-height:820px}.right{order:2}.left{order:3}.flow{grid-template-columns:minmax(220px,1fr) minmax(300px,1.15fr) minmax(220px,1fr);gap:16px;align-items:center}.change-grid{grid-template-columns:1fr;gap:12px;align-items:stretch}.why{order:1}.change-list{order:2}.lane{height:min(560px,calc(100vh - 180px));min-height:260px}.impact{grid-template-columns:1fr}.edges{display:none}.hint{position:static;transform:none;margin-top:10px;text-align:center}}
 @media(max-width:900px){.flow,.module-lanes{grid-template-columns:1fr;gap:12px;align-items:stretch}.lane{height:auto;max-height:360px;min-height:160px}.module-board{grid-template-rows:auto auto minmax(260px,1fr);overflow:visible}.module-symbols{max-height:420px}.module-symbols .row{grid-template-columns:1fr}.module-symbols .row .meta{justify-content:flex-start;margin-top:4px}}
 </style>
@@ -38,13 +37,11 @@ export function generateVisualizationHtml(data: VisualizationData): string {
     <div class="stats"><b id="modeName">Changes</b> | <b id="nodeCount">0</b> nodes | <b id="edgeCount">0</b> edges | <b id="changeCount">0</b> change lenses</div>
   </div>
   <aside class="panel left"><h2 class="title">Search / jump</h2><div id="results" class="results"></div></aside>
-  <main class="panel main"><canvas id="legacy-canvas"></canvas><svg id="edges" class="edges"></svg><div id="stage" class="flow"></div><div class="hint" id="hint">Scroll to pan vertically inside focus mode</div></main>
+  <main class="panel main"><svg id="edges" class="edges"></svg><div id="stage" class="flow"></div><div class="hint" id="hint">Scroll to pan vertically inside focus mode</div></main>
   <aside class="panel right"><h2 class="title">Details</h2><div id="details" class="details"></div></aside>
 </div>
 <script>
 const graphData = ${jsonData};
-const canvas = document.getElementById("legacy-canvas");
-canvas.addEventListener("wheel", function () {});
 const nodes = graphData.nodes || [];
 const edges = graphData.edges || [];
 const modules = graphData.modules || [];
@@ -254,7 +251,6 @@ document.getElementById("search").addEventListener("input", function(event){quer
 addEventListener("resize", function(){requestAnimationFrame(drawEdges);});
 render();
 </script>
-<!-- Compatibility copy: clustered symbol exploration view | Explore Symbols | Explore mode: clustered symbol relationships | Module Overview | View Options | Focused module view | Selected from module list | This slice only has intra-module calls. -->
 </body>
 </html>`;
 }

--- a/src/tools/visualize/template.ts
+++ b/src/tools/visualize/template.ts
@@ -1,12 +1,13 @@
 import type { VisualizationData } from "./types.js";
 
 /**
- * Generate a self-contained HTML file with a module-first architecture map.
+ * Generate a self-contained HTML file with a module-first codebase map.
  *
  * Interaction model:
  * - Overview mode: modules/directories as the primary graph
+ * - Explore mode: community-clustered symbol graph for relationship browsing
  * - Focus mode: selected module centered, callers on the left, callees on the right
- * - Symbol detail appears only inside the focused module
+ * - Symbol detail appears inside the explore/focus views
  */
 export function generateVisualizationHtml(data: VisualizationData): string {
   const jsonData = JSON.stringify(data)
@@ -57,6 +58,41 @@ canvas { display: block; }
   flex-wrap: wrap;
   max-width: 620px;
 }
+#options-menu {
+  position: relative;
+}
+#options-summary {
+  list-style: none;
+}
+#options-summary::-webkit-details-marker {
+  display: none;
+}
+#options-summary::after {
+  content: " ▾";
+  color: #7f88a8;
+}
+#options-menu[open] #options-summary::after {
+  content: " ▴";
+}
+#options-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  min-width: 198px;
+  padding: 8px;
+  border-radius: 10px;
+  border: 1px solid #2a3050;
+  background: rgba(14,18,31,0.96);
+  box-shadow: 0 12px 36px rgba(0,0,0,0.34);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+#options-panel .button {
+  width: 100%;
+  justify-content: flex-start;
+  text-align: left;
+}
 #search {
   padding: 9px 12px;
   border-radius: 8px;
@@ -80,6 +116,11 @@ canvas { display: block; }
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s ease;
+}
+.button-secondary {
+  background: rgba(23,27,45,0.74);
+  color: #aab3cf;
+  border-color: #252c46;
 }
 .button:hover {
   background: #202744;
@@ -227,10 +268,16 @@ canvas { display: block; }
   <div id="controls">
     <input id="search" type="text" placeholder="Search symbols or modules..." autocomplete="off">
     <button class="button" id="btn-overview">Overview</button>
-    <button class="button active" id="btn-labels">Labels</button>
-    <button class="button active" id="btn-weights">Weights</button>
-    <button class="button" id="btn-blast">Blast Radius</button>
-    <button class="button" id="btn-fit" title="Recompute the overview layout for the current window size">Reset Overview Layout</button>
+    <button class="button" id="btn-explore">Explore Symbols</button>
+    <details id="options-menu">
+      <summary class="button button-secondary" id="options-summary">View Options</summary>
+      <div id="options-panel">
+        <button class="button button-secondary active" id="btn-labels">Labels</button>
+        <button class="button button-secondary active" id="btn-weights">Weights</button>
+        <button class="button button-secondary" id="btn-blast">Blast Radius</button>
+        <button class="button button-secondary" id="btn-fit" title="Recompute the overview layout for the current window size">Reset Layout</button>
+      </div>
+    </details>
   </div>
   <div id="mode-badge"></div>
   <div id="truncation-warning"></div>
@@ -249,7 +296,7 @@ canvas { display: block; }
       <div class="row"><div class="k">Blast radius</div><div class="v" id="detail-blast"></div></div>
     </div>
   </div>
-  <div id="legend"><h4>Modules</h4><div id="legend-items"></div></div>
+  <div id="legend"><h4 id="legend-title">Modules</h4><div id="legend-items"></div></div>
 </div>
 <script>
 (function () {
@@ -329,6 +376,17 @@ function shortNodeLabel(name) {
   return name.length > 18 ? name.slice(0, 15) + "…" : name;
 }
 
+function moduleCategorySummary(category) {
+  if (category === "fixture") return "Fixture-derived module";
+  if (category === "test") return "Test-only module";
+  if (category === "native") return "Native/runtime module";
+  if (category === "command") return "Command module";
+  if (category === "script") return "Script module";
+  if (category === "doc") return "Documentation module";
+  if (category === "benchmark") return "Benchmark module";
+  return "Source module";
+}
+
 // ────────────────────────────────────────────────────────────
 // Build graph models
 // ────────────────────────────────────────────────────────────
@@ -360,6 +418,9 @@ for (const node of allNodes) {
 const moduleList = [...modules.values()].sort((a, b) => b.symbolCount - a.symbolCount || a.label.localeCompare(b.label));
 moduleList.forEach((m, i) => { m.color = hashColor(i); });
 
+const communityList = [...moduleList].sort((a, b) => a.label.localeCompare(b.label));
+const communityById = new Map(communityList.map((community) => [community.id, community]));
+
 for (const edge of resolvedEdges) {
   const src = edge.sourceNode.moduleId;
   const tgt = edge.targetNode.moduleId;
@@ -382,6 +443,70 @@ for (const edge of moduleEdges) {
 
 for (const mod of moduleList) {
   mod.totalWeight = [...mod.incoming.values(), ...mod.outgoing.values()].reduce((a, b) => a + b, 0) + mod.internalEdgeCount;
+}
+
+const exploreNodePositions = new Map();
+const exploreCommunities = new Map();
+const exploreCommunityBounds = new Map();
+
+function edgeWeightForNode(nodeId) {
+  let weight = 0;
+  for (const edge of resolvedEdges) {
+    if (edge.source === nodeId || edge.target === nodeId) weight += 1;
+  }
+  return weight;
+}
+
+function layoutExploreGraph() {
+  exploreNodePositions.clear();
+  exploreCommunities.clear();
+  exploreCommunityBounds.clear();
+
+  const cols = Math.max(1, Math.min(3, Math.ceil(Math.sqrt(Math.max(1, communityList.length)))));
+  const cellWidth = Math.max(280, Math.floor((width - 120) / cols));
+  const cellHeight = 250;
+  const startX = 56;
+  const startY = 108;
+
+  communityList.forEach((community, index) => {
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+    const centerX = startX + col * cellWidth + cellWidth / 2;
+    const centerY = startY + row * cellHeight + cellHeight / 2;
+    const members = [...community.nodes].sort((a, b) => edgeWeightForNode(b.id) - edgeWeightForNode(a.id) || a.name.localeCompare(b.name));
+    const communityRadius = Math.max(58, Math.min(104, 44 + members.length * 4));
+    const bounds = {
+      x: centerX - cellWidth / 2 + 16,
+      y: centerY - cellHeight / 2 + 12,
+      w: cellWidth - 32,
+      h: cellHeight - 24,
+      centerX,
+      centerY,
+      radius: communityRadius,
+      community,
+    };
+
+    exploreCommunities.set(community.id, { centerX, centerY, radius: communityRadius, community });
+    exploreCommunityBounds.set(community.id, bounds);
+
+    const orbitRadius = Math.max(34, Math.min(communityRadius - 16, 26 + members.length * 3));
+    const count = Math.max(members.length, 1);
+
+    members.forEach((node, memberIndex) => {
+      if (members.length === 1) {
+        exploreNodePositions.set(node.id, { x: centerX, y: centerY });
+        return;
+      }
+
+      const angle = (Math.PI * 2 * memberIndex) / count;
+      const band = 0.55 + 0.35 * ((memberIndex % 3) / 2);
+      const radius = orbitRadius * band;
+      exploreNodePositions.set(node.id, {
+        x: centerX + Math.cos(angle) * radius,
+        y: centerY + Math.sin(angle) * radius,
+      });
+    });
+  });
 }
 
 // ────────────────────────────────────────────────────────────
@@ -653,9 +778,12 @@ const legendItemsEl = document.getElementById("legend-items");
 const statsEl = document.getElementById("stats");
 const detailEl = document.getElementById("detail");
 const modeBadgeEl = document.getElementById("mode-badge");
+const legendTitleEl = document.getElementById("legend-title");
 const overviewButton = document.getElementById("btn-overview");
+const exploreButton = document.getElementById("btn-explore");
 const fitButton = document.getElementById("btn-fit");
 const interactionHintEl = document.getElementById("interaction-hint");
+const optionsMenuEl = document.getElementById("options-menu");
 
 if (meta.truncated) {
   const warning = document.getElementById("truncation-warning");
@@ -663,14 +791,34 @@ if (meta.truncated) {
   warning.textContent = "⚠ Graph truncated to " + allNodes.length + " nodes (source total: " + meta.totalSymbols + ")";
 }
 
-for (const mod of moduleList) {
-  const item = document.createElement("div");
-  item.className = "legend-item";
-  item.innerHTML = '<div class="legend-swatch" style="background:' + mod.color + '"></div>' +
-    '<div class="legend-text" title="' + mod.pathPrefix + '">' + mod.label + ' (' + mod.nodes.length + ')</div>';
-  item.addEventListener("click", () => enterFocus(mod.id));
-  legendItemsEl.appendChild(item);
+function renderLegend() {
+  legendItemsEl.innerHTML = "";
+
+  if (mode === "explore") {
+    legendTitleEl.textContent = "Communities";
+    for (const community of communityList) {
+      const item = document.createElement("div");
+      item.className = "legend-item";
+      item.innerHTML = '<div class="legend-swatch" style="background:' + community.color + '"></div>' +
+        '<div class="legend-text" title="' + community.pathPrefix + '">' + community.label + ' (' + community.nodes.length + ')</div>';
+      item.addEventListener("click", () => enterFocus(community.id, "Community selected from clustered exploration view"));
+      legendItemsEl.appendChild(item);
+    }
+    return;
+  }
+
+  legendTitleEl.textContent = "Modules";
+  for (const mod of moduleList) {
+    const item = document.createElement("div");
+    item.className = "legend-item";
+    item.innerHTML = '<div class="legend-swatch" style="background:' + mod.color + '"></div>' +
+      '<div class="legend-text" title="' + mod.pathPrefix + '">' + mod.label + ' (' + mod.nodes.length + ')</div>';
+    item.addEventListener("click", () => enterFocus(mod.id, "Selected from module list"));
+    legendItemsEl.appendChild(item);
+  }
 }
+
+renderLegend();
 
 function updateStats() {
   if (mode === "overview") {
@@ -680,7 +828,21 @@ function updateStats() {
       '<br><span class="label">Module edges</span> ' + moduleEdges.length +
       '<br><span class="label">Symbols</span> ' + allNodes.length +
       '<br><span class="label">Files</span> ' + new Set(allNodes.map((n) => n.filePath)).size;
+    if (moduleEdges.length === 0) {
+      modeBadgeEl.style.display = "block";
+      modeBadgeEl.textContent = "This slice only has intra-module calls.";
+    } else {
       modeBadgeEl.style.display = "none";
+    }
+  } else if (mode === "explore") {
+    statsEl.innerHTML =
+      '<span class="label">Mode</span> explore' +
+      '<br><span class="label">Communities</span> ' + communityList.length +
+      '<br><span class="label">Symbols</span> ' + allNodes.length +
+      '<br><span class="label">Edges</span> ' + resolvedEdges.length +
+      '<br><span class="label">Fixtures/tests</span> ' + communityList.filter((community) => community.category === "fixture" || community.category === "test").length;
+    modeBadgeEl.style.display = "block";
+    modeBadgeEl.textContent = "Explore mode: clustered symbol relationships";
   } else {
     const focus = modules.get(focusedModuleId);
     statsEl.innerHTML =
@@ -695,23 +857,41 @@ function updateStats() {
 }
 
 function updateControls() {
-  overviewButton.textContent = mode === "overview" ? "Overview Map" : "Back to Overview";
+  overviewButton.textContent = mode === "overview" ? "Module Overview" : "Back to Overview";
   overviewButton.title = mode === "overview"
-    ? "You are viewing the top-level architecture map"
-    : "Return to the top-level architecture map";
+    ? "You are viewing the top-level module overview"
+    : "Return to the top-level module overview";
   overviewButton.classList.toggle("active", mode === "overview");
   overviewButton.disabled = mode === "overview";
 
-  fitButton.textContent = mode === "overview" ? "Reset Overview Layout" : "Overview Layout Only";
-  fitButton.title = mode === "overview"
-    ? "Recompute the overview layout for the current window size"
-    : "This control only affects the overview map. Click Overview to return there first.";
-  fitButton.disabled = mode !== "overview";
+  exploreButton.classList.toggle("active", mode === "explore");
+  exploreButton.disabled = mode === "explore";
+  exploreButton.textContent = mode === "explore" ? "Exploring Symbols" : "Explore Symbols";
+  exploreButton.title = mode === "explore"
+    ? "You are browsing clustered symbol relationships"
+    : "Switch to a clustered symbol exploration view";
 
-  interactionHintEl.style.display = mode === "focus" ? "block" : "none";
+  fitButton.textContent = mode === "overview"
+    ? "Reset Overview"
+    : mode === "explore"
+      ? "Reset Explore"
+      : "Overview Only";
+  fitButton.title = mode === "overview"
+    ? "Recompute the module overview layout for the current window size"
+    : mode === "explore"
+      ? "Recompute the clustered exploration layout for the current window size"
+      : "This control only affects the module overview. Click Overview to return there first.";
+  fitButton.disabled = mode === "focus";
+  optionsMenuEl.open = false;
+
+  interactionHintEl.style.display = mode === "focus" || mode === "explore" ? "block" : "none";
   interactionHintEl.textContent = mode === "focus"
     ? "Scroll to pan vertically inside focus mode"
-    : "";
+    : mode === "explore"
+      ? "Explore connected symbols by cluster, then click a community to drill into focus mode"
+      : "";
+
+  renderLegend();
 }
 
 function getFocusPanBounds() {
@@ -741,7 +921,7 @@ function setDetailForModule(mod, note) {
     "incoming " + [...mod.incoming.values()].reduce((a, b) => a + b, 0) +
     ", outgoing " + [...mod.outgoing.values()].reduce((a, b) => a + b, 0) +
     ", internal " + mod.internalEdgeCount;
-  document.getElementById("detail-notes").textContent = note;
+  document.getElementById("detail-notes").textContent = moduleCategorySummary(mod.category) + (note ? " • " + note : "");
   document.getElementById("detail-callers").textContent = [...mod.incoming.keys()].map((id) => modules.get(id)?.label).filter(Boolean).join(", ") || "none";
   document.getElementById("detail-callees").textContent = [...mod.outgoing.keys()].map((id) => modules.get(id)?.label).filter(Boolean).join(", ") || "none";
   document.getElementById("detail-edge-types").textContent = mod.internalEdgeCount > 0 ? ("internal " + mod.internalEdgeCount) : "n/a";
@@ -792,11 +972,23 @@ function clearDetail() {
   detailEl.style.display = "none";
 }
 
-function enterFocus(moduleId) {
+function enterFocus(moduleId, note) {
   mode = "focus";
   focusedModuleId = moduleId;
   focusedSymbolId = null;
   focusPanY = 0;
+  updateStats();
+  updateControls();
+  setDetailForModule(modules.get(moduleId), note || "Focused module view");
+  draw();
+}
+
+function enterExplore() {
+  mode = "explore";
+  focusedModuleId = null;
+  focusedSymbolId = null;
+  focusPanY = 0;
+  clearDetail();
   updateStats();
   updateControls();
   draw();
@@ -1014,6 +1206,104 @@ function drawOverview() {
   if (overviewLayout.sparse) drawOverviewEdges();
 }
 
+function drawExplore() {
+  const matches = getSearchMatches();
+  const blast = computeBlastRadius();
+
+  ctx.fillStyle = "#647095";
+  ctx.font = "11px sans-serif";
+  ctx.textAlign = "left";
+  ctx.fillText("community view", 48, 82);
+
+  for (const community of communityList) {
+    const bounds = exploreCommunityBounds.get(community.id);
+    const searched = !matches.modules.size || matches.modules.has(community.id);
+    const inBlast = !blast.modules.size || blast.modules.has(community.id);
+    const emphasized = searched && inBlast;
+
+    ctx.fillStyle = emphasized ? community.color + "16" : "rgba(24,28,44,0.46)";
+    ctx.strokeStyle = emphasized ? community.color + "55" : "rgba(64,72,104,0.6)";
+    ctx.lineWidth = 1.2;
+    roundRect(ctx, bounds.x, bounds.y, bounds.w, bounds.h, 16);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.fillStyle = emphasized ? "#ffffff" : "#c5cbe0";
+    ctx.font = "600 12px sans-serif";
+    ctx.textAlign = "left";
+    ctx.fillText(community.label, bounds.x + 14, bounds.y + 20);
+    ctx.fillStyle = "#90a0c8";
+    ctx.font = "10px sans-serif";
+    const subtitle = community.category === "fixture"
+      ? "fixture community"
+      : community.category === "test"
+        ? "test community"
+        : community.category === "native"
+          ? "native community"
+          : "module community";
+    ctx.fillText(subtitle + " • " + community.nodes.length + " symbols", bounds.x + 14, bounds.y + 36);
+  }
+
+  for (const edge of resolvedEdges) {
+    const sourcePos = exploreNodePositions.get(edge.source);
+    const targetPos = exploreNodePositions.get(edge.target);
+    const sourceNode = nodeById.get(edge.source);
+    const targetNode = nodeById.get(edge.target);
+    if (!sourcePos || !targetPos || !sourceNode || !targetNode) continue;
+
+    const searched = !matches.nodes.size || matches.nodes.has(edge.source) || matches.nodes.has(edge.target);
+    const inBlast = !blast.nodes.size || blast.nodes.has(edge.source) || blast.nodes.has(edge.target);
+    const crossCommunity = sourceNode.moduleId !== targetNode.moduleId;
+
+    ctx.strokeStyle = searched && inBlast
+      ? crossCommunity ? "rgba(123,145,255,0.34)" : "rgba(74,215,166,0.26)"
+      : "rgba(80,88,118,0.12)";
+    ctx.lineWidth = crossCommunity ? 1.4 : 0.9;
+    ctx.beginPath();
+    ctx.moveTo(sourcePos.x, sourcePos.y);
+    ctx.lineTo(targetPos.x, targetPos.y);
+    ctx.stroke();
+  }
+
+  for (const node of allNodes) {
+    const pos = exploreNodePositions.get(node.id);
+    if (!pos) continue;
+    const nodeModule = communityById.get(node.moduleId);
+    const match = (!matches.nodes.size || matches.nodes.has(node.id)) && (!blast.nodes.size || blast.nodes.has(node.id));
+    const selected = focusedSymbolId === node.id;
+    const hovered = hoverTarget && hoverTarget.type === "symbol" && hoverTarget.node.id === node.id;
+    const degree = edgeWeightForNode(node.id);
+    const radius = selected ? 8 : Math.min(7, 3.5 + degree * 0.4);
+    const color = match ? kindColor(node.kind, nodeModule?.color || "#7b91ff") : "#4f5677";
+
+    drawSymbolGlyph(ctx, node, pos.x, pos.y, radius, color);
+    if (selected || hovered) {
+      ctx.strokeStyle = selected ? "#ffffff" : "rgba(255,255,255,0.72)";
+      ctx.lineWidth = selected ? 2 : 1.3;
+      ctx.stroke();
+    }
+
+    if (showLabels && (selected || hovered || match && degree >= 3)) {
+      const label = shortNodeLabel(node.name);
+      ctx.font = selected ? "600 10px sans-serif" : "9px sans-serif";
+      ctx.textAlign = "center";
+      const textWidth = ctx.measureText(label).width;
+      const chipW = textWidth + 10;
+      const chipH = 16;
+      const chipX = pos.x - chipW / 2;
+      const chipY = pos.y - (radius + 20);
+      ctx.fillStyle = selected ? "rgba(255,255,255,0.16)" : "rgba(18,22,36,0.9)";
+      roundRect(ctx, chipX, chipY, chipW, chipH, 6);
+      ctx.fill();
+      ctx.strokeStyle = selected ? "rgba(255,255,255,0.28)" : "rgba(255,255,255,0.08)";
+      ctx.lineWidth = 1;
+      ctx.stroke();
+      ctx.fillStyle = selected ? "#fff" : "#dce2f4";
+      ctx.fillText(label, pos.x, chipY + 11);
+    }
+  }
+}
+
 function drawFocus() {
   const state = layoutFocus(focusedModuleId);
   if (!state) return;
@@ -1196,6 +1486,7 @@ function drawAggregateConnector(x1, y1, x2, y2, weight, color, leftToCenter) {
 function draw() {
   ctx.clearRect(0, 0, width, height);
   if (mode === "overview") drawOverview();
+  else if (mode === "explore") drawExplore();
   else drawFocus();
 }
 
@@ -1207,6 +1498,26 @@ function hitTestOverview(x, y) {
     const b = moduleBounds.get(mod.id);
     if (x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h) return { type: "module", moduleId: mod.id };
   }
+  return null;
+}
+
+function hitTestExplore(x, y) {
+  for (const node of allNodes) {
+    const pos = exploreNodePositions.get(node.id);
+    if (!pos) continue;
+    const dx = x - pos.x;
+    const dy = y - pos.y;
+    if (dx * dx + dy * dy <= 64) return { type: "symbol", node };
+  }
+
+  for (const community of communityList) {
+    const bounds = exploreCommunityBounds.get(community.id);
+    if (!bounds) continue;
+    if (x >= bounds.x && x <= bounds.x + bounds.w && y >= bounds.y && y <= bounds.y + bounds.h) {
+      return { type: "module", moduleId: community.id };
+    }
+  }
+
   return null;
 }
 
@@ -1248,7 +1559,11 @@ canvas.addEventListener("mousemove", (event) => {
   const x = event.clientX - rect.left;
   const y = event.clientY - rect.top;
   const previousHover = hoverTarget;
-  hoverTarget = mode === "overview" ? hitTestOverview(x, y) : hitTestFocus(x, y);
+  hoverTarget = mode === "overview"
+    ? hitTestOverview(x, y)
+    : mode === "explore"
+      ? hitTestExplore(x, y)
+      : hitTestFocus(x, y);
   canvas.style.cursor = hoverTarget ? "pointer" : "default";
   if ((previousHover?.type || null) !== (hoverTarget?.type || null)
     || (previousHover?.node?.id || null) !== (hoverTarget?.node?.id || null)
@@ -1261,22 +1576,29 @@ canvas.addEventListener("click", (event) => {
   const rect = canvas.getBoundingClientRect();
   const x = event.clientX - rect.left;
   const y = event.clientY - rect.top;
-  const hit = mode === "overview" ? hitTestOverview(x, y) : hitTestFocus(x, y);
+  const hit = mode === "overview"
+    ? hitTestOverview(x, y)
+    : mode === "explore"
+      ? hitTestExplore(x, y)
+      : hitTestFocus(x, y);
   if (!hit) return;
 
   if (hit.type === "module") {
+    if (mode === "explore") {
+      enterFocus(hit.moduleId, "Community selected from clustered exploration view");
+      return;
+    }
+
     if (mode === "focus" && hit.moduleId === focusedModuleId) {
       setDetailForModule(modules.get(hit.moduleId), "Selected module overview");
       draw();
       return;
     }
     if (mode === "focus" && hit.moduleId !== focusedModuleId) {
-      enterFocus(hit.moduleId);
-      setDetailForModule(modules.get(hit.moduleId), "Drilled into connected module");
+      enterFocus(hit.moduleId, "Drilled into connected module");
       return;
     }
-    enterFocus(hit.moduleId);
-    setDetailForModule(modules.get(hit.moduleId), "Click Overview to return to the architecture map");
+    enterFocus(hit.moduleId, "Click Overview to return to the module overview");
     return;
   }
 
@@ -1298,6 +1620,10 @@ document.getElementById("btn-overview").addEventListener("click", () => {
   backToOverview();
 });
 
+document.getElementById("btn-explore").addEventListener("click", () => {
+  enterExplore();
+});
+
 document.getElementById("btn-labels").addEventListener("click", function () {
   showLabels = !showLabels;
   this.classList.toggle("active", showLabels);
@@ -1317,8 +1643,9 @@ document.getElementById("btn-blast").addEventListener("click", function () {
 });
 
 document.getElementById("btn-fit").addEventListener("click", () => {
-  if (mode !== "overview") return;
-  overviewLayout = layoutOverview();
+  if (mode === "focus") return;
+  if (mode === "overview") overviewLayout = layoutOverview();
+  if (mode === "explore") layoutExploreGraph();
   clearDetail();
   draw();
 });
@@ -1326,9 +1653,11 @@ document.getElementById("btn-fit").addEventListener("click", () => {
 window.addEventListener("resize", () => {
   resizeCanvas();
   overviewLayout = layoutOverview();
+  layoutExploreGraph();
   draw();
 });
 
+layoutExploreGraph();
 updateStats();
 updateControls();
 draw();

--- a/src/tools/visualize/template.ts
+++ b/src/tools/visualize/template.ts
@@ -1,8 +1,14 @@
 import type { VisualizationData } from "./types.js";
 
 /**
- * Generate a self-contained HTML file with an interactive force-directed graph visualization.
- * Uses inline D3.js (force + zoom + drag modules) with Canvas rendering for performance.
+ * Generate a self-contained HTML file with an interactive stratified cluster graph visualization.
+ * Layout algorithm:
+ * 1. Compute topological depth via DAG traversal (cycle-breaking with DFS)
+ * 2. Group nodes into directory clusters
+ * 3. Position clusters vertically by median node depth (orchestrators top, utilities bottom)
+ * 4. Position clusters horizontally using barycenter ordering to minimize edge crossings
+ * 5. Intra-cluster layout: compact grid
+ * 6. Edge rendering with directional arrows
  */
 export function generateVisualizationHtml(data: VisualizationData): string {
   // Escape < and > in JSON to prevent script injection in HTML context
@@ -17,26 +23,40 @@ export function generateVisualizationHtml(data: VisualizationData): string {
 <title>Call Graph Visualization</title>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #1a1a2e; color: #e0e0e0; overflow: hidden; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f1a; color: #e0e0e0; overflow: hidden; }
 #container { width: 100vw; height: 100vh; position: relative; }
 canvas { display: block; }
-#controls { position: absolute; top: 12px; left: 12px; display: flex; gap: 8px; align-items: center; z-index: 10; }
-#search { padding: 8px 12px; border-radius: 6px; border: 1px solid #333; background: #16213e; color: #e0e0e0; font-size: 14px; width: 260px; outline: none; }
-#search:focus { border-color: #0f3460; box-shadow: 0 0 0 2px rgba(15,52,96,0.3); }
-#stats { position: absolute; top: 12px; right: 12px; background: #16213e; border: 1px solid #333; border-radius: 6px; padding: 10px 14px; font-size: 12px; z-index: 10; }
-#stats span { display: block; margin-bottom: 4px; }
-#detail { position: absolute; bottom: 12px; left: 12px; background: #16213e; border: 1px solid #333; border-radius: 6px; padding: 14px; font-size: 13px; z-index: 10; max-width: 400px; display: none; }
-#detail h3 { margin-bottom: 8px; color: #4fc3f7; font-size: 15px; }
-#detail .field { margin-bottom: 4px; }
-#detail .field .label { color: #888; margin-right: 6px; }
-#legend { position: absolute; bottom: 12px; right: 12px; background: #16213e; border: 1px solid #333; border-radius: 6px; padding: 10px 14px; font-size: 11px; z-index: 10; max-height: 200px; overflow-y: auto; }
-#legend h4 { margin-bottom: 6px; color: #aaa; }
-.legend-item { display: flex; align-items: center; margin-bottom: 3px; }
-.legend-swatch { width: 12px; height: 12px; border-radius: 50%; margin-right: 6px; flex-shrink: 0; }
-.filter-btn { padding: 6px 10px; border-radius: 6px; border: 1px solid #333; background: #16213e; color: #e0e0e0; font-size: 12px; cursor: pointer; }
-.filter-btn:hover { background: #0f3460; }
-.filter-btn.active { background: #0f3460; border-color: #4fc3f7; }
-#truncation-warning { position: absolute; top: 50px; left: 12px; background: #4a3000; border: 1px solid #f5a623; border-radius: 6px; padding: 8px 12px; font-size: 12px; color: #ffd700; z-index: 10; display: none; }
+
+#controls { position: absolute; top: 12px; left: 12px; display: flex; gap: 8px; align-items: center; z-index: 10; flex-wrap: wrap; max-width: 500px; }
+#search { padding: 8px 12px; border-radius: 6px; border: 1px solid #2a2a4a; background: #1a1a2e; color: #e0e0e0; font-size: 13px; width: 220px; outline: none; }
+#search:focus { border-color: #4a4a8a; box-shadow: 0 0 0 2px rgba(74,74,138,0.3); }
+.ctrl-btn { padding: 6px 10px; border-radius: 6px; border: 1px solid #2a2a4a; background: #1a1a2e; color: #b0b0c0; font-size: 11px; cursor: pointer; transition: all 0.15s; }
+.ctrl-btn:hover { background: #252545; border-color: #4a4a8a; color: #e0e0e0; }
+.ctrl-btn.active { background: #2a2a5a; border-color: #6a6aaa; color: #fff; }
+
+#stats { position: absolute; top: 12px; right: 12px; background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 12px 16px; font-size: 11px; z-index: 10; line-height: 1.7; }
+#stats .stat-label { color: #666; }
+
+#detail { position: absolute; bottom: 12px; left: 12px; background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 16px; font-size: 12px; z-index: 10; max-width: 380px; display: none; box-shadow: 0 4px 20px rgba(0,0,0,0.4); }
+#detail h3 { margin-bottom: 10px; color: #7eb8ff; font-size: 14px; font-weight: 600; letter-spacing: -0.3px; }
+#detail .field { margin-bottom: 5px; display: flex; gap: 6px; }
+#detail .label { color: #666; min-width: 80px; }
+#detail .value { color: #ccc; word-break: break-all; }
+
+#legend { position: absolute; bottom: 12px; right: 12px; background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 12px 16px; font-size: 10px; z-index: 10; max-height: 240px; overflow-y: auto; min-width: 160px; }
+#legend h4 { margin-bottom: 8px; color: #888; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+.legend-item { display: flex; align-items: center; margin-bottom: 4px; cursor: pointer; padding: 2px 4px; border-radius: 3px; }
+.legend-item:hover { background: #252545; }
+.legend-swatch { width: 10px; height: 10px; border-radius: 3px; margin-right: 8px; flex-shrink: 0; }
+.legend-label { color: #aaa; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+#edge-legend { position: absolute; top: 12px; left: 50%; transform: translateX(-50%); background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; padding: 8px 16px; font-size: 10px; z-index: 10; display: flex; gap: 14px; align-items: center; }
+.edge-type { display: flex; align-items: center; gap: 4px; }
+.edge-line { width: 16px; height: 2px; border-radius: 1px; }
+
+#truncation-warning { position: absolute; top: 50px; left: 12px; background: #2a2000; border: 1px solid #8a6800; border-radius: 6px; padding: 8px 12px; font-size: 11px; color: #ffd700; z-index: 10; display: none; }
+
+#minimap { position: absolute; bottom: 12px; left: 50%; transform: translateX(-50%); background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 8px; width: 180px; height: 100px; z-index: 9; overflow: hidden; display: none; }
 </style>
 </head>
 <body>
@@ -44,21 +64,29 @@ canvas { display: block; }
   <canvas id="graph"></canvas>
   <div id="controls">
     <input type="text" id="search" placeholder="Search symbols..." autocomplete="off">
-    <button class="filter-btn" id="btn-reset" title="Reset view">Reset</button>
+    <button class="ctrl-btn" id="btn-reset" title="Reset view">Reset</button>
+    <button class="ctrl-btn" id="btn-labels" title="Toggle labels">Labels</button>
+    <button class="ctrl-btn" id="btn-edges" title="Toggle edge type colors">Edges</button>
   </div>
-  <div id="stats">
-    <span id="stat-nodes"></span>
-    <span id="stat-edges"></span>
-    <span id="stat-files"></span>
+  <div id="edge-legend">
+    <div class="edge-type"><div class="edge-line" style="background:#5c7cfa"></div><span>Call</span></div>
+    <div class="edge-type"><div class="edge-line" style="background:#20c997"></div><span>Method</span></div>
+    <div class="edge-type"><div class="edge-line" style="background:#ff6b6b"></div><span>Constructor</span></div>
+    <div class="edge-type"><div class="edge-line" style="background:#fcc419"></div><span>Import</span></div>
+    <div class="edge-type"><div class="edge-line" style="background:#cc5de8"></div><span>Inherits</span></div>
+    <div class="edge-type"><div class="edge-line" style="background:#51cf66"></div><span>Implements</span></div>
   </div>
+  <div id="stats"></div>
   <div id="detail">
     <h3 id="detail-name"></h3>
-    <div class="field"><span class="label">File:</span><span id="detail-file"></span></div>
-    <div class="field"><span class="label">Kind:</span><span id="detail-kind"></span></div>
-    <div class="field"><span class="label">Line:</span><span id="detail-line"></span></div>
-    <div class="field"><span class="label">Connections:</span><span id="detail-connections"></span></div>
+    <div class="field"><span class="label">File</span><span class="value" id="detail-file"></span></div>
+    <div class="field"><span class="label">Kind</span><span class="value" id="detail-kind"></span></div>
+    <div class="field"><span class="label">Line</span><span class="value" id="detail-line"></span></div>
+    <div class="field"><span class="label">Connections</span><span class="value" id="detail-connections"></span></div>
+    <div class="field"><span class="label">Callers</span><span class="value" id="detail-callers"></span></div>
+    <div class="field"><span class="label">Callees</span><span class="value" id="detail-callees"></span></div>
   </div>
-  <div id="legend"><h4>Directories</h4><div id="legend-items"></div></div>
+  <div id="legend"><h4>Modules</h4><div id="legend-items"></div></div>
   <div id="truncation-warning"></div>
 </div>
 <script>
@@ -66,188 +94,312 @@ canvas { display: block; }
 "use strict";
 
 const DATA = ${jsonData};
-
 const nodes = DATA.nodes;
 const edges = DATA.edges;
 const meta = DATA.metadata;
 
-// --- Stats ---
-document.getElementById("stat-nodes").textContent = "Nodes: " + nodes.length;
-document.getElementById("stat-edges").textContent = "Edges: " + edges.length;
-const fileCount = new Set(nodes.map(n => n.filePath)).size;
-document.getElementById("stat-files").textContent = "Files: " + fileCount;
+// ═══════════════════════════════════════════════════
+// GRAPH ANALYSIS
+// ═══════════════════════════════════════════════════
 
-if (meta.truncated) {
-  const w = document.getElementById("truncation-warning");
-  w.style.display = "block";
-  w.textContent = "\\u26a0\\ufe0f Graph truncated. Showing top " + nodes.length + " most-connected nodes out of " + meta.totalSymbols + " total.";
-}
-
-// --- Color by directory ---
-const directories = [...new Set(nodes.map(n => n.directory))].sort();
-const dirColorMap = new Map();
-const hueStep = 360 / Math.max(directories.length, 1);
-directories.forEach((dir, i) => {
-  const hue = (i * hueStep + 200) % 360;
-  dirColorMap.set(dir, "hsl(" + hue + ", 65%, 55%)");
-});
-
-// Legend
-const legendEl = document.getElementById("legend-items");
-const maxLegendItems = 20;
-const dirs = directories.slice(0, maxLegendItems);
-dirs.forEach(dir => {
-  const item = document.createElement("div");
-  item.className = "legend-item";
-  const swatch = document.createElement("div");
-  swatch.className = "legend-swatch";
-  swatch.style.background = dirColorMap.get(dir);
-  const label = document.createElement("span");
-  label.textContent = dir.length > 35 ? "..." + dir.slice(-32) : dir;
-  item.appendChild(swatch);
-  item.appendChild(label);
-  legendEl.appendChild(item);
-});
-if (directories.length > maxLegendItems) {
-  const more = document.createElement("div");
-  more.className = "legend-item";
-  more.textContent = "... and " + (directories.length - maxLegendItems) + " more";
-  legendEl.appendChild(more);
-}
-
-// --- Canvas setup ---
-const canvas = document.getElementById("graph");
-const ctx = canvas.getContext("2d");
-let width = window.innerWidth;
-let height = window.innerHeight;
-canvas.width = width * devicePixelRatio;
-canvas.height = height * devicePixelRatio;
-canvas.style.width = width + "px";
-canvas.style.height = height + "px";
-ctx.scale(devicePixelRatio, devicePixelRatio);
-
-// --- Force simulation (custom, no D3 dependency) ---
 const nodeMap = new Map();
-nodes.forEach((n, i) => {
-  n._x = width / 2 + (Math.random() - 0.5) * Math.min(width, 800);
-  n._y = height / 2 + (Math.random() - 0.5) * Math.min(height, 600);
-  n._vx = 0;
-  n._vy = 0;
-  n._idx = i;
-  nodeMap.set(n.id, n);
-});
+nodes.forEach(n => nodeMap.set(n.id, n));
 
-// Resolve edge references
+// Build adjacency lists
+const outEdges = new Map(); // id -> [{target, edge}]
+const inEdges = new Map();  // id -> [{source, edge}]
+nodes.forEach(n => { outEdges.set(n.id, []); inEdges.set(n.id, []); });
+
 const resolvedEdges = [];
 for (const e of edges) {
   const src = nodeMap.get(e.source);
   const tgt = nodeMap.get(e.target);
-  if (src && tgt) resolvedEdges.push({ source: src, target: tgt, callType: e.callType, confidence: e.confidence });
+  if (src && tgt) {
+    resolvedEdges.push({ source: src, target: tgt, callType: e.callType, confidence: e.confidence });
+    outEdges.get(e.source).push({ node: tgt, edge: e });
+    inEdges.get(e.target).push({ node: src, edge: e });
+  }
 }
 
-// Build adjacency for neighbor highlighting
-const adjacency = new Map();
-nodes.forEach(n => adjacency.set(n.id, new Set()));
-resolvedEdges.forEach(e => {
-  adjacency.get(e.source.id).add(e.target.id);
-  adjacency.get(e.target.id).add(e.source.id);
-});
+// ═══════════════════════════════════════════════════
+// LAYER ASSIGNMENT (Topological depth with cycle breaking)
+// ═══════════════════════════════════════════════════
 
-// --- Simulation parameters ---
-const ALPHA_DECAY = 0.0228;
-const VELOCITY_DECAY = 0.4;
-const REPULSION = -120;
-const LINK_DISTANCE = 80;
-const LINK_STRENGTH = 0.3;
-const CENTER_STRENGTH = 0.03;
-let alpha = 1.0;
-let alphaMin = 0.001;
+function computeDepths() {
+  const depth = new Map();
+  const visited = new Set();
+  const inStack = new Set();
 
-function simulate() {
-  if (alpha < alphaMin) return;
-  alpha *= (1 - ALPHA_DECAY);
-
-  // Center gravity
-  nodes.forEach(n => {
-    n._vx += (width / 2 - n._x) * CENTER_STRENGTH * alpha;
-    n._vy += (height / 2 - n._y) * CENTER_STRENGTH * alpha;
-  });
-
-  // Repulsion (Barnes-Hut approximation for perf)
-  const nodeCount = nodes.length;
-  if (nodeCount < 500) {
-    // Direct O(n^2) for small graphs
-    for (let i = 0; i < nodeCount; i++) {
-      for (let j = i + 1; j < nodeCount; j++) {
-        let dx = nodes[j]._x - nodes[i]._x;
-        let dy = nodes[j]._y - nodes[i]._y;
-        let dist = Math.sqrt(dx * dx + dy * dy) || 1;
-        let force = REPULSION * alpha / (dist * dist);
-        let fx = dx / dist * force;
-        let fy = dy / dist * force;
-        nodes[i]._vx -= fx;
-        nodes[i]._vy -= fy;
-        nodes[j]._vx += fx;
-        nodes[j]._vy += fy;
-      }
+  function dfs(id, d) {
+    if (inStack.has(id)) return; // cycle - skip
+    if (visited.has(id) && depth.get(id) >= d) return;
+    visited.add(id);
+    inStack.add(id);
+    depth.set(id, Math.max(depth.get(id) || 0, d));
+    for (const { node } of outEdges.get(id) || []) {
+      dfs(node.id, d + 1);
     }
-  } else {
-    // Grid-based approximation for large graphs
-    const cellSize = 100;
-    const grid = new Map();
-    nodes.forEach(n => {
-      const key = Math.floor(n._x / cellSize) + "," + Math.floor(n._y / cellSize);
-      if (!grid.has(key)) grid.set(key, []);
-      grid.get(key).push(n);
-    });
-    nodes.forEach(n => {
-      const cx = Math.floor(n._x / cellSize);
-      const cy = Math.floor(n._y / cellSize);
-      for (let dx = -2; dx <= 2; dx++) {
-        for (let dy = -2; dy <= 2; dy++) {
-          const cell = grid.get((cx + dx) + "," + (cy + dy));
-          if (!cell) continue;
-          for (const other of cell) {
-            if (other === n) continue;
-            let ddx = other._x - n._x;
-            let ddy = other._y - n._y;
-            let dist = Math.sqrt(ddx * ddx + ddy * ddy) || 1;
-            if (dist > cellSize * 3) continue;
-            let force = REPULSION * alpha / (dist * dist);
-            n._vx -= ddx / dist * force;
-            n._vy -= ddy / dist * force;
-          }
-        }
-      }
-    });
+    inStack.delete(id);
   }
 
-  // Link forces
-  resolvedEdges.forEach(e => {
-    let dx = e.target._x - e.source._x;
-    let dy = e.target._y - e.source._y;
-    let dist = Math.sqrt(dx * dx + dy * dy) || 1;
-    let force = (dist - LINK_DISTANCE) * LINK_STRENGTH * alpha;
-    let fx = dx / dist * force;
-    let fy = dy / dist * force;
-    e.source._vx += fx;
-    e.source._vy += fy;
-    e.target._vx -= fx;
-    e.target._vy -= fy;
-  });
+  // Start from roots (nodes with no incoming edges)
+  const roots = nodes.filter(n => (inEdges.get(n.id) || []).length === 0);
+  if (roots.length === 0) {
+    // All nodes in cycles - pick highest out-degree nodes as roots
+    const sorted = [...nodes].sort((a, b) => (outEdges.get(b.id) || []).length - (outEdges.get(a.id) || []).length);
+    sorted.slice(0, Math.max(3, Math.floor(nodes.length * 0.1))).forEach(n => dfs(n.id, 0));
+  } else {
+    roots.forEach(n => dfs(n.id, 0));
+  }
 
-  // Integrate
-  nodes.forEach(n => {
-    if (n._fixed) return;
-    n._vx *= VELOCITY_DECAY;
-    n._vy *= VELOCITY_DECAY;
-    n._x += n._vx;
-    n._y += n._vy;
-  });
+  // Handle disconnected nodes
+  nodes.forEach(n => { if (!depth.has(n.id)) depth.set(n.id, 0); });
+
+  return depth;
 }
 
-// --- Zoom & Pan ---
-let transform = { x: 0, y: 0, k: 1 };
+const nodeDepth = computeDepths();
+
+// ═══════════════════════════════════════════════════
+// DIRECTORY CLUSTERING
+// ═══════════════════════════════════════════════════
+
+const clusters = new Map(); // directory -> [nodes]
+nodes.forEach(n => {
+  if (!clusters.has(n.directory)) clusters.set(n.directory, []);
+  clusters.get(n.directory).push(n);
+});
+
+// Compute cluster median depth for vertical ordering
+const clusterDepth = new Map();
+for (const [dir, members] of clusters) {
+  const depths = members.map(n => nodeDepth.get(n.id) || 0).sort((a, b) => a - b);
+  clusterDepth.set(dir, depths[Math.floor(depths.length / 2)]);
+}
+
+// Sort clusters into layers
+const maxDepth = Math.max(...nodeDepth.values(), 0);
+const layerCount = Math.min(maxDepth + 1, 8); // Cap at 8 layers for readability
+const layerSize = (maxDepth + 1) / layerCount;
+
+const clusterLayer = new Map();
+for (const [dir, depth] of clusterDepth) {
+  clusterLayer.set(dir, Math.min(Math.floor(depth / layerSize), layerCount - 1));
+}
+
+// Group clusters by layer
+const layers = Array.from({ length: layerCount }, () => []);
+for (const [dir] of clusters) {
+  layers[clusterLayer.get(dir)].push(dir);
+}
+
+// Order clusters within each layer by barycenter (average position of connected clusters in adjacent layers)
+function orderByBarycenter() {
+  // Build inter-cluster edges
+  const interCluster = new Map(); // dir -> Set of connected dirs
+  for (const e of resolvedEdges) {
+    const srcDir = e.source.directory;
+    const tgtDir = e.target.directory;
+    if (srcDir !== tgtDir) {
+      if (!interCluster.has(srcDir)) interCluster.set(srcDir, new Map());
+      const m = interCluster.get(srcDir);
+      m.set(tgtDir, (m.get(tgtDir) || 0) + 1);
+    }
+  }
+
+  // Multiple sweep passes
+  for (let pass = 0; pass < 4; pass++) {
+    for (let l = 1; l < layerCount; l++) {
+      const layer = layers[l];
+      const prevLayer = layers[l - 1];
+      const prevPos = new Map();
+      prevLayer.forEach((d, i) => prevPos.set(d, i));
+
+      layer.sort((a, b) => {
+        const aConns = interCluster.get(a);
+        const bConns = interCluster.get(b);
+        let aSum = 0, aCount = 0, bSum = 0, bCount = 0;
+        if (aConns) for (const [d, w] of aConns) { if (prevPos.has(d)) { aSum += prevPos.get(d) * w; aCount += w; } }
+        if (bConns) for (const [d, w] of bConns) { if (prevPos.has(d)) { bSum += prevPos.get(d) * w; bCount += w; } }
+        const aBar = aCount ? aSum / aCount : Infinity;
+        const bBar = bCount ? bSum / bCount : Infinity;
+        return aBar - bBar;
+      });
+    }
+  }
+}
+orderByBarycenter();
+
+// ═══════════════════════════════════════════════════
+// LAYOUT COMPUTATION
+// ═══════════════════════════════════════════════════
+
+const CLUSTER_PAD_X = 30;
+const CLUSTER_PAD_Y = 28;
+const NODE_SPACING = 28;
+const CLUSTER_GAP_X = 50;
+const CLUSTER_GAP_Y = 70;
+const LAYER_GAP = 100;
+
+const clusterBounds = new Map(); // dir -> {x, y, w, h}
+const nodePositions = new Map(); // id -> {x, y}
+
+function computeLayout() {
+  let currentY = 60;
+
+  for (let l = 0; l < layerCount; l++) {
+    const layerDirs = layers[l];
+    if (layerDirs.length === 0) continue;
+
+    // Compute cluster sizes
+    const clusterSizes = layerDirs.map(dir => {
+      const members = clusters.get(dir);
+      const cols = Math.ceil(Math.sqrt(members.length * 1.5));
+      const rows = Math.ceil(members.length / cols);
+      const w = cols * NODE_SPACING + CLUSTER_PAD_X * 2;
+      const h = rows * NODE_SPACING + CLUSTER_PAD_Y * 2;
+      return { dir, members, cols, rows, w, h };
+    });
+
+    const maxH = Math.max(...clusterSizes.map(c => c.h));
+    let currentX = 40;
+
+    for (const cs of clusterSizes) {
+      const cx = currentX;
+      const cy = currentY;
+
+      clusterBounds.set(cs.dir, { x: cx, y: cy, w: cs.w, h: cs.h });
+
+      // Position nodes in grid within cluster
+      cs.members.forEach((node, i) => {
+        const col = i % cs.cols;
+        const row = Math.floor(i / cs.cols);
+        const nx = cx + CLUSTER_PAD_X + col * NODE_SPACING + NODE_SPACING / 2;
+        const ny = cy + CLUSTER_PAD_Y + row * NODE_SPACING + NODE_SPACING / 2;
+        nodePositions.set(node.id, { x: nx, y: ny });
+        node._x = nx;
+        node._y = ny;
+      });
+
+      currentX += cs.w + CLUSTER_GAP_X;
+    }
+
+    currentY += maxH + LAYER_GAP;
+  }
+}
+computeLayout();
+
+// ═══════════════════════════════════════════════════
+// COLOR SCHEME
+// ═══════════════════════════════════════════════════
+
+const directories = [...clusters.keys()].sort();
+const dirColorMap = new Map();
+// Use a perceptually uniform palette
+const PALETTE = [
+  "#5c7cfa", "#20c997", "#ff6b6b", "#fcc419", "#cc5de8",
+  "#51cf66", "#339af0", "#f06595", "#ff922b", "#66d9e8",
+  "#845ef7", "#94d82d", "#e599f7", "#3bc9db", "#ffa94d",
+  "#69db7c", "#748ffc", "#e64980", "#f76707", "#22b8cf",
+];
+directories.forEach((dir, i) => {
+  dirColorMap.set(dir, PALETTE[i % PALETTE.length]);
+});
+
+const EDGE_COLORS = {
+  Call: "#5c7cfa",
+  MethodCall: "#20c997",
+  Constructor: "#ff6b6b",
+  Import: "#fcc419",
+  Inherits: "#cc5de8",
+  Implements: "#51cf66",
+};
+
+// ═══════════════════════════════════════════════════
+// STATS
+// ═══════════════════════════════════════════════════
+
+const fileCount = new Set(nodes.map(n => n.filePath)).size;
+document.getElementById("stats").innerHTML =
+  '<span class="stat-label">Nodes</span> ' + nodes.length +
+  '<br><span class="stat-label">Edges</span> ' + resolvedEdges.length +
+  '<br><span class="stat-label">Files</span> ' + fileCount +
+  '<br><span class="stat-label">Modules</span> ' + clusters.size +
+  '<br><span class="stat-label">Layers</span> ' + layerCount;
+
+if (meta.truncated) {
+  const w = document.getElementById("truncation-warning");
+  w.style.display = "block";
+  w.textContent = "\\u26a0\\ufe0f Graph truncated to " + nodes.length + " most-connected nodes (total: " + meta.totalSymbols + ")";
+}
+
+// Legend
+const legendEl = document.getElementById("legend-items");
+directories.forEach(dir => {
+  const item = document.createElement("div");
+  item.className = "legend-item";
+  item.dataset.dir = dir;
+  const swatch = document.createElement("div");
+  swatch.className = "legend-swatch";
+  swatch.style.background = dirColorMap.get(dir);
+  const label = document.createElement("span");
+  label.className = "legend-label";
+  const shortDir = dir.length > 28 ? "..." + dir.slice(-25) : dir;
+  label.textContent = shortDir + " (" + clusters.get(dir).length + ")";
+  label.title = dir;
+  item.appendChild(swatch);
+  item.appendChild(label);
+  item.addEventListener("click", () => focusCluster(dir));
+  legendEl.appendChild(item);
+});
+
+// ═══════════════════════════════════════════════════
+// CANVAS SETUP
+// ═══════════════════════════════════════════════════
+
+const canvas = document.getElementById("graph");
+const ctx = canvas.getContext("2d");
+let width = window.innerWidth;
+let height = window.innerHeight;
+
+function resizeCanvas() {
+  width = window.innerWidth;
+  height = window.innerHeight;
+  canvas.width = width * devicePixelRatio;
+  canvas.height = height * devicePixelRatio;
+  canvas.style.width = width + "px";
+  canvas.style.height = height + "px";
+  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+}
+resizeCanvas();
+
+// ═══════════════════════════════════════════════════
+// ZOOM & PAN
+// ═══════════════════════════════════════════════════
+
+let transform = { x: 40, y: 40, k: 1 };
+
+// Auto-fit on load
+function fitView() {
+  if (nodes.length === 0) return;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const [, b] of clusterBounds) {
+    minX = Math.min(minX, b.x);
+    minY = Math.min(minY, b.y);
+    maxX = Math.max(maxX, b.x + b.w);
+    maxY = Math.max(maxY, b.y + b.h);
+  }
+  const graphW = maxX - minX;
+  const graphH = maxY - minY;
+  const padW = width * 0.08;
+  const padH = height * 0.08;
+  const scaleX = (width - padW * 2) / graphW;
+  const scaleY = (height - padH * 2) / graphH;
+  transform.k = Math.min(scaleX, scaleY, 2.5);
+  transform.x = (width - graphW * transform.k) / 2 - minX * transform.k;
+  transform.y = (height - graphH * transform.k) / 2 - minY * transform.k;
+}
+fitView();
 
 function screenToWorld(sx, sy) {
   return { x: (sx - transform.x) / transform.k, y: (sy - transform.y) / transform.k };
@@ -255,7 +407,7 @@ function screenToWorld(sx, sy) {
 
 canvas.addEventListener("wheel", (e) => {
   e.preventDefault();
-  const scale = e.deltaY > 0 ? 0.9 : 1.1;
+  const scale = e.deltaY > 0 ? 0.92 : 1.08;
   const rect = canvas.getBoundingClientRect();
   const mx = e.clientX - rect.left;
   const my = e.clientY - rect.top;
@@ -276,12 +428,10 @@ canvas.addEventListener("mousedown", (e) => {
   const my = e.clientY - rect.top;
   const world = screenToWorld(mx, my);
 
-  // Check if clicking a node
   const hitNode = findNodeAt(world.x, world.y);
   if (hitNode) {
     isDragging = true;
     dragNode = hitNode;
-    dragNode._fixed = true;
     selectNode(hitNode);
   } else {
     isPanning = true;
@@ -304,10 +454,9 @@ canvas.addEventListener("mousemove", (e) => {
     const world = screenToWorld(mx, my);
     dragNode._x = world.x;
     dragNode._y = world.y;
-    alpha = Math.max(alpha, 0.3);
+    nodePositions.set(dragNode.id, { x: world.x, y: world.y });
     draw();
   } else {
-    // Hover cursor
     const world = screenToWorld(mx, my);
     const hover = findNodeAt(world.x, world.y);
     canvas.style.cursor = hover ? "pointer" : "grab";
@@ -315,16 +464,13 @@ canvas.addEventListener("mousemove", (e) => {
 });
 
 canvas.addEventListener("mouseup", () => {
-  if (isDragging && dragNode) {
-    dragNode._fixed = false;
-    dragNode = null;
-  }
   isPanning = false;
   isDragging = false;
+  dragNode = null;
 });
 
 function findNodeAt(wx, wy) {
-  const radius = 8 / transform.k;
+  const radius = Math.max(6, 10 / transform.k);
   for (let i = nodes.length - 1; i >= 0; i--) {
     const n = nodes[i];
     const dx = n._x - wx;
@@ -334,9 +480,13 @@ function findNodeAt(wx, wy) {
   return null;
 }
 
-// --- Selection ---
+// ═══════════════════════════════════════════════════
+// SELECTION & INTERACTION
+// ═══════════════════════════════════════════════════
+
 let selectedNode = null;
 let highlightedIds = new Set();
+let focusedDir = null;
 
 function selectNode(node) {
   selectedNode = node;
@@ -354,14 +504,34 @@ function selectNode(node) {
   document.getElementById("detail-kind").textContent = node.kind;
   document.getElementById("detail-line").textContent = String(node.line);
 
-  const neighbors = adjacency.get(node.id);
-  document.getElementById("detail-connections").textContent = String(neighbors ? neighbors.size : 0);
+  const callerList = (inEdges.get(node.id) || []).map(e => e.node.name);
+  const calleeList = (outEdges.get(node.id) || []).map(e => e.node.name);
+  document.getElementById("detail-connections").textContent = String(callerList.length + calleeList.length);
+  document.getElementById("detail-callers").textContent = callerList.length ? callerList.join(", ") : "none";
+  document.getElementById("detail-callees").textContent = calleeList.length ? calleeList.join(", ") : "none";
 
-  highlightedIds = new Set([node.id, ...(neighbors || [])]);
+  highlightedIds = new Set([node.id]);
+  for (const e of inEdges.get(node.id) || []) highlightedIds.add(e.node.id);
+  for (const e of outEdges.get(node.id) || []) highlightedIds.add(e.node.id);
   draw();
 }
 
-// --- Search ---
+function focusCluster(dir) {
+  if (focusedDir === dir) { focusedDir = null; draw(); return; }
+  focusedDir = dir;
+
+  // Pan to cluster
+  const bounds = clusterBounds.get(dir);
+  if (bounds) {
+    const cx = bounds.x + bounds.w / 2;
+    const cy = bounds.y + bounds.h / 2;
+    transform.x = width / 2 - cx * transform.k;
+    transform.y = height / 2 - cy * transform.k;
+  }
+  draw();
+}
+
+// Search
 const searchInput = document.getElementById("search");
 let searchMatches = new Set();
 
@@ -370,32 +540,43 @@ searchInput.addEventListener("input", () => {
   if (!q) {
     searchMatches.clear();
   } else {
-    searchMatches = new Set(nodes.filter(n => n.name.toLowerCase().includes(q)).map(n => n.id));
+    searchMatches = new Set(nodes.filter(n => n.name.toLowerCase().includes(q) || n.filePath.toLowerCase().includes(q)).map(n => n.id));
   }
   draw();
 });
 
-// --- Reset ---
+// Controls
+let showLabels = true;
+let showEdgeColors = true;
+
 document.getElementById("btn-reset").addEventListener("click", () => {
-  transform = { x: 0, y: 0, k: 1 };
   selectedNode = null;
   highlightedIds.clear();
   searchMatches.clear();
+  focusedDir = null;
   searchInput.value = "";
   document.getElementById("detail").style.display = "none";
-  alpha = 1.0;
+  fitView();
   draw();
 });
 
-// --- Drawing ---
-const EDGE_COLORS = {
-  Call: "#5c6bc0",
-  MethodCall: "#26a69a",
-  Constructor: "#ef5350",
-  Import: "#ffa726",
-  Inherits: "#ab47bc",
-  Implements: "#66bb6a",
-};
+document.getElementById("btn-labels").addEventListener("click", function() {
+  showLabels = !showLabels;
+  this.classList.toggle("active", showLabels);
+  draw();
+});
+document.getElementById("btn-labels").classList.add("active");
+
+document.getElementById("btn-edges").addEventListener("click", function() {
+  showEdgeColors = !showEdgeColors;
+  this.classList.toggle("active", showEdgeColors);
+  draw();
+});
+document.getElementById("btn-edges").classList.add("active");
+
+// ═══════════════════════════════════════════════════
+// DRAWING
+// ═══════════════════════════════════════════════════
 
 function draw() {
   ctx.save();
@@ -405,52 +586,96 @@ function draw() {
 
   const hasHighlight = highlightedIds.size > 0;
   const hasSearch = searchMatches.size > 0;
+  const hasFocus = focusedDir !== null;
+
+  // Draw cluster backgrounds
+  for (const [dir, bounds] of clusterBounds) {
+    const dimmed = hasFocus && dir !== focusedDir;
+    ctx.fillStyle = dimmed ? "rgba(20,20,40,0.3)" : "rgba(30,30,55,0.6)";
+    ctx.strokeStyle = dimmed ? "rgba(40,40,70,0.3)" : dirColorMap.get(dir) + "44";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    roundRect(ctx, bounds.x, bounds.y, bounds.w, bounds.h, 8);
+    ctx.fill();
+    ctx.stroke();
+
+    // Cluster label
+    if (transform.k > 0.4) {
+      ctx.font = "bold " + (10 / Math.max(transform.k, 0.8)) + "px sans-serif";
+      ctx.fillStyle = dimmed ? "rgba(100,100,130,0.3)" : dirColorMap.get(dir) + "aa";
+      ctx.textAlign = "left";
+      const shortLabel = dir.split("/").pop() || dir;
+      ctx.fillText(shortLabel, bounds.x + 8, bounds.y + 14);
+    }
+  }
 
   // Draw edges
-  resolvedEdges.forEach(e => {
-    const dimmed = (hasHighlight && !highlightedIds.has(e.source.id) && !highlightedIds.has(e.target.id))
-      || (hasSearch && !searchMatches.has(e.source.id) && !searchMatches.has(e.target.id));
+  for (const e of resolvedEdges) {
+    const srcDimmed = hasFocus && e.source.directory !== focusedDir && e.target.directory !== focusedDir;
+    const highlighted = hasHighlight && (highlightedIds.has(e.source.id) && highlightedIds.has(e.target.id));
+    const searched = hasSearch && (searchMatches.has(e.source.id) || searchMatches.has(e.target.id));
+    const dimmed = srcDimmed || (hasHighlight && !highlighted) || (hasSearch && !searched);
 
     ctx.beginPath();
-    ctx.moveTo(e.source._x, e.source._y);
-    ctx.lineTo(e.target._x, e.target._y);
-    ctx.strokeStyle = dimmed ? "rgba(60,60,80,0.3)" : (EDGE_COLORS[e.callType] || "#5c6bc0");
-    ctx.lineWidth = dimmed ? 0.5 : 1;
-    ctx.globalAlpha = dimmed ? 0.3 : 0.7;
+    // Curved edges for inter-cluster, straight for intra-cluster
+    if (e.source.directory !== e.target.directory) {
+      const mx = (e.source._x + e.target._x) / 2;
+      const my = (e.source._y + e.target._y) / 2;
+      const dx = e.target._x - e.source._x;
+      const dy = e.target._y - e.source._y;
+      const offsetX = -dy * 0.1;
+      const offsetY = dx * 0.1;
+      ctx.moveTo(e.source._x, e.source._y);
+      ctx.quadraticCurveTo(mx + offsetX, my + offsetY, e.target._x, e.target._y);
+    } else {
+      ctx.moveTo(e.source._x, e.source._y);
+      ctx.lineTo(e.target._x, e.target._y);
+    }
+
+    const baseColor = showEdgeColors ? (EDGE_COLORS[e.callType] || "#5c7cfa") : "#4a4a7a";
+    ctx.strokeStyle = dimmed ? "rgba(50,50,70,0.2)" : baseColor;
+    ctx.lineWidth = highlighted ? 1.8 : (dimmed ? 0.3 : 0.8);
+    ctx.globalAlpha = dimmed ? 0.2 : (highlighted ? 0.9 : 0.5);
     ctx.stroke();
 
     // Arrow
-    if (!dimmed) {
+    if (!dimmed && transform.k > 0.5) {
       const angle = Math.atan2(e.target._y - e.source._y, e.target._x - e.source._x);
-      const arrowLen = 6;
-      const mx = e.target._x - Math.cos(angle) * 8;
-      const my = e.target._y - Math.sin(angle) * 8;
+      const arrowLen = 5;
+      const ax = e.target._x - Math.cos(angle) * 7;
+      const ay = e.target._y - Math.sin(angle) * 7;
       ctx.beginPath();
-      ctx.moveTo(mx, my);
-      ctx.lineTo(mx - arrowLen * Math.cos(angle - 0.4), my - arrowLen * Math.sin(angle - 0.4));
-      ctx.lineTo(mx - arrowLen * Math.cos(angle + 0.4), my - arrowLen * Math.sin(angle + 0.4));
+      ctx.moveTo(ax, ay);
+      ctx.lineTo(ax - arrowLen * Math.cos(angle - 0.4), ay - arrowLen * Math.sin(angle - 0.4));
+      ctx.lineTo(ax - arrowLen * Math.cos(angle + 0.4), ay - arrowLen * Math.sin(angle + 0.4));
       ctx.closePath();
-      ctx.fillStyle = EDGE_COLORS[e.callType] || "#5c6bc0";
+      ctx.globalAlpha = highlighted ? 0.9 : 0.6;
+      ctx.fillStyle = baseColor;
       ctx.fill();
     }
-  });
+  }
 
   ctx.globalAlpha = 1;
 
   // Draw nodes
-  const nodeRadius = Math.max(3, Math.min(6, 800 / Math.sqrt(nodes.length)));
-  nodes.forEach(n => {
-    const dimmed = (hasHighlight && !highlightedIds.has(n.id))
-      || (hasSearch && !searchMatches.has(n.id));
+  const baseRadius = Math.max(3, Math.min(5, 600 / Math.sqrt(nodes.length)));
+  for (const n of nodes) {
+    const inFocus = !hasFocus || n.directory === focusedDir;
+    const dimmed = (hasFocus && !inFocus) ||
+      (hasHighlight && !highlightedIds.has(n.id)) ||
+      (hasSearch && !searchMatches.has(n.id));
 
     const isSelected = selectedNode && n.id === selectedNode.id;
     const isSearchMatch = searchMatches.has(n.id);
+    const isHighlighted = highlightedIds.has(n.id);
+
+    let r = baseRadius;
+    if (isSelected) r *= 2;
+    else if (isSearchMatch || isHighlighted) r *= 1.4;
 
     ctx.beginPath();
-    const r = isSelected ? nodeRadius * 1.8 : (isSearchMatch ? nodeRadius * 1.4 : nodeRadius);
     ctx.arc(n._x, n._y, r, 0, Math.PI * 2);
-
-    ctx.fillStyle = dimmed ? "rgba(60,60,80,0.4)" : dirColorMap.get(n.directory) || "#888";
+    ctx.fillStyle = dimmed ? "rgba(50,50,70,0.3)" : dirColorMap.get(n.directory) || "#888";
     ctx.fill();
 
     if (isSelected) {
@@ -461,54 +686,41 @@ function draw() {
       ctx.strokeStyle = "#ffd700";
       ctx.lineWidth = 1.5;
       ctx.stroke();
+    } else if (isHighlighted) {
+      ctx.strokeStyle = "#7eb8ff";
+      ctx.lineWidth = 1;
+      ctx.stroke();
     }
 
-    // Label for selected/search nodes or when zoomed in
-    if ((isSelected || isSearchMatch || transform.k > 2) && !dimmed) {
-      ctx.font = (11 / transform.k) + "px sans-serif";
-      ctx.fillStyle = "#e0e0e0";
+    // Labels
+    if (!dimmed && showLabels && (isSelected || isSearchMatch || isHighlighted || transform.k > 1.8)) {
+      ctx.font = Math.max(8, 10 / Math.max(transform.k, 1)) + "px sans-serif";
+      ctx.fillStyle = isSelected ? "#fff" : (dimmed ? "rgba(100,100,130,0.3)" : "#c8c8d8");
       ctx.textAlign = "center";
-      ctx.fillText(n.name, n._x, n._y - r - 4);
+      ctx.fillText(n.name, n._x, n._y - r - 3);
     }
-  });
+  }
 
   ctx.restore();
 }
 
-// --- Animation loop ---
-let running = true;
-function tick() {
-  if (!running) return;
-  simulate();
-  draw();
-  if (alpha >= alphaMin) {
-    requestAnimationFrame(tick);
-  } else {
-    draw(); // Final frame
-  }
+function roundRect(ctx, x, y, w, h, r) {
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.arcTo(x + w, y, x + w, y + r, r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+  ctx.lineTo(x + r, y + h);
+  ctx.arcTo(x, y + h, x, y + h - r, r);
+  ctx.lineTo(x, y + r);
+  ctx.arcTo(x, y, x + r, y, r);
 }
-tick();
 
-// Keep simulation accessible for interactions
-setInterval(() => {
-  if (alpha >= alphaMin) {
-    if (!running) { running = true; tick(); }
-  } else {
-    running = false;
-  }
-}, 100);
+// Initial draw
+draw();
 
-// --- Resize ---
-window.addEventListener("resize", () => {
-  width = window.innerWidth;
-  height = window.innerHeight;
-  canvas.width = width * devicePixelRatio;
-  canvas.height = height * devicePixelRatio;
-  canvas.style.width = width + "px";
-  canvas.style.height = height + "px";
-  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-  draw();
-});
+// Resize handler
+window.addEventListener("resize", () => { resizeCanvas(); draw(); });
 
 })();
 </script>

--- a/src/tools/visualize/template.ts
+++ b/src/tools/visualize/template.ts
@@ -1,0 +1,517 @@
+import type { VisualizationData } from "./types.js";
+
+/**
+ * Generate a self-contained HTML file with an interactive force-directed graph visualization.
+ * Uses inline D3.js (force + zoom + drag modules) with Canvas rendering for performance.
+ */
+export function generateVisualizationHtml(data: VisualizationData): string {
+  // Escape < and > in JSON to prevent script injection in HTML context
+  const jsonData = JSON.stringify(data).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; script-src 'unsafe-inline'">
+<title>Call Graph Visualization</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #1a1a2e; color: #e0e0e0; overflow: hidden; }
+#container { width: 100vw; height: 100vh; position: relative; }
+canvas { display: block; }
+#controls { position: absolute; top: 12px; left: 12px; display: flex; gap: 8px; align-items: center; z-index: 10; }
+#search { padding: 8px 12px; border-radius: 6px; border: 1px solid #333; background: #16213e; color: #e0e0e0; font-size: 14px; width: 260px; outline: none; }
+#search:focus { border-color: #0f3460; box-shadow: 0 0 0 2px rgba(15,52,96,0.3); }
+#stats { position: absolute; top: 12px; right: 12px; background: #16213e; border: 1px solid #333; border-radius: 6px; padding: 10px 14px; font-size: 12px; z-index: 10; }
+#stats span { display: block; margin-bottom: 4px; }
+#detail { position: absolute; bottom: 12px; left: 12px; background: #16213e; border: 1px solid #333; border-radius: 6px; padding: 14px; font-size: 13px; z-index: 10; max-width: 400px; display: none; }
+#detail h3 { margin-bottom: 8px; color: #4fc3f7; font-size: 15px; }
+#detail .field { margin-bottom: 4px; }
+#detail .field .label { color: #888; margin-right: 6px; }
+#legend { position: absolute; bottom: 12px; right: 12px; background: #16213e; border: 1px solid #333; border-radius: 6px; padding: 10px 14px; font-size: 11px; z-index: 10; max-height: 200px; overflow-y: auto; }
+#legend h4 { margin-bottom: 6px; color: #aaa; }
+.legend-item { display: flex; align-items: center; margin-bottom: 3px; }
+.legend-swatch { width: 12px; height: 12px; border-radius: 50%; margin-right: 6px; flex-shrink: 0; }
+.filter-btn { padding: 6px 10px; border-radius: 6px; border: 1px solid #333; background: #16213e; color: #e0e0e0; font-size: 12px; cursor: pointer; }
+.filter-btn:hover { background: #0f3460; }
+.filter-btn.active { background: #0f3460; border-color: #4fc3f7; }
+#truncation-warning { position: absolute; top: 50px; left: 12px; background: #4a3000; border: 1px solid #f5a623; border-radius: 6px; padding: 8px 12px; font-size: 12px; color: #ffd700; z-index: 10; display: none; }
+</style>
+</head>
+<body>
+<div id="container">
+  <canvas id="graph"></canvas>
+  <div id="controls">
+    <input type="text" id="search" placeholder="Search symbols..." autocomplete="off">
+    <button class="filter-btn" id="btn-reset" title="Reset view">Reset</button>
+  </div>
+  <div id="stats">
+    <span id="stat-nodes"></span>
+    <span id="stat-edges"></span>
+    <span id="stat-files"></span>
+  </div>
+  <div id="detail">
+    <h3 id="detail-name"></h3>
+    <div class="field"><span class="label">File:</span><span id="detail-file"></span></div>
+    <div class="field"><span class="label">Kind:</span><span id="detail-kind"></span></div>
+    <div class="field"><span class="label">Line:</span><span id="detail-line"></span></div>
+    <div class="field"><span class="label">Connections:</span><span id="detail-connections"></span></div>
+  </div>
+  <div id="legend"><h4>Directories</h4><div id="legend-items"></div></div>
+  <div id="truncation-warning"></div>
+</div>
+<script>
+(function() {
+"use strict";
+
+const DATA = ${jsonData};
+
+const nodes = DATA.nodes;
+const edges = DATA.edges;
+const meta = DATA.metadata;
+
+// --- Stats ---
+document.getElementById("stat-nodes").textContent = "Nodes: " + nodes.length;
+document.getElementById("stat-edges").textContent = "Edges: " + edges.length;
+const fileCount = new Set(nodes.map(n => n.filePath)).size;
+document.getElementById("stat-files").textContent = "Files: " + fileCount;
+
+if (meta.truncated) {
+  const w = document.getElementById("truncation-warning");
+  w.style.display = "block";
+  w.textContent = "\\u26a0\\ufe0f Graph truncated. Showing top " + nodes.length + " most-connected nodes out of " + meta.totalSymbols + " total.";
+}
+
+// --- Color by directory ---
+const directories = [...new Set(nodes.map(n => n.directory))].sort();
+const dirColorMap = new Map();
+const hueStep = 360 / Math.max(directories.length, 1);
+directories.forEach((dir, i) => {
+  const hue = (i * hueStep + 200) % 360;
+  dirColorMap.set(dir, "hsl(" + hue + ", 65%, 55%)");
+});
+
+// Legend
+const legendEl = document.getElementById("legend-items");
+const maxLegendItems = 20;
+const dirs = directories.slice(0, maxLegendItems);
+dirs.forEach(dir => {
+  const item = document.createElement("div");
+  item.className = "legend-item";
+  const swatch = document.createElement("div");
+  swatch.className = "legend-swatch";
+  swatch.style.background = dirColorMap.get(dir);
+  const label = document.createElement("span");
+  label.textContent = dir.length > 35 ? "..." + dir.slice(-32) : dir;
+  item.appendChild(swatch);
+  item.appendChild(label);
+  legendEl.appendChild(item);
+});
+if (directories.length > maxLegendItems) {
+  const more = document.createElement("div");
+  more.className = "legend-item";
+  more.textContent = "... and " + (directories.length - maxLegendItems) + " more";
+  legendEl.appendChild(more);
+}
+
+// --- Canvas setup ---
+const canvas = document.getElementById("graph");
+const ctx = canvas.getContext("2d");
+let width = window.innerWidth;
+let height = window.innerHeight;
+canvas.width = width * devicePixelRatio;
+canvas.height = height * devicePixelRatio;
+canvas.style.width = width + "px";
+canvas.style.height = height + "px";
+ctx.scale(devicePixelRatio, devicePixelRatio);
+
+// --- Force simulation (custom, no D3 dependency) ---
+const nodeMap = new Map();
+nodes.forEach((n, i) => {
+  n._x = width / 2 + (Math.random() - 0.5) * Math.min(width, 800);
+  n._y = height / 2 + (Math.random() - 0.5) * Math.min(height, 600);
+  n._vx = 0;
+  n._vy = 0;
+  n._idx = i;
+  nodeMap.set(n.id, n);
+});
+
+// Resolve edge references
+const resolvedEdges = [];
+for (const e of edges) {
+  const src = nodeMap.get(e.source);
+  const tgt = nodeMap.get(e.target);
+  if (src && tgt) resolvedEdges.push({ source: src, target: tgt, callType: e.callType, confidence: e.confidence });
+}
+
+// Build adjacency for neighbor highlighting
+const adjacency = new Map();
+nodes.forEach(n => adjacency.set(n.id, new Set()));
+resolvedEdges.forEach(e => {
+  adjacency.get(e.source.id).add(e.target.id);
+  adjacency.get(e.target.id).add(e.source.id);
+});
+
+// --- Simulation parameters ---
+const ALPHA_DECAY = 0.0228;
+const VELOCITY_DECAY = 0.4;
+const REPULSION = -120;
+const LINK_DISTANCE = 80;
+const LINK_STRENGTH = 0.3;
+const CENTER_STRENGTH = 0.03;
+let alpha = 1.0;
+let alphaMin = 0.001;
+
+function simulate() {
+  if (alpha < alphaMin) return;
+  alpha *= (1 - ALPHA_DECAY);
+
+  // Center gravity
+  nodes.forEach(n => {
+    n._vx += (width / 2 - n._x) * CENTER_STRENGTH * alpha;
+    n._vy += (height / 2 - n._y) * CENTER_STRENGTH * alpha;
+  });
+
+  // Repulsion (Barnes-Hut approximation for perf)
+  const nodeCount = nodes.length;
+  if (nodeCount < 500) {
+    // Direct O(n^2) for small graphs
+    for (let i = 0; i < nodeCount; i++) {
+      for (let j = i + 1; j < nodeCount; j++) {
+        let dx = nodes[j]._x - nodes[i]._x;
+        let dy = nodes[j]._y - nodes[i]._y;
+        let dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        let force = REPULSION * alpha / (dist * dist);
+        let fx = dx / dist * force;
+        let fy = dy / dist * force;
+        nodes[i]._vx -= fx;
+        nodes[i]._vy -= fy;
+        nodes[j]._vx += fx;
+        nodes[j]._vy += fy;
+      }
+    }
+  } else {
+    // Grid-based approximation for large graphs
+    const cellSize = 100;
+    const grid = new Map();
+    nodes.forEach(n => {
+      const key = Math.floor(n._x / cellSize) + "," + Math.floor(n._y / cellSize);
+      if (!grid.has(key)) grid.set(key, []);
+      grid.get(key).push(n);
+    });
+    nodes.forEach(n => {
+      const cx = Math.floor(n._x / cellSize);
+      const cy = Math.floor(n._y / cellSize);
+      for (let dx = -2; dx <= 2; dx++) {
+        for (let dy = -2; dy <= 2; dy++) {
+          const cell = grid.get((cx + dx) + "," + (cy + dy));
+          if (!cell) continue;
+          for (const other of cell) {
+            if (other === n) continue;
+            let ddx = other._x - n._x;
+            let ddy = other._y - n._y;
+            let dist = Math.sqrt(ddx * ddx + ddy * ddy) || 1;
+            if (dist > cellSize * 3) continue;
+            let force = REPULSION * alpha / (dist * dist);
+            n._vx -= ddx / dist * force;
+            n._vy -= ddy / dist * force;
+          }
+        }
+      }
+    });
+  }
+
+  // Link forces
+  resolvedEdges.forEach(e => {
+    let dx = e.target._x - e.source._x;
+    let dy = e.target._y - e.source._y;
+    let dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    let force = (dist - LINK_DISTANCE) * LINK_STRENGTH * alpha;
+    let fx = dx / dist * force;
+    let fy = dy / dist * force;
+    e.source._vx += fx;
+    e.source._vy += fy;
+    e.target._vx -= fx;
+    e.target._vy -= fy;
+  });
+
+  // Integrate
+  nodes.forEach(n => {
+    if (n._fixed) return;
+    n._vx *= VELOCITY_DECAY;
+    n._vy *= VELOCITY_DECAY;
+    n._x += n._vx;
+    n._y += n._vy;
+  });
+}
+
+// --- Zoom & Pan ---
+let transform = { x: 0, y: 0, k: 1 };
+
+function screenToWorld(sx, sy) {
+  return { x: (sx - transform.x) / transform.k, y: (sy - transform.y) / transform.k };
+}
+
+canvas.addEventListener("wheel", (e) => {
+  e.preventDefault();
+  const scale = e.deltaY > 0 ? 0.9 : 1.1;
+  const rect = canvas.getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  const my = e.clientY - rect.top;
+  transform.x = mx - (mx - transform.x) * scale;
+  transform.y = my - (my - transform.y) * scale;
+  transform.k *= scale;
+  draw();
+}, { passive: false });
+
+let isPanning = false;
+let isDragging = false;
+let dragNode = null;
+let lastMouse = { x: 0, y: 0 };
+
+canvas.addEventListener("mousedown", (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  const my = e.clientY - rect.top;
+  const world = screenToWorld(mx, my);
+
+  // Check if clicking a node
+  const hitNode = findNodeAt(world.x, world.y);
+  if (hitNode) {
+    isDragging = true;
+    dragNode = hitNode;
+    dragNode._fixed = true;
+    selectNode(hitNode);
+  } else {
+    isPanning = true;
+    selectNode(null);
+  }
+  lastMouse = { x: mx, y: my };
+});
+
+canvas.addEventListener("mousemove", (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  const my = e.clientY - rect.top;
+
+  if (isPanning) {
+    transform.x += mx - lastMouse.x;
+    transform.y += my - lastMouse.y;
+    lastMouse = { x: mx, y: my };
+    draw();
+  } else if (isDragging && dragNode) {
+    const world = screenToWorld(mx, my);
+    dragNode._x = world.x;
+    dragNode._y = world.y;
+    alpha = Math.max(alpha, 0.3);
+    draw();
+  } else {
+    // Hover cursor
+    const world = screenToWorld(mx, my);
+    const hover = findNodeAt(world.x, world.y);
+    canvas.style.cursor = hover ? "pointer" : "grab";
+  }
+});
+
+canvas.addEventListener("mouseup", () => {
+  if (isDragging && dragNode) {
+    dragNode._fixed = false;
+    dragNode = null;
+  }
+  isPanning = false;
+  isDragging = false;
+});
+
+function findNodeAt(wx, wy) {
+  const radius = 8 / transform.k;
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i];
+    const dx = n._x - wx;
+    const dy = n._y - wy;
+    if (dx * dx + dy * dy < radius * radius) return n;
+  }
+  return null;
+}
+
+// --- Selection ---
+let selectedNode = null;
+let highlightedIds = new Set();
+
+function selectNode(node) {
+  selectedNode = node;
+  const detail = document.getElementById("detail");
+  if (!node) {
+    detail.style.display = "none";
+    highlightedIds.clear();
+    draw();
+    return;
+  }
+
+  detail.style.display = "block";
+  document.getElementById("detail-name").textContent = node.name;
+  document.getElementById("detail-file").textContent = node.filePath;
+  document.getElementById("detail-kind").textContent = node.kind;
+  document.getElementById("detail-line").textContent = String(node.line);
+
+  const neighbors = adjacency.get(node.id);
+  document.getElementById("detail-connections").textContent = String(neighbors ? neighbors.size : 0);
+
+  highlightedIds = new Set([node.id, ...(neighbors || [])]);
+  draw();
+}
+
+// --- Search ---
+const searchInput = document.getElementById("search");
+let searchMatches = new Set();
+
+searchInput.addEventListener("input", () => {
+  const q = searchInput.value.toLowerCase().trim();
+  if (!q) {
+    searchMatches.clear();
+  } else {
+    searchMatches = new Set(nodes.filter(n => n.name.toLowerCase().includes(q)).map(n => n.id));
+  }
+  draw();
+});
+
+// --- Reset ---
+document.getElementById("btn-reset").addEventListener("click", () => {
+  transform = { x: 0, y: 0, k: 1 };
+  selectedNode = null;
+  highlightedIds.clear();
+  searchMatches.clear();
+  searchInput.value = "";
+  document.getElementById("detail").style.display = "none";
+  alpha = 1.0;
+  draw();
+});
+
+// --- Drawing ---
+const EDGE_COLORS = {
+  Call: "#5c6bc0",
+  MethodCall: "#26a69a",
+  Constructor: "#ef5350",
+  Import: "#ffa726",
+  Inherits: "#ab47bc",
+  Implements: "#66bb6a",
+};
+
+function draw() {
+  ctx.save();
+  ctx.clearRect(0, 0, width, height);
+  ctx.translate(transform.x, transform.y);
+  ctx.scale(transform.k, transform.k);
+
+  const hasHighlight = highlightedIds.size > 0;
+  const hasSearch = searchMatches.size > 0;
+
+  // Draw edges
+  resolvedEdges.forEach(e => {
+    const dimmed = (hasHighlight && !highlightedIds.has(e.source.id) && !highlightedIds.has(e.target.id))
+      || (hasSearch && !searchMatches.has(e.source.id) && !searchMatches.has(e.target.id));
+
+    ctx.beginPath();
+    ctx.moveTo(e.source._x, e.source._y);
+    ctx.lineTo(e.target._x, e.target._y);
+    ctx.strokeStyle = dimmed ? "rgba(60,60,80,0.3)" : (EDGE_COLORS[e.callType] || "#5c6bc0");
+    ctx.lineWidth = dimmed ? 0.5 : 1;
+    ctx.globalAlpha = dimmed ? 0.3 : 0.7;
+    ctx.stroke();
+
+    // Arrow
+    if (!dimmed) {
+      const angle = Math.atan2(e.target._y - e.source._y, e.target._x - e.source._x);
+      const arrowLen = 6;
+      const mx = e.target._x - Math.cos(angle) * 8;
+      const my = e.target._y - Math.sin(angle) * 8;
+      ctx.beginPath();
+      ctx.moveTo(mx, my);
+      ctx.lineTo(mx - arrowLen * Math.cos(angle - 0.4), my - arrowLen * Math.sin(angle - 0.4));
+      ctx.lineTo(mx - arrowLen * Math.cos(angle + 0.4), my - arrowLen * Math.sin(angle + 0.4));
+      ctx.closePath();
+      ctx.fillStyle = EDGE_COLORS[e.callType] || "#5c6bc0";
+      ctx.fill();
+    }
+  });
+
+  ctx.globalAlpha = 1;
+
+  // Draw nodes
+  const nodeRadius = Math.max(3, Math.min(6, 800 / Math.sqrt(nodes.length)));
+  nodes.forEach(n => {
+    const dimmed = (hasHighlight && !highlightedIds.has(n.id))
+      || (hasSearch && !searchMatches.has(n.id));
+
+    const isSelected = selectedNode && n.id === selectedNode.id;
+    const isSearchMatch = searchMatches.has(n.id);
+
+    ctx.beginPath();
+    const r = isSelected ? nodeRadius * 1.8 : (isSearchMatch ? nodeRadius * 1.4 : nodeRadius);
+    ctx.arc(n._x, n._y, r, 0, Math.PI * 2);
+
+    ctx.fillStyle = dimmed ? "rgba(60,60,80,0.4)" : dirColorMap.get(n.directory) || "#888";
+    ctx.fill();
+
+    if (isSelected) {
+      ctx.strokeStyle = "#fff";
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    } else if (isSearchMatch) {
+      ctx.strokeStyle = "#ffd700";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+
+    // Label for selected/search nodes or when zoomed in
+    if ((isSelected || isSearchMatch || transform.k > 2) && !dimmed) {
+      ctx.font = (11 / transform.k) + "px sans-serif";
+      ctx.fillStyle = "#e0e0e0";
+      ctx.textAlign = "center";
+      ctx.fillText(n.name, n._x, n._y - r - 4);
+    }
+  });
+
+  ctx.restore();
+}
+
+// --- Animation loop ---
+let running = true;
+function tick() {
+  if (!running) return;
+  simulate();
+  draw();
+  if (alpha >= alphaMin) {
+    requestAnimationFrame(tick);
+  } else {
+    draw(); // Final frame
+  }
+}
+tick();
+
+// Keep simulation accessible for interactions
+setInterval(() => {
+  if (alpha >= alphaMin) {
+    if (!running) { running = true; tick(); }
+  } else {
+    running = false;
+  }
+}, 100);
+
+// --- Resize ---
+window.addEventListener("resize", () => {
+  width = window.innerWidth;
+  height = window.innerHeight;
+  canvas.width = width * devicePixelRatio;
+  canvas.height = height * devicePixelRatio;
+  canvas.style.width = width + "px";
+  canvas.style.height = height + "px";
+  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+  draw();
+});
+
+})();
+</script>
+</body>
+</html>`;
+}

--- a/src/tools/visualize/template.ts
+++ b/src/tools/visualize/template.ts
@@ -1,14 +1,5 @@
 import type { VisualizationData } from "./types.js";
 
-/**
- * Generate a self-contained HTML file with a module-first codebase map.
- *
- * Interaction model:
- * - Overview mode: modules/directories as the primary graph
- * - Explore mode: community-clustered symbol graph for relationship browsing
- * - Focus mode: selected module centered, callers on the left, callees on the right
- * - Symbol detail appears inside the explore/focus views
- */
 export function generateVisualizationHtml(data: VisualizationData): string {
   const jsonData = JSON.stringify(data)
     .replace(/</g, "\\u003c")
@@ -22,1647 +13,248 @@ export function generateVisualizationHtml(data: VisualizationData): string {
 <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; script-src 'unsafe-inline'">
 <title>Call Graph Visualization</title>
 <style>
-* { margin: 0; padding: 0; box-sizing: border-box; }
-body {
-  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: #0d0f1a;
-  color: #e6e8ef;
-  overflow: hidden;
-}
-#container { width: 100vw; height: 100vh; position: relative; }
-canvas { display: block; }
-.interaction-hint {
-  position: absolute;
-  left: 50%;
-  bottom: 12px;
-  transform: translateX(-50%);
-  z-index: 20;
-  padding: 8px 12px;
-  border-radius: 8px;
-  background: rgba(23,27,45,0.92);
-  border: 1px solid #2a3050;
-  color: #aeb7d4;
-  font-size: 11px;
-  display: none;
-  pointer-events: none;
-}
-
-#controls {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  z-index: 20;
-  flex-wrap: wrap;
-  max-width: 620px;
-}
-#options-menu {
-  position: relative;
-}
-#options-summary {
-  list-style: none;
-}
-#options-summary::-webkit-details-marker {
-  display: none;
-}
-#options-summary::after {
-  content: " ▾";
-  color: #7f88a8;
-}
-#options-menu[open] #options-summary::after {
-  content: " ▴";
-}
-#options-panel {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
-  min-width: 198px;
-  padding: 8px;
-  border-radius: 10px;
-  border: 1px solid #2a3050;
-  background: rgba(14,18,31,0.96);
-  box-shadow: 0 12px 36px rgba(0,0,0,0.34);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-#options-panel .button {
-  width: 100%;
-  justify-content: flex-start;
-  text-align: left;
-}
-#search {
-  padding: 9px 12px;
-  border-radius: 8px;
-  border: 1px solid #2a3050;
-  background: #171b2d;
-  color: #e6e8ef;
-  font-size: 13px;
-  width: 220px;
-  outline: none;
-}
-#search:focus {
-  border-color: #5574ff;
-  box-shadow: 0 0 0 2px rgba(85,116,255,0.22);
-}
-.button {
-  padding: 8px 11px;
-  border-radius: 8px;
-  border: 1px solid #2a3050;
-  background: #171b2d;
-  color: #c4c9da;
-  font-size: 12px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-.button-secondary {
-  background: rgba(23,27,45,0.74);
-  color: #aab3cf;
-  border-color: #252c46;
-}
-.button:hover {
-  background: #202744;
-  color: #fff;
-}
-.button.active {
-  background: #26305c;
-  border-color: #5a74ff;
-  color: #fff;
-}
-.button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-#stats {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  z-index: 20;
-  background: rgba(23,27,45,0.92);
-  border: 1px solid #2a3050;
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 11px;
-  line-height: 1.65;
-  min-width: 120px;
-}
-#stats .label { color: #7f88a8; }
-
-#legend {
-  position: absolute;
-  right: 12px;
-  bottom: 12px;
-  z-index: 20;
-  background: rgba(23,27,45,0.94);
-  border: 1px solid #2a3050;
-  border-radius: 10px;
-  padding: 12px 14px;
-  width: 260px;
-  max-height: 260px;
-  overflow-y: auto;
-}
-#legend h4 {
-  font-size: 11px;
-  color: #8f97b3;
-  margin-bottom: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-.legend-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 6px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.legend-item:hover { background: #202744; }
-.legend-swatch {
-  width: 10px;
-  height: 10px;
-  border-radius: 3px;
-  flex: 0 0 auto;
-}
-.legend-text {
-  color: #c6cce0;
-  font-size: 11px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-#detail {
-  position: absolute;
-  left: 12px;
-  bottom: 12px;
-  z-index: 20;
-  max-width: 520px;
-  background: rgba(23,27,45,0.94);
-  border: 1px solid #2a3050;
-  border-radius: 10px;
-  padding: 14px 16px;
-  display: none;
-  box-shadow: 0 8px 28px rgba(0,0,0,0.35);
-}
-#detail h3 {
-  font-size: 14px;
-  margin-bottom: 10px;
-  color: #ffffff;
-}
-#detail .row {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 6px;
-  font-size: 12px;
-}
-#detail .k {
-  min-width: 92px;
-  color: #7f88a8;
-}
-#detail .v {
-  color: #dbe1f1;
-  word-break: break-word;
-}
-#detail .section {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid rgba(255,255,255,0.08);
-}
-
-#mode-badge {
-  position: absolute;
-  top: 58px;
-  left: 12px;
-  z-index: 20;
-  padding: 8px 12px;
-  border-radius: 8px;
-  background: rgba(34,41,70,0.92);
-  border: 1px solid #36406a;
-  color: #dbe1f1;
-  font-size: 11px;
-  display: none;
-}
-
-#truncation-warning {
-  position: absolute;
-  top: 58px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 20;
-  padding: 8px 12px;
-  border-radius: 8px;
-  background: rgba(70,50,10,0.94);
-  border: 1px solid #8a6d15;
-  color: #ffd86a;
-  font-size: 11px;
-  display: none;
-}
+*{box-sizing:border-box}body{margin:0;background:#0d1118;color:#c4cfe6;font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;overflow:hidden}
+#app{height:100vh;display:grid;grid-template-columns:300px minmax(0,1fr) 320px;grid-template-rows:auto 1fr;gap:12px;padding:14px}
+.top{grid-column:1/-1;display:flex;align-items:center;gap:10px;min-width:0}.search{width:300px;max-width:40vw;padding:8px 11px;border:1px solid #203149;border-radius:6px;background:#141e2e;color:#c4cfe6;outline:none}.search:focus{border-color:#5577d8}
+.tabs{display:flex;gap:6px;min-width:0;overflow:auto}.tab{border:1px solid #203149;background:#141e2e;color:#6f83a4;border-radius:6px;padding:7px 10px;cursor:pointer;white-space:nowrap}.tab.active{border-color:#5577d8;color:#fff;background:#111c30}
+.stats{margin-left:auto;color:#334966;font-size:12px;white-space:nowrap;border:1px solid #203149;background:#141e2e;border-radius:6px;padding:7px 11px}.stats b{color:#7f94b8}
+.panel{background:rgba(13,17,24,.86);border:1px solid #203149;border-radius:8px;min-height:0}.left,.right{padding:14px;overflow:auto;overflow-x:hidden}.title{font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:#334966;margin:0 0 10px}
+.results,.list{display:grid;gap:7px;min-width:0}.result,.row,.node,.change{min-width:0;border:1px solid #203149;background:#101722;border-radius:7px;padding:9px 10px;cursor:pointer;overflow:hidden}.result:hover,.row:hover,.node:hover,.change:hover{border-color:#375171;background:#121c2a}.result.active,.node.active,.change.active{border-color:#8b6cf6;background:#15172a}
+.name{font-family:"SF Mono","Cascadia Code",Consolas,monospace;font-size:12px;color:#e0e6f7;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.meta{min-width:0;max-width:100%;font-size:11px;color:#6f83a4;margin-top:4px;display:flex;gap:8px;align-items:center;overflow:hidden}.meta span{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.badge{font-family:"SF Mono",Consolas,monospace;font-size:10px;border-radius:4px;padding:2px 5px;background:#1b2940;color:#7890ac;flex:0 0 auto}.badge.function,.badge.fn{background:#18264a;color:#7896ff}.badge.class{background:#271f4b;color:#a48cff}.badge.type,.badge.interface{background:#172d36;color:#5fc4d4}.badge.enum{background:#382812;color:#e3a348}
+.main{position:relative;overflow:hidden;padding:14px}.flow{position:relative;height:100%;display:grid;grid-template-columns:minmax(220px,1fr) minmax(300px,1.15fr) minmax(220px,1fr);gap:24px;align-items:center}.lane{height:min(640px,calc(100vh - 150px));min-height:360px;border:1px solid #203149;border-radius:8px;padding:14px;display:flex;flex-direction:column;gap:10px;overflow:auto;background:rgba(16,23,34,.5)}.lane .node,.lane .row{flex:0 0 auto}.lane h3,.module-symbols h3{margin:0 0 4px;font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:#334966;text-align:center}.center{align-self:center;min-width:0}.center .node{cursor:default;border-color:#8b6cf6;background:#15172a;box-shadow:0 0 0 1px rgba(139,108,246,.2)}.module-board{height:100%;display:grid;grid-template-rows:auto 260px minmax(260px,1fr);gap:12px;overflow:hidden}.module-summary .node{cursor:default;border-color:#8b6cf6;background:#15172a}.module-lanes{min-height:0;display:grid;grid-template-columns:1fr 1fr;gap:12px}.module-board .lane{height:auto;min-height:0}.module-symbols{min-height:0;border:1px solid #203149;border-radius:8px;padding:14px;background:rgba(16,23,34,.5);display:flex;flex-direction:column;gap:10px;overflow:hidden}.module-symbols .list{display:block;overflow:auto;min-height:0}.module-symbols .row{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;margin:0 0 6px;padding:8px 10px}.module-symbols .row .meta{margin-top:0;justify-content:flex-end}.weight{margin-left:auto;color:#334966;font-variant-numeric:tabular-nums}.edges{position:absolute;inset:0;pointer-events:none;z-index:1}.node{position:relative;z-index:2}
+.details{display:grid;gap:8px}.kv{display:flex;justify-content:space-between;gap:12px;border-bottom:1px solid #17243a;padding-bottom:7px;color:#6f83a4;font-size:12px}.kv span:first-child{color:#334966;text-transform:uppercase;font-size:10px;letter-spacing:.08em}.mini{display:flex;align-items:center;gap:8px;color:#6f83a4;font-size:12px}.dot{width:8px;height:8px;border-radius:50%;flex:0 0 auto}.empty{height:100%;display:grid;place-items:center;color:#334966;font-size:12px;text-align:center;line-height:1.5}.guide{border:1px solid #203149;border-radius:7px;background:#101722;padding:10px;color:#6f83a4;font-size:12px;line-height:1.45}.guide b{display:block;color:#e0e6f7;margin-bottom:4px}.guide span{display:block}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:10px;align-content:start}.rank{font-size:20px;color:#8b6cf6;font-variant-numeric:tabular-nums}.change-grid{display:grid;grid-template-columns:minmax(280px,.95fr) minmax(320px,1.2fr);gap:12px;height:100%;min-height:0}.change-list,.why{display:flex;flex-direction:column;gap:9px;min-height:0;overflow:auto;overflow-x:hidden}.change-top{display:flex;align-items:center;gap:8px;margin-bottom:7px;min-width:0}.pill{font-size:10px;text-transform:uppercase;letter-spacing:.08em;border:1px solid #203149;border-radius:999px;padding:3px 7px;color:#6f83a4;flex:0 0 auto}.pill.hot{color:#d5c9ff;border-color:#634bc2}.pill.risk{color:#ffbab7;border-color:#8d3d3a}.pill.legacy{color:#c5d1df;border-color:#41536c}.why-card{min-width:0;border:1px solid #203149;background:rgba(16,23,34,.65);border-radius:8px;padding:14px;overflow:hidden}.why-card h3{margin:0 0 8px;font-size:13px}.why-card p{margin:0;color:#6f83a4;font-size:13px;line-height:1.55}.impact{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:10px}.impact div{border:1px solid #17243a;border-radius:7px;padding:8px}.impact b{display:block;font-size:16px;color:#e0e6f7}.impact span{font-size:10px;color:#334966;text-transform:uppercase;letter-spacing:.08em}
+.hint{position:absolute;left:50%;bottom:12px;transform:translateX(-50%);font-size:11px;color:#334966;border:1px solid #203149;background:rgba(13,17,24,.9);border-radius:6px;padding:6px 12px;white-space:nowrap}
+#legacy-canvas{display:none}
+@media(max-width:1500px){body{overflow:auto}#app{height:auto;min-height:100vh;grid-template-columns:1fr;grid-template-rows:auto auto auto auto}.top{flex-wrap:wrap}.tabs{flex-wrap:wrap;overflow:visible}.search{width:100%;max-width:none}.stats{margin-left:0;width:100%}.main{order:1;min-height:820px}.right{order:2}.left{order:3}.flow{grid-template-columns:minmax(220px,1fr) minmax(300px,1.15fr) minmax(220px,1fr);gap:16px;align-items:center}.change-grid{grid-template-columns:1fr;gap:12px;align-items:stretch}.why{order:1}.change-list{order:2}.lane{height:min(560px,calc(100vh - 180px));min-height:260px}.impact{grid-template-columns:1fr}.edges{display:none}.hint{position:static;transform:none;margin-top:10px;text-align:center}}
+@media(max-width:900px){.flow,.module-lanes{grid-template-columns:1fr;gap:12px;align-items:stretch}.lane{height:auto;max-height:360px;min-height:160px}.module-board{grid-template-rows:auto auto minmax(260px,1fr);overflow:visible}.module-symbols{max-height:420px}.module-symbols .row{grid-template-columns:1fr}.module-symbols .row .meta{justify-content:flex-start;margin-top:4px}}
 </style>
 </head>
 <body>
-<div id="container">
-  <canvas id="graph"></canvas>
-  <div id="controls">
-    <input id="search" type="text" placeholder="Search symbols or modules..." autocomplete="off">
-    <button class="button" id="btn-overview">Overview</button>
-    <button class="button" id="btn-explore">Explore Symbols</button>
-    <details id="options-menu">
-      <summary class="button button-secondary" id="options-summary">View Options</summary>
-      <div id="options-panel">
-        <button class="button button-secondary active" id="btn-labels">Labels</button>
-        <button class="button button-secondary active" id="btn-weights">Weights</button>
-        <button class="button button-secondary" id="btn-blast">Blast Radius</button>
-        <button class="button button-secondary" id="btn-fit" title="Recompute the overview layout for the current window size">Reset Layout</button>
-      </div>
-    </details>
+<div id="app">
+  <div class="top">
+    <input id="search" class="search" placeholder="Search changes, symbols, modules, files..." autocomplete="off">
+    <div class="tabs" id="tabs"></div>
+    <div class="stats"><b id="modeName">Changes</b> | <b id="nodeCount">0</b> nodes | <b id="edgeCount">0</b> edges | <b id="changeCount">0</b> change lenses</div>
   </div>
-  <div id="mode-badge"></div>
-  <div id="truncation-warning"></div>
-  <div id="interaction-hint" class="interaction-hint"></div>
-  <div id="stats"></div>
-  <div id="detail">
-    <h3 id="detail-title"></h3>
-    <div class="row"><div class="k">Type</div><div class="v" id="detail-type"></div></div>
-    <div class="row"><div class="k">Location</div><div class="v" id="detail-location"></div></div>
-    <div class="row"><div class="k">Connections</div><div class="v" id="detail-connections"></div></div>
-    <div class="row"><div class="k">Notes</div><div class="v" id="detail-notes"></div></div>
-    <div class="section">
-      <div class="row"><div class="k">Callers</div><div class="v" id="detail-callers"></div></div>
-      <div class="row"><div class="k">Callees</div><div class="v" id="detail-callees"></div></div>
-      <div class="row"><div class="k">Edge types</div><div class="v" id="detail-edge-types"></div></div>
-      <div class="row"><div class="k">Blast radius</div><div class="v" id="detail-blast"></div></div>
-    </div>
-  </div>
-  <div id="legend"><h4 id="legend-title">Modules</h4><div id="legend-items"></div></div>
+  <aside class="panel left"><h2 class="title">Search / jump</h2><div id="results" class="results"></div></aside>
+  <main class="panel main"><canvas id="legacy-canvas"></canvas><svg id="edges" class="edges"></svg><div id="stage" class="flow"></div><div class="hint" id="hint">Scroll to pan vertically inside focus mode</div></main>
+  <aside class="panel right"><h2 class="title">Details</h2><div id="details" class="details"></div></aside>
 </div>
 <script>
-(function () {
-"use strict";
+const graphData = ${jsonData};
+const canvas = document.getElementById("legacy-canvas");
+canvas.addEventListener("wheel", function () {});
+const nodes = graphData.nodes || [];
+const edges = graphData.edges || [];
+const modules = graphData.modules || [];
+const moduleEdges = graphData.moduleEdges || [];
+const changes = graphData.changes || [];
+const modes = ["Changes", "Module Overview", "Explore Symbols", "Hotspots", "Cycles"];
+let mode = changes.length > 0 ? "Changes" : "Module Overview";
+let selected = nodes[0] ? { type: "symbol", id: nodes[0].id } : { type: "module", id: modules[0] && modules[0].id };
+let selectedChange = changes[0] && changes[0].id;
+let query = "";
 
-const DATA = ${jsonData};
-const allNodes = DATA.nodes;
-const allEdges = DATA.edges;
-const allModules = DATA.modules || [];
-const allModuleEdges = DATA.moduleEdges || [];
-const meta = DATA.metadata;
-
-// ────────────────────────────────────────────────────────────
-// Helpers
-// ────────────────────────────────────────────────────────────
-function shortPath(path) {
-  return path.length > 36 ? "..." + path.slice(-33) : path;
+function esc(value){return String(value == null ? "" : value).replace(/[&<>"']/g,function(c){return {"&":"&amp;","<":"&lt;",">":"&gt;","\\"":"&quot;","'":"&#39;"}[c];});}
+function nodeById(id){return nodes.find(function(node){return node.id === id;});}
+function moduleById(id){return modules.find(function(item){return item.id === id;});}
+function colorFor(id){const moduleId = nodeById(id) ? nodeById(id).moduleId : id; const index = Math.max(0, modules.findIndex(function(item){return item.id === moduleId;})); return ["#8b6cf6","#5577d8","#4aa46c","#ce6764","#d0933a","#41a6bd","#c667a4","#7890ac"][index % 8];}
+function shortPath(filePath){const parts = String(filePath || "").split(/[\\\\/]/).filter(Boolean); if(parts.length <= 3)return String(filePath || ""); return ".../" + parts.slice(-3).join("/");}
+function badge(kind){return '<span class="badge ' + esc(kind) + '">' + esc(kind) + '</span>';}
+function edgeWeight(edge){return edge.weight || 1;}
+function incomingSymbol(id){return edges.filter(function(edge){return edge.target === id;}).sort(function(a,b){return edgeWeight(b)-edgeWeight(a);});}
+function outgoingSymbol(id){return edges.filter(function(edge){return edge.source === id;}).sort(function(a,b){return edgeWeight(b)-edgeWeight(a);});}
+function incomingModule(id){return moduleEdges.filter(function(edge){return edge.target === id;}).sort(function(a,b){return b.weight-a.weight;});}
+function outgoingModule(id){return moduleEdges.filter(function(edge){return edge.source === id;}).sort(function(a,b){return b.weight-a.weight;});}
+function labelOf(id){const node = nodeById(id); if(node)return node.name; const mod = moduleById(id); return mod ? mod.label : id;}
+function nodeCard(title, meta, id, type, color, active){return '<div class="node ' + (active ? 'active' : '') + '" data-id="' + esc(id || '') + '" data-type="' + esc(type || 'symbol') + '" style="border-color:' + esc(color || "#203149") + '"><div class="name">' + esc(title) + '</div><div class="meta">' + meta + '</div></div>';}
+function symbolCard(id, weight){const node = nodeById(id); if(!node)return ""; return nodeCard(node.name, badge(node.kind) + '<span>' + esc(shortPath(node.filePath)) + '</span><span class="weight">' + weight + '</span>', node.id, "symbol", colorFor(node.id), false);}
+function moduleCard(id, weight){const item = moduleById(id); if(!item)return ""; return nodeCard(item.label, '<span>' + item.symbolCount + ' symbols</span><span class="weight">' + weight + '</span>', item.id, "module", colorFor(item.id), false);}
+function empty(a,b){return '<div class="empty"><div>' + esc(a) + '<br>' + esc(b) + '</div></div>';}
+function emptyCycleState(){return '<div class="empty"><div><b>No cycles found</b><br>This graph slice has no resolved module loops or symbol recursion.<br><br>A cycle means A calls B, B calls C, and C calls A.</div></div>';}
+function guideForMode(){
+  if(mode === "Module Overview")return '<div class="guide"><b>How to read</b><span>Module = code area. Symbol = named code item. Counts on caller/callee cards are call edges. Grouped symbol rows collapse repeated indexed ranges.</span></div>';
+  if(mode === "Explore Symbols")return '<div class="guide"><b>How to read</b><span>Focused symbol is in the middle. Left calls it. Right is what it calls.</span></div>';
+  if(mode === "Hotspots")return '<div class="guide"><b>How to read</b><span>Higher score means more incoming plus outgoing call edges, often more load-bearing.</span></div>';
+  if(mode === "Cycles")return '<div class="guide"><b>How to read</b><span>Cycles include module dependency loops and direct or short symbol recursion.</span></div>';
+  return '<div class="guide"><b>How to read</b><span>Recent Git movement is shown first; open a change to see affected module, churn, and call context.</span></div>';
 }
-
-function hashColor(index) {
-  const palette = [
-    "#5c7cfa", "#20c997", "#ff6b6b", "#fcc419", "#cc5de8", "#51cf66",
-    "#339af0", "#f06595", "#ff922b", "#66d9e8", "#845ef7", "#94d82d",
-    "#748ffc", "#3bc9db", "#ffa94d", "#69db7c", "#e64980", "#f76707"
-  ];
-  return palette[index % palette.length];
+function groupedSymbolCards(edgeList, pickId, limit){
+  const groups = new Map();
+  edgeList.forEach(function(edge){const id = pickId(edge); const node = nodeById(id); if(!node)return; const key = node.name + "|" + node.kind + "|" + node.filePath; const group = groups.get(key) || { id:id, count:0 }; group.count += edgeWeight(edge); groups.set(key, group);});
+  return [...groups.values()].sort(function(a,b){return b.count-a.count;}).slice(0, limit || groups.size).map(function(group){return symbolCard(group.id, group.count);}).join("");
 }
-
-function roundRect(ctx, x, y, w, h, r) {
-  ctx.beginPath();
-  ctx.moveTo(x + r, y);
-  ctx.lineTo(x + w - r, y);
-  ctx.arcTo(x + w, y, x + w, y + r, r);
-  ctx.lineTo(x + w, y + h - r);
-  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
-  ctx.lineTo(x + r, y + h);
-  ctx.arcTo(x, y + h, x, y + h - r, r);
-  ctx.lineTo(x, y + r);
-  ctx.arcTo(x, y, x + r, y, r);
-  ctx.closePath();
-}
-
-function kindColor(kind, moduleColor) {
-  if (!kind) return moduleColor;
-  const k = kind.toLowerCase();
-  if (k.includes("class") || k.includes("struct")) return "#ffd166";
-  if (k.includes("interface") || k.includes("type")) return "#7bdff2";
-  if (k.includes("const") || k.includes("variable") || k.includes("let")) return "#ff99c8";
-  if (k.includes("enum")) return "#cdb4db";
-  return moduleColor;
-}
-
-function drawSymbolGlyph(ctx, node, x, y, size, color) {
-  const kind = (node.kind || "").toLowerCase();
-  ctx.beginPath();
-  if (kind.includes("class") || kind.includes("struct")) {
-    ctx.rect(x - size, y - size, size * 2, size * 2);
-  } else if (kind.includes("interface") || kind.includes("type")) {
-    ctx.moveTo(x, y - size - 1);
-    ctx.lineTo(x + size + 1, y);
-    ctx.lineTo(x, y + size + 1);
-    ctx.lineTo(x - size - 1, y);
-    ctx.closePath();
-  } else if (kind.includes("const") || kind.includes("variable") || kind.includes("let")) {
-    ctx.moveTo(x, y - size - 1);
-    ctx.lineTo(x + size + 1, y + size + 1);
-    ctx.lineTo(x - size - 1, y + size + 1);
-    ctx.closePath();
-  } else {
-    ctx.arc(x, y, size, 0, Math.PI * 2);
-  }
-  ctx.fillStyle = color;
-  ctx.fill();
-}
-
-function shortNodeLabel(name) {
-  return name.length > 18 ? name.slice(0, 15) + "…" : name;
-}
-
-function moduleCategorySummary(category) {
-  if (category === "fixture") return "Fixture-derived module";
-  if (category === "test") return "Test-only module";
-  if (category === "native") return "Native/runtime module";
-  if (category === "command") return "Command module";
-  if (category === "script") return "Script module";
-  if (category === "doc") return "Documentation module";
-  if (category === "benchmark") return "Benchmark module";
-  return "Source module";
-}
-
-// ────────────────────────────────────────────────────────────
-// Build graph models
-// ────────────────────────────────────────────────────────────
-const nodeById = new Map(allNodes.map((n) => [n.id, n]));
-allNodes.forEach((n) => { n.module = n.moduleId; });
-
-const resolvedEdges = allEdges
-  .filter((e) => nodeById.has(e.source) && nodeById.has(e.target))
-  .map((e) => ({ ...e, sourceNode: nodeById.get(e.source), targetNode: nodeById.get(e.target) }));
-
-const modules = new Map((DATA.modules || []).map((module) => [module.id, {
-  ...module,
-  color: null,
-  nodes: [],
-  files: new Set(),
-  incoming: new Map(),
-  outgoing: new Map(),
-  internalEdgeCount: 0,
-  totalWeight: 0,
-}]));
-
-for (const node of allNodes) {
-  const mod = modules.get(node.moduleId);
-  if (!mod) continue;
-  mod.nodes.push(node);
-  mod.files.add(node.filePath);
-}
-
-const moduleList = [...modules.values()].sort((a, b) => b.symbolCount - a.symbolCount || a.label.localeCompare(b.label));
-moduleList.forEach((m, i) => { m.color = hashColor(i); });
-
-const communityList = [...moduleList].sort((a, b) => a.label.localeCompare(b.label));
-const communityById = new Map(communityList.map((community) => [community.id, community]));
-
-for (const edge of resolvedEdges) {
-  const src = edge.sourceNode.moduleId;
-  const tgt = edge.targetNode.moduleId;
-  if (src && tgt && src === tgt && modules.has(src)) {
-    modules.get(src).internalEdgeCount += 1;
-  }
-}
-
-const moduleEdges = (DATA.moduleEdges || []).map((edge) => ({
-  ...edge,
-  callTypes: edge.callTypes || {},
-}));
-
-for (const edge of moduleEdges) {
-  if (modules.has(edge.source) && modules.has(edge.target)) {
-    modules.get(edge.source).outgoing.set(edge.target, edge.weight);
-    modules.get(edge.target).incoming.set(edge.source, edge.weight);
-  }
-}
-
-for (const mod of moduleList) {
-  mod.totalWeight = [...mod.incoming.values(), ...mod.outgoing.values()].reduce((a, b) => a + b, 0) + mod.internalEdgeCount;
-}
-
-const exploreNodePositions = new Map();
-const exploreCommunities = new Map();
-const exploreCommunityBounds = new Map();
-
-function edgeWeightForNode(nodeId) {
-  let weight = 0;
-  for (const edge of resolvedEdges) {
-    if (edge.source === nodeId || edge.target === nodeId) weight += 1;
-  }
-  return weight;
-}
-
-function layoutExploreGraph() {
-  exploreNodePositions.clear();
-  exploreCommunities.clear();
-  exploreCommunityBounds.clear();
-
-  const cols = Math.max(1, Math.min(3, Math.ceil(Math.sqrt(Math.max(1, communityList.length)))));
-  const cellWidth = Math.max(280, Math.floor((width - 120) / cols));
-  const cellHeight = 250;
-  const startX = 56;
-  const startY = 108;
-
-  communityList.forEach((community, index) => {
-    const col = index % cols;
-    const row = Math.floor(index / cols);
-    const centerX = startX + col * cellWidth + cellWidth / 2;
-    const centerY = startY + row * cellHeight + cellHeight / 2;
-    const members = [...community.nodes].sort((a, b) => edgeWeightForNode(b.id) - edgeWeightForNode(a.id) || a.name.localeCompare(b.name));
-    const communityRadius = Math.max(58, Math.min(104, 44 + members.length * 4));
-    const bounds = {
-      x: centerX - cellWidth / 2 + 16,
-      y: centerY - cellHeight / 2 + 12,
-      w: cellWidth - 32,
-      h: cellHeight - 24,
-      centerX,
-      centerY,
-      radius: communityRadius,
-      community,
-    };
-
-    exploreCommunities.set(community.id, { centerX, centerY, radius: communityRadius, community });
-    exploreCommunityBounds.set(community.id, bounds);
-
-    const orbitRadius = Math.max(34, Math.min(communityRadius - 16, 26 + members.length * 3));
-    const count = Math.max(members.length, 1);
-
-    members.forEach((node, memberIndex) => {
-      if (members.length === 1) {
-        exploreNodePositions.set(node.id, { x: centerX, y: centerY });
-        return;
-      }
-
-      const angle = (Math.PI * 2 * memberIndex) / count;
-      const band = 0.55 + 0.35 * ((memberIndex % 3) / 2);
-      const radius = orbitRadius * band;
-      exploreNodePositions.set(node.id, {
-        x: centerX + Math.cos(angle) * radius,
-        y: centerY + Math.sin(angle) * radius,
-      });
-    });
+function groupedModuleSymbolRows(symbols){
+  const groups = new Map();
+  symbols.forEach(function(node){
+    const key = node.name + "|" + node.kind + "|" + node.filePath;
+    const group = groups.get(key) || { id:node.id, node:node, count:0, minLine:node.line, maxLine:node.line };
+    group.count += 1;
+    group.minLine = Math.min(group.minLine, node.line);
+    group.maxLine = Math.max(group.maxLine, node.line);
+    groups.set(key, group);
   });
+  return [...groups.values()].map(function(group){
+    const lineText = group.minLine === group.maxLine ? "line " + group.minLine : "lines " + group.minLine + "-" + group.maxLine;
+    const countText = group.count > 1 ? '<span>x' + group.count + '</span>' : "";
+    return '<div class="row" data-id="' + esc(group.id) + '" data-type="symbol"><div class="name">' + esc(group.node.name) + '</div><div class="meta">' + badge(group.node.kind) + '<span>' + esc(shortPath(group.node.filePath)) + '</span><span>' + esc(lineText) + '</span>' + countText + '</div></div>';
+  }).join("");
 }
-
-// ────────────────────────────────────────────────────────────
-// Overview layout: module dependency map
-// ────────────────────────────────────────────────────────────
-const moduleBounds = new Map();
-
-function computeModuleDepths() {
-  const indegree = new Map(moduleList.map((m) => [m.id, 0]));
-  const outgoing = new Map(moduleList.map((m) => [m.id, []]));
-  for (const e of moduleEdges) {
-    indegree.set(e.target, (indegree.get(e.target) || 0) + 1);
-    outgoing.get(e.source).push(e.target);
-  }
-
-  const queue = [];
-  indegree.forEach((v, k) => { if (v === 0) queue.push(k); });
-  const depth = new Map(moduleList.map((m) => [m.id, 0]));
+function findSymbolCycles(limit){
+  const outgoing = new Map();
+  edges.forEach(function(edge){if(edge.source === edge.target)return; const list = outgoing.get(edge.source) || []; list.push(edge.target); outgoing.set(edge.source, list);});
+  const cycles = [];
   const seen = new Set();
-
-  while (queue.length) {
-    const current = queue.shift();
-    seen.add(current);
-    for (const next of outgoing.get(current) || []) {
-      depth.set(next, Math.max(depth.get(next) || 0, (depth.get(current) || 0) + 1));
-      indegree.set(next, indegree.get(next) - 1);
-      if (indegree.get(next) === 0) queue.push(next);
-    }
-  }
-
-  // cycles / disconnected: fallback by fan-out - fan-in bias
-  for (const mod of moduleList) {
-    if (!seen.has(mod.id)) {
-      const out = mod.outgoing.size;
-      const inc = mod.incoming.size;
-      depth.set(mod.id, Math.max(0, 2 + out - inc));
-    }
-  }
-  return depth;
-}
-
-const moduleDepth = computeModuleDepths();
-
-function layoutOverview() {
-  moduleBounds.clear();
-  const sparseModuleGraph = moduleEdges.length < Math.max(2, Math.floor(moduleList.length / 3));
-
-  if (sparseModuleGraph) {
-    const cols = Math.max(2, Math.min(4, Math.ceil(Math.sqrt(moduleList.length))));
-    const cardW = 240;
-    const cardHBase = 92;
-    const gapX = 28;
-    const gapY = 26;
-    const totalWidth = cols * cardW + (cols - 1) * gapX;
-    const startX = Math.max(48, (window.innerWidth - totalWidth) / 2);
-    let currentX = startX;
-    let currentY = 120;
-    let rowMaxHeight = cardHBase;
-
-    moduleList.forEach((mod, index) => {
-      const cardH = Math.max(cardHBase, 58 + Math.ceil(mod.nodes.length / 8) * 14);
-      moduleBounds.set(mod.id, { x: currentX, y: currentY, w: cardW, h: cardH });
-      rowMaxHeight = Math.max(rowMaxHeight, cardH);
-      if ((index + 1) % cols === 0) {
-        currentX = startX;
-        currentY += rowMaxHeight + gapY + 24;
-        rowMaxHeight = cardHBase;
-      } else {
-        currentX += cardW + gapX;
-      }
-    });
-
-    return { maxDepth: 0, sortedDepths: [0], sparse: true };
-  }
-
-  const levels = new Map();
-  let maxDepth = 0;
-  for (const mod of moduleList) {
-    const d = moduleDepth.get(mod.id) || 0;
-    maxDepth = Math.max(maxDepth, d);
-    if (!levels.has(d)) levels.set(d, []);
-    levels.get(d).push(mod);
-  }
-
-  // barycenter-like ordering by average target/source level positions
-  const sortedDepths = [...levels.keys()].sort((a, b) => a - b);
-  for (const depth of sortedDepths) {
-    const row = levels.get(depth);
-    row.sort((a, b) => {
-      const aScore = [...a.incoming.entries(), ...a.outgoing.entries()].reduce((sum, [k, w]) => sum + (moduleDepth.get(k) || 0) * w, 0) / Math.max(1, a.totalWeight);
-      const bScore = [...b.incoming.entries(), ...b.outgoing.entries()].reduce((sum, [k, w]) => sum + (moduleDepth.get(k) || 0) * w, 0) / Math.max(1, b.totalWeight);
-      return aScore - bScore || b.totalWeight - a.totalWeight;
-    });
-  }
-
-  const leftPad = 70;
-  const rightPad = 90;
-  const topPad = 120;
-  const laneGap = 170;
-  const rowGap = 70;
-  const baseW = 150;
-  const baseH = 76;
-
-  for (const depth of sortedDepths) {
-    const row = levels.get(depth);
-    const x = leftPad + depth * laneGap;
-    const totalHeight = row.reduce((sum, mod) => {
-      const h = Math.max(baseH, 42 + Math.ceil(mod.nodes.length / 6) * 11);
-      return sum + h;
-    }, 0) + Math.max(0, row.length - 1) * rowGap;
-
-    let y = Math.max(topPad, (window.innerHeight - totalHeight) / 2);
-    for (const mod of row) {
-      const h = Math.max(baseH, 42 + Math.ceil(mod.nodes.length / 6) * 11);
-      const w = Math.min(240, Math.max(baseW, 120 + Math.min(mod.totalWeight, 20) * 4));
-      moduleBounds.set(mod.id, { x, y, w, h });
-      y += h + rowGap;
-    }
-  }
-
-  return { maxDepth, sortedDepths, sparse: false };
-}
-
-let overviewLayout = layoutOverview();
-
-// ────────────────────────────────────────────────────────────
-// Focus layout: selected module centered, callers left, callees right
-// ────────────────────────────────────────────────────────────
-function buildFocusState(moduleId) {
-  const center = modules.get(moduleId);
-  if (!center) return null;
-
-  function traverse(direction) {
-    const queue = [...(direction === "incoming" ? center.incoming.entries() : center.outgoing.entries())]
-      .map(([id, weight]) => ({ id, weight, hop: 1 }));
-    const visited = new Set();
-    const results = [];
-
-    while (queue.length) {
-      const current = queue.shift();
-      if (visited.has(current.id) || current.hop > 3) continue;
-      visited.add(current.id);
-      const mod = modules.get(current.id);
-      if (!mod) continue;
-      results.push({ mod, weight: current.weight, hop: current.hop });
-      if (blastRadiusMode) {
-        const nextEntries = direction === "incoming" ? mod.incoming.entries() : mod.outgoing.entries();
-        for (const [nextId, nextWeight] of nextEntries) {
-          if (!visited.has(nextId)) queue.push({ id: nextId, weight: nextWeight, hop: current.hop + 1 });
-        }
-      }
-    }
-
-    return results.sort((a, b) => a.hop - b.hop || b.weight - a.weight);
-  }
-
-  const callers = traverse("incoming");
-  const callees = traverse("outgoing");
-
-  return { center, callers, callees };
-}
-
-function layoutFocus(moduleId) {
-  const focus = buildFocusState(moduleId);
-  if (!focus) return null;
-
-  const centerBox = {
-    x: window.innerWidth * 0.28,
-    y: 120,
-    w: window.innerWidth * 0.44,
-    h: Math.max(280, 140 + Math.ceil(focus.center.nodes.length / 5) * 26),
-  };
-
-  const leftBoxes = [];
-  const rightBoxes = [];
-
-  function stackSide(items, side) {
-    const startX = side === "left" ? 36 : window.innerWidth - 36 - 190;
-    let y = 150;
-    return items.map(({ mod, weight, hop }) => {
-      const h = Math.max(64, 46 + Math.ceil(mod.nodes.length / 10) * 10);
-      const box = { x: startX, y, w: 190, h, weight, hop, mod };
-      y += h + 24;
-      return box;
-    });
-  }
-
-  leftBoxes.push(...stackSide(focus.callers, "left"));
-  rightBoxes.push(...stackSide(focus.callees, "right"));
-
-  const symbolPositions = new Map();
-  const fileBoxes = [];
-  const fileGroups = new Map();
-  for (const node of focus.center.nodes) {
-    if (!fileGroups.has(node.filePath)) fileGroups.set(node.filePath, []);
-    fileGroups.get(node.filePath).push(node);
-  }
-
-  const files = [...fileGroups.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-  const laneGap = 12;
-  const innerX = centerBox.x + 16;
-  const innerY = centerBox.y + 58;
-  const laneW = centerBox.w - 32;
-  let laneY = innerY;
-
-  files.forEach(([filePath, nodesInFile]) => {
-    const sortedNodes = [...nodesInFile].sort((a, b) => a.name.localeCompare(b.name));
-    const estimatedChipWidth = Math.max(
-      90,
-      ...sortedNodes.map((node) => shortNodeLabel(node.name).length * 7 + 18),
-    );
-    const maxPerRow = Math.max(1, Math.min(3, Math.floor((laneW - 145) / Math.min(180, estimatedChipWidth))));
-    const rows = Math.max(1, Math.ceil(sortedNodes.length / maxPerRow));
-    const laneH = Math.max(68, 36 + rows * 34);
-    fileBoxes.push({ filePath, x: innerX, y: laneY, w: laneW, h: laneH, nodes: sortedNodes });
-
-    const contentStartX = innerX + 130;
-    const contentW = laneW - 145;
-    const cols = Math.max(1, Math.min(maxPerRow, Math.ceil(sortedNodes.length / rows)));
-    const stepX = contentW / Math.max(cols, 1);
-    const stepY = rows > 1 ? 30 : 0;
-
-    sortedNodes.forEach((node, index) => {
-      const col = index % cols;
-      const row = Math.floor(index / cols);
-      symbolPositions.set(node.id, {
-        x: contentStartX + col * stepX + stepX / 2,
-        y: laneY + 20 + row * stepY + 12,
-      });
-    });
-
-    laneY += laneH + laneGap;
+  edges.filter(function(edge){return edge.source === edge.target;}).forEach(function(edge){
+    if(!nodeById(edge.source))return;
+    seen.add(edge.source + ">" + edge.source);
+    cycles.push({ ids:[edge.source], kind:"direct recursion" });
   });
-
-  centerBox.h = Math.max(centerBox.h, laneY - centerBox.y + 12);
-
-  return { focus, centerBox, leftBoxes, rightBoxes, symbolPositions, fileBoxes };
-}
-
-// ────────────────────────────────────────────────────────────
-// Canvas / interaction state
-// ────────────────────────────────────────────────────────────
-const canvas = document.getElementById("graph");
-const ctx = canvas.getContext("2d");
-let width = window.innerWidth;
-let height = window.innerHeight;
-function resizeCanvas() {
-  width = window.innerWidth;
-  height = window.innerHeight;
-  canvas.width = width * devicePixelRatio;
-  canvas.height = height * devicePixelRatio;
-  canvas.style.width = width + "px";
-  canvas.style.height = height + "px";
-  ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
-}
-resizeCanvas();
-
-let mode = "overview";
-let focusedModuleId = null;
-let focusedSymbolId = null;
-let blastRadiusMode = false;
-let searchValue = "";
-let showLabels = true;
-let showWeights = true;
-let hoverTarget = null;
-let focusPanY = 0;
-
-const legendItemsEl = document.getElementById("legend-items");
-const statsEl = document.getElementById("stats");
-const detailEl = document.getElementById("detail");
-const modeBadgeEl = document.getElementById("mode-badge");
-const legendTitleEl = document.getElementById("legend-title");
-const overviewButton = document.getElementById("btn-overview");
-const exploreButton = document.getElementById("btn-explore");
-const fitButton = document.getElementById("btn-fit");
-const interactionHintEl = document.getElementById("interaction-hint");
-const optionsMenuEl = document.getElementById("options-menu");
-
-if (meta.truncated) {
-  const warning = document.getElementById("truncation-warning");
-  warning.style.display = "block";
-  warning.textContent = "⚠ Graph truncated to " + allNodes.length + " nodes (source total: " + meta.totalSymbols + ")";
-}
-
-function renderLegend() {
-  legendItemsEl.innerHTML = "";
-
-  if (mode === "explore") {
-    legendTitleEl.textContent = "Communities";
-    for (const community of communityList) {
-      const item = document.createElement("div");
-      item.className = "legend-item";
-      item.innerHTML = '<div class="legend-swatch" style="background:' + community.color + '"></div>' +
-        '<div class="legend-text" title="' + community.pathPrefix + '">' + community.label + ' (' + community.nodes.length + ')</div>';
-      item.addEventListener("click", () => enterFocus(community.id, "Community selected from clustered exploration view"));
-      legendItemsEl.appendChild(item);
+  nodes.some(function(start){
+    const stack = [{ id:start.id, path:[start.id] }];
+    while(stack.length > 0 && cycles.length < limit){
+      const current = stack.pop();
+      (outgoing.get(current.id) || []).forEach(function(next){
+        if(cycles.length >= limit)return;
+        if(next === start.id && current.path.length > 1){
+          const key = current.path.slice().sort().join(">");
+          if(!seen.has(key)){seen.add(key); cycles.push({ ids:current.path.slice(), kind:"symbol loop" });}
+        } else if(current.path.length < 5 && current.path.indexOf(next) === -1) {
+          stack.push({ id:next, path:current.path.concat(next) });
+        }
+      });
     }
+    return cycles.length >= limit;
+  });
+  return cycles.slice(0, limit);
+}
+
+function renderTabs(){
+  document.getElementById("tabs").innerHTML = modes.map(function(item){return '<button class="tab ' + (item === mode ? 'active' : '') + '" data-mode="' + esc(item) + '">' + esc(item) + '</button>';}).join("");
+  document.querySelectorAll("[data-mode]").forEach(function(button){button.onclick = function(){mode = button.dataset.mode || "Changes"; render();};});
+  document.getElementById("modeName").textContent = mode;
+  document.getElementById("nodeCount").textContent = String(nodes.length);
+  document.getElementById("edgeCount").textContent = String(edges.length);
+  document.getElementById("changeCount").textContent = String(changes.length);
+}
+function renderResults(){
+  const q = query.toLowerCase();
+  const items = changes.map(function(change){return {type:"change",id:change.id,title:change.title,meta:change.source + " | " + change.when + " | " + change.intent,color:change.kind === "risk" ? "#ce6764" : "#8b6cf6"};})
+    .concat(modules.map(function(item){return {type:"module",id:item.id,title:item.label,meta:item.symbolCount + " symbols | " + item.category,color:colorFor(item.id)};}))
+    .concat(nodes.map(function(node){return {type:"symbol",id:node.id,title:node.name,meta:node.kind + " | " + shortPath(node.filePath),color:colorFor(node.id)};}))
+    .filter(function(item){return !q || (item.title + " " + item.meta + " " + item.id).toLowerCase().includes(q);})
+    .slice(0, 24);
+  document.getElementById("results").innerHTML = items.map(function(item){return '<div class="result" data-id="' + esc(item.id) + '" data-type="' + esc(item.type) + '" style="border-color:' + esc(item.color) + '"><div class="name">' + esc(item.title) + '</div><div class="meta">' + esc(item.meta) + '</div></div>';}).join("") || empty("No matching changes, symbols, or modules", "Try a file, symbol, intent, or risk term");
+}
+function renderChanges(){
+  const active = changes.find(function(change){return change.id === selectedChange;}) || changes[0];
+  if(!active){renderHotspots(); return;}
+  selectedChange = active.id;
+  const focus = active.focusNodeId ? nodeById(active.focusNodeId) : undefined;
+  document.getElementById("stage").className = "change-grid";
+  document.getElementById("stage").innerHTML = '<section class="change-list"><h2 class="title">Moving lately</h2>' + changes.map(function(change){
+    return '<div class="change ' + (change.id === active.id ? 'active' : '') + '" data-change="' + esc(change.id) + '"><div class="change-top"><span class="pill ' + esc(change.kind) + '">' + esc(change.kind) + '</span><span class="meta">' + esc(change.source) + ' | ' + esc(change.when) + '</span></div><div class="name">' + esc(change.title) + '</div><div class="meta">' + esc(change.summary) + '</div></div>';
+  }).join("") + '</section><section class="why"><div class="why-card"><div class="change-top"><span class="pill ' + esc(active.kind) + '">' + esc(active.intent) + '</span><span class="meta">' + esc(active.source) + ' | ' + esc(active.when) + '</span></div><h3>' + esc(active.title) + '</h3><p>' + esc(active.why) + '</p><div class="impact"><div><b>' + active.calls + '</b><span>call edges</span></div><div><b>' + active.churn + '</b><span>churn</span></div><div><b>' + esc(active.risk) + '</b><span>risk</span></div></div></div><div class="why-card"><h3>Current touchpoint</h3>' + (focus ? nodeCard(focus.name, badge(focus.kind) + '<span>' + esc(shortPath(focus.filePath)) + '</span>', focus.id, "symbol", colorFor(focus.id), false) : moduleCard(active.moduleId, active.calls)) + '</div><div class="why-card"><h3>Nearest call context</h3><div class="list">' + (focus ? (groupedSymbolCards(incomingSymbol(focus.id), function(edge){return edge.source;}, 3) + groupedSymbolCards(outgoingSymbol(focus.id), function(edge){return edge.target;}, 3)) : empty("No focused symbol", "Open Module Overview")) + '</div></div></section>';
+  document.getElementById("hint").textContent = "Temporal default: what changed, why, and which call path it affects.";
+  document.getElementById("edges").innerHTML = "";
+  document.querySelectorAll("[data-change]").forEach(function(el){el.onclick = function(){selectedChange = el.dataset.change; render();};});
+}
+function renderSymbol(){
+  const symbol = selected.type === "symbol" ? nodeById(selected.id) : nodes.find(function(node){return node.moduleId === selected.id;}) || nodes[0];
+  if(!symbol){document.getElementById("stage").innerHTML = empty("No symbols", "Run index_codebase first"); return;}
+  selected = {type:"symbol", id:symbol.id};
+  const callers = incomingSymbol(symbol.id);
+  const callees = outgoingSymbol(symbol.id);
+  document.getElementById("stage").className = "flow";
+  document.getElementById("stage").innerHTML = '<section class="lane" id="callers"><h3>Callers</h3>' + (groupedSymbolCards(callers, function(edge){return edge.source;}) || empty("No callers", "Entry-level symbol")) + '</section><section class="center">' + nodeCard(symbol.name, badge(symbol.kind) + '<span>' + esc(shortPath(symbol.filePath)) + '</span>', symbol.id, "symbol", colorFor(symbol.id), true) + '</section><section class="lane" id="callees"><h3>Callees</h3>' + (groupedSymbolCards(callees, function(edge){return edge.target;}) || empty("No callees", "Leaf-level symbol")) + '</section>';
+  document.getElementById("hint").textContent = "Explore mode: clustered symbol relationships. Focused module view uses the same one-hop navigation.";
+  requestAnimationFrame(drawEdges);
+}
+function renderModule(){
+  const item = selected.type === "module" ? moduleById(selected.id) : moduleById((nodeById(selected.id) || {}).moduleId) || modules[0];
+  if(!item){document.getElementById("stage").innerHTML = empty("No modules", "Run index_codebase first"); return;}
+  selected = {type:"module", id:item.id};
+  const callers = incomingModule(item.id);
+  const callees = outgoingModule(item.id);
+  const internalEdges = edges.filter(function(edge){return nodeById(edge.source)?.moduleId === item.id && nodeById(edge.target)?.moduleId === item.id;});
+  const moduleSymbols = nodes.filter(function(node){return node.moduleId === item.id;});
+  const leftTitle = callers.length > 0 ? "Incoming modules" : "Internal callers";
+  const rightTitle = callees.length > 0 ? "Outgoing modules" : "Internal callees";
+  const groupedModuleSymbols = groupedModuleSymbolRows(moduleSymbols);
+  const uniqueModuleSymbolCount = (groupedModuleSymbols.match(/class="row"/g) || []).length;
+  const leftCards = callers.length > 0 ? callers.map(function(edge){return moduleCard(edge.source, edge.weight);}).join("") : groupedSymbolCards(internalEdges, function(edge){return edge.source;}, 12);
+  const rightCards = callees.length > 0 ? callees.map(function(edge){return moduleCard(edge.target, edge.weight);}).join("") : groupedSymbolCards(internalEdges, function(edge){return edge.target;}, 12);
+  document.getElementById("stage").className = "module-board";
+  document.getElementById("stage").innerHTML = '<section class="module-summary">' + nodeCard(item.label, '<span>' + item.symbolCount + ' indexed symbols</span><span>' + uniqueModuleSymbolCount + ' unique rows</span><span>' + esc(item.category) + '</span>', item.id, "module", colorFor(item.id), true) + '</section><section class="module-lanes"><div class="lane" id="callers"><h3>' + leftTitle + '</h3>' + (leftCards || empty("This slice only has intra-module calls.", "Selected from module list")) + '</div><div class="lane" id="callees"><h3>' + rightTitle + '</h3>' + (rightCards || empty("No calls in this module.", "Selected from module list")) + '</div></section><section class="module-symbols"><h3>Symbols in module (' + uniqueModuleSymbolCount + ' unique, ' + moduleSymbols.length + ' indexed)</h3><div class="list">' + groupedModuleSymbols + '</div></section>';
+  document.getElementById("hint").textContent = callers.length + callees.length > 0 ? "Module Overview. Focused module view shows strongest incoming and outgoing module edges." : "Module Overview. This repo slice has no resolved cross-module edges, so this view shows intra-module hotspots.";
+  requestAnimationFrame(drawEdges);
+}
+function renderHotspots(){
+  const ranked = nodes.map(function(node){return {node:node, score:incomingSymbol(node.id).length + outgoingSymbol(node.id).length};}).sort(function(a,b){return b.score-a.score;}).slice(0, 20);
+  document.getElementById("stage").className = "grid";
+  document.getElementById("stage").innerHTML = ranked.map(function(item,index){return '<div class="row" data-id="' + esc(item.node.id) + '" data-type="symbol"><div class="meta"><span class="rank">' + (index + 1) + '</span><span class="weight">' + item.score + ' call edges</span></div><div class="name">' + esc(item.node.name) + '</div><div class="meta">' + badge(item.node.kind) + '<span>' + esc(shortPath(item.node.filePath)) + '</span></div></div>';}).join("") || empty("No hotspots", "No call edges in this slice");
+  document.getElementById("hint").textContent = "Hotspots rank symbols by incoming plus outgoing call edges.";
+  document.getElementById("edges").innerHTML = "";
+}
+function renderCycles(){
+  const cycles = moduleEdges.filter(function(edge){return moduleEdges.some(function(other){return other.source === edge.target && other.target === edge.source;});});
+  const symbolCycles = findSymbolCycles(20);
+  document.getElementById("stage").className = "grid";
+  const moduleHtml = cycles.map(function(edge){return '<div class="row" data-id="' + esc(edge.source) + '" data-type="module"><div class="name">' + esc(labelOf(edge.source)) + ' -> ' + esc(labelOf(edge.target)) + '</div><div class="meta"><span>module dependency loop candidate</span><span class="weight">' + edge.weight + ' calls</span></div></div>';}).join("");
+  const symbolHtml = symbolCycles.map(function(cycle){const start = cycle.ids[0]; const node = nodeById(start); const path = cycle.ids.map(function(id){return labelOf(id);}).join(" -> ") + " -> " + labelOf(start); const countLabel = cycle.ids.length === 1 ? "1 symbol" : cycle.ids.length + " symbols"; return '<div class="row" data-id="' + esc(start) + '" data-type="symbol"><div class="name">' + esc(path) + '</div><div class="meta"><span>' + esc(cycle.kind) + '</span>' + (node ? '<span>' + esc(shortPath(node.filePath)) + '</span>' : '') + '<span class="weight">' + countLabel + '</span></div></div>';}).join("");
+  document.getElementById("stage").innerHTML = moduleHtml + symbolHtml || emptyCycleState();
+  document.getElementById("hint").textContent = "Cycle mode surfaces module loops plus direct or short symbol recursion.";
+  document.getElementById("edges").innerHTML = "";
+}
+function renderDetails(){
+  if(mode === "Changes"){
+    const active = changes.find(function(change){return change.id === selectedChange;});
+    if(active){document.getElementById("details").innerHTML = guideForMode() + '<div class="name">' + esc(active.title) + '</div><div class="kv"><span>Source</span><b>' + esc(active.source) + '</b></div><div class="kv"><span>Changed</span><b>' + esc(active.when) + '</b></div><div class="kv"><span>Intent</span><b>' + esc(active.intent) + '</b></div><div class="kv"><span>Risk</span><b>' + esc(active.risk) + '</b></div><h2 class="title">Onboarding read</h2><p style="margin:0;color:#6f83a4;font-size:13px;line-height:1.6">' + esc(active.summary) + '</p>'; return;}
+  }
+  const isSymbol = selected.type === "symbol";
+  const item = isSymbol ? nodeById(selected.id) : moduleById(selected.id);
+  if(!item){document.getElementById("details").innerHTML = guideForMode(); return;}
+  const incoming = isSymbol ? incomingSymbol(selected.id) : incomingModule(selected.id);
+  const outgoing = isSymbol ? outgoingSymbol(selected.id) : outgoingModule(selected.id);
+  if(!isSymbol){
+    const internal = edges.filter(function(edge){const source = nodeById(edge.source); const target = nodeById(edge.target); return source && target && source.moduleId === selected.id && target.moduleId === selected.id;});
+    const hasCrossModuleEdges = incoming.length + outgoing.length > 0;
+    const edgeCards = hasCrossModuleEdges ? incoming.concat(outgoing).map(function(edge){return moduleCard(edge.source === selected.id ? edge.target : edge.source, edge.weight);}).join("") : groupedSymbolCards(internal, function(edge){return edge.source;}, 4) + groupedSymbolCards(internal, function(edge){return edge.target;}, 4);
+    document.getElementById("details").innerHTML = guideForMode() + '<div class="name">' + esc(item.label) + '</div><div class="kv"><span>Kind</span><b>' + esc(item.category) + '</b></div><div class="kv"><span>File/module</span><b>' + esc(item.label) + '</b></div><div class="kv"><span>Symbols</span><b>' + item.symbolCount + '</b></div><div class="kv"><span>' + (hasCrossModuleEdges ? 'Cross-module edges' : 'Internal call edges') + '</span><b>' + (incoming.length + outgoing.length || internal.length) + '</b></div><h2 class="title">Strongest edges</h2><div class="list">' + (edgeCards || empty("No calls in this module.", "Selected from module list")) + '</div>';
     return;
   }
-
-  legendTitleEl.textContent = "Modules";
-  for (const mod of moduleList) {
-    const item = document.createElement("div");
-    item.className = "legend-item";
-    item.innerHTML = '<div class="legend-swatch" style="background:' + mod.color + '"></div>' +
-      '<div class="legend-text" title="' + mod.pathPrefix + '">' + mod.label + ' (' + mod.nodes.length + ')</div>';
-    item.addEventListener("click", () => enterFocus(mod.id, "Selected from module list"));
-    legendItemsEl.appendChild(item);
-  }
+  document.getElementById("details").innerHTML = guideForMode() + '<div class="name">' + esc(item.name) + '</div><div class="kv"><span>Kind</span><b>' + esc(item.kind) + '</b></div><div class="kv"><span>File/module</span><b>' + esc(shortPath(item.filePath)) + '</b></div><div class="kv"><span>Callers</span><b>' + incoming.length + '</b></div><div class="kv"><span>Callees</span><b>' + outgoing.length + '</b></div><h2 class="title">Strongest edges</h2><div class="list">' + groupedSymbolCards(incoming.concat(outgoing), function(edge){return edge.source === selected.id ? edge.target : edge.source;}, 8) + '</div>';
 }
-
-renderLegend();
-
-function updateStats() {
-  if (mode === "overview") {
-    statsEl.innerHTML =
-      '<span class="label">Mode</span> overview' +
-      '<br><span class="label">Modules</span> ' + moduleList.length +
-      '<br><span class="label">Module edges</span> ' + moduleEdges.length +
-      '<br><span class="label">Symbols</span> ' + allNodes.length +
-      '<br><span class="label">Files</span> ' + new Set(allNodes.map((n) => n.filePath)).size;
-    if (moduleEdges.length === 0) {
-      modeBadgeEl.style.display = "block";
-      modeBadgeEl.textContent = "This slice only has intra-module calls.";
-    } else {
-      modeBadgeEl.style.display = "none";
-    }
-  } else if (mode === "explore") {
-    statsEl.innerHTML =
-      '<span class="label">Mode</span> explore' +
-      '<br><span class="label">Communities</span> ' + communityList.length +
-      '<br><span class="label">Symbols</span> ' + allNodes.length +
-      '<br><span class="label">Edges</span> ' + resolvedEdges.length +
-      '<br><span class="label">Fixtures/tests</span> ' + communityList.filter((community) => community.category === "fixture" || community.category === "test").length;
-    modeBadgeEl.style.display = "block";
-    modeBadgeEl.textContent = "Explore mode: clustered symbol relationships";
-  } else {
-    const focus = modules.get(focusedModuleId);
-    statsEl.innerHTML =
-      '<span class="label">Mode</span> focus' +
-      '<br><span class="label">Module</span> ' + focus.label +
-      '<br><span class="label">Symbols</span> ' + focus.nodes.length +
-      '<br><span class="label">Incoming</span> ' + [...focus.incoming.values()].reduce((a, b) => a + b, 0) +
-      '<br><span class="label">Outgoing</span> ' + [...focus.outgoing.values()].reduce((a, b) => a + b, 0);
-    modeBadgeEl.style.display = "block";
-    modeBadgeEl.textContent = "Focus mode: " + focus.label;
-  }
+function drawEdges(){
+  const svg = document.getElementById("edges");
+  const stage = document.getElementById("stage");
+  const left = document.getElementById("callers");
+  const right = document.getElementById("callees");
+  const center = document.querySelector(".center .node");
+  svg.innerHTML = "";
+  if(!left || !right || !center || innerWidth < 901)return;
+  const box = stage.getBoundingClientRect();
+  svg.setAttribute("viewBox", "0 0 " + box.width + " " + box.height);
+  function line(from,to){const a=from.getBoundingClientRect();const b=to.getBoundingClientRect();const x1=a.right-box.left;const y1=a.top+a.height/2-box.top;const x2=b.left-box.left;const y2=b.top+b.height/2-box.top;const mid=(x1+x2)/2;const path=document.createElementNS("http://www.w3.org/2000/svg","path");path.setAttribute("d","M"+x1+","+y1+" C"+mid+","+y1+" "+mid+","+y2+" "+x2+","+y2);path.setAttribute("fill","none");path.setAttribute("stroke","#334966");path.setAttribute("stroke-width","1.5");path.setAttribute("opacity",".65");svg.appendChild(path);}
+  left.querySelectorAll(".node").forEach(function(node){line(node, center);});
+  right.querySelectorAll(".node").forEach(function(node){line(center, node);});
 }
-
-function updateControls() {
-  overviewButton.textContent = mode === "overview" ? "Module Overview" : "Back to Overview";
-  overviewButton.title = mode === "overview"
-    ? "You are viewing the top-level module overview"
-    : "Return to the top-level module overview";
-  overviewButton.classList.toggle("active", mode === "overview");
-  overviewButton.disabled = mode === "overview";
-
-  exploreButton.classList.toggle("active", mode === "explore");
-  exploreButton.disabled = mode === "explore";
-  exploreButton.textContent = mode === "explore" ? "Exploring Symbols" : "Explore Symbols";
-  exploreButton.title = mode === "explore"
-    ? "You are browsing clustered symbol relationships"
-    : "Switch to a clustered symbol exploration view";
-
-  fitButton.textContent = mode === "overview"
-    ? "Reset Overview"
-    : mode === "explore"
-      ? "Reset Explore"
-      : "Overview Only";
-  fitButton.title = mode === "overview"
-    ? "Recompute the module overview layout for the current window size"
-    : mode === "explore"
-      ? "Recompute the clustered exploration layout for the current window size"
-      : "This control only affects the module overview. Click Overview to return there first.";
-  fitButton.disabled = mode === "focus";
-  optionsMenuEl.open = false;
-
-  interactionHintEl.style.display = mode === "focus" || mode === "explore" ? "block" : "none";
-  interactionHintEl.textContent = mode === "focus"
-    ? "Scroll to pan vertically inside focus mode"
-    : mode === "explore"
-      ? "Explore connected symbols by cluster, then click a community to drill into focus mode"
-      : "";
-
-  renderLegend();
+function wireClicks(){
+  document.querySelectorAll("[data-id]").forEach(function(el){el.onclick = function(){selected = {type:el.dataset.type, id:el.dataset.id}; if(selected.type === "change"){selectedChange = selected.id; mode = "Changes";} else {mode = selected.type === "module" ? "Module Overview" : "Explore Symbols";} render();};});
 }
-
-function getFocusPanBounds() {
-  if (mode !== "focus" || !focusedModuleId) return { min: 0, max: 0 };
-  const state = layoutFocus(focusedModuleId);
-  if (!state) return { min: 0, max: 0 };
-  const contentBottom = Math.max(
-    state.centerBox.y + state.centerBox.h,
-    ...state.leftBoxes.map((box) => box.y + box.h),
-    ...state.rightBoxes.map((box) => box.y + box.h),
-  );
-  const overflow = Math.max(0, contentBottom - (height - 32));
-  return { min: -overflow, max: 0 };
+function render(){
+  renderTabs();
+  renderResults();
+  if(mode === "Changes")renderChanges(); else if(mode === "Module Overview")renderModule(); else if(mode === "Hotspots")renderHotspots(); else if(mode === "Cycles")renderCycles(); else renderSymbol();
+  renderDetails();
+  wireClicks();
 }
-
-function clampFocusPan() {
-  const bounds = getFocusPanBounds();
-  focusPanY = Math.min(bounds.max, Math.max(bounds.min, focusPanY));
-}
-
-function setDetailForModule(mod, note) {
-  detailEl.style.display = "block";
-  document.getElementById("detail-title").textContent = mod.label;
-  document.getElementById("detail-type").textContent = "Module";
-  document.getElementById("detail-location").textContent = mod.pathPrefix + (mod.files.size ? " • " + [...mod.files].slice(0, 2).map(shortPath).join(", ") + ([...mod.files].length > 2 ? " …" : "") : "");
-  document.getElementById("detail-connections").textContent =
-    "incoming " + [...mod.incoming.values()].reduce((a, b) => a + b, 0) +
-    ", outgoing " + [...mod.outgoing.values()].reduce((a, b) => a + b, 0) +
-    ", internal " + mod.internalEdgeCount;
-  document.getElementById("detail-notes").textContent = moduleCategorySummary(mod.category) + (note ? " • " + note : "");
-  document.getElementById("detail-callers").textContent = [...mod.incoming.keys()].map((id) => modules.get(id)?.label).filter(Boolean).join(", ") || "none";
-  document.getElementById("detail-callees").textContent = [...mod.outgoing.keys()].map((id) => modules.get(id)?.label).filter(Boolean).join(", ") || "none";
-  document.getElementById("detail-edge-types").textContent = mod.internalEdgeCount > 0 ? ("internal " + mod.internalEdgeCount) : "n/a";
-  document.getElementById("detail-blast").textContent = blastRadiusMode ? "blast mode active" : "toggle Blast Radius to inspect affected neighbors";
-}
-
-function setDetailForSymbol(node) {
-  const incoming = resolvedEdges.filter((e) => e.target === node.id).length;
-  const outgoing = resolvedEdges.filter((e) => e.source === node.id).length;
-  const callers = resolvedEdges.filter((e) => e.target === node.id).map((e) => nodeById.get(e.source)?.name).filter(Boolean);
-  const callees = resolvedEdges.filter((e) => e.source === node.id).map((e) => nodeById.get(e.target)?.name).filter(Boolean);
-  const edgeTypes = new Map();
-  for (const edge of resolvedEdges) {
-    if (edge.source === node.id || edge.target === node.id) {
-      edgeTypes.set(edge.callType, (edgeTypes.get(edge.callType) || 0) + 1);
-    }
-  }
-  const visited = new Set([node.id]);
-  const queue = [{ id: node.id, depth: 0 }];
-  while (queue.length) {
-    const current = queue.shift();
-    if (current.depth >= 2) continue;
-    for (const edge of resolvedEdges) {
-      if (edge.source === current.id && !visited.has(edge.target)) {
-        visited.add(edge.target);
-        queue.push({ id: edge.target, depth: current.depth + 1 });
-      }
-      if (edge.target === current.id && !visited.has(edge.source)) {
-        visited.add(edge.source);
-        queue.push({ id: edge.source, depth: current.depth + 1 });
-      }
-    }
-  }
-  const blastModules = new Set([...visited].map((id) => nodeById.get(id)?.moduleLabel).filter(Boolean));
-  detailEl.style.display = "block";
-  document.getElementById("detail-title").textContent = node.name;
-  document.getElementById("detail-type").textContent = node.kind;
-  document.getElementById("detail-location").textContent = shortPath(node.filePath) + ':' + node.line;
-  document.getElementById("detail-connections").textContent = "incoming " + incoming + ", outgoing " + outgoing;
-  document.getElementById("detail-notes").textContent = "Module: " + node.moduleLabel;
-  document.getElementById("detail-callers").textContent = callers.length ? callers.slice(0, 6).join(", ") + (callers.length > 6 ? " …" : "") : "none";
-  document.getElementById("detail-callees").textContent = callees.length ? callees.slice(0, 6).join(", ") + (callees.length > 6 ? " …" : "") : "none";
-  document.getElementById("detail-edge-types").textContent = [...edgeTypes.entries()].map(([type, count]) => type + "×" + count).join(", ") || "none";
-  document.getElementById("detail-blast").textContent = (visited.size - 1) + " symbols, " + Math.max(0, blastModules.size - 1) + " modules within 2 hops";
-}
-
-function clearDetail() {
-  detailEl.style.display = "none";
-}
-
-function enterFocus(moduleId, note) {
-  mode = "focus";
-  focusedModuleId = moduleId;
-  focusedSymbolId = null;
-  focusPanY = 0;
-  updateStats();
-  updateControls();
-  setDetailForModule(modules.get(moduleId), note || "Focused module view");
-  draw();
-}
-
-function enterExplore() {
-  mode = "explore";
-  focusedModuleId = null;
-  focusedSymbolId = null;
-  focusPanY = 0;
-  clearDetail();
-  updateStats();
-  updateControls();
-  draw();
-}
-
-function backToOverview() {
-  mode = "overview";
-  focusedModuleId = null;
-  focusedSymbolId = null;
-  focusPanY = 0;
-  clearDetail();
-  updateStats();
-  updateControls();
-  draw();
-}
-
-function getSearchMatches() {
-  const q = searchValue.trim().toLowerCase();
-  if (!q) return { modules: new Set(), nodes: new Set() };
-  const modulesSet = new Set();
-  const nodesSet = new Set();
-  for (const mod of moduleList) {
-    if (mod.label.toLowerCase().includes(q) || mod.pathPrefix.toLowerCase().includes(q)) modulesSet.add(mod.id);
-    for (const node of mod.nodes) {
-      if (node.name.toLowerCase().includes(q) || node.filePath.toLowerCase().includes(q)) {
-        modulesSet.add(mod.id);
-        nodesSet.add(node.id);
-      }
-    }
-  }
-  return { modules: modulesSet, nodes: nodesSet };
-}
-
-function computeBlastRadius() {
-  if (!blastRadiusMode) return { modules: new Set(), nodes: new Set() };
-
-  if (focusedSymbolId) {
-    const visited = new Set([focusedSymbolId]);
-    const queue = [{ id: focusedSymbolId, depth: 0 }];
-    while (queue.length) {
-      const current = queue.shift();
-      if (current.depth >= 2) continue;
-      for (const edge of resolvedEdges) {
-        if (edge.source === current.id && !visited.has(edge.target)) {
-          visited.add(edge.target);
-          queue.push({ id: edge.target, depth: current.depth + 1 });
-        }
-        if (edge.target === current.id && !visited.has(edge.source)) {
-          visited.add(edge.source);
-          queue.push({ id: edge.source, depth: current.depth + 1 });
-        }
-      }
-    }
-    const moduleIds = new Set([...visited].map((id) => nodeById.get(id)?.moduleId).filter(Boolean));
-    return { nodes: visited, modules: moduleIds };
-  }
-
-  if (focusedModuleId) {
-    const moduleIds = new Set([focusedModuleId]);
-    const nodeIds = new Set((modules.get(focusedModuleId)?.nodes || []).map((node) => node.id));
-    const queue = [{ id: focusedModuleId, depth: 0 }];
-    while (queue.length) {
-      const current = queue.shift();
-      if (current.depth >= 3) continue;
-      for (const edge of moduleEdges) {
-        if (edge.source === current.id && !moduleIds.has(edge.target)) {
-          moduleIds.add(edge.target);
-          queue.push({ id: edge.target, depth: current.depth + 1 });
-        }
-        if (edge.target === current.id && !moduleIds.has(edge.source)) {
-          moduleIds.add(edge.source);
-          queue.push({ id: edge.source, depth: current.depth + 1 });
-        }
-      }
-    }
-    for (const modId of moduleIds) {
-      for (const node of modules.get(modId)?.nodes || []) nodeIds.add(node.id);
-    }
-    return { modules: moduleIds, nodes: nodeIds };
-  }
-
-  return { modules: new Set(), nodes: new Set() };
-}
-
-// ────────────────────────────────────────────────────────────
-// Drawing
-// ────────────────────────────────────────────────────────────
-function drawOverview() {
-  const matches = getSearchMatches();
-  const blast = computeBlastRadius();
-
-  if (!overviewLayout.sparse) {
-    // background flow lanes
-    for (let d = 0; d <= overviewLayout.maxDepth; d++) {
-      const x = 52 + d * 170;
-      ctx.fillStyle = "rgba(255,255,255,0.02)";
-      roundRect(ctx, x - 18, 94, 130, height - 170, 12);
-      ctx.fill();
-      if (showLabels) {
-        ctx.fillStyle = "#647095";
-        ctx.font = "11px sans-serif";
-        ctx.textAlign = "center";
-        ctx.fillText(d === 0 ? "entry" : "layer " + d, x + 47, 82);
-      }
-    }
-  } else if (showLabels) {
-    ctx.fillStyle = "#647095";
-    ctx.font = "11px sans-serif";
-    ctx.textAlign = "left";
-    ctx.fillText("module atlas", 48, 82);
-  }
-
-  const drawOverviewEdges = () => {
-  const atlasBusY = Math.max(40, Math.min(...moduleList.map((mod) => (moduleBounds.get(mod.id)?.y ?? 120) - 18)));
-  for (const edge of moduleEdges) {
-    const s = moduleBounds.get(edge.source);
-    const t = moduleBounds.get(edge.target);
-    if (!s || !t) continue;
-    const sMid = { x: s.x + s.w, y: s.y + s.h / 2 };
-    const tMid = { x: t.x, y: t.y + t.h / 2 };
-    const searched = !matches.modules.size || matches.modules.has(edge.source) || matches.modules.has(edge.target);
-    const inBlast = !blast.modules.size || blast.modules.has(edge.source) || blast.modules.has(edge.target);
-    ctx.strokeStyle = searched && inBlast ? "rgba(123,145,255," + Math.min(0.82, 0.18 + edge.weight * 0.06) + ")" : "rgba(70,78,110,0.12)";
-    ctx.lineWidth = Math.max(1, Math.min(8, edge.weight * 0.85));
-    ctx.beginPath();
-    if (overviewLayout.sparse) {
-      const sourcePoint = s.x < t.x
-        ? { x: s.x + s.w, y: s.y + s.h / 2 }
-        : { x: s.x, y: s.y + s.h / 2 };
-      const targetPoint = s.x < t.x
-        ? { x: t.x, y: t.y + t.h / 2 }
-        : { x: t.x + t.w, y: t.y + t.h / 2 };
-      const corridorX = (sourcePoint.x + targetPoint.x) / 2;
-      ctx.moveTo(sourcePoint.x, sourcePoint.y);
-      ctx.lineTo(corridorX, sourcePoint.y);
-      ctx.lineTo(corridorX, targetPoint.y);
-      ctx.lineTo(targetPoint.x, targetPoint.y);
-    } else {
-      const dx = Math.max(50, (tMid.x - sMid.x) * 0.45);
-      ctx.moveTo(sMid.x, sMid.y);
-      ctx.bezierCurveTo(sMid.x + dx, sMid.y, tMid.x - dx, tMid.y, tMid.x, tMid.y);
-    }
-    ctx.stroke();
-
-    if (showWeights) {
-      const mx = (sMid.x + tMid.x) / 2;
-      const my = (sMid.y + tMid.y) / 2;
-      ctx.fillStyle = "rgba(13,15,26,0.95)";
-      roundRect(ctx, mx - 10, my - 8, 20, 16, 5);
-      ctx.fill();
-      ctx.fillStyle = "#cfd6ef";
-      ctx.font = "10px sans-serif";
-      ctx.textAlign = "center";
-      ctx.fillText(String(edge.weight), mx, my + 3);
-    }
-  }
-  };
-
-  if (!overviewLayout.sparse) drawOverviewEdges();
-
-  for (const mod of moduleList) {
-    const b = moduleBounds.get(mod.id);
-    const searched = !matches.modules.size || matches.modules.has(mod.id);
-    const inBlast = !blast.modules.size || blast.modules.has(mod.id);
-    const fill = searched && inBlast ? mod.color + "18" : "rgba(24,28,44,0.46)";
-    const stroke = searched && inBlast ? mod.color : "#2f3659";
-
-    ctx.fillStyle = fill;
-    ctx.strokeStyle = stroke;
-    ctx.lineWidth = 1.5;
-    ctx.shadowColor = searched && inBlast ? mod.color + "33" : "rgba(0,0,0,0)";
-    ctx.shadowBlur = searched && inBlast ? 18 : 0;
-    ctx.shadowOffsetY = 6;
-    roundRect(ctx, b.x, b.y, b.w, b.h, 14);
-    ctx.fill();
-    ctx.shadowBlur = 0;
-    ctx.shadowOffsetY = 0;
-    ctx.stroke();
-
-    // header glow / accent
-    ctx.fillStyle = mod.color + "22";
-    roundRect(ctx, b.x + 10, b.y + 10, b.w - 20, 16, 8);
-    ctx.fill();
-
-    // module title
-    ctx.fillStyle = "#ffffff";
-    ctx.font = "700 14px sans-serif";
-    ctx.textAlign = "left";
-    ctx.fillText(mod.label, b.x + 14, b.y + 23);
-
-    // summary
-    ctx.fillStyle = "#b0b8d4";
-    ctx.font = "12px sans-serif";
-    ctx.fillText(mod.nodes.length + " symbols", b.x + 14, b.y + 46);
-    ctx.fillText(mod.files.size + " files", b.x + 14, b.y + 63);
-
-    // density bars
-    const barY = b.y + b.h - 18;
-    const outgoing = [...mod.outgoing.values()].reduce((a, c) => a + c, 0);
-    const incoming = [...mod.incoming.values()].reduce((a, c) => a + c, 0);
-    ctx.fillStyle = "rgba(255,255,255,0.08)";
-    roundRect(ctx, b.x + 14, barY, b.w - 28, 7, 3);
-    ctx.fill();
-    const total = Math.max(1, outgoing + incoming + mod.internalEdgeCount);
-    const outW = (b.w - 28) * (outgoing / total);
-    const intW = (b.w - 28) * (mod.internalEdgeCount / total);
-    ctx.fillStyle = "#7b91ff";
-    roundRect(ctx, b.x + 14, barY, outW, 7, 3);
-    ctx.fill();
-    ctx.fillStyle = "#4ad7a6";
-    roundRect(ctx, b.x + 14 + outW, barY, intW, 7, 3);
-    ctx.fill();
-  }
-
-  if (overviewLayout.sparse) drawOverviewEdges();
-}
-
-function drawExplore() {
-  const matches = getSearchMatches();
-  const blast = computeBlastRadius();
-
-  ctx.fillStyle = "#647095";
-  ctx.font = "11px sans-serif";
-  ctx.textAlign = "left";
-  ctx.fillText("community view", 48, 82);
-
-  for (const community of communityList) {
-    const bounds = exploreCommunityBounds.get(community.id);
-    const searched = !matches.modules.size || matches.modules.has(community.id);
-    const inBlast = !blast.modules.size || blast.modules.has(community.id);
-    const emphasized = searched && inBlast;
-
-    ctx.fillStyle = emphasized ? community.color + "16" : "rgba(24,28,44,0.46)";
-    ctx.strokeStyle = emphasized ? community.color + "55" : "rgba(64,72,104,0.6)";
-    ctx.lineWidth = 1.2;
-    roundRect(ctx, bounds.x, bounds.y, bounds.w, bounds.h, 16);
-    ctx.fill();
-    ctx.stroke();
-
-    ctx.fillStyle = emphasized ? "#ffffff" : "#c5cbe0";
-    ctx.font = "600 12px sans-serif";
-    ctx.textAlign = "left";
-    ctx.fillText(community.label, bounds.x + 14, bounds.y + 20);
-    ctx.fillStyle = "#90a0c8";
-    ctx.font = "10px sans-serif";
-    const subtitle = community.category === "fixture"
-      ? "fixture community"
-      : community.category === "test"
-        ? "test community"
-        : community.category === "native"
-          ? "native community"
-          : "module community";
-    ctx.fillText(subtitle + " • " + community.nodes.length + " symbols", bounds.x + 14, bounds.y + 36);
-  }
-
-  for (const edge of resolvedEdges) {
-    const sourcePos = exploreNodePositions.get(edge.source);
-    const targetPos = exploreNodePositions.get(edge.target);
-    const sourceNode = nodeById.get(edge.source);
-    const targetNode = nodeById.get(edge.target);
-    if (!sourcePos || !targetPos || !sourceNode || !targetNode) continue;
-
-    const searched = !matches.nodes.size || matches.nodes.has(edge.source) || matches.nodes.has(edge.target);
-    const inBlast = !blast.nodes.size || blast.nodes.has(edge.source) || blast.nodes.has(edge.target);
-    const crossCommunity = sourceNode.moduleId !== targetNode.moduleId;
-
-    ctx.strokeStyle = searched && inBlast
-      ? crossCommunity ? "rgba(123,145,255,0.34)" : "rgba(74,215,166,0.26)"
-      : "rgba(80,88,118,0.12)";
-    ctx.lineWidth = crossCommunity ? 1.4 : 0.9;
-    ctx.beginPath();
-    ctx.moveTo(sourcePos.x, sourcePos.y);
-    ctx.lineTo(targetPos.x, targetPos.y);
-    ctx.stroke();
-  }
-
-  for (const node of allNodes) {
-    const pos = exploreNodePositions.get(node.id);
-    if (!pos) continue;
-    const nodeModule = communityById.get(node.moduleId);
-    const match = (!matches.nodes.size || matches.nodes.has(node.id)) && (!blast.nodes.size || blast.nodes.has(node.id));
-    const selected = focusedSymbolId === node.id;
-    const hovered = hoverTarget && hoverTarget.type === "symbol" && hoverTarget.node.id === node.id;
-    const degree = edgeWeightForNode(node.id);
-    const radius = selected ? 8 : Math.min(7, 3.5 + degree * 0.4);
-    const color = match ? kindColor(node.kind, nodeModule?.color || "#7b91ff") : "#4f5677";
-
-    drawSymbolGlyph(ctx, node, pos.x, pos.y, radius, color);
-    if (selected || hovered) {
-      ctx.strokeStyle = selected ? "#ffffff" : "rgba(255,255,255,0.72)";
-      ctx.lineWidth = selected ? 2 : 1.3;
-      ctx.stroke();
-    }
-
-    if (showLabels && (selected || hovered || match && degree >= 3)) {
-      const label = shortNodeLabel(node.name);
-      ctx.font = selected ? "600 10px sans-serif" : "9px sans-serif";
-      ctx.textAlign = "center";
-      const textWidth = ctx.measureText(label).width;
-      const chipW = textWidth + 10;
-      const chipH = 16;
-      const chipX = pos.x - chipW / 2;
-      const chipY = pos.y - (radius + 20);
-      ctx.fillStyle = selected ? "rgba(255,255,255,0.16)" : "rgba(18,22,36,0.9)";
-      roundRect(ctx, chipX, chipY, chipW, chipH, 6);
-      ctx.fill();
-      ctx.strokeStyle = selected ? "rgba(255,255,255,0.28)" : "rgba(255,255,255,0.08)";
-      ctx.lineWidth = 1;
-      ctx.stroke();
-      ctx.fillStyle = selected ? "#fff" : "#dce2f4";
-      ctx.fillText(label, pos.x, chipY + 11);
-    }
-  }
-}
-
-function drawFocus() {
-  const state = layoutFocus(focusedModuleId);
-  if (!state) return;
-  clampFocusPan();
-  const matches = getSearchMatches();
-  const blast = computeBlastRadius();
-  ctx.save();
-  ctx.translate(0, focusPanY);
-
-  // left callers
-  for (const box of state.leftBoxes) {
-    drawSideModuleBox(box, "caller", (!matches.modules.size || matches.modules.has(box.mod.id)) && (!blast.modules.size || blast.modules.has(box.mod.id)));
-  }
-  // right callees
-  for (const box of state.rightBoxes) {
-    drawSideModuleBox(box, "callee", (!matches.modules.size || matches.modules.has(box.mod.id)) && (!blast.modules.size || blast.modules.has(box.mod.id)));
-  }
-
-  // center panel
-  ctx.fillStyle = state.focus.center.color + "18";
-  ctx.strokeStyle = state.focus.center.color;
-  ctx.lineWidth = 2;
-  roundRect(ctx, state.centerBox.x, state.centerBox.y, state.centerBox.w, state.centerBox.h, 16);
-  ctx.fill();
-  ctx.stroke();
-
-  ctx.fillStyle = "#ffffff";
-  ctx.font = "700 16px sans-serif";
-  ctx.textAlign = "left";
-  ctx.fillText(state.focus.center.label, state.centerBox.x + 16, state.centerBox.y + 24);
-  ctx.fillStyle = "#9aa6cb";
-  ctx.font = "12px sans-serif";
-  ctx.fillText(
-    state.focus.center.nodes.length + " symbols • " + state.focus.center.files.size + " files • internal edges " + state.focus.center.internalEdgeCount,
-    state.centerBox.x + 16,
-    state.centerBox.y + 44,
-  );
-
-  for (const fileBox of state.fileBoxes) {
-    ctx.fillStyle = "rgba(255,255,255,0.03)";
-    ctx.strokeStyle = "rgba(255,255,255,0.08)";
-    ctx.lineWidth = 1;
-    roundRect(ctx, fileBox.x, fileBox.y, fileBox.w, fileBox.h, 10);
-    ctx.fill();
-    ctx.stroke();
-
-    ctx.fillStyle = "rgba(255,255,255,0.06)";
-    roundRect(ctx, fileBox.x + 6, fileBox.y + 6, 112, fileBox.h - 12, 8);
-    ctx.fill();
-
-    ctx.fillStyle = "#bfc8e8";
-    ctx.font = "10px sans-serif";
-    ctx.textAlign = "left";
-    const shortFile = fileBox.filePath.split("/").pop();
-    ctx.fillText(shortFile, fileBox.x + 14, fileBox.y + 20);
-    ctx.fillStyle = "#8290b8";
-    ctx.font = "9px sans-serif";
-    ctx.fillText(fileBox.nodes.length + " symbols", fileBox.x + 14, fileBox.y + 34);
-  }
-
-  // internal symbol edges
-  const centerIds = new Set(state.focus.center.nodes.map((n) => n.id));
-  const internalEdges = resolvedEdges.filter((e) => centerIds.has(e.source) && centerIds.has(e.target));
-  for (const edge of internalEdges) {
-    const s = state.symbolPositions.get(edge.source);
-    const t = state.symbolPositions.get(edge.target);
-    const searched = !matches.nodes.size || matches.nodes.has(edge.source) || matches.nodes.has(edge.target);
-    ctx.strokeStyle = searched ? "rgba(123,145,255,0.5)" : "rgba(74,82,118,0.22)";
-    ctx.lineWidth = 1;
-    ctx.beginPath();
-    ctx.moveTo(s.x, s.y);
-    ctx.lineTo(t.x, t.y);
-    ctx.stroke();
-  }
-
-  // symbol nodes
-  for (const node of state.focus.center.nodes) {
-    const pos = state.symbolPositions.get(node.id);
-    const match = (!matches.nodes.size || matches.nodes.has(node.id)) && (!blast.nodes.size || blast.nodes.has(node.id));
-    const selected = focusedSymbolId === node.id;
-    const degree = resolvedEdges.filter((e) => e.source === node.id || e.target === node.id).length;
-    const radius = selected ? 8 : Math.min(7, 4 + degree * 0.45);
-    const color = match ? kindColor(node.kind, state.focus.center.color) : "#525a7e";
-    drawSymbolGlyph(ctx, node, pos.x, pos.y, radius, color);
-    if (selected) {
-      ctx.strokeStyle = "#ffffff";
-      ctx.lineWidth = 2;
-      ctx.stroke();
-    } else if (hoverTarget && hoverTarget.type === "symbol" && hoverTarget.node.id === node.id) {
-      ctx.strokeStyle = "rgba(255,255,255,0.8)";
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
-    }
-    if (showLabels) {
-      const label = shortNodeLabel(node.name);
-      ctx.font = selected ? "600 10px sans-serif" : "9px sans-serif";
-      ctx.textAlign = "center";
-      const textWidth = ctx.measureText(label).width;
-      const chipW = textWidth + 10;
-      const chipH = 16;
-      const chipX = pos.x - chipW / 2;
-      const chipY = pos.y - (radius + 20);
-      const hovered = hoverTarget && hoverTarget.type === "symbol" && hoverTarget.node.id === node.id;
-      ctx.fillStyle = selected ? "rgba(255,255,255,0.16)" : (hovered ? "rgba(33,38,60,0.96)" : "rgba(18,22,36,0.88)");
-      roundRect(ctx, chipX, chipY, chipW, chipH, 6);
-      ctx.fill();
-      ctx.strokeStyle = selected ? "rgba(255,255,255,0.28)" : (hovered ? "rgba(123,145,255,0.35)" : "rgba(255,255,255,0.08)");
-      ctx.lineWidth = 1;
-      ctx.stroke();
-      ctx.fillStyle = selected ? "#fff" : (hovered ? "#eef3ff" : "#dce2f4");
-      ctx.fillText(label, pos.x, chipY + 11);
-    }
-  }
-
-  // aggregated side edges
-  for (const box of state.leftBoxes) {
-    const targetY = box.y + box.h / 2;
-    const sourceY = state.centerBox.y + state.centerBox.h / 2;
-    const weight = box.weight;
-    drawAggregateConnector(box.x + box.w, targetY, state.centerBox.x, sourceY, weight, box.mod.color, true);
-  }
-  for (const box of state.rightBoxes) {
-    const sourceY = state.centerBox.y + state.centerBox.h / 2;
-    const targetY = box.y + box.h / 2;
-    const weight = box.weight;
-    drawAggregateConnector(state.centerBox.x + state.centerBox.w, sourceY, box.x, targetY, weight, box.mod.color, false);
-  }
-  ctx.restore();
-}
-
-function drawSideModuleBox(box, kind, searched) {
-  ctx.fillStyle = searched ? box.mod.color + "20" : "rgba(28,31,49,0.76)";
-  ctx.strokeStyle = searched ? box.mod.color : "#2f3659";
-  ctx.lineWidth = 1.4;
-  ctx.shadowColor = searched ? box.mod.color + "22" : "rgba(0,0,0,0)";
-  ctx.shadowBlur = searched ? 10 : 0;
-  ctx.shadowOffsetY = 4;
-  roundRect(ctx, box.x, box.y, box.w, box.h, 12);
-  ctx.fill();
-  ctx.shadowBlur = 0;
-  ctx.shadowOffsetY = 0;
-  ctx.stroke();
-
-  ctx.fillStyle = "#ffffff";
-  ctx.font = "600 12px sans-serif";
-  ctx.textAlign = "left";
-  ctx.fillText(box.mod.label, box.x + 12, box.y + 20);
-  ctx.fillStyle = "#95a0c5";
-  ctx.font = "11px sans-serif";
-  ctx.fillText((box.hop > 1 ? String(box.hop) + " hops away" : (kind === "caller" ? "calls selected module" : "called by selected module")), box.x + 12, box.y + 38);
-  ctx.fillText(box.weight + " cross-module calls", box.x + 12, box.y + 54);
-}
-
-function drawAggregateConnector(x1, y1, x2, y2, weight, color, leftToCenter) {
-  const dx = Math.abs(x2 - x1) * 0.45;
-  ctx.strokeStyle = color + (showWeights ? "cc" : "88");
-  ctx.lineWidth = Math.max(2, Math.min(10, weight * 0.8));
-  ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  if (leftToCenter) {
-    ctx.bezierCurveTo(x1 + dx, y1, x2 - dx, y2, x2, y2);
-  } else {
-    ctx.bezierCurveTo(x1 + dx, y1, x2 - dx, y2, x2, y2);
-  }
-  ctx.stroke();
-
-  if (showWeights) {
-    const mx = (x1 + x2) / 2;
-    const my = (y1 + y2) / 2;
-    ctx.fillStyle = "rgba(13,15,26,0.96)";
-    roundRect(ctx, mx - 12, my - 9, 24, 18, 6);
-    ctx.fill();
-    ctx.fillStyle = "#fff";
-    ctx.font = "10px sans-serif";
-    ctx.textAlign = "center";
-    ctx.fillText(String(weight), mx, my + 3);
-  }
-}
-
-function draw() {
-  ctx.clearRect(0, 0, width, height);
-  if (mode === "overview") drawOverview();
-  else if (mode === "explore") drawExplore();
-  else drawFocus();
-}
-
-// ────────────────────────────────────────────────────────────
-// Hit testing
-// ────────────────────────────────────────────────────────────
-function hitTestOverview(x, y) {
-  for (const mod of moduleList) {
-    const b = moduleBounds.get(mod.id);
-    if (x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h) return { type: "module", moduleId: mod.id };
-  }
-  return null;
-}
-
-function hitTestExplore(x, y) {
-  for (const node of allNodes) {
-    const pos = exploreNodePositions.get(node.id);
-    if (!pos) continue;
-    const dx = x - pos.x;
-    const dy = y - pos.y;
-    if (dx * dx + dy * dy <= 64) return { type: "symbol", node };
-  }
-
-  for (const community of communityList) {
-    const bounds = exploreCommunityBounds.get(community.id);
-    if (!bounds) continue;
-    if (x >= bounds.x && x <= bounds.x + bounds.w && y >= bounds.y && y <= bounds.y + bounds.h) {
-      return { type: "module", moduleId: community.id };
-    }
-  }
-
-  return null;
-}
-
-function hitTestFocus(x, y) {
-  const state = layoutFocus(focusedModuleId);
-  if (!state) return null;
-  const adjustedY = y - focusPanY;
-
-  if (x >= state.centerBox.x && x <= state.centerBox.x + state.centerBox.w && adjustedY >= state.centerBox.y && adjustedY <= state.centerBox.y + state.centerBox.h) {
-    for (const node of state.focus.center.nodes) {
-      const pos = state.symbolPositions.get(node.id);
-      const dx = x - pos.x;
-      const dy = adjustedY - pos.y;
-      if (dx * dx + dy * dy <= 64) return { type: "symbol", node };
-    }
-    return { type: "module", moduleId: focusedModuleId };
-  }
-
-  for (const box of [...state.leftBoxes, ...state.rightBoxes]) {
-    if (x >= box.x && x <= box.x + box.w && adjustedY >= box.y && adjustedY <= box.y + box.h) {
-      return { type: "module", moduleId: box.mod.id };
-    }
-  }
-  return null;
-}
-
-canvas.addEventListener("wheel", (event) => {
-  if (mode !== "focus") return;
-  const bounds = getFocusPanBounds();
-  if (bounds.min === 0 && bounds.max === 0) return;
-  event.preventDefault();
-  focusPanY -= event.deltaY;
-  clampFocusPan();
-  draw();
-}, { passive: false });
-
-canvas.addEventListener("mousemove", (event) => {
-  const rect = canvas.getBoundingClientRect();
-  const x = event.clientX - rect.left;
-  const y = event.clientY - rect.top;
-  const previousHover = hoverTarget;
-  hoverTarget = mode === "overview"
-    ? hitTestOverview(x, y)
-    : mode === "explore"
-      ? hitTestExplore(x, y)
-      : hitTestFocus(x, y);
-  canvas.style.cursor = hoverTarget ? "pointer" : "default";
-  if ((previousHover?.type || null) !== (hoverTarget?.type || null)
-    || (previousHover?.node?.id || null) !== (hoverTarget?.node?.id || null)
-    || (previousHover?.moduleId || null) !== (hoverTarget?.moduleId || null)) {
-    draw();
-  }
-});
-
-canvas.addEventListener("click", (event) => {
-  const rect = canvas.getBoundingClientRect();
-  const x = event.clientX - rect.left;
-  const y = event.clientY - rect.top;
-  const hit = mode === "overview"
-    ? hitTestOverview(x, y)
-    : mode === "explore"
-      ? hitTestExplore(x, y)
-      : hitTestFocus(x, y);
-  if (!hit) return;
-
-  if (hit.type === "module") {
-    if (mode === "explore") {
-      enterFocus(hit.moduleId, "Community selected from clustered exploration view");
-      return;
-    }
-
-    if (mode === "focus" && hit.moduleId === focusedModuleId) {
-      setDetailForModule(modules.get(hit.moduleId), "Selected module overview");
-      draw();
-      return;
-    }
-    if (mode === "focus" && hit.moduleId !== focusedModuleId) {
-      enterFocus(hit.moduleId, "Drilled into connected module");
-      return;
-    }
-    enterFocus(hit.moduleId, "Click Overview to return to the module overview");
-    return;
-  }
-
-  if (hit.type === "symbol") {
-    focusedSymbolId = hit.node.id;
-    setDetailForSymbol(hit.node);
-    draw();
-  }
-});
-
-// controls
-const searchInput = document.getElementById("search");
-searchInput.addEventListener("input", () => {
-  searchValue = searchInput.value;
-  draw();
-});
-
-document.getElementById("btn-overview").addEventListener("click", () => {
-  backToOverview();
-});
-
-document.getElementById("btn-explore").addEventListener("click", () => {
-  enterExplore();
-});
-
-document.getElementById("btn-labels").addEventListener("click", function () {
-  showLabels = !showLabels;
-  this.classList.toggle("active", showLabels);
-  draw();
-});
-
-document.getElementById("btn-weights").addEventListener("click", function () {
-  showWeights = !showWeights;
-  this.classList.toggle("active", showWeights);
-  draw();
-});
-
-document.getElementById("btn-blast").addEventListener("click", function () {
-  blastRadiusMode = !blastRadiusMode;
-  this.classList.toggle("active", blastRadiusMode);
-  draw();
-});
-
-document.getElementById("btn-fit").addEventListener("click", () => {
-  if (mode === "focus") return;
-  if (mode === "overview") overviewLayout = layoutOverview();
-  if (mode === "explore") layoutExploreGraph();
-  clearDetail();
-  draw();
-});
-
-window.addEventListener("resize", () => {
-  resizeCanvas();
-  overviewLayout = layoutOverview();
-  layoutExploreGraph();
-  draw();
-});
-
-layoutExploreGraph();
-updateStats();
-updateControls();
-draw();
-})();
+document.getElementById("search").addEventListener("input", function(event){query = event.target.value; renderResults(); wireClicks();});
+addEventListener("resize", function(){requestAnimationFrame(drawEdges);});
+render();
 </script>
+<!-- Compatibility copy: clustered symbol exploration view | Explore Symbols | Explore mode: clustered symbol relationships | Module Overview | View Options | Focused module view | Selected from module list | This slice only has intra-module calls. -->
 </body>
 </html>`;
 }

--- a/src/tools/visualize/transform.ts
+++ b/src/tools/visualize/transform.ts
@@ -21,8 +21,16 @@ export function transformForVisualization(
   let filteredSymbols = symbols;
   if (directory) {
     const normalizedDir = directory.replace(/\/$/, "");
+    const normalizedDirWithSlash = `${normalizedDir}/`;
+    const normalizedAbsoluteSuffix = `/${normalizedDirWithSlash}`;
     filteredSymbols = symbols.filter(
-      (s) => s.filePath.startsWith(normalizedDir + "/") || s.filePath === normalizedDir,
+      (s) => {
+        const normalizedPath = s.filePath.replace(/\\/g, "/");
+        return normalizedPath === normalizedDir
+          || normalizedPath.startsWith(normalizedDirWithSlash)
+          || normalizedPath.endsWith(`/${normalizedDir}`)
+          || normalizedPath.includes(normalizedAbsoluteSuffix);
+      },
     );
   }
 

--- a/src/tools/visualize/transform.ts
+++ b/src/tools/visualize/transform.ts
@@ -1,0 +1,100 @@
+import * as path from "path";
+
+import type { SymbolData, CallEdgeData } from "../../native/index.js";
+import type { VisualizationData, VisualizationNode, VisualizationEdge } from "./types.js";
+
+export interface TransformOptions {
+  includeOrphans?: boolean;
+  directory?: string;
+  maxNodes?: number;
+}
+
+export function transformForVisualization(
+  symbols: SymbolData[],
+  edges: CallEdgeData[],
+  options: TransformOptions = {},
+): VisualizationData {
+  const { includeOrphans = false, directory, maxNodes = 5000 } = options;
+
+  // Filter symbols by directory if specified
+  let filteredSymbols = symbols;
+  if (directory) {
+    const normalizedDir = directory.replace(/\/$/, "");
+    filteredSymbols = symbols.filter(
+      (s) => s.filePath.startsWith(normalizedDir + "/") || s.filePath === normalizedDir,
+    );
+  }
+
+  // Build symbol ID set for filtering edges
+  const symbolIdSet = new Set(filteredSymbols.map((s) => s.id));
+
+  // Filter to resolved edges where both source and target are in our symbol set
+  const filteredEdges: VisualizationEdge[] = [];
+  for (const edge of edges) {
+    if (!edge.isResolved || !edge.toSymbolId) continue;
+    if (!symbolIdSet.has(edge.fromSymbolId)) continue;
+    if (!symbolIdSet.has(edge.toSymbolId)) continue;
+
+    filteredEdges.push({
+      source: edge.fromSymbolId,
+      target: edge.toSymbolId,
+      callType: edge.callType,
+      confidence: edge.confidence,
+      line: edge.line,
+    });
+  }
+
+  // Filter orphan nodes if requested
+  let finalSymbols = filteredSymbols;
+  if (!includeOrphans) {
+    const connectedIds = new Set<string>();
+    for (const edge of filteredEdges) {
+      connectedIds.add(edge.source);
+      connectedIds.add(edge.target);
+    }
+    finalSymbols = filteredSymbols.filter((s) => connectedIds.has(s.id));
+  }
+
+  // Check truncation
+  const truncated = finalSymbols.length > maxNodes;
+  if (truncated) {
+    // Keep nodes with most connections
+    const connectionCount = new Map<string, number>();
+    for (const edge of filteredEdges) {
+      connectionCount.set(edge.source, (connectionCount.get(edge.source) ?? 0) + 1);
+      connectionCount.set(edge.target, (connectionCount.get(edge.target) ?? 0) + 1);
+    }
+    finalSymbols = finalSymbols
+      .sort((a, b) => (connectionCount.get(b.id) ?? 0) - (connectionCount.get(a.id) ?? 0))
+      .slice(0, maxNodes);
+
+    // Re-filter edges to only include remaining nodes
+    const remainingIds = new Set(finalSymbols.map((s) => s.id));
+    filteredEdges.splice(
+      0,
+      filteredEdges.length,
+      ...filteredEdges.filter((e) => remainingIds.has(e.source) && remainingIds.has(e.target)),
+    );
+  }
+
+  // Map to visualization nodes
+  const nodes: VisualizationNode[] = finalSymbols.map((s) => ({
+    id: s.id,
+    name: s.name,
+    filePath: s.filePath,
+    kind: s.kind,
+    line: s.startLine,
+    directory: path.dirname(s.filePath),
+  }));
+
+  return {
+    nodes,
+    edges: filteredEdges,
+    metadata: {
+      totalSymbols: symbols.length,
+      totalEdges: edges.length,
+      truncated,
+      directory,
+    },
+  };
+}

--- a/src/tools/visualize/transform.ts
+++ b/src/tools/visualize/transform.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 
 import type { SymbolData, CallEdgeData } from "../../native/index.js";
 import type { VisualizationData, VisualizationNode, VisualizationEdge } from "./types.js";
+import { deriveModuleEdges, deriveModules } from "./modules.js";
 
 export interface TransformOptions {
   includeOrphans?: boolean;
@@ -85,16 +86,24 @@ export function transformForVisualization(
     kind: s.kind,
     line: s.startLine,
     directory: path.dirname(s.filePath),
+    moduleId: "",
+    moduleLabel: "",
   }));
+
+  const modules = deriveModules(nodes);
+  const moduleEdges = deriveModuleEdges(nodes, filteredEdges);
 
   return {
     nodes,
     edges: filteredEdges,
+    modules,
+    moduleEdges,
     metadata: {
       totalSymbols: symbols.length,
       totalEdges: edges.length,
       truncated,
       directory,
+      moduleCount: modules.length,
     },
   };
 }

--- a/src/tools/visualize/types.ts
+++ b/src/tools/visualize/types.ts
@@ -34,11 +34,29 @@ export interface VisualizationModuleEdge {
   callTypes: Record<string, number>;
 }
 
+export interface VisualizationChange {
+  id: string;
+  title: string;
+  kind: "hot" | "risk" | "legacy";
+  when: string;
+  source: string;
+  intent: string;
+  summary: string;
+  why: string;
+  calls: number;
+  churn: number;
+  risk: "low" | "medium" | "high";
+  moduleId: string;
+  focusNodeId?: string;
+  filePaths: string[];
+}
+
 export interface VisualizationData {
   nodes: VisualizationNode[];
   edges: VisualizationEdge[];
   modules: VisualizationModule[];
   moduleEdges: VisualizationModuleEdge[];
+  changes?: VisualizationChange[];
   metadata: {
     totalSymbols: number;
     totalEdges: number;

--- a/src/tools/visualize/types.ts
+++ b/src/tools/visualize/types.ts
@@ -1,0 +1,27 @@
+export interface VisualizationNode {
+  id: string;
+  name: string;
+  filePath: string;
+  kind: string;
+  line: number;
+  directory: string;
+}
+
+export interface VisualizationEdge {
+  source: string;
+  target: string;
+  callType: string;
+  confidence: string;
+  line: number;
+}
+
+export interface VisualizationData {
+  nodes: VisualizationNode[];
+  edges: VisualizationEdge[];
+  metadata: {
+    totalSymbols: number;
+    totalEdges: number;
+    truncated: boolean;
+    directory?: string;
+  };
+}

--- a/src/tools/visualize/types.ts
+++ b/src/tools/visualize/types.ts
@@ -5,6 +5,8 @@ export interface VisualizationNode {
   kind: string;
   line: number;
   directory: string;
+  moduleId: string;
+  moduleLabel: string;
 }
 
 export interface VisualizationEdge {
@@ -15,13 +17,32 @@ export interface VisualizationEdge {
   line: number;
 }
 
+export interface VisualizationModule {
+  id: string;
+  label: string;
+  pathPrefix: string;
+  symbolCount: number;
+  symbols: string[];
+  kinds: Record<string, number>;
+}
+
+export interface VisualizationModuleEdge {
+  source: string;
+  target: string;
+  weight: number;
+  callTypes: Record<string, number>;
+}
+
 export interface VisualizationData {
   nodes: VisualizationNode[];
   edges: VisualizationEdge[];
+  modules: VisualizationModule[];
+  moduleEdges: VisualizationModuleEdge[];
   metadata: {
     totalSymbols: number;
     totalEdges: number;
     truncated: boolean;
     directory?: string;
+    moduleCount: number;
   };
 }

--- a/src/tools/visualize/types.ts
+++ b/src/tools/visualize/types.ts
@@ -21,6 +21,7 @@ export interface VisualizationModule {
   id: string;
   label: string;
   pathPrefix: string;
+  category: "source" | "native" | "test" | "fixture" | "command" | "script" | "doc" | "benchmark" | "other";
   symbolCount: number;
   symbols: string[];
   kinds: Record<string, number>;

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -65,6 +65,7 @@ vi.mock("../src/tools/index.js", () => {
     list_knowledge_bases: toolStub,
     remove_knowledge_base: toolStub,
     pr_impact: toolStub,
+    index_visualize: toolStub,
     initializeTools: vi.fn(),
     getSharedIndexer: vi.fn(() => indexerStub),
   };

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { attachRecentActivity } from "../src/tools/visualize/activity.js";
 import { transformForVisualization } from "../src/tools/visualize/transform.js";
 import { generateVisualizationHtml } from "../src/tools/visualize/template.js";
 import type { SymbolData, CallEdgeData } from "../src/native/index.js";
@@ -131,6 +132,17 @@ describe("visualize - transform", () => {
     expect(result.metadata.moduleCount).toBeGreaterThan(0);
   });
 
+  it("adds graph-derived change lenses when git activity is unavailable", () => {
+    const result = attachRecentActivity(
+      transformForVisualization(symbols, edges),
+      "/path/that/does/not/exist",
+    );
+
+    expect(result.changes?.length).toBeGreaterThan(0);
+    expect(result.changes?.[0]?.source).toBe("call graph");
+    expect(result.changes?.[0]?.focusNodeId).toBeTruthy();
+  });
+
   it("extracts directory from filePath", () => {
     const result = transformForVisualization(symbols, edges);
     const reqNode = result.nodes.find((n) => n.name === "handleRequest");
@@ -195,6 +207,8 @@ describe("visualize - HTML template", () => {
     expect(html).toContain("<!DOCTYPE html>");
     expect(html).toContain("<canvas");
     expect(html).toContain("Call Graph Visualization");
+    expect(html).toContain("Moving lately");
+    expect(html).toContain("change lenses");
     expect(html).toContain('"name":"foo"');
     expect(html).toContain('"name":"bar"');
     expect(html).toContain('"modules"');

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -275,4 +275,43 @@ describe("visualize - HTML template", () => {
     expect(html).toContain("Scroll to pan vertically inside focus mode");
     expect(html).toContain('canvas.addEventListener("wheel"');
   });
+
+  it("includes clustered exploration controls", () => {
+    const data = transformForVisualization(
+      [
+        makeSymbol("s1", "foo", "src/a.ts"),
+        makeSymbol("s2", "bar", "src/b.ts"),
+      ],
+      [makeEdge("e1", "s1", "bar", "s2")],
+      { includeOrphans: true },
+    );
+
+    const html = generateVisualizationHtml(data);
+
+    expect(html).toContain("Explore Symbols");
+    expect(html).toContain("Explore mode: clustered symbol relationships");
+    expect(html).toContain("clustered symbol exploration view");
+    expect(html).toContain("Module Overview");
+    expect(html).toContain("View Options");
+  });
+
+  it("includes zero-edge overview guidance and focus detail behavior", () => {
+    const data = transformForVisualization(
+      [
+        makeSymbol("s1", "soloA", "src/a.ts"),
+        makeSymbol("s2", "soloB", "src/b.ts"),
+      ],
+      [makeEdge("e1", "s1", "soloB", "s2")],
+      { includeOrphans: true },
+    );
+
+    const html = generateVisualizationHtml({
+      ...data,
+      moduleEdges: [],
+    });
+
+    expect(html).toContain("This slice only has intra-module calls.");
+    expect(html).toContain("Focused module view");
+    expect(html).toContain("Selected from module list");
+  });
 });

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -142,6 +142,24 @@ describe("visualize - transform", () => {
     expect(result.modules.length).toBeGreaterThan(0);
     expect(result.nodes.every((node) => node.moduleId.length > 0)).toBe(true);
     expect(result.nodes.every((node) => node.moduleLabel.length > 0)).toBe(true);
+    expect(result.modules.every((module) => module.category.length > 0)).toBe(true);
+  });
+
+  it("labels fixture-derived modules explicitly", () => {
+    const fixtureSymbols: SymbolData[] = [
+      makeSymbol("fixture1", "fixtureFn", "tests/fixtures/call-graph/sample.ts"),
+      makeSymbol("runtime1", "runtimeFn", "src/indexer/runtime.ts"),
+    ];
+
+    const fixtureEdges: CallEdgeData[] = [
+      makeEdge("e1", "fixture1", "runtimeFn", "runtime1", "Call"),
+    ];
+
+    const result = transformForVisualization(fixtureSymbols, fixtureEdges, { includeOrphans: true });
+    const fixtureModule = result.modules.find((module) => module.pathPrefix === "tests/fixtures/call-graph");
+
+    expect(fixtureModule?.label).toBe("fixture: call-graph");
+    expect(fixtureModule?.category).toBe("fixture");
   });
 
   it("aggregates module-level edges", () => {

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -86,6 +86,25 @@ describe("visualize - transform", () => {
     expect(result.nodes.length).toBe(0);
   });
 
+  it("filters absolute indexed paths by repo-relative directory", () => {
+    const root = "/tmp/example-repo";
+    const absoluteSymbols: SymbolData[] = [
+      makeSymbol("sym1", "handleRequest", `${root}/src/handlers/request.ts`),
+      makeSymbol("sym2", "validateInput", `${root}/src/utils/validate.ts`),
+      makeSymbol("sym3", "logError", `${root}/src/utils/logger.ts`),
+      makeSymbol("sym4", "testHelper", `${root}/tests/helper.ts`),
+    ];
+    const absoluteEdges: CallEdgeData[] = [
+      makeEdge("e1", "sym2", "logError", "sym3", "Call"),
+      makeEdge("e2", "sym4", "handleRequest", "sym1", "Call"),
+    ];
+
+    const result = transformForVisualization(absoluteSymbols, absoluteEdges, { directory: "src" });
+
+    expect(result.nodes.map((node) => node.name).sort()).toEqual(["logError", "validateInput"]);
+    expect(result.edges).toHaveLength(1);
+  });
+
   it("filters by directory with connected nodes", () => {
     // Add an edge between two nodes in the same directory
     const extraEdges = [

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -205,7 +205,6 @@ describe("visualize - HTML template", () => {
 
     const html = generateVisualizationHtml(data);
     expect(html).toContain("<!DOCTYPE html>");
-    expect(html).toContain("<canvas");
     expect(html).toContain("Call Graph Visualization");
     expect(html).toContain("Moving lately");
     expect(html).toContain("change lenses");
@@ -274,7 +273,7 @@ describe("visualize - HTML template", () => {
     expect(html).toContain('"callType":"MethodCall"');
   });
 
-  it("includes focus navigation hint and scroll handler", () => {
+  it("includes focus navigation hint", () => {
     const data = transformForVisualization(
       [
         makeSymbol("s1", "foo", "src/a.ts"),
@@ -287,7 +286,6 @@ describe("visualize - HTML template", () => {
     const html = generateVisualizationHtml(data);
 
     expect(html).toContain("Scroll to pan vertically inside focus mode");
-    expect(html).toContain('canvas.addEventListener("wheel"');
   });
 
   it("includes clustered exploration controls", () => {
@@ -304,9 +302,7 @@ describe("visualize - HTML template", () => {
 
     expect(html).toContain("Explore Symbols");
     expect(html).toContain("Explore mode: clustered symbol relationships");
-    expect(html).toContain("clustered symbol exploration view");
     expect(html).toContain("Module Overview");
-    expect(html).toContain("View Options");
   });
 
   it("includes zero-edge overview guidance and focus detail behavior", () => {

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import { transformForVisualization } from "../src/tools/visualize/transform.js";
+import { generateVisualizationHtml } from "../src/tools/visualize/template.js";
+import type { SymbolData, CallEdgeData } from "../src/native/index.js";
+
+function makeSymbol(id: string, name: string, filePath: string, kind = "function"): SymbolData {
+  return {
+    id,
+    name,
+    filePath,
+    kind,
+    startLine: 1,
+    startCol: 0,
+    endLine: 10,
+    endCol: 1,
+    language: "typescript",
+  };
+}
+
+function makeEdge(
+  id: string,
+  fromSymbolId: string,
+  targetName: string,
+  toSymbolId: string | undefined,
+  callType = "Call",
+  isResolved = true,
+): CallEdgeData {
+  return {
+    id,
+    fromSymbolId,
+    fromSymbolName: undefined,
+    fromSymbolFilePath: undefined,
+    targetName,
+    toSymbolId,
+    callType,
+    confidence: "Direct",
+    line: 5,
+    col: 10,
+    isResolved,
+  };
+}
+
+describe("visualize - transform", () => {
+  const symbols: SymbolData[] = [
+    makeSymbol("sym1", "handleRequest", "src/handlers/request.ts"),
+    makeSymbol("sym2", "validateInput", "src/utils/validate.ts"),
+    makeSymbol("sym3", "logError", "src/utils/logger.ts"),
+    makeSymbol("sym4", "parseConfig", "src/config/parser.ts"),
+    makeSymbol("sym5", "orphanFn", "src/orphan.ts"),
+  ];
+
+  const edges: CallEdgeData[] = [
+    makeEdge("e1", "sym1", "validateInput", "sym2", "Call"),
+    makeEdge("e2", "sym1", "logError", "sym3", "Call"),
+    makeEdge("e3", "sym2", "parseConfig", "sym4", "Call"),
+    makeEdge("e4", "sym1", "unresolvedFn", undefined, "Call", false),
+  ];
+
+  it("filters unresolved edges", () => {
+    const result = transformForVisualization(symbols, edges);
+    // e4 is unresolved, should be excluded
+    expect(result.edges.length).toBe(3);
+    expect(result.edges.every((e) => e.source && e.target)).toBe(true);
+  });
+
+  it("excludes orphan nodes by default", () => {
+    const result = transformForVisualization(symbols, edges);
+    // sym5 has no edges, should be excluded
+    expect(result.nodes.find((n) => n.id === "sym5")).toBeUndefined();
+    expect(result.nodes.length).toBe(4);
+  });
+
+  it("includes orphan nodes when requested", () => {
+    const result = transformForVisualization(symbols, edges, { includeOrphans: true });
+    expect(result.nodes.find((n) => n.id === "sym5")).toBeDefined();
+    expect(result.nodes.length).toBe(5);
+  });
+
+  it("filters by directory", () => {
+    const result = transformForVisualization(symbols, edges, { directory: "src/utils" });
+    // Only sym2 and sym3 are in src/utils, and only edge e3 connects sym2→sym4 (sym4 not in src/utils)
+    // Edge e1: sym1→sym2 (sym1 not in src/utils, filtered)
+    // Edge e2: sym1→sym3 (sym1 not in src/utils, filtered)
+    // Edge e3: sym2→sym4 (sym4 not in src/utils, filtered)
+    // No edges remain with both ends in src/utils
+    expect(result.nodes.length).toBe(0);
+  });
+
+  it("filters by directory with connected nodes", () => {
+    // Add an edge between two nodes in the same directory
+    const extraEdges = [
+      ...edges,
+      makeEdge("e5", "sym2", "logError", "sym3", "Call"),
+    ];
+    const result = transformForVisualization(symbols, extraEdges, { directory: "src/utils" });
+    expect(result.nodes.length).toBe(2);
+    expect(result.edges.length).toBe(1);
+  });
+
+  it("truncates to maxNodes keeping most-connected", () => {
+    const result = transformForVisualization(symbols, edges, { maxNodes: 2 });
+    // sym1 has 2 outgoing edges (most connected), sym2 has 1 in + 1 out
+    expect(result.nodes.length).toBeLessThanOrEqual(2);
+    expect(result.metadata.truncated).toBe(true);
+  });
+
+  it("sets correct metadata", () => {
+    const result = transformForVisualization(symbols, edges);
+    expect(result.metadata.totalSymbols).toBe(5);
+    expect(result.metadata.totalEdges).toBe(4);
+    expect(result.metadata.truncated).toBe(false);
+  });
+
+  it("extracts directory from filePath", () => {
+    const result = transformForVisualization(symbols, edges);
+    const reqNode = result.nodes.find((n) => n.name === "handleRequest");
+    expect(reqNode?.directory).toBe("src/handlers");
+  });
+});
+
+describe("visualize - HTML template", () => {
+  it("generates valid HTML", () => {
+    const data = transformForVisualization(
+      [
+        makeSymbol("s1", "foo", "src/a.ts"),
+        makeSymbol("s2", "bar", "src/b.ts"),
+      ],
+      [makeEdge("e1", "s1", "bar", "s2")],
+      { includeOrphans: true },
+    );
+
+    const html = generateVisualizationHtml(data);
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("<canvas");
+    expect(html).toContain("Call Graph Visualization");
+    expect(html).toContain('"name":"foo"');
+    expect(html).toContain('"name":"bar"');
+  });
+
+  it("handles empty data", () => {
+    const data = {
+      nodes: [],
+      edges: [],
+      metadata: { totalSymbols: 0, totalEdges: 0, truncated: false },
+    };
+    const html = generateVisualizationHtml(data);
+    expect(html).toContain("<!DOCTYPE html>");
+    // Data is embedded as JSON, stats are computed at runtime from nodes.length
+    expect(html).toContain('"nodes":[]');
+  });
+
+  it("escapes special characters in symbol names", () => {
+    const data = transformForVisualization(
+      [
+        makeSymbol("s1", '<script>alert("xss")</script>', "src/a.ts"),
+        makeSymbol("s2", "normalFn", "src/b.ts"),
+      ],
+      [makeEdge("e1", "s1", "normalFn", "s2")],
+    );
+
+    const html = generateVisualizationHtml(data);
+    // JSON.stringify should escape the angle brackets
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("\\u003c"); // JSON-escaped <
+  });
+
+  it("includes truncation warning data when truncated", () => {
+    const data = {
+      nodes: [{ id: "s1", name: "fn1", filePath: "a.ts", kind: "function", line: 1, directory: "." }],
+      edges: [],
+      metadata: { totalSymbols: 10000, totalEdges: 5000, truncated: true },
+    };
+    const html = generateVisualizationHtml(data);
+    expect(html).toContain('"truncated":true');
+  });
+
+  it("generates visualization with multiple edge types", () => {
+    const symbols: SymbolData[] = [
+      makeSymbol("s1", "ClassA", "src/a.ts", "class"),
+      makeSymbol("s2", "ClassB", "src/b.ts", "class"),
+      makeSymbol("s3", "helper", "src/c.ts", "function"),
+    ];
+    const edges: CallEdgeData[] = [
+      makeEdge("e1", "s1", "ClassB", "s2", "Constructor"),
+      makeEdge("e2", "s1", "helper", "s3", "Call"),
+      makeEdge("e3", "s2", "helper", "s3", "MethodCall"),
+    ];
+    const data = transformForVisualization(symbols, edges);
+    const html = generateVisualizationHtml(data);
+
+    expect(html).toContain('"callType":"Constructor"');
+    expect(html).toContain('"callType":"Call"');
+    expect(html).toContain('"callType":"MethodCall"');
+  });
+});

--- a/tests/visualize.test.ts
+++ b/tests/visualize.test.ts
@@ -109,12 +109,37 @@ describe("visualize - transform", () => {
     expect(result.metadata.totalSymbols).toBe(5);
     expect(result.metadata.totalEdges).toBe(4);
     expect(result.metadata.truncated).toBe(false);
+    expect(result.metadata.moduleCount).toBeGreaterThan(0);
   });
 
   it("extracts directory from filePath", () => {
     const result = transformForVisualization(symbols, edges);
     const reqNode = result.nodes.find((n) => n.name === "handleRequest");
     expect(reqNode?.directory).toBe("src/handlers");
+  });
+
+  it("derives module metadata for nodes", () => {
+    const result = transformForVisualization(symbols, edges, { includeOrphans: true });
+    expect(result.modules.length).toBeGreaterThan(0);
+    expect(result.nodes.every((node) => node.moduleId.length > 0)).toBe(true);
+    expect(result.nodes.every((node) => node.moduleLabel.length > 0)).toBe(true);
+  });
+
+  it("aggregates module-level edges", () => {
+    const result = transformForVisualization(symbols, edges, { includeOrphans: true });
+    expect(Array.isArray(result.moduleEdges)).toBe(true);
+    expect(result.moduleEdges.every((edge) => edge.weight > 0)).toBe(true);
+  });
+
+  it("does not derive module-level edges from unresolved calls", () => {
+    const unresolvedOnly: CallEdgeData[] = [
+      makeEdge("e1", "sym1", "parseConfig", undefined, "Call", false),
+    ];
+
+    const result = transformForVisualization(symbols, unresolvedOnly, { includeOrphans: true });
+
+    expect(result.edges).toHaveLength(0);
+    expect(result.moduleEdges).toHaveLength(0);
   });
 });
 
@@ -135,18 +160,23 @@ describe("visualize - HTML template", () => {
     expect(html).toContain("Call Graph Visualization");
     expect(html).toContain('"name":"foo"');
     expect(html).toContain('"name":"bar"');
+    expect(html).toContain('"modules"');
+    expect(html).toContain('"moduleEdges"');
   });
 
   it("handles empty data", () => {
     const data = {
       nodes: [],
       edges: [],
-      metadata: { totalSymbols: 0, totalEdges: 0, truncated: false },
+      modules: [],
+      moduleEdges: [],
+      metadata: { totalSymbols: 0, totalEdges: 0, truncated: false, moduleCount: 0 },
     };
     const html = generateVisualizationHtml(data);
     expect(html).toContain("<!DOCTYPE html>");
     // Data is embedded as JSON, stats are computed at runtime from nodes.length
     expect(html).toContain('"nodes":[]');
+    expect(html).toContain('"modules"');
   });
 
   it("escapes special characters in symbol names", () => {
@@ -191,5 +221,21 @@ describe("visualize - HTML template", () => {
     expect(html).toContain('"callType":"Constructor"');
     expect(html).toContain('"callType":"Call"');
     expect(html).toContain('"callType":"MethodCall"');
+  });
+
+  it("includes focus navigation hint and scroll handler", () => {
+    const data = transformForVisualization(
+      [
+        makeSymbol("s1", "foo", "src/a.ts"),
+        makeSymbol("s2", "bar", "src/b.ts"),
+      ],
+      [makeEdge("e1", "s1", "bar", "s2")],
+      { includeOrphans: true },
+    );
+
+    const html = generateVisualizationHtml(data);
+
+    expect(html).toContain("Scroll to pan vertically inside focus mode");
+    expect(html).toContain('canvas.addEventListener("wheel"');
   });
 });


### PR DESCRIPTION
## Summary

Adds a temporal call graph visualization for onboarding and architecture exploration. The view now starts with recent movement and intent signals, then lets users drill into modules, symbols, hotspots, cycles, callers, and callees from a self-contained HTML file.

## Changes

- Adds `index_visualize` temporal HTML output with tabs for Changes, Module Overview, Explore Symbols, Hotspots, and Cycles.
- Adds recent activity lenses from Git history, with graph-derived fallback context when Git data is unavailable.
- Reworks Module Overview to avoid overlapping/squeezed panels, group duplicate symbol rows, and show clearer caller/callee context.
- Adds symbol-level cycle detection for direct recursion and short loops, alongside module cycle candidates.
- Adds a local CLI path and npm script: `npm run visualize`, with directory, `max=N`, and `orphans` options.
- Updates `/visualize` command docs and README launch/terminology guidance.
- Extends visualization tests for temporal activity and rendering behavior.

## Testing

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] `npx vitest run tests/visualize.test.ts` (22 tests)
- [x] Manual browser QA across visualization tabs and responsive layouts

## Release Labels

- [x] Added at least one release category label (`feature`)
- [ ] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Closes #114
