### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-16
+
+### Added
+- Shortest-path queries between symbols in call graph (`e5f9046`).
+- Extract inheritance and implements relationships in call graph (#118, `b12ff6b`).
+- Confidence metadata on call graph edges (`af29b8a`).
+
+### Changed
+- Apply rustfmt formatting fixes in `db.rs` (`26e0d2b`).
+
+### Fixed
+- Reject ambiguous source/target names in path queries (`a30a09c`).
+- Prevent fabricated paths through ambiguous intermediate edges (`1102072`).
+- Avoid ambiguous target resolution in BFS path queries (`12f1d19`).
+- Resolve clippy lints in BFS path reconstruction and Rust code (`ab2e325`, `933ddf1`).
+- Restore `@opencode-ai/plugin` version pin (`ca0fdee`).
+
+### Security
+- Bump `vite` 8.0.16 / `esbuild` 0.28.1 overrides (`20a10c4`).
+
 ## [0.10.0] - 2026-06-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "~1.3.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Prepare release v0.11.0. This is a minor release introducing new call-graph capabilities and bug fixes since v0.10.0.

## Changes

### Added
- Shortest-path queries between symbols in call graph
- Extract inheritance and implements relationships in call graph (#118)
- Confidence metadata on call graph edges

### Changed
- Apply rustfmt formatting fixes in db.rs

### Fixed
- Reject ambiguous source/target names in path queries
- Prevent fabricated paths through ambiguous intermediate edges
- Avoid ambiguous target resolution in BFS path queries
- Resolve clippy lints in BFS path reconstruction and Rust code
- Restore @opencode-ai/plugin version pin

### Security
- Bump vite 8.0.16 / esbuild 0.28.1 overrides

## Testing

- [x] Build passes (CI)
- [x] Typecheck passes (CI)
- [x] Tests pass (CI)
- [x] Lint passes (CI)

## Release Labels

- [x] Added at least one release category label (documentation, dependencies)
- [x] Added at most one semver label (semver:minor)

## Related Issues

n/a