### PR TITLE
feat: add pr_impact tool for call-graph-based PR impact analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ Query the call graph to find callers or callees of a function/method. Automatica
 - **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries).
 - **Example**: Find who calls `validateToken` → `call_graph(name="validateToken", direction="callers")`
 
+### `pr_impact`
+Analyzes a PR's changed files to determine impact scope within the codebase.
+- **Use for**: Understanding which symbols are affected by a PR, their call-graph reach, risk level, and community/cluster detection.
+- **Parameters**: `checkConflicts` (optional, default `false`) — when `true`, detects overlapping concurrent PRs sharing affected symbols and returns `conflictingPRs`.
 ### `add_knowledge_base`
 Add a folder as a knowledge base to be indexed alongside project code.
 - **Use for**: Indexing external documentation, API references, example programs.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    npx opencode-codebase-index-mcp                            # uses current directory
    ```
 
-The MCP server exposes all 9 tools (`codebase_search`, `codebase_peek`, `find_similar`, `call_graph`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 4 prompts (`search`, `find`, `index`, `status`).
+The MCP server exposes all 10 tools (`codebase_search`, `codebase_peek`, `find_similar`, `call_graph`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 4 prompts (`search`, `find`, `index`, `status`).
 
 The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) are optional peer dependencies — they're only needed if you use the MCP server.
 
@@ -397,6 +397,7 @@ The plugin automatically registers these slash commands:
 | `/search <query>` | **Pure Semantic Search**. Best for "How does X work?" |
 | `/find <query>` | **Hybrid Search**. Combines semantic search + grep. Best for "Find usage of X". |
 | `/call-graph <query>` | **Call Graph Trace**. Find callers/callees to understand execution flow. |
+| `/pr-impact <PR number or branch>` | **PR Impact Analysis**. Analyze changed files, affected symbols, communities, hub nodes, and risk. |
 | `/index` | **Update Index**. Runs incremental indexing by default; use `/index force` for a full rebuild. |
 | `/status` | **Check Status**. Shows if indexed, chunk count, and provider info. |
 

--- a/commands/pr-impact.md
+++ b/commands/pr-impact.md
@@ -1,0 +1,23 @@
+---
+description: Analyze PR or branch impact using the call graph
+---
+
+Analyze the impact of a pull request or branch before merging.
+
+User input: $ARGUMENTS
+
+Interpret input as follows:
+- `pr=N` or plain number at the start → set `pr`
+- `branch=<name>` or plain branch name → set `branch`
+- `maxDepth=N` → set max traversal depth
+- `hubThreshold=N` → set hub node threshold
+- `checkConflicts` or `conflicts` → set `checkConflicts=true`
+
+Call `pr_impact` with the parsed arguments.
+
+Examples:
+- `/pr-impact 42` → pr=42
+- `/pr-impact branch=feature/auth` → branch="feature/auth"
+- `/pr-impact branch=feature/x maxDepth=3 checkConflicts` → branch="feature/x", maxDepth=3, checkConflicts=true
+
+If the index doesn't exist, run `index_codebase` first.

--- a/native/src/community.rs
+++ b/native/src/community.rs
@@ -1,0 +1,1038 @@
+use rusqlite::{params, Connection};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::db::{self, DbResult, SymbolRow};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReachabilityResult {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub file_path: String,
+    pub depth: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommunityAssignment {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub file_path: String,
+    pub community_id: u32,
+    pub community_label: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CentralityScore {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub file_path: String,
+    pub caller_count: u32,
+    pub callee_count: u32,
+    pub total_connections: u32,
+}
+
+pub fn get_transitive_reachability(
+    conn: &Connection,
+    root_symbol_ids: &[String],
+    branch: &str,
+    direction: &str,
+    max_depth: u32,
+) -> DbResult<Vec<ReachabilityResult>> {
+    if root_symbol_ids.is_empty() || max_depth == 0 {
+        return Ok(vec![]);
+    }
+
+    let symbols = db::get_symbols_for_branch(conn, branch)?;
+    let symbol_map: HashMap<String, SymbolRow> =
+        symbols.iter().map(|s| (s.id.clone(), s.clone())).collect();
+    let mut name_map: HashMap<String, Vec<String>> = HashMap::new();
+    for s in &symbols {
+        name_map
+            .entry(s.name.to_lowercase())
+            .or_default()
+            .push(s.id.clone());
+    }
+
+    let seed_refs: Vec<String> = root_symbol_ids
+        .iter()
+        .filter(|r| symbol_map.contains_key(*r))
+        .cloned()
+        .collect();
+    if seed_refs.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // Build the merged visited map based on direction
+    let visited = match direction {
+        "callees" => bfs_callees(conn, branch, &seed_refs, &symbol_map, &name_map, max_depth)?,
+        "callers" => bfs_callers(conn, branch, &seed_refs, &symbol_map, &name_map, max_depth)?,
+        _ => {
+            // "both" or any other value: run both and merge by min depth
+            let callees = bfs_callees(conn, branch, &seed_refs, &symbol_map, &name_map, max_depth)?;
+            let callers = bfs_callers(conn, branch, &seed_refs, &symbol_map, &name_map, max_depth)?;
+            let mut merged: HashMap<String, u32> = HashMap::new();
+            for (id, depth) in callees.into_iter().chain(callers.into_iter()) {
+                merged
+                    .entry(id)
+                    .and_modify(|d| *d = (*d).min(depth))
+                    .or_insert(depth);
+            }
+            merged
+        }
+    };
+
+    let mut results = Vec::new();
+    for (symbol_id, depth) in visited {
+        if root_symbol_ids.contains(&symbol_id) {
+            continue;
+        }
+        if let Some(sym) = symbol_map.get(&symbol_id) {
+            results.push(ReachabilityResult {
+                symbol_id: sym.id.clone(),
+                symbol_name: sym.name.clone(),
+                file_path: sym.file_path.clone(),
+                depth,
+            });
+        }
+    }
+
+    results.sort_by(|a, b| {
+        a.depth
+            .cmp(&b.depth)
+            .then_with(|| a.symbol_id.cmp(&b.symbol_id))
+    });
+    Ok(results)
+}
+
+fn bfs_callees(
+    conn: &Connection,
+    branch: &str,
+    seed_ids: &[String],
+    symbol_map: &HashMap<String, SymbolRow>,
+    name_map: &HashMap<String, Vec<String>>,
+    max_depth: u32,
+) -> DbResult<HashMap<String, u32>> {
+    let mut visited: HashMap<String, u32> = HashMap::new();
+    let mut queue: VecDeque<(String, u32)> = VecDeque::new();
+
+    for id in seed_ids {
+        visited.insert(id.clone(), 0);
+        queue.push_back((id.clone(), 0));
+    }
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT ce.target_name, ce.to_symbol_id
+        FROM call_edges ce
+        INNER JOIN symbols s ON ce.from_symbol_id = s.id
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
+        WHERE ce.from_symbol_id = ?
+        "#,
+    )?;
+
+    while let Some((current_id, depth)) = queue.pop_front() {
+        if depth >= max_depth {
+            continue;
+        }
+
+        let edges: Vec<(String, Option<String>)> = stmt
+            .query_map(params![branch, &current_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        for (target_name, to_symbol_id) in edges {
+            let resolved = if let Some(ref tid) = to_symbol_id {
+                if symbol_map.contains_key(tid) {
+                    Some(tid.clone())
+                } else {
+                    None
+                }
+            } else {
+                let candidates = name_map.get(&target_name.to_lowercase());
+                if let Some(cands) = candidates {
+                    if cands.len() == 1 {
+                        Some(cands[0].clone())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            };
+
+            if let Some(next_id) = resolved {
+                if !visited.contains_key(&next_id) {
+                    visited.insert(next_id.clone(), depth + 1);
+                    queue.push_back((next_id, depth + 1));
+                }
+            }
+        }
+    }
+
+    Ok(visited)
+}
+
+fn bfs_callers(
+    conn: &Connection,
+    branch: &str,
+    seed_ids: &[String],
+    symbol_map: &HashMap<String, SymbolRow>,
+    name_map: &HashMap<String, Vec<String>>,
+    max_depth: u32,
+) -> DbResult<HashMap<String, u32>> {
+    let mut visited: HashMap<String, u32> = HashMap::new();
+    let mut queue: VecDeque<(String, u32)> = VecDeque::new();
+
+    for id in seed_ids {
+        visited.insert(id.clone(), 0);
+        queue.push_back((id.clone(), 0));
+    }
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT ce.from_symbol_id, ce.to_symbol_id, ce.target_name
+        FROM call_edges ce
+        INNER JOIN symbols s ON ce.from_symbol_id = s.id
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
+        WHERE (ce.to_symbol_id = ? OR ce.target_name = ? COLLATE NOCASE)
+        "#,
+    )?;
+
+    while let Some((current_id, depth)) = queue.pop_front() {
+        if depth >= max_depth {
+            continue;
+        }
+
+        let current_name = symbol_map
+            .get(&current_id)
+            .map(|s| s.name.clone())
+            .unwrap_or_default();
+        if current_name.is_empty() {
+            continue;
+        }
+
+        let edges: Vec<(String, Option<String>, String)> = stmt
+            .query_map(params![branch, &current_id, &current_name], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        for (from_symbol_id, to_symbol_id, target_name) in edges {
+            let is_match = if let Some(ref tid) = to_symbol_id {
+                tid == &current_id
+            } else {
+                let candidates = name_map.get(&target_name.to_lowercase());
+                if let Some(cands) = candidates {
+                    cands.len() == 1 && cands[0] == current_id
+                } else {
+                    false
+                }
+            };
+
+            if is_match && !visited.contains_key(&from_symbol_id) {
+                visited.insert(from_symbol_id.clone(), depth + 1);
+                queue.push_back((from_symbol_id, depth + 1));
+            }
+        }
+    }
+
+    Ok(visited)
+}
+
+pub fn detect_communities(
+    conn: &Connection,
+    branch: &str,
+    symbol_ids: Option<&[String]>,
+) -> DbResult<Vec<CommunityAssignment>> {
+    let symbols = db::get_symbols_for_branch(conn, branch)?;
+    if symbols.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let symbol_map: HashMap<String, SymbolRow> =
+        symbols.iter().map(|s| (s.id.clone(), s.clone())).collect();
+    let mut name_map: HashMap<String, Vec<String>> = HashMap::new();
+    for s in &symbols {
+        name_map
+            .entry(s.name.to_lowercase())
+            .or_default()
+            .push(s.id.clone());
+    }
+
+    // Build adjacency list from branch-scoped edges
+    let mut adjacency: HashMap<String, HashSet<String>> = HashMap::new();
+    for s in &symbols {
+        adjacency.insert(s.id.clone(), HashSet::new());
+    }
+
+    let mut edges_stmt = conn.prepare(
+        r#"
+        SELECT ce.from_symbol_id, ce.target_name, ce.to_symbol_id
+        FROM call_edges ce
+        INNER JOIN branch_symbols bs ON ce.from_symbol_id = bs.symbol_id AND bs.branch = ?
+        "#,
+    )?;
+
+    let edge_rows: Vec<(String, String, Option<String>)> = edges_stmt
+        .query_map(params![branch], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    for (from_id, target_name, to_symbol_id) in edge_rows {
+        let resolved = if let Some(ref tid) = to_symbol_id {
+            if symbol_map.contains_key(tid) {
+                Some(tid.clone())
+            } else {
+                None
+            }
+        } else {
+            let candidates = name_map.get(&target_name.to_lowercase());
+            if let Some(cands) = candidates {
+                if cands.len() == 1 {
+                    Some(cands[0].clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some(to_id) = resolved {
+            if to_id != from_id {
+                adjacency
+                    .entry(from_id.clone())
+                    .or_default()
+                    .insert(to_id.clone());
+                adjacency.entry(to_id).or_default().insert(from_id.clone());
+            }
+        }
+    }
+
+    // Determine the set of symbols to process
+    let active_ids: HashSet<String> = if let Some(ids) = symbol_ids {
+        let seed: HashSet<String> = ids.iter().cloned().collect();
+        let mut component = HashSet::new();
+        let mut stack: Vec<String> = seed.iter().cloned().collect();
+        while let Some(node) = stack.pop() {
+            if !component.contains(&node) && adjacency.contains_key(&node) {
+                component.insert(node.clone());
+                for neighbor in &adjacency[&node] {
+                    if !component.contains(neighbor) {
+                        stack.push(neighbor.clone());
+                    }
+                }
+            }
+        }
+        component
+    } else {
+        symbol_map.keys().cloned().collect()
+    };
+
+    if active_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // Label propagation
+    let mut labels: HashMap<String, String> = HashMap::new();
+    for id in &active_ids {
+        labels.insert(id.clone(), id.clone());
+    }
+
+    let mut degrees: HashMap<String, usize> = HashMap::new();
+    for id in &active_ids {
+        let deg = adjacency.get(id).map(|s| s.len()).unwrap_or(0);
+        degrees.insert(id.clone(), deg);
+    }
+
+    // Deterministic seed ordering by degree-descending, then symbol_id ascending
+    let mut order: Vec<String> = active_ids.iter().cloned().collect();
+    order.sort_by(|a, b| {
+        let da = degrees.get(a).unwrap_or(&0);
+        let db = degrees.get(b).unwrap_or(&0);
+        db.cmp(da).then_with(|| a.cmp(b))
+    });
+
+    for _ in 0..50 {
+        let mut changed = false;
+        for id in &order {
+            let neighbors = adjacency.get(id).cloned().unwrap_or_default();
+            let active_neighbors: Vec<&String> = neighbors
+                .iter()
+                .filter(|n| active_ids.contains(*n))
+                .collect();
+            if active_neighbors.is_empty() {
+                continue;
+            }
+
+            let mut label_counts: HashMap<String, usize> = HashMap::new();
+            for n in &active_neighbors {
+                let lbl = labels.get(*n).cloned().unwrap_or_else(|| (*n).clone());
+                *label_counts.entry(lbl).or_insert(0) += 1;
+            }
+
+            let mut best_label: Option<String> = None;
+            let mut best_count: usize = 0;
+            for (lbl, cnt) in label_counts {
+                if cnt > best_count
+                    || (cnt == best_count && lbl < best_label.clone().unwrap_or_default())
+                {
+                    best_count = cnt;
+                    best_label = Some(lbl);
+                }
+            }
+
+            if let Some(new_label) = best_label {
+                let current = labels.get(id).cloned().unwrap_or_else(|| id.clone());
+                if new_label != current {
+                    labels.insert(id.clone(), new_label);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Group by community label
+    let mut communities: HashMap<String, Vec<String>> = HashMap::new();
+    for id in &active_ids {
+        let lbl = labels.get(id).cloned().unwrap_or_else(|| id.clone());
+        communities.entry(lbl).or_default().push(id.clone());
+    }
+
+    let mut results = Vec::new();
+    let mut community_id = 0u32;
+    for (label, members) in communities {
+        community_id += 1;
+
+        // Find highest-degree symbol in community
+        let mut best_member: Option<&String> = None;
+        let mut best_deg: usize = 0;
+        for m in &members {
+            let deg = degrees.get(m).unwrap_or(&0);
+            if best_member.is_none() || *deg > best_deg {
+                best_deg = *deg;
+                best_member = Some(m);
+            }
+        }
+        let community_label = best_member
+            .and_then(|m| symbol_map.get(m))
+            .map(|s| s.name.clone())
+            .unwrap_or_else(|| label.clone());
+
+        for m in &members {
+            if let Some(sym) = symbol_map.get(m) {
+                results.push(CommunityAssignment {
+                    symbol_id: sym.id.clone(),
+                    symbol_name: sym.name.clone(),
+                    file_path: sym.file_path.clone(),
+                    community_id,
+                    community_label: community_label.clone(),
+                });
+            }
+        }
+    }
+
+    // Sort for determinism: by symbol_id
+    results.sort_by(|a, b| a.symbol_id.cmp(&b.symbol_id));
+    Ok(results)
+}
+
+pub fn compute_centrality(conn: &Connection, branch: &str) -> DbResult<Vec<CentralityScore>> {
+    let symbols = db::get_symbols_for_branch(conn, branch)?;
+    if symbols.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let symbol_map: HashMap<String, SymbolRow> =
+        symbols.iter().map(|s| (s.id.clone(), s.clone())).collect();
+    let mut name_map: HashMap<String, Vec<String>> = HashMap::new();
+    for s in &symbols {
+        name_map
+            .entry(s.name.to_lowercase())
+            .or_default()
+            .push(s.id.clone());
+    }
+
+    let mut caller_counts: HashMap<String, u32> = HashMap::new();
+    let mut callee_counts: HashMap<String, u32> = HashMap::new();
+
+    for s in &symbols {
+        caller_counts.insert(s.id.clone(), 0);
+        callee_counts.insert(s.id.clone(), 0);
+    }
+
+    let mut edges_stmt = conn.prepare(
+        r#"
+        SELECT ce.from_symbol_id, ce.target_name, ce.to_symbol_id
+        FROM call_edges ce
+        INNER JOIN branch_symbols bs ON ce.from_symbol_id = bs.symbol_id AND bs.branch = ?
+        "#,
+    )?;
+
+    let edge_rows: Vec<(String, String, Option<String>)> = edges_stmt
+        .query_map(params![branch], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    for (from_id, target_name, to_symbol_id) in edge_rows {
+        *callee_counts.entry(from_id.clone()).or_insert(0) += 1;
+
+        let resolved = if let Some(ref tid) = to_symbol_id {
+            if symbol_map.contains_key(tid) {
+                Some(tid.clone())
+            } else {
+                None
+            }
+        } else {
+            let candidates = name_map.get(&target_name.to_lowercase());
+            if let Some(cands) = candidates {
+                if cands.len() == 1 {
+                    Some(cands[0].clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some(to_id) = resolved {
+            *caller_counts.entry(to_id).or_insert(0) += 1;
+        }
+    }
+
+    let mut results: Vec<CentralityScore> = symbols
+        .iter()
+        .map(|s| {
+            let cc = *caller_counts.get(&s.id).unwrap_or(&0);
+            let ec = *callee_counts.get(&s.id).unwrap_or(&0);
+            CentralityScore {
+                symbol_id: s.id.clone(),
+                symbol_name: s.name.clone(),
+                file_path: s.file_path.clone(),
+                caller_count: cc,
+                callee_count: ec,
+                total_connections: cc + ec,
+            }
+        })
+        .collect();
+
+    // Sort by caller_count descending, then symbol_id ascending for determinism
+    results.sort_by(|a, b| {
+        b.caller_count
+            .cmp(&a.caller_count)
+            .then_with(|| a.symbol_id.cmp(&b.symbol_id))
+    });
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::CallEdgeRow;
+    use tempfile::TempDir;
+
+    fn setup_test_db() -> (TempDir, Connection) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let conn = db::init_db(&db_path).unwrap();
+        (temp_dir, conn)
+    }
+
+    fn make_symbol(id: &str, name: &str, file_path: &str) -> SymbolRow {
+        SymbolRow {
+            id: id.to_string(),
+            file_path: file_path.to_string(),
+            name: name.to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 10,
+            end_col: 1,
+            language: "typescript".to_string(),
+        }
+    }
+
+    fn make_edge(id: &str, from: &str, target_name: &str, to: Option<&str>) -> CallEdgeRow {
+        CallEdgeRow {
+            id: id.to_string(),
+            from_symbol_id: from.to_string(),
+            target_name: target_name.to_string(),
+            to_symbol_id: to.map(|s| s.to_string()),
+            call_type: "Call".to_string(),
+            confidence: "Direct".to_string(),
+            line: 1,
+            col: 0,
+            is_resolved: to.is_some(),
+        }
+    }
+
+    #[test]
+    fn test_reachability_callees_chain() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &["s_a".to_string(), "s_b".to_string(), "s_c".to_string()],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")),
+            make_edge("e2", "s_b", "C", Some("s_c")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results =
+            get_transitive_reachability(&conn, &["s_a".to_string()], "main", "callees", 5).unwrap();
+        let map: HashMap<String, u32> = results
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert_eq!(map.get("s_b"), Some(&1));
+        assert_eq!(map.get("s_c"), Some(&2));
+        assert!(map.get("s_a").is_none()); // root excluded
+    }
+
+    #[test]
+    fn test_reachability_callers_chain() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &["s_a".to_string(), "s_b".to_string(), "s_c".to_string()],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")),
+            make_edge("e2", "s_b", "C", Some("s_c")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results =
+            get_transitive_reachability(&conn, &["s_c".to_string()], "main", "callers", 5).unwrap();
+        let map: HashMap<String, u32> = results
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert_eq!(map.get("s_b"), Some(&1));
+        assert_eq!(map.get("s_a"), Some(&2));
+        assert!(map.get("s_c").is_none()); // root excluded
+    }
+
+    #[test]
+    fn test_reachability_depth_cap() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+            make_symbol("s_d", "D", "src/d.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &[
+                "s_a".to_string(),
+                "s_b".to_string(),
+                "s_c".to_string(),
+                "s_d".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")),
+            make_edge("e2", "s_b", "C", Some("s_c")),
+            make_edge("e3", "s_c", "D", Some("s_d")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results =
+            get_transitive_reachability(&conn, &["s_a".to_string()], "main", "callees", 2).unwrap();
+        let map: HashMap<String, u32> = results
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert_eq!(map.get("s_b"), Some(&1));
+        assert_eq!(map.get("s_c"), Some(&2));
+        assert!(map.get("s_d").is_none()); // depth 3 capped
+    }
+
+    #[test]
+    fn test_reachability_unresolved_edge() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(&conn, "main", &["s_a".to_string(), "s_b".to_string()]).unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", None), // unresolved
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results =
+            get_transitive_reachability(&conn, &["s_a".to_string()], "main", "callees", 5).unwrap();
+        let map: HashMap<String, u32> = results
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert_eq!(map.get("s_b"), Some(&1));
+    }
+
+    #[test]
+    fn test_reachability_multiple_roots() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &["s_a".to_string(), "s_b".to_string(), "s_c".to_string()],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "C", Some("s_c")),
+            make_edge("e2", "s_b", "C", Some("s_c")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results = get_transitive_reachability(
+            &conn,
+            &["s_a".to_string(), "s_b".to_string()],
+            "main",
+            "callees",
+            5,
+        )
+        .unwrap();
+        let map: HashMap<String, u32> = results
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert_eq!(map.get("s_c"), Some(&1));
+    }
+
+    #[test]
+    fn test_reachability_both_directions() {
+        // Graph: A -> B -> C (callees chain), also D -> A and E -> C (callers)
+        // Root: A
+        // callers: D (depth 1)
+        // callees: B (depth 1), C (depth 2)
+        // both: D (depth 1), B (depth 1), C (depth 2)
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+            make_symbol("s_d", "D", "src/d.ts"),
+            make_symbol("s_e", "E", "src/e.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &[
+                "s_a".to_string(),
+                "s_b".to_string(),
+                "s_c".to_string(),
+                "s_d".to_string(),
+                "s_e".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")), // A calls B
+            make_edge("e2", "s_b", "C", Some("s_c")), // B calls C (transitive callee of A)
+            make_edge("e3", "s_d", "A", Some("s_a")), // D calls A (caller of A)
+            make_edge("e4", "s_e", "C", Some("s_c")), // E calls C (caller of C, but not A directly)
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        // callers: should find D at depth 1, E at depth 1 (via A->B->C, E calls C)
+        let callers =
+            get_transitive_reachability(&conn, &["s_a".to_string()], "main", "callers", 5).unwrap();
+        let callers_map: HashMap<String, u32> = callers
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert!(callers_map.contains_key("s_d")); // D calls A directly
+                                                  // E calls C which is a callee of A, not a caller of A — E should NOT appear as caller of A
+
+        // callees: should find B at depth 1, C at depth 2
+        let callees =
+            get_transitive_reachability(&conn, &["s_a".to_string()], "main", "callees", 5).unwrap();
+        let callees_map: HashMap<String, u32> = callees
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert_eq!(callees_map.get("s_b"), Some(&1));
+        assert_eq!(callees_map.get("s_c"), Some(&2));
+        assert!(!callees_map.contains_key("s_d")); // D is a caller, not callee
+
+        // both: should contain union of callers and callees
+        let both =
+            get_transitive_reachability(&conn, &["s_a".to_string()], "main", "both", 5).unwrap();
+        let both_map: HashMap<String, u32> = both
+            .iter()
+            .map(|r| (r.symbol_id.clone(), r.depth))
+            .collect();
+        assert!(both_map.contains_key("s_b")); // callee
+        assert!(both_map.contains_key("s_c")); // transitive callee
+        assert!(both_map.contains_key("s_d")); // caller
+                                               // Min depth for B should be 1 (reached via callees)
+        assert_eq!(both_map.get("s_b"), Some(&1));
+    }
+
+    #[test]
+    fn test_communities_disconnected() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+            make_symbol("s_d", "D", "src/d.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &[
+                "s_a".to_string(),
+                "s_b".to_string(),
+                "s_c".to_string(),
+                "s_d".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")),
+            make_edge("e2", "s_c", "D", Some("s_d")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results = detect_communities(&conn, "main", None).unwrap();
+        assert_eq!(results.len(), 4);
+
+        let communities: HashSet<u32> = results.iter().map(|r| r.community_id).collect();
+        assert_eq!(communities.len(), 2);
+
+        // Each pair should share a community
+        let a_comm = results
+            .iter()
+            .find(|r| r.symbol_id == "s_a")
+            .unwrap()
+            .community_id;
+        let b_comm = results
+            .iter()
+            .find(|r| r.symbol_id == "s_b")
+            .unwrap()
+            .community_id;
+        assert_eq!(a_comm, b_comm);
+
+        let c_comm = results
+            .iter()
+            .find(|r| r.symbol_id == "s_c")
+            .unwrap()
+            .community_id;
+        let d_comm = results
+            .iter()
+            .find(|r| r.symbol_id == "s_d")
+            .unwrap()
+            .community_id;
+        assert_eq!(c_comm, d_comm);
+        assert_ne!(a_comm, c_comm);
+    }
+
+    #[test]
+    fn test_communities_triangle() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &["s_a".to_string(), "s_b".to_string(), "s_c".to_string()],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")),
+            make_edge("e2", "s_b", "C", Some("s_c")),
+            make_edge("e3", "s_c", "A", Some("s_a")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results = detect_communities(&conn, "main", None).unwrap();
+        let communities: HashSet<u32> = results.iter().map(|r| r.community_id).collect();
+        assert_eq!(communities.len(), 1);
+    }
+
+    #[test]
+    fn test_communities_single_node() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![make_symbol("s_a", "A", "src/a.ts")];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(&conn, "main", &["s_a".to_string()]).unwrap();
+
+        let results = detect_communities(&conn, "main", None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].symbol_id, "s_a");
+        assert_eq!(results[0].community_label, "A");
+    }
+
+    #[test]
+    fn test_communities_filtered_component() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_a", "A", "src/a.ts"),
+            make_symbol("s_b", "B", "src/b.ts"),
+            make_symbol("s_c", "C", "src/c.ts"),
+            make_symbol("s_d", "D", "src/d.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &[
+                "s_a".to_string(),
+                "s_b".to_string(),
+                "s_c".to_string(),
+                "s_d".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_a", "B", Some("s_b")),
+            make_edge("e2", "s_c", "D", Some("s_d")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results =
+            detect_communities(&conn, "main", Some(&["s_a".to_string(), "s_b".to_string()]))
+                .unwrap();
+        assert_eq!(results.len(), 2);
+        let comm_a = results
+            .iter()
+            .find(|r| r.symbol_id == "s_a")
+            .unwrap()
+            .community_id;
+        let comm_b = results
+            .iter()
+            .find(|r| r.symbol_id == "s_b")
+            .unwrap()
+            .community_id;
+        assert_eq!(comm_a, comm_b);
+    }
+
+    #[test]
+    fn test_centrality_star_graph() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![
+            make_symbol("s_center", "Center", "src/center.ts"),
+            make_symbol("s_l1", "Leaf1", "src/leaf1.ts"),
+            make_symbol("s_l2", "Leaf2", "src/leaf2.ts"),
+            make_symbol("s_l3", "Leaf3", "src/leaf3.ts"),
+        ];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(
+            &conn,
+            "main",
+            &[
+                "s_center".to_string(),
+                "s_l1".to_string(),
+                "s_l2".to_string(),
+                "s_l3".to_string(),
+            ],
+        )
+        .unwrap();
+
+        let edges = vec![
+            make_edge("e1", "s_center", "Leaf1", Some("s_l1")),
+            make_edge("e2", "s_center", "Leaf2", Some("s_l2")),
+            make_edge("e3", "s_center", "Leaf3", Some("s_l3")),
+            make_edge("e4", "s_l1", "Center", Some("s_center")),
+            make_edge("e5", "s_l2", "Center", Some("s_center")),
+            make_edge("e6", "s_l3", "Center", Some("s_center")),
+        ];
+        db::upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let results = compute_centrality(&conn, "main").unwrap();
+        let center = results.iter().find(|r| r.symbol_id == "s_center").unwrap();
+        assert_eq!(center.caller_count, 3);
+        assert_eq!(center.callee_count, 3);
+        assert_eq!(center.total_connections, 6);
+
+        let leaf = results.iter().find(|r| r.symbol_id == "s_l1").unwrap();
+        assert_eq!(leaf.caller_count, 1);
+        assert_eq!(leaf.callee_count, 1);
+        assert_eq!(leaf.total_connections, 2);
+
+        // Center should be first (sorted by caller_count desc)
+        assert_eq!(results[0].symbol_id, "s_center");
+    }
+
+    #[test]
+    fn test_centrality_isolated_node() {
+        let (_temp, mut conn) = setup_test_db();
+        let syms = vec![make_symbol("s_a", "A", "src/a.ts")];
+        db::upsert_symbols_batch(&mut conn, &syms).unwrap();
+        db::add_symbols_to_branch(&conn, "main", &["s_a".to_string()]).unwrap();
+
+        let results = compute_centrality(&conn, "main").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].caller_count, 0);
+        assert_eq!(results[0].callee_count, 0);
+        assert_eq!(results[0].total_connections, 0);
+    }
+}

--- a/native/src/community.rs
+++ b/native/src/community.rs
@@ -70,7 +70,7 @@ pub fn get_transitive_reachability(
             let callees = bfs_callees(conn, branch, &seed_refs, &symbol_map, &name_map, max_depth)?;
             let callers = bfs_callers(conn, branch, &seed_refs, &symbol_map, &name_map, max_depth)?;
             let mut merged: HashMap<String, u32> = HashMap::new();
-            for (id, depth) in callees.into_iter().chain(callers.into_iter()) {
+            for (id, depth) in callees.into_iter().chain(callers) {
                 merged
                     .entry(id)
                     .and_modify(|d| *d = (*d).min(depth))
@@ -415,9 +415,8 @@ pub fn detect_communities(
     }
 
     let mut results = Vec::new();
-    let mut community_id = 0u32;
-    for (label, members) in communities {
-        community_id += 1;
+    for (idx, (label, members)) in communities.into_iter().enumerate() {
+        let community_id = idx as u32;
 
         // Find highest-degree symbol in community
         let mut best_member: Option<&String> = None;
@@ -619,7 +618,7 @@ mod tests {
             .collect();
         assert_eq!(map.get("s_b"), Some(&1));
         assert_eq!(map.get("s_c"), Some(&2));
-        assert!(map.get("s_a").is_none()); // root excluded
+        assert!(!map.contains_key("s_a")); // root excluded
     }
 
     #[test]
@@ -652,7 +651,7 @@ mod tests {
             .collect();
         assert_eq!(map.get("s_b"), Some(&1));
         assert_eq!(map.get("s_a"), Some(&2));
-        assert!(map.get("s_c").is_none()); // root excluded
+        assert!(!map.contains_key("s_c")); // root excluded
     }
 
     #[test]
@@ -692,7 +691,7 @@ mod tests {
             .collect();
         assert_eq!(map.get("s_b"), Some(&1));
         assert_eq!(map.get("s_c"), Some(&2));
-        assert!(map.get("s_d").is_none()); // depth 3 capped
+        assert!(!map.contains_key("s_d")); // depth 3 capped
     }
 
     #[test]

--- a/native/src/community.rs
+++ b/native/src/community.rs
@@ -415,7 +415,9 @@ pub fn detect_communities(
     }
 
     let mut results = Vec::new();
-    for (idx, (label, members)) in communities.into_iter().enumerate() {
+    let mut sorted_communities: Vec<(String, Vec<String>)> = communities.into_iter().collect();
+    sorted_communities.sort_by(|a, b| a.0.cmp(&b.0));
+    for (idx, (label, members)) in sorted_communities.into_iter().enumerate() {
         let community_id = idx as u32;
 
         // Find highest-degree symbol in community

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -1041,6 +1041,91 @@ pub fn get_symbols_by_name_ci(conn: &Connection, name: &str) -> DbResult<Vec<Sym
     Ok(results)
 }
 
+/// Get all symbols for a branch
+pub fn get_symbols_for_branch(conn: &Connection, branch: &str) -> DbResult<Vec<SymbolRow>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT s.id, s.file_path, s.name, s.kind, s.start_line, s.start_col, s.end_line, s.end_col, s.language
+        FROM symbols s
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id
+        WHERE bs.branch = ?
+        ORDER BY s.start_line
+        "#,
+    )?;
+
+    let rows = stmt.query_map(params![branch], |row| {
+        Ok(SymbolRow {
+            id: row.get(0)?,
+            file_path: row.get(1)?,
+            name: row.get(2)?,
+            kind: row.get(3)?,
+            start_line: row.get(4)?,
+            start_col: row.get(5)?,
+            end_line: row.get(6)?,
+            end_col: row.get(7)?,
+            language: row.get(8)?,
+        })
+    })?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        results.push(row?);
+    }
+    Ok(results)
+}
+
+/// Get symbols for specific files on a branch
+pub fn get_symbols_for_files(
+    conn: &Connection,
+    file_paths: &[String],
+    branch: &str,
+) -> DbResult<Vec<SymbolRow>> {
+    if file_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::new();
+    for chunk in file_paths.chunks(SQL_BIND_PARAM_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            r#"
+            SELECT s.id, s.file_path, s.name, s.kind, s.start_line, s.start_col, s.end_line, s.end_col, s.language
+            FROM symbols s
+            INNER JOIN branch_symbols bs ON s.id = bs.symbol_id
+            WHERE bs.branch = ? AND s.file_path IN ({})
+            ORDER BY s.start_line
+            "#,
+            placeholders
+        );
+        let params = rusqlite::params_from_iter(
+            std::iter::once(branch).chain(chunk.iter().map(|s| s.as_str())),
+        );
+
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params, |row| {
+            Ok(SymbolRow {
+                id: row.get(0)?,
+                file_path: row.get(1)?,
+                name: row.get(2)?,
+                kind: row.get(3)?,
+                start_line: row.get(4)?,
+                start_col: row.get(5)?,
+                end_line: row.get(6)?,
+                end_col: row.get(7)?,
+                language: row.get(8)?,
+            })
+        })?;
+
+        for row in rows {
+            results.push(row?);
+        }
+    }
+
+    Ok(results)
+}
+
 /// Delete all symbols for a file
 pub fn delete_symbols_by_file(conn: &Connection, file_path: &str) -> DbResult<usize> {
     let count = conn.execute(
@@ -2614,5 +2699,222 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 0);
+    }
+    #[test]
+    fn test_get_symbols_for_branch_empty() {
+        let (_temp_dir, conn) = setup_test_db();
+        let result = get_symbols_for_branch(&conn, "main").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_get_symbols_for_branch_populated() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        let sym1 = SymbolRow {
+            id: "s1".to_string(),
+            file_path: "src/a.ts".to_string(),
+            name: "funcA".to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 5,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        let sym2 = SymbolRow {
+            id: "s2".to_string(),
+            file_path: "src/b.ts".to_string(),
+            name: "funcB".to_string(),
+            kind: "function".to_string(),
+            start_line: 10,
+            start_col: 0,
+            end_line: 15,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        upsert_symbol(&conn, &sym1).unwrap();
+        upsert_symbol(&conn, &sym2).unwrap();
+        add_symbols_to_branch(&conn, "main", &["s1".to_string(), "s2".to_string()]).unwrap();
+
+        let result = get_symbols_for_branch(&conn, "main").unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, "s1");
+        assert_eq!(result[1].id, "s2");
+    }
+
+    #[test]
+    fn test_get_symbols_for_branch_isolation() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        let sym1 = SymbolRow {
+            id: "s1".to_string(),
+            file_path: "src/a.ts".to_string(),
+            name: "funcA".to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 5,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        let sym2 = SymbolRow {
+            id: "s2".to_string(),
+            file_path: "src/b.ts".to_string(),
+            name: "funcB".to_string(),
+            kind: "function".to_string(),
+            start_line: 10,
+            start_col: 0,
+            end_line: 15,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        upsert_symbol(&conn, &sym1).unwrap();
+        upsert_symbol(&conn, &sym2).unwrap();
+        add_symbols_to_branch(&conn, "main", &["s1".to_string()]).unwrap();
+        add_symbols_to_branch(&conn, "feature", &["s2".to_string()]).unwrap();
+
+        let main_result = get_symbols_for_branch(&conn, "main").unwrap();
+        assert_eq!(main_result.len(), 1);
+        assert_eq!(main_result[0].id, "s1");
+
+        let feature_result = get_symbols_for_branch(&conn, "feature").unwrap();
+        assert_eq!(feature_result.len(), 1);
+        assert_eq!(feature_result[0].id, "s2");
+    }
+
+    #[test]
+    fn test_get_symbols_for_files_empty() {
+        let (_temp_dir, conn) = setup_test_db();
+        let result = get_symbols_for_files(&conn, &[], "main").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_get_symbols_for_files_single() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        let sym1 = SymbolRow {
+            id: "s1".to_string(),
+            file_path: "src/a.ts".to_string(),
+            name: "funcA".to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 5,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        let sym2 = SymbolRow {
+            id: "s2".to_string(),
+            file_path: "src/b.ts".to_string(),
+            name: "funcB".to_string(),
+            kind: "function".to_string(),
+            start_line: 10,
+            start_col: 0,
+            end_line: 15,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        upsert_symbol(&conn, &sym1).unwrap();
+        upsert_symbol(&conn, &sym2).unwrap();
+        add_symbols_to_branch(&conn, "main", &["s1".to_string(), "s2".to_string()]).unwrap();
+
+        let result = get_symbols_for_files(&conn, &["src/a.ts".to_string()], "main").unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "s1");
+    }
+
+    #[test]
+    fn test_get_symbols_for_files_multiple() {
+        let (_temp_dir, conn) = setup_test_db();
+
+        let sym1 = SymbolRow {
+            id: "s1".to_string(),
+            file_path: "src/a.ts".to_string(),
+            name: "funcA".to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 5,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        let sym2 = SymbolRow {
+            id: "s2".to_string(),
+            file_path: "src/b.ts".to_string(),
+            name: "funcB".to_string(),
+            kind: "function".to_string(),
+            start_line: 10,
+            start_col: 0,
+            end_line: 15,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        let sym3 = SymbolRow {
+            id: "s3".to_string(),
+            file_path: "src/c.ts".to_string(),
+            name: "funcC".to_string(),
+            kind: "function".to_string(),
+            start_line: 20,
+            start_col: 0,
+            end_line: 25,
+            end_col: 1,
+            language: "typescript".to_string(),
+        };
+        upsert_symbol(&conn, &sym1).unwrap();
+        upsert_symbol(&conn, &sym2).unwrap();
+        upsert_symbol(&conn, &sym3).unwrap();
+        add_symbols_to_branch(
+            &conn,
+            "main",
+            &["s1".to_string(), "s2".to_string(), "s3".to_string()],
+        )
+        .unwrap();
+
+        let result = get_symbols_for_files(
+            &conn,
+            &["src/a.ts".to_string(), "src/b.ts".to_string()],
+            "main",
+        )
+        .unwrap();
+        assert_eq!(result.len(), 2);
+        let ids: Vec<String> = result.into_iter().map(|r| r.id).collect();
+        assert!(ids.contains(&"s1".to_string()));
+        assert!(ids.contains(&"s2".to_string()));
+    }
+
+    #[test]
+    fn test_get_symbols_for_files_batch_chunking() {
+        let (_temp_dir, mut conn) = setup_test_db();
+
+        let mut symbols = Vec::new();
+        let mut file_paths = Vec::new();
+        let mut symbol_ids = Vec::new();
+
+        for i in 0..1000 {
+            let id = format!("s{}", i);
+            let file_path = format!("src/f{}.ts", i);
+            let sym = SymbolRow {
+                id: id.clone(),
+                file_path: file_path.clone(),
+                name: format!("func{}", i),
+                kind: "function".to_string(),
+                start_line: i as u32,
+                start_col: 0,
+                end_line: i as u32 + 1,
+                end_col: 10,
+                language: "typescript".to_string(),
+            };
+            symbols.push(sym);
+            file_paths.push(file_path);
+            symbol_ids.push(id);
+        }
+
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+        add_symbols_to_branch(&conn, "main", &symbol_ids).unwrap();
+
+        let result = get_symbols_for_files(&conn, &file_paths, "main").unwrap();
+        assert_eq!(result.len(), 1000);
     }
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod call_extractor;
 mod chunker;
+mod community;
 mod db;
 mod hasher;
 mod inverted_index;
@@ -252,6 +253,33 @@ pub struct PathHopData {
     pub file_path: String,
     pub line: u32,
     pub call_type: String,
+}
+
+#[napi(object)]
+pub struct ReachabilityData {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub file_path: String,
+    pub depth: u32,
+}
+
+#[napi(object)]
+pub struct CommunityData {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub file_path: String,
+    pub community_id: u32,
+    pub community_label: String,
+}
+
+#[napi(object)]
+pub struct CentralityData {
+    pub symbol_id: String,
+    pub symbol_name: String,
+    pub file_path: String,
+    pub caller_count: u32,
+    pub callee_count: u32,
+    pub total_connections: u32,
 }
 
 #[napi(object)]
@@ -910,6 +938,53 @@ impl Database {
                 .collect())
         })
     }
+    #[napi]
+    pub fn get_symbols_for_branch(&self, branch: String) -> Result<Vec<SymbolData>> {
+        self.with_conn(|conn| {
+            let rows = db::get_symbols_for_branch(conn, &branch)
+                .map_err(|e| Error::from_reason(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|r| SymbolData {
+                    id: r.id,
+                    file_path: r.file_path,
+                    name: r.name,
+                    kind: r.kind,
+                    start_line: r.start_line,
+                    start_col: r.start_col,
+                    end_line: r.end_line,
+                    end_col: r.end_col,
+                    language: r.language,
+                })
+                .collect())
+        })
+    }
+
+    #[napi]
+    pub fn get_symbols_for_files(
+        &self,
+        file_paths: Vec<String>,
+        branch: String,
+    ) -> Result<Vec<SymbolData>> {
+        self.with_conn(|conn| {
+            let rows = db::get_symbols_for_files(conn, &file_paths, &branch)
+                .map_err(|e| Error::from_reason(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|r| SymbolData {
+                    id: r.id,
+                    file_path: r.file_path,
+                    name: r.name,
+                    kind: r.kind,
+                    start_line: r.start_line,
+                    start_col: r.start_col,
+                    end_line: r.end_line,
+                    end_col: r.end_col,
+                    language: r.language,
+                })
+                .collect())
+        })
+    }
 
     #[napi]
     pub fn delete_symbols_by_file(&self, file_path: String) -> Result<u32> {
@@ -1180,6 +1255,77 @@ impl Database {
             let count =
                 db::gc_orphan_call_edges(conn).map_err(|e| Error::from_reason(e.to_string()))?;
             Ok(count as u32)
+        })
+    }
+
+    #[napi]
+    pub fn get_transitive_reachability(
+        &self,
+        root_symbol_ids: Vec<String>,
+        branch: String,
+        direction: String,
+        max_depth: Option<u32>,
+    ) -> Result<Vec<ReachabilityData>> {
+        self.with_conn(|conn| {
+            let depth = max_depth.unwrap_or(10);
+            let rows = community::get_transitive_reachability(
+                conn,
+                &root_symbol_ids,
+                &branch,
+                &direction,
+                depth,
+            )
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|r| ReachabilityData {
+                    symbol_id: r.symbol_id,
+                    symbol_name: r.symbol_name,
+                    file_path: r.file_path,
+                    depth: r.depth,
+                })
+                .collect())
+        })
+    }
+
+    #[napi]
+    pub fn detect_communities(
+        &self,
+        branch: String,
+        symbol_ids: Option<Vec<String>>,
+    ) -> Result<Vec<CommunityData>> {
+        self.with_conn(|conn| {
+            let rows = community::detect_communities(conn, &branch, symbol_ids.as_deref())
+                .map_err(|e| Error::from_reason(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|r| CommunityData {
+                    symbol_id: r.symbol_id,
+                    symbol_name: r.symbol_name,
+                    file_path: r.file_path,
+                    community_id: r.community_id,
+                    community_label: r.community_label,
+                })
+                .collect())
+        })
+    }
+
+    #[napi]
+    pub fn compute_centrality(&self, branch: String) -> Result<Vec<CentralityData>> {
+        self.with_conn(|conn| {
+            let rows = community::compute_centrality(conn, &branch)
+                .map_err(|e| Error::from_reason(e.to_string()))?;
+            Ok(rows
+                .into_iter()
+                .map(|r| CentralityData {
+                    symbol_id: r.symbol_id,
+                    symbol_name: r.symbol_name,
+                    file_path: r.file_path,
+                    caller_count: r.caller_count,
+                    callee_count: r.callee_count,
+                    total_connections: r.total_connections,
+                })
+                .collect())
         })
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   remove_knowledge_base,
   getIndexerForProject,
   initializeTools,
+  pr_impact,
 } from "./tools/index.js";
 import { loadCommandsFromDirectory } from "./commands/loader.js";
 import { RoutingHintController } from "./routing-hints.js";
@@ -135,6 +136,7 @@ const plugin: Plugin = async ({ directory, worktree }) => {
         add_knowledge_base,
         list_knowledge_bases,
         remove_knowledge_base,
+        pr_impact,
       },
 
       async "chat.message"(input, output) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4963,7 +4963,9 @@ export class Indexer {
       );
     }
 
-    const resolvedBranch = headRefName || opts.branch || this.currentBranch;
+    const resolvedBranch = opts.pr !== undefined
+      ? headRefName
+      : opts.branch || this.currentBranch;
     const branchKey = this.getBranchCatalogKeyFor(resolvedBranch || "default");
 
     const branchSymbols = database.getSymbolsForBranch(branchKey);

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5056,8 +5056,10 @@ export class Indexer {
         const currentCommunityLabels = new Set(communities.map((c) => c.label));
         const allCommunitiesData = database.detectCommunities(resolvedBranch);
         const symbolToCommunity = new Map<string, string>();
+        const structuralKey = (filePath: string, name: string): string =>
+          `${filePath.toLowerCase()}:${name.toLowerCase()}`;
         for (const c of allCommunitiesData) {
-          symbolToCommunity.set(c.symbolId, c.communityLabel);
+          symbolToCommunity.set(structuralKey(c.filePath, c.symbolName), c.communityLabel);
         }
 
         for (const openPr of openPRs) {
@@ -5073,7 +5075,7 @@ export class Indexer {
             const otherSymbols = database.getSymbolsForFiles(otherAbsolute, openPr.headRefName);
             const otherLabels = new Set<string>();
             for (const sym of otherSymbols) {
-              const label = symbolToCommunity.get(sym.id);
+              const label = symbolToCommunity.get(structuralKey(sym.filePath, sym.name));
               if (label) {
                 otherLabels.add(label);
               }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5036,7 +5036,7 @@ export class Indexer {
       try {
         const { stdout } = await execFileAsync(
           "gh",
-          ["pr", "list", "--state", "open", "--json", "number,headRefName"],
+          ["pr", "list", "--state", "open", "--json", "number,headRefName", "--limit", "10000"],
           { cwd: this.projectRoot, timeout: 30000 }
         );
         const openPRs = JSON.parse(stdout) as Array<{ number: number; headRefName: string }>;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4946,27 +4946,15 @@ export class Indexer {
       baseBranch: this.baseBranch,
     });
     const changedFiles = changedFilesResult.files;
+    const headRefName = changedFilesResult.headRefName;
 
-    let branch = opts.branch;
-    if (!branch && opts.pr !== undefined) {
-      try {
-        const { stdout } = await execFileAsync(
-          "gh",
-          ["pr", "view", String(opts.pr), "--json", "headRefName"],
-          { cwd: this.projectRoot, timeout: 30000 }
-        );
-        const data = JSON.parse(stdout) as { headRefName?: string };
-        if (data.headRefName) {
-          branch = data.headRefName;
-        }
-      } catch {
-        /* ignore gh failure */
-      }
+    if (opts.pr !== undefined && headRefName === undefined) {
+      throw new Error(
+        `Could not resolve head branch for PR #${opts.pr}. Run index_codebase on the PR branch first.`,
+      );
     }
-    if (!branch) {
-      branch = this.currentBranch;
-    }
-    const resolvedBranch = branch;
+
+    const resolvedBranch = headRefName || opts.branch || this.currentBranch;
 
     const branchSymbols = database.getSymbolsForBranch(resolvedBranch);
     if (branchSymbols.length === 0) {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5070,7 +5070,7 @@ export class Indexer {
               baseBranch: this.baseBranch,
             });
             const otherAbsolute = otherChanged.files.map((f) => path.resolve(this.projectRoot, f));
-            const otherSymbols = database.getSymbolsForFiles(otherAbsolute, resolvedBranch);
+            const otherSymbols = database.getSymbolsForFiles(otherAbsolute, openPr.headRefName);
             const otherLabels = new Set<string>();
             for (const sym of otherSymbols) {
               const label = symbolToCommunity.get(sym.id);
@@ -5117,6 +5117,7 @@ export class Indexer {
       riskLevel,
       riskReason,
       direction,
+      conflictingPRs,
     };
   }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fsPromises } from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import PQueue from "p-queue";
 import pRetry from "p-retry";
 
@@ -32,9 +34,11 @@ import {
   parseFileAsText,
   estimateTokens,
 } from "../native/index.js";
-import type { SymbolData, CallEdgeData, PathHopData } from "../native/index.js";
+import type { SymbolData, CallEdgeData, PathHopData, ReachabilityData, CommunityData, CentralityData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 import { resolveProjectIndexPath } from "../config/paths.js";
+import { getChangedFiles } from "../tools/changed-files.js";
+import type { PrImpactResult } from "./pr-impact-types.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab"]);
 // Languages whose identifiers are case-insensitive at the language level.
@@ -4887,6 +4891,233 @@ export class Indexer {
     }
 
     return shortest;
+  }
+
+
+  async getSymbolsForBranch(branch?: string): Promise<SymbolData[]> {
+    const { database } = await this.ensureInitialized();
+    const resolvedBranch = branch ?? this.getBranchCatalogKey();
+    return database.getSymbolsForBranch(resolvedBranch);
+  }
+
+  async getSymbolsForFiles(filePaths: string[], branch?: string): Promise<SymbolData[]> {
+    const { database } = await this.ensureInitialized();
+    const resolvedBranch = branch ?? this.getBranchCatalogKey();
+    return database.getSymbolsForFiles(filePaths, resolvedBranch);
+  }
+
+  async getTransitiveReachability(
+    rootSymbolIds: string[],
+    direction: "callers" | "callees",
+    maxDepth?: number
+  ): Promise<ReachabilityData[]> {
+    const { database } = await this.ensureInitialized();
+    const branch = this.getBranchCatalogKey();
+    return database.getTransitiveReachability(rootSymbolIds, branch, direction, maxDepth);
+  }
+
+  async detectCommunities(branch?: string, symbolIds?: string[]): Promise<CommunityData[]> {
+    const { database } = await this.ensureInitialized();
+    const resolvedBranch = branch ?? this.getBranchCatalogKey();
+    return database.detectCommunities(resolvedBranch, symbolIds);
+  }
+
+  async computeCentrality(branch?: string): Promise<CentralityData[]> {
+    const { database } = await this.ensureInitialized();
+    const resolvedBranch = branch ?? this.getBranchCatalogKey();
+    return database.computeCentrality(resolvedBranch);
+  }
+
+  async getPrImpact(opts: {
+    pr?: number;
+    branch?: string;
+    maxDepth?: number;
+    hubThreshold?: number;
+    checkConflicts?: boolean;
+    direction?: "callers" | "callees" | "both";
+  }): Promise<PrImpactResult> {
+    const { database } = await this.ensureInitialized();
+    const execFileAsync = promisify(execFile);
+
+    const changedFilesResult = await getChangedFiles({
+      pr: opts.pr,
+      branch: opts.branch,
+      projectRoot: this.projectRoot,
+      baseBranch: this.baseBranch,
+    });
+    const changedFiles = changedFilesResult.files;
+
+    let branch = opts.branch;
+    if (!branch && opts.pr !== undefined) {
+      try {
+        const { stdout } = await execFileAsync(
+          "gh",
+          ["pr", "view", String(opts.pr), "--json", "headRefName"],
+          { cwd: this.projectRoot, timeout: 30000 }
+        );
+        const data = JSON.parse(stdout) as { headRefName?: string };
+        if (data.headRefName) {
+          branch = data.headRefName;
+        }
+      } catch {
+        /* ignore gh failure */
+      }
+    }
+    if (!branch) {
+      branch = this.currentBranch;
+    }
+    const resolvedBranch = branch;
+
+    const branchSymbols = database.getSymbolsForBranch(resolvedBranch);
+    if (branchSymbols.length === 0) {
+      throw new Error(
+        "Run index_codebase first to build the call graph and symbol index for this branch."
+      );
+    }
+
+    const absoluteChangedFiles = changedFiles.map((f) => path.resolve(this.projectRoot, f));
+    const directSymbols = database.getSymbolsForFiles(absoluteChangedFiles, resolvedBranch);
+    const directIds = directSymbols.map((s) => s.id);
+
+    const direction = opts.direction ?? "both";
+    const maxDepth = opts.maxDepth ?? 5;
+    const transitiveCallers = database.getTransitiveReachability(
+      directIds,
+      resolvedBranch,
+      direction,
+      maxDepth
+    );
+
+    const affectedIdsSet = new Set<string>(directIds);
+    for (const caller of transitiveCallers) {
+      affectedIdsSet.add(caller.symbolId);
+    }
+    const allAffectedIds = Array.from(affectedIdsSet);
+
+    const communitiesData = database.detectCommunities(resolvedBranch, allAffectedIds);
+    const communityMap = new Map<string, { label: string; symbolCount: number; directSymbols: Set<string> }>();
+    for (const c of communitiesData) {
+      if (!communityMap.has(c.communityLabel)) {
+        communityMap.set(c.communityLabel, {
+          label: c.communityLabel,
+          symbolCount: 0,
+          directSymbols: new Set(),
+        });
+      }
+      const entry = communityMap.get(c.communityLabel)!;
+      entry.symbolCount++;
+      if (directIds.includes(c.symbolId)) {
+        entry.directSymbols.add(c.symbolId);
+      }
+    }
+    const communities = Array.from(communityMap.values()).map((c) => ({
+      label: c.label,
+      symbolCount: c.symbolCount,
+      directSymbols: Array.from(c.directSymbols),
+    }));
+
+    const centralityData = database.computeCentrality(resolvedBranch);
+    const hubThreshold = opts.hubThreshold ?? 10;
+    const hubNodes = centralityData
+      .filter((c) => directIds.includes(c.symbolId) && c.callerCount >= hubThreshold)
+      .map((c) => ({
+        id: c.symbolId,
+        name: c.symbolName,
+        callerCount: c.callerCount,
+        filePath: c.filePath,
+      }));
+
+    const totalAffected = allAffectedIds.length;
+    let riskLevel: "LOW" | "MEDIUM" | "HIGH";
+    let riskReason: string;
+
+    if (totalAffected < 5 && hubNodes.length === 0) {
+      riskLevel = "LOW";
+      riskReason = `Small impact: ${totalAffected} affected symbols, no hub nodes touched.`;
+    } else if (totalAffected > 20 || hubNodes.length > 1) {
+      riskLevel = "HIGH";
+      riskReason = `Large impact: ${totalAffected} affected symbols${hubNodes.length > 0 ? `, ${hubNodes.length} hub nodes touched` : ""}.`;
+    } else {
+      riskLevel = "MEDIUM";
+      riskReason = `Moderate impact: ${totalAffected} affected symbols${hubNodes.length === 1 ? ", 1 hub node touched" : ""}.`;
+    }
+
+    let conflictingPRs: PrImpactResult["conflictingPRs"];
+    if (opts.checkConflicts) {
+      conflictingPRs = [];
+      try {
+        const { stdout } = await execFileAsync(
+          "gh",
+          ["pr", "list", "--state", "open", "--json", "number,headRefName"],
+          { cwd: this.projectRoot, timeout: 30000 }
+        );
+        const openPRs = JSON.parse(stdout) as Array<{ number: number; headRefName: string }>;
+
+        const currentCommunityLabels = new Set(communities.map((c) => c.label));
+        const allCommunitiesData = database.detectCommunities(resolvedBranch);
+        const symbolToCommunity = new Map<string, string>();
+        for (const c of allCommunitiesData) {
+          symbolToCommunity.set(c.symbolId, c.communityLabel);
+        }
+
+        for (const openPr of openPRs) {
+          if (openPr.number === opts.pr) continue;
+
+          try {
+            const otherChanged = await getChangedFiles({
+              pr: openPr.number,
+              projectRoot: this.projectRoot,
+              baseBranch: this.baseBranch,
+            });
+            const otherAbsolute = otherChanged.files.map((f) => path.resolve(this.projectRoot, f));
+            const otherSymbols = database.getSymbolsForFiles(otherAbsolute, resolvedBranch);
+            const otherLabels = new Set<string>();
+            for (const sym of otherSymbols) {
+              const label = symbolToCommunity.get(sym.id);
+              if (label) {
+                otherLabels.add(label);
+              }
+            }
+            const overlapping = Array.from(otherLabels).filter((l) =>
+              currentCommunityLabels.has(l)
+            );
+            if (overlapping.length > 0) {
+              conflictingPRs.push({
+                pr: openPr.number,
+                branch: openPr.headRefName,
+                overlappingCommunities: overlapping,
+              });
+            }
+          } catch {
+            /* skip PRs we can't analyze */
+          }
+        }
+      } catch {
+        /* gh CLI not available or failed; skip conflict detection */
+      }
+    }
+
+    return {
+      changedFiles,
+      directSymbols: directSymbols.map((s) => ({
+        id: s.id,
+        name: s.name,
+        kind: s.kind,
+        filePath: s.filePath,
+      })),
+      transitiveCallers: transitiveCallers.map((c) => ({
+        id: c.symbolId,
+        name: c.symbolName,
+        filePath: c.filePath,
+        depth: c.depth,
+      })),
+      totalAffected,
+      communities,
+      hubNodes,
+      riskLevel,
+      riskReason,
+      direction,
+    };
   }
 
   async close(): Promise<void> {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1878,6 +1878,15 @@ export class Indexer {
     return `${projectHash}:${branchName}`;
   }
 
+  private getBranchCatalogKeyFor(branchName: string): string {
+    if (this.config.scope !== "global") {
+      return branchName;
+    }
+
+    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
+    return `${projectHash}:${branchName}`;
+  }
+
   private getLegacyBranchCatalogKey(): string {
     return this.currentBranch || "default";
   }
@@ -4955,8 +4964,9 @@ export class Indexer {
     }
 
     const resolvedBranch = headRefName || opts.branch || this.currentBranch;
+    const branchKey = this.getBranchCatalogKeyFor(resolvedBranch || "default");
 
-    const branchSymbols = database.getSymbolsForBranch(resolvedBranch);
+    const branchSymbols = database.getSymbolsForBranch(branchKey);
     if (branchSymbols.length === 0) {
       throw new Error(
         "Run index_codebase first to build the call graph and symbol index for this branch."
@@ -4964,14 +4974,14 @@ export class Indexer {
     }
 
     const absoluteChangedFiles = changedFiles.map((f) => path.resolve(this.projectRoot, f));
-    const directSymbols = database.getSymbolsForFiles(absoluteChangedFiles, resolvedBranch);
+    const directSymbols = database.getSymbolsForFiles(absoluteChangedFiles, branchKey);
     const directIds = directSymbols.map((s) => s.id);
 
     const direction = opts.direction ?? "both";
     const maxDepth = opts.maxDepth ?? 5;
     const transitiveCallers = database.getTransitiveReachability(
       directIds,
-      resolvedBranch,
+      branchKey,
       direction,
       maxDepth
     );
@@ -4982,7 +4992,7 @@ export class Indexer {
     }
     const allAffectedIds = Array.from(affectedIdsSet);
 
-    const communitiesData = database.detectCommunities(resolvedBranch, allAffectedIds);
+    const communitiesData = database.detectCommunities(branchKey, allAffectedIds);
     const communityMap = new Map<string, { label: string; symbolCount: number; directSymbols: Set<string> }>();
     for (const c of communitiesData) {
       if (!communityMap.has(c.communityLabel)) {
@@ -5004,7 +5014,7 @@ export class Indexer {
       directSymbols: Array.from(c.directSymbols),
     }));
 
-    const centralityData = database.computeCentrality(resolvedBranch);
+    const centralityData = database.computeCentrality(branchKey);
     const hubThreshold = opts.hubThreshold ?? 10;
     const hubNodes = centralityData
       .filter((c) => directIds.includes(c.symbolId) && c.callerCount >= hubThreshold)
@@ -5042,7 +5052,7 @@ export class Indexer {
         const openPRs = JSON.parse(stdout) as Array<{ number: number; headRefName: string }>;
 
         const currentCommunityLabels = new Set(communities.map((c) => c.label));
-        const allCommunitiesData = database.detectCommunities(resolvedBranch);
+        const allCommunitiesData = database.detectCommunities(branchKey);
         const symbolToCommunity = new Map<string, string>();
         const structuralKey = (filePath: string, name: string): string =>
           `${filePath.toLowerCase()}:${name.toLowerCase()}`;
@@ -5060,7 +5070,8 @@ export class Indexer {
               baseBranch: this.baseBranch,
             });
             const otherAbsolute = otherChanged.files.map((f) => path.resolve(this.projectRoot, f));
-            const otherSymbols = database.getSymbolsForFiles(otherAbsolute, openPr.headRefName);
+            const otherBranchKey = this.getBranchCatalogKeyFor(openPr.headRefName);
+            const otherSymbols = database.getSymbolsForFiles(otherAbsolute, otherBranchKey);
             const otherLabels = new Set<string>();
             for (const sym of otherSymbols) {
               const label = symbolToCommunity.get(structuralKey(sym.filePath, sym.name));

--- a/src/indexer/pr-impact-types.ts
+++ b/src/indexer/pr-impact-types.ts
@@ -1,0 +1,35 @@
+export interface PrImpactResult {
+  changedFiles: string[];
+  directSymbols: Array<{
+    id: string;
+    name: string;
+    kind: string;
+    filePath: string;
+  }>;
+  transitiveCallers: Array<{
+    id: string;
+    name: string;
+    filePath: string;
+    depth: number;
+  }>;
+  totalAffected: number;
+  communities: Array<{
+    label: string;
+    symbolCount: number;
+    directSymbols: string[];
+  }>;
+  hubNodes: Array<{
+    id: string;
+    name: string;
+    callerCount: number;
+    filePath: string;
+  }>;
+  riskLevel: "LOW" | "MEDIUM" | "HIGH";
+  riskReason: string;
+  conflictingPRs?: Array<{
+    pr: number;
+    branch: string;
+    overlappingCommunities: string[];
+  }>;
+  direction?: "callers" | "callees" | "both";
+}

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -6,6 +6,7 @@ import type { LogLevel } from "../config/schema.js";
 import { formatCostEstimate } from "../utils/cost.js";
 import type { LogEntry } from "../utils/logger.js";
 import { formatDefinitionLookup, formatHealthCheck, formatIndexStats, formatStatus } from "../tools/utils.js";
+import { formatPrImpact } from "../tools/format-pr-impact.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime, truncateContent } from "./shared.js";
 
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
@@ -308,6 +309,36 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         return `${prefix} ${hop.symbolName}${location}`;
       });
       return { content: [{ type: "text", text: `Path (${path.length} hops):\n${formatted.join("\n")}` }] };
+    },
+  );
+  server.tool(
+    "pr_impact",
+    "Analyze the impact of a pull request or branch by examining changed files, affected symbols, transitive callers, communities touched, hub nodes, and risk level. Use to understand blast radius before merging.",
+    {
+      pr: z.number().optional().describe("Pull request number to analyze"),
+      branch: z.string().optional().describe("Branch name to analyze (defaults to current branch)"),
+      maxDepth: z.number().optional().default(5).describe("Maximum traversal depth for transitive callers (default: 5)"),
+      hubThreshold: z.number().optional().default(10).describe("Minimum caller count to flag a symbol as a hub node (default: 10)"),
+      checkConflicts: z.boolean().optional().default(false).describe("Check for conflicting open PRs touching the same communities (default: false)"),
+      direction: z.enum(["callers", "callees", "both"]).optional().default("both").describe("Call-graph traversal direction: 'callers' for upstream, 'callees' for downstream, 'both' for union (default: both)"),
+    },
+    async (args) => {
+      await runtime.ensureInitialized();
+      const indexer = runtime.getIndexer();
+      try {
+        const result = await indexer.getPrImpact({
+          pr: args.pr,
+          branch: args.branch,
+          maxDepth: args.maxDepth,
+          hubThreshold: args.hubThreshold,
+          checkConflicts: args.checkConflicts,
+          direction: args.direction,
+        });
+        return { content: [{ type: "text", text: formatPrImpact(result) }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { content: [{ type: "text", text: `Error analyzing PR impact: ${message}` }] };
+      }
     },
   );
 }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -78,8 +78,11 @@ function createMockNativeBinding() {
     Database: class {
       constructor() { throw error; }
       close() { throw error; }
+      getTransitiveReachability() { throw error; }
+      detectCommunities() { throw error; }
+      computeCentrality() { throw error; }
     },
-  };
+}
 }
 
 let native: any;
@@ -171,6 +174,30 @@ export interface PathHopData {
   filePath: string;
   line: number;
   callType: string;
+}
+
+export interface ReachabilityData {
+  symbolId: string;
+  symbolName: string;
+  filePath: string;
+  depth: number;
+}
+
+export interface CommunityData {
+  symbolId: string;
+  symbolName: string;
+  filePath: string;
+  communityId: number;
+  communityLabel: string;
+}
+
+export interface CentralityData {
+  symbolId: string;
+  symbolName: string;
+  filePath: string;
+  callerCount: number;
+  calleeCount: number;
+  totalConnections: number;
 }
 
 export interface SearchResult {
@@ -926,6 +953,15 @@ export class Database {
     this.throwIfClosed();
     return this.inner.getSymbolsByNameCi(name);
   }
+  getSymbolsForBranch(branch: string): SymbolData[] {
+    this.throwIfClosed();
+    return this.inner.getSymbolsForBranch(branch);
+  }
+
+  getSymbolsForFiles(filePaths: string[], branch: string): SymbolData[] {
+    this.throwIfClosed();
+    return this.inner.getSymbolsForFiles(filePaths, branch);
+  }
 
   deleteSymbolsByFile(filePath: string): number {
     this.throwIfClosed();
@@ -1026,5 +1062,33 @@ export class Database {
   gcOrphanCallEdges(): number {
     this.throwIfClosed();
     return this.inner.gcOrphanCallEdges();
+  }
+
+  getTransitiveReachability(
+    rootSymbolIds: string[],
+    branch: string,
+    direction: string,
+    maxDepth?: number
+  ): ReachabilityData[] {
+    this.throwIfClosed();
+    return this.inner.getTransitiveReachability(
+      rootSymbolIds,
+      branch,
+      direction,
+      maxDepth ?? null
+    );
+  }
+
+  detectCommunities(
+    branch: string,
+    symbolIds?: string[]
+  ): CommunityData[] {
+    this.throwIfClosed();
+    return this.inner.detectCommunities(branch, symbolIds ?? null);
+  }
+
+  computeCentrality(branch: string): CentralityData[] {
+    this.throwIfClosed();
+    return this.inner.computeCentrality(branch);
   }
 }

--- a/src/tools/changed-files.ts
+++ b/src/tools/changed-files.ts
@@ -13,6 +13,7 @@ export interface ChangedFilesResult {
   files: string[];
   baseBranch: string;
   source: "gh" | "git";
+  headRefName?: string;
 }
 
 export interface GetChangedFilesOptions {
@@ -67,6 +68,7 @@ async function getChangedFilesForPr(
         ),
         baseBranch: actualBaseBranch,
         source: "gh",
+        headRefName,
       };
     }
   } catch (error) {
@@ -81,7 +83,8 @@ async function getChangedFilesForPr(
     );
   }
 
-  return getChangedFilesForBranch(headRefName, projectRoot, actualBaseBranch);
+  const result = await getChangedFilesForBranch(headRefName, projectRoot, actualBaseBranch);
+  return { ...result, headRefName };
 }
 
 async function getChangedFilesForBranch(
@@ -102,6 +105,7 @@ async function getChangedFilesForBranch(
     files: normalizeFiles(stdout.split("\n"), projectRoot),
     baseBranch,
     source: "git",
+    headRefName: targetBranch,
   };
 }
 

--- a/src/tools/changed-files.ts
+++ b/src/tools/changed-files.ts
@@ -1,0 +1,145 @@
+import * as path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+export interface ChangedFilesResult {
+  files: string[];
+  baseBranch: string;
+  source: "gh" | "git";
+}
+
+export interface GetChangedFilesOptions {
+  pr?: number;
+  branch?: string;
+  projectRoot: string;
+  baseBranch?: string;
+}
+
+interface GhPrViewResponse {
+  headRefName?: string;
+  baseRefName?: string;
+  files?: Array<{ path: string }>;
+}
+
+export async function getChangedFiles(
+  opts: GetChangedFilesOptions,
+): Promise<ChangedFilesResult> {
+  const { pr, branch, projectRoot, baseBranch = "main" } = opts;
+
+  if (pr !== undefined) {
+    const result = await getChangedFilesForPr(pr, projectRoot, baseBranch);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
+  return getChangedFilesForBranch(branch, projectRoot, baseBranch);
+}
+
+async function getChangedFilesForPr(
+  pr: number,
+  projectRoot: string,
+  baseBranch: string,
+): Promise<ChangedFilesResult | undefined> {
+  let headRefName: string | undefined;
+  let actualBaseBranch = baseBranch;
+
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      ["pr", "view", String(pr), "--json", "headRefName,baseRefName,files"],
+      { cwd: projectRoot, timeout: 30000 },
+    );
+
+    const data = JSON.parse(stdout) as GhPrViewResponse;
+    headRefName = data.headRefName;
+    actualBaseBranch = data.baseRefName || baseBranch;
+
+    if (data.files && data.files.length > 0) {
+      return {
+        files: normalizeFiles(
+          data.files.map((f) => f.path),
+          projectRoot,
+        ),
+        baseBranch: actualBaseBranch,
+        source: "gh",
+      };
+    }
+  } catch {
+    // gh CLI failed or returned no files; fall through to git diff.
+  }
+
+  if (headRefName === undefined) {
+    return undefined;
+  }
+
+  return getChangedFilesForBranch(headRefName, projectRoot, actualBaseBranch);
+}
+
+async function getChangedFilesForBranch(
+  branch: string | undefined,
+  projectRoot: string,
+  baseBranch: string,
+): Promise<ChangedFilesResult> {
+  const targetBranch = branch || (await getCurrentBranch(projectRoot));
+  const mergeBase = await getMergeBase(projectRoot, baseBranch, targetBranch);
+
+  const { stdout } = await execFileAsync(
+    "git",
+    ["diff", "--name-only", `${mergeBase}...${targetBranch}`],
+    { cwd: projectRoot, timeout: 30000 },
+  );
+
+  return {
+    files: normalizeFiles(stdout.split("\n"), projectRoot),
+    baseBranch,
+    source: "git",
+  };
+}
+
+async function getCurrentBranch(projectRoot: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["branch", "--show-current"],
+    { cwd: projectRoot, timeout: 30000 },
+  );
+  return stdout.trim();
+}
+
+async function getMergeBase(
+  projectRoot: string,
+  baseBranch: string,
+  branch: string,
+): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["merge-base", baseBranch, branch],
+    { cwd: projectRoot, timeout: 30000 },
+  );
+  return stdout.trim();
+}
+
+function normalizeFiles(rawFiles: string[], projectRoot: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const raw of rawFiles) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+
+    const absolute = path.resolve(projectRoot, trimmed);
+    const relative = path.relative(projectRoot, absolute);
+    const cleaned = relative.startsWith("./")
+      ? relative.slice(2)
+      : relative;
+
+    if (!seen.has(cleaned)) {
+      seen.add(cleaned);
+      result.push(cleaned);
+    }
+  }
+
+  return result;
+}

--- a/src/tools/changed-files.ts
+++ b/src/tools/changed-files.ts
@@ -4,6 +4,11 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
 export interface ChangedFilesResult {
   files: string[];
   baseBranch: string;
@@ -29,10 +34,7 @@ export async function getChangedFiles(
   const { pr, branch, projectRoot, baseBranch = "main" } = opts;
 
   if (pr !== undefined) {
-    const result = await getChangedFilesForPr(pr, projectRoot, baseBranch);
-    if (result !== undefined) {
-      return result;
-    }
+    return getChangedFilesForPr(pr, projectRoot, baseBranch);
   }
 
   return getChangedFilesForBranch(branch, projectRoot, baseBranch);
@@ -42,7 +44,7 @@ async function getChangedFilesForPr(
   pr: number,
   projectRoot: string,
   baseBranch: string,
-): Promise<ChangedFilesResult | undefined> {
+): Promise<ChangedFilesResult> {
   let headRefName: string | undefined;
   let actualBaseBranch = baseBranch;
 
@@ -67,12 +69,16 @@ async function getChangedFilesForPr(
         source: "gh",
       };
     }
-  } catch {
-    // gh CLI failed or returned no files; fall through to git diff.
+  } catch (error) {
+    throw new Error(
+      `Failed to retrieve PR #${pr} via gh CLI: ${getErrorMessage(error)}`,
+    );
   }
 
   if (headRefName === undefined) {
-    return undefined;
+    throw new Error(
+      `PR #${pr} returned no usable branch or file information.`,
+    );
   }
 
   return getChangedFilesForBranch(headRefName, projectRoot, actualBaseBranch);

--- a/src/tools/changed-files.ts
+++ b/src/tools/changed-files.ts
@@ -115,7 +115,7 @@ async function getCurrentBranch(projectRoot: string): Promise<string> {
     ["branch", "--show-current"],
     { cwd: projectRoot, timeout: 30000 },
   );
-  return stdout.trim();
+  return stdout.trim() || "HEAD";
 }
 
 async function getMergeBase(

--- a/src/tools/format-pr-impact.ts
+++ b/src/tools/format-pr-impact.ts
@@ -1,0 +1,58 @@
+import type { PrImpactResult } from "../indexer/pr-impact-types.js";
+
+export function formatPrImpact(result: PrImpactResult): string {
+  const lines: string[] = [];
+
+  lines.push(`→ Files changed: ${result.changedFiles.length}`);
+  for (const file of result.changedFiles) {
+    lines.push(`  - ${file}`);
+  }
+
+  const directCount = result.directSymbols.length;
+  const transitiveCount = result.transitiveCallers.length;
+  const directionLabel = result.direction === 'callees' ? 'callees' : result.direction === 'both' ? 'reachable (callers + callees)' : 'callers';
+  lines.push(
+    `\u2192 Symbols affected: ${result.totalAffected} (${directCount} direct, ${transitiveCount} transitive ${directionLabel})`,
+  );
+
+  if (directCount > 0) {
+    lines.push(
+      `  Direct: ${result.directSymbols.map((s) => `${s.name} (${s.kind})`).join(", ")}`,
+    );
+  }
+
+  if (transitiveCount > 0) {
+    lines.push(
+      `  Transitive ${directionLabel}: ${result.transitiveCallers.map((s) => s.name).join(", ")}`,
+    );
+  }
+  if (result.communities.length > 0) {
+    lines.push(
+      `→ Communities touched: ${result.communities.map((c) => c.label).join(", ")}`,
+    );
+    for (const community of result.communities) {
+      lines.push(
+        `  - ${community.label}: ${community.symbolCount} symbols`,
+      );
+    }
+  } else {
+    lines.push("→ Communities touched: none");
+  }
+
+  lines.push(`→ Risk: ${result.riskLevel} — ${result.riskReason}`);
+  if (result.hubNodes.length > 0) {
+    lines.push("  Hub nodes in change scope:");
+    for (const hub of result.hubNodes) {
+      lines.push(`    - ${hub.name} (${hub.callerCount} callers) at ${hub.filePath}`);
+    }
+  }
+
+  if (result.conflictingPRs && result.conflictingPRs.length > 0) {
+    const conflictList = result.conflictingPRs.map(
+      (c) => `PR #${c.pr} (also touches ${c.overlappingCommunities.join(", ")} community)`,
+    );
+    lines.push(`→ Potential conflicts with: ${conflictList.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,7 @@ import {
   formatLogs,
   formatSearchResults,
 } from "./utils.js";
+import { pr_impact } from "./pr-impact.js";
 import {
   findKnowledgeBasePathIndex,
   hasMatchingKnowledgeBasePath,
@@ -531,3 +532,4 @@ export const remove_knowledge_base: ToolDefinition = tool({
     return result;
   },
 });
+export { pr_impact };

--- a/src/tools/pr-impact.ts
+++ b/src/tools/pr-impact.ts
@@ -1,0 +1,38 @@
+import { tool, type ToolDefinition } from "@opencode-ai/plugin";
+import type { PrImpactResult } from "../indexer/pr-impact-types.js";
+import { getIndexerForProject } from "./index.js";
+import { formatPrImpact } from "./format-pr-impact.js";
+
+const z = tool.schema;
+
+export const pr_impact: ToolDefinition = tool({
+  description:
+    "Analyze the impact of a pull request or branch by examining changed files, " +
+    "affected symbols, transitive callers, communities touched, hub nodes, and risk level. " +
+    "Use to understand blast radius before merging.",
+  args: {
+    pr: z.number().optional().describe("Pull request number to analyze"),
+    branch: z.string().optional().describe("Branch name to analyze (defaults to current branch)"),
+    maxDepth: z.number().optional().default(5).describe("Maximum traversal depth for transitive callers (default: 5)"),
+    hubThreshold: z.number().optional().default(10).describe("Minimum caller count to flag a symbol as a hub node (default: 10)"),
+    checkConflicts: z.boolean().optional().default(false).describe("Check for conflicting open PRs touching the same communities (default: false)"),
+    direction: z.enum(["callers", "callees", "both"]).optional().default("both").describe("Call-graph traversal direction: 'callers' for upstream, 'callees' for downstream, 'both' for union (default: both)"),
+  },
+  async execute(args, context) {
+    const indexer = getIndexerForProject(context?.worktree);
+    try {
+      const result: PrImpactResult = await indexer.getPrImpact({
+        pr: args.pr,
+        branch: args.branch,
+        maxDepth: args.maxDepth,
+        hubThreshold: args.hubThreshold,
+        checkConflicts: args.checkConflicts,
+        direction: args.direction,
+      });
+      return formatPrImpact(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return `Error analyzing PR impact: ${message}`;
+    }
+  },
+});

--- a/tests/changed-files.test.ts
+++ b/tests/changed-files.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as path from "path";
+import { getChangedFiles } from "../src/tools/changed-files.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile as typeof execFile);
+
+interface MockResponse {
+  command?: string;
+  args?: string[];
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+}
+
+function mockExecFile(responses: MockResponse[]): void {
+  let callIndex = 0;
+  (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (cmd: string, args: string[], _options: unknown, callback: unknown) => {
+      const response = responses[callIndex];
+      callIndex += 1;
+
+      if (response === undefined) {
+        return (callback as (err: Error | null, result?: { stdout: string; stderr: string }) => void)(
+          new Error(`Unexpected execFile call: ${cmd} ${JSON.stringify(args)}`),
+        );
+      }
+
+      if (response.error !== undefined) {
+        return (callback as (err: Error | null, result?: { stdout: string; stderr: string }) => void)(
+          response.error,
+        );
+      }
+
+      if (response.command !== undefined && response.command !== cmd) {
+        return (callback as (err: Error | null, result?: { stdout: string; stderr: string }) => void)(
+          new Error(`Expected command ${response.command}, got ${cmd}`),
+        );
+      }
+
+      if (response.args !== undefined && JSON.stringify(response.args) !== JSON.stringify(args)) {
+        return (callback as (err: Error | null, result?: { stdout: string; stderr: string }) => void)(
+          new Error(`Expected args ${JSON.stringify(response.args)}, got ${JSON.stringify(args)}`),
+        );
+      }
+
+      return (callback as (err: Error | null, result?: { stdout: string; stderr: string }) => void)(
+        null,
+        { stdout: response.stdout ?? "", stderr: response.stderr ?? "" },
+      );
+    },
+  );
+}
+
+describe("getChangedFiles", () => {
+  const projectRoot = "/test/project";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns changed files for a branch via git", async () => {
+    mockExecFile([
+      { command: "git", args: ["merge-base", "main", "feature/x"], stdout: "abc123\n" },
+      { command: "git", args: ["diff", "--name-only", "abc123...feature/x"], stdout: "src/a.ts\nsrc/b.ts\n" },
+    ]);
+
+    const result = await getChangedFiles({
+      branch: "feature/x",
+      projectRoot,
+    });
+
+    expect(result.source).toBe("git");
+    expect(result.baseBranch).toBe("main");
+    expect(result.files).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("uses the current branch when no branch is provided", async () => {
+    mockExecFile([
+      { command: "git", args: ["branch", "--show-current"], stdout: "feature/current\n" },
+      { command: "git", args: ["merge-base", "main", "feature/current"], stdout: "def456\n" },
+      { command: "git", args: ["diff", "--name-only", "def456...feature/current"], stdout: "README.md\n" },
+    ]);
+
+    const result = await getChangedFiles({ projectRoot });
+
+    expect(result.source).toBe("git");
+    expect(result.files).toEqual(["README.md"]);
+  });
+
+  it("extracts files from gh pr view when available", async () => {
+    mockExecFile([
+      {
+        command: "gh",
+        args: ["pr", "view", "42", "--json", "headRefName,baseRefName,files"],
+        stdout: JSON.stringify({
+          headRefName: "feature/pr-42",
+          baseRefName: "main",
+          files: [{ path: "src/pr.ts" }, { path: "tests/pr.test.ts" }],
+        }),
+      },
+    ]);
+
+    const result = await getChangedFiles({ pr: 42, projectRoot });
+
+    expect(result.source).toBe("gh");
+    expect(result.baseBranch).toBe("main");
+    expect(result.files).toEqual(["src/pr.ts", "tests/pr.test.ts"]);
+  });
+
+  it("falls back to git diff when gh fails", async () => {
+    mockExecFile([
+      {
+        command: "gh",
+        args: ["pr", "view", "99", "--json", "headRefName,baseRefName,files"],
+        error: new Error("GraphQL: Could not resolve to a PullRequest"),
+      },
+      { command: "git", args: ["branch", "--show-current"], stdout: "feature/fallback\n" },
+      { command: "git", args: ["merge-base", "main", "feature/fallback"], stdout: "fallback-base\n" },
+      { command: "git", args: ["diff", "--name-only", "fallback-base...feature/fallback"], stdout: "src/fallback.ts\n" },
+    ]);
+
+    const result = await getChangedFiles({ pr: 99, projectRoot });
+
+    expect(result.source).toBe("git");
+    expect(result.files).toEqual(["src/fallback.ts"]);
+  });
+
+  it("handles empty diffs gracefully", async () => {
+    mockExecFile([
+      { command: "git", args: ["merge-base", "main", "feature/empty"], stdout: "base789\n" },
+      { command: "git", args: ["diff", "--name-only", "base789...feature/empty"], stdout: "\n" },
+    ]);
+
+    const result = await getChangedFiles({
+      branch: "feature/empty",
+      projectRoot,
+    });
+
+    expect(result.files).toEqual([]);
+  });
+
+  it("strips leading ./ from file paths", async () => {
+    mockExecFile([
+      { command: "git", args: ["merge-base", "main", "feature/dotslash"], stdout: "base000\n" },
+      { command: "git", args: ["diff", "--name-only", "base000...feature/dotslash"], stdout: "./src/file.ts\n" },
+    ]);
+
+    const result = await getChangedFiles({
+      branch: "feature/dotslash",
+      projectRoot,
+    });
+
+    expect(result.files).toEqual(["src/file.ts"]);
+  });
+
+  it("deduplicates repeated file paths", async () => {
+    mockExecFile([
+      { command: "git", args: ["merge-base", "main", "feature/dup"], stdout: "base111\n" },
+      { command: "git", args: ["diff", "--name-only", "base111...feature/dup"], stdout: "src/a.ts\nsrc/a.ts\nsrc/b.ts\n" },
+    ]);
+
+    const result = await getChangedFiles({
+      branch: "feature/dup",
+      projectRoot,
+    });
+
+    expect(result.files).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("respects a custom baseBranch", async () => {
+    mockExecFile([
+      { command: "git", args: ["merge-base", "develop", "feature/dev"], stdout: "devbase\n" },
+      { command: "git", args: ["diff", "--name-only", "devbase...feature/dev"], stdout: "src/dev.ts\n" },
+    ]);
+
+    const result = await getChangedFiles({
+      branch: "feature/dev",
+      projectRoot,
+      baseBranch: "develop",
+    });
+
+    expect(result.baseBranch).toBe("develop");
+    expect(result.files).toEqual(["src/dev.ts"]);
+  });
+});

--- a/tests/changed-files.test.ts
+++ b/tests/changed-files.test.ts
@@ -100,6 +100,20 @@ describe("getChangedFiles", () => {
     expect(result.files).toEqual(["README.md"]);
   });
 
+  it("falls back to HEAD in detached-HEAD state", async () => {
+    mockExecFile([
+      { command: "git", args: ["branch", "--show-current"], stdout: "" },
+      { command: "git", args: ["merge-base", "main", "HEAD"], stdout: "detached-base\n" },
+      { command: "git", args: ["diff", "--name-only", "detached-base...HEAD"], stdout: "src/detached.ts\n" },
+    ]);
+
+    const result = await getChangedFiles({ projectRoot });
+
+    expect(result.source).toBe("git");
+    expect(result.headRefName).toBe("HEAD");
+    expect(result.files).toEqual(["src/detached.ts"]);
+  });
+
   it("extracts files from gh pr view when available", async () => {
     mockExecFile([
       {

--- a/tests/changed-files.test.ts
+++ b/tests/changed-files.test.ts
@@ -118,22 +118,18 @@ describe("getChangedFiles", () => {
     expect(result.files).toEqual(["src/pr.ts", "tests/pr.test.ts"]);
   });
 
-  it("falls back to git diff when gh fails", async () => {
+  it("throws when gh pr view fails", async () => {
     mockExecFile([
       {
         command: "gh",
         args: ["pr", "view", "99", "--json", "headRefName,baseRefName,files"],
         error: new Error("GraphQL: Could not resolve to a PullRequest"),
       },
-      { command: "git", args: ["branch", "--show-current"], stdout: "feature/fallback\n" },
-      { command: "git", args: ["merge-base", "main", "feature/fallback"], stdout: "fallback-base\n" },
-      { command: "git", args: ["diff", "--name-only", "fallback-base...feature/fallback"], stdout: "src/fallback.ts\n" },
     ]);
 
-    const result = await getChangedFiles({ pr: 99, projectRoot });
-
-    expect(result.source).toBe("git");
-    expect(result.files).toEqual(["src/fallback.ts"]);
+    await expect(
+      getChangedFiles({ pr: 99, projectRoot }),
+    ).rejects.toThrow("Failed to retrieve PR #99 via gh CLI");
   });
 
   it("handles empty diffs gracefully", async () => {

--- a/tests/changed-files.test.ts
+++ b/tests/changed-files.test.ts
@@ -82,6 +82,7 @@ describe("getChangedFiles", () => {
 
     expect(result.source).toBe("git");
     expect(result.baseBranch).toBe("main");
+    expect(result.headRefName).toBe("feature/x");
     expect(result.files).toEqual(["src/a.ts", "src/b.ts"]);
   });
 
@@ -95,6 +96,7 @@ describe("getChangedFiles", () => {
     const result = await getChangedFiles({ projectRoot });
 
     expect(result.source).toBe("git");
+    expect(result.headRefName).toBe("feature/current");
     expect(result.files).toEqual(["README.md"]);
   });
 
@@ -115,6 +117,7 @@ describe("getChangedFiles", () => {
 
     expect(result.source).toBe("gh");
     expect(result.baseBranch).toBe("main");
+    expect(result.headRefName).toBe("feature/pr-42");
     expect(result.files).toEqual(["src/pr.ts", "tests/pr.test.ts"]);
   });
 
@@ -144,6 +147,7 @@ describe("getChangedFiles", () => {
     });
 
     expect(result.files).toEqual([]);
+    expect(result.headRefName).toBe("feature/empty");
   });
 
   it("strips leading ./ from file paths", async () => {
@@ -158,6 +162,7 @@ describe("getChangedFiles", () => {
     });
 
     expect(result.files).toEqual(["src/file.ts"]);
+    expect(result.headRefName).toBe("feature/dotslash");
   });
 
   it("deduplicates repeated file paths", async () => {
@@ -172,6 +177,7 @@ describe("getChangedFiles", () => {
     });
 
     expect(result.files).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(result.headRefName).toBe("feature/dup");
   });
 
   it("respects a custom baseBranch", async () => {
@@ -187,6 +193,7 @@ describe("getChangedFiles", () => {
     });
 
     expect(result.baseBranch).toBe("develop");
+    expect(result.headRefName).toBe("feature/dev");
     expect(result.files).toEqual(["src/dev.ts"]);
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -133,6 +133,17 @@ vi.mock("../src/indexer/index.js", () => {
       getLogsByLevel: vi.fn().mockReturnValue([]),
       formatMetrics: vi.fn().mockReturnValue(""),
     });
+    getPrImpact = vi.fn().mockResolvedValue({
+      changedFiles: ["src/a.ts"],
+      directSymbols: [{ id: "sym_1", name: "funcA", kind: "function", filePath: "src/a.ts" }],
+      transitiveCallers: [],
+      totalAffected: 1,
+      communities: [{ label: "Core", symbolCount: 1, directSymbols: ["sym_1"] }],
+      hubNodes: [],
+      riskLevel: "LOW",
+      riskReason: "Small impact: 1 affected symbols, no hub nodes touched.",
+      conflictingPRs: undefined,
+    });
   }
   return { Indexer: MockIndexer };
 });
@@ -214,10 +225,10 @@ describe("MCP server tools and prompts", () => {
     await client.close();
   });
 
-  it("should register all 11 tools", async () => {
+  it("should register all 12 tools", async () => {
     const tools = await client.listTools();
 
-    expect(tools.tools).toHaveLength(11);
+    expect(tools.tools).toHaveLength(12);
 
     const toolNames = tools.tools.map(t => t.name).sort();
     const expectedNames = [
@@ -227,6 +238,8 @@ describe("MCP server tools and prompts", () => {
       "codebase_search",
       "find_similar",
       "implementation_lookup",
+      "pr_impact",
+
       "index_codebase",
       "index_health_check",
       "index_logs",

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -63,6 +63,7 @@ vi.mock("../src/tools/index.js", () => {
     add_knowledge_base: toolStub,
     list_knowledge_bases: toolStub,
     remove_knowledge_base: toolStub,
+    pr_impact: toolStub,
     initializeTools: vi.fn(),
     getSharedIndexer: vi.fn(() => indexerStub),
   };

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -7,6 +7,10 @@ import { Indexer } from "../src/indexer/index.js";
 import { pr_impact, call_graph, initializeTools } from "../src/tools/index.js";
 import { getChangedFiles } from "../src/tools/changed-files.js";
 import type { Database } from "../src/native/index.js";
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+import { execFile } from "child_process";
 
 vi.mock("../src/tools/changed-files.js", () => ({
   getChangedFiles: vi.fn(),
@@ -357,5 +361,102 @@ describe("pr_impact tool", () => {
     const bothIds = both.map((c) => c.symbolId);
     expect(bothIds).toContain("sym_x");
     expect(bothIds).toContain("sym_b");
+  });
+
+  it("regression: checkConflicts detects overlapping PRs using correct branch for getSymbolsForFiles", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (args: { pr?: number }) => {
+        if (args.pr === 1) return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+        if (args.pr === 2) return { files: ["src/b.ts"], baseBranch: "main", source: "git" };
+        if (args.pr === 3) return { files: ["src/c.ts"], baseBranch: "main", source: "git" };
+        return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+      },
+    );
+
+    (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (
+        cmd: string,
+        args: string[],
+        _opts: unknown,
+        callback: (err: Error | null, result?: { stdout: string }) => void,
+      ) => {
+        if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+          callback(null, { stdout: '{"headRefName":"feature-branch"}\n' });
+        } else if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+          callback(null, {
+            stdout: '[{"number":2,"headRefName":"other-branch"},{"number":3,"headRefName":"third-branch"}]\n',
+          });
+        } else {
+          callback(new Error("Unexpected execFile: " + cmd + " " + JSON.stringify(args)));
+        }
+      },
+    );
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    db.upsertSymbol({
+      id: "sym_a",
+      filePath: path.join(tempDir, "src", "a.ts"),
+      name: "funcA",
+      kind: "function",
+      startLine: 1, startCol: 0, endLine: 10, endCol: 0,
+      language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_b",
+      filePath: path.join(tempDir, "src", "b.ts"),
+      name: "funcB",
+      kind: "function",
+      startLine: 1, startCol: 0, endLine: 10, endCol: 0,
+      language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_c",
+      filePath: path.join(tempDir, "src", "c.ts"),
+      name: "funcC",
+      kind: "function",
+      startLine: 1, startCol: 0, endLine: 10, endCol: 0,
+      language: "typescript",
+    });
+
+    db.addSymbolsToBranch("feature-branch", ["sym_a", "sym_b", "sym_c"]);
+    db.addSymbolsToBranch("other-branch", ["sym_b"]);
+
+    db.upsertCallEdge({
+      id: "edge_ab",
+      fromSymbolId: "sym_a",
+      targetName: "funcB",
+      toSymbolId: "sym_b",
+      callType: "Call",
+      confidence: "Direct",
+      line: 5, col: 0,
+      isResolved: true,
+    });
+    db.upsertCallEdge({
+      id: "edge_bc",
+      fromSymbolId: "sym_b",
+      targetName: "funcC",
+      toSymbolId: "sym_c",
+      callType: "Call",
+      confidence: "Direct",
+      line: 5, col: 0,
+      isResolved: true,
+    });
+
+    const getSymbolsSpy = vi.spyOn(db, "getSymbolsForFiles");
+
+    const result = await indexer.getPrImpact({ pr: 1, checkConflicts: true });
+
+    expect(result.conflictingPRs).toBeDefined();
+    expect(result.conflictingPRs!.length).toBeGreaterThan(0);
+
+    const prNums = result.conflictingPRs!.map((c) => c.pr);
+    expect(prNums).toContain(2);
+
+    expect(getSymbolsSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining("b.ts")]),
+      "other-branch",
+    );
   });
 });

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -89,6 +89,7 @@ describe("pr_impact tool", () => {
       files: ["src/a.ts"],
       baseBranch: "main",
       source: "git",
+      headRefName: "main",
     });
 
     const indexer = await createIndexer();
@@ -143,6 +144,7 @@ describe("pr_impact tool", () => {
       files: ["src/a.ts"],
       baseBranch: "main",
       source: "git",
+      headRefName: "feature",
     });
 
     const indexer = await createIndexer();
@@ -155,11 +157,27 @@ describe("pr_impact tool", () => {
     expect(result).toContain("Run index_codebase first");
   });
 
+  it("throws when headRefName cannot be resolved in PR mode", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: ["src/a.ts"],
+      baseBranch: "main",
+      source: "git",
+      headRefName: undefined,
+    });
+
+    const indexer = await createIndexer();
+
+    await expect(indexer.getPrImpact({ pr: 42 })).rejects.toThrow(
+      "Could not resolve head branch for PR #42",
+    );
+  });
+
   it("detects hub nodes and flags HIGH risk", async () => {
     (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       files: ["src/db.ts"],
       baseBranch: "main",
       source: "git",
+      headRefName: "main",
     });
 
     const indexer = await createIndexer();
@@ -366,10 +384,10 @@ describe("pr_impact tool", () => {
   it("regression: checkConflicts detects overlapping PRs using correct branch for getSymbolsForFiles", async () => {
     (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       async (args: { pr?: number }) => {
-        if (args.pr === 1) return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
-        if (args.pr === 2) return { files: ["src/b.ts"], baseBranch: "main", source: "git" };
-        if (args.pr === 3) return { files: ["src/c.ts"], baseBranch: "main", source: "git" };
-        return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+        if (args.pr === 1) return { files: ["src/a.ts"], baseBranch: "main", source: "git", headRefName: "feature-branch" };
+        if (args.pr === 2) return { files: ["src/b.ts"], baseBranch: "main", source: "git", headRefName: "other-branch" };
+        if (args.pr === 3) return { files: ["src/c.ts"], baseBranch: "main", source: "git", headRefName: "third-branch" };
+        return { files: ["src/a.ts"], baseBranch: "main", source: "git", headRefName: "feature-branch" };
       },
     );
 
@@ -380,9 +398,7 @@ describe("pr_impact tool", () => {
         _opts: unknown,
         callback: (err: Error | null, result?: { stdout: string }) => void,
       ) => {
-        if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-          callback(null, { stdout: '{"headRefName":"feature-branch"}\n' });
-        } else if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+        if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
           callback(null, {
             stdout: '[{"number":2,"headRefName":"other-branch"},{"number":3,"headRefName":"third-branch"}]\n',
           });
@@ -463,9 +479,9 @@ describe("pr_impact tool", () => {
   it("regression: checkConflicts detects overlapping PRs despite cross-branch line drift", async () => {
     (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       async (args: { pr?: number }) => {
-        if (args.pr === 1) return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
-        if (args.pr === 2) return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
-        return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+        if (args.pr === 1) return { files: ["src/a.ts"], baseBranch: "main", source: "git", headRefName: "feature-branch" };
+        if (args.pr === 2) return { files: ["src/a.ts"], baseBranch: "main", source: "git", headRefName: "other-branch" };
+        return { files: ["src/a.ts"], baseBranch: "main", source: "git", headRefName: "feature-branch" };
       },
     );
 
@@ -476,9 +492,7 @@ describe("pr_impact tool", () => {
         _opts: unknown,
         callback: (err: Error | null, result?: { stdout: string }) => void,
       ) => {
-        if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
-          callback(null, { stdout: '{"headRefName":"feature-branch"}\n' });
-        } else if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+        if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
           callback(null, {
             stdout: '[{"number":2,"headRefName":"other-branch"}]\n',
           });

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -172,6 +172,39 @@ describe("pr_impact tool", () => {
     );
   });
 
+  it("uses the indexed detached-HEAD branch key in branch mode", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: ["src/a.ts"],
+      baseBranch: "main",
+      source: "git",
+      headRefName: "HEAD",
+    });
+
+    fs.writeFileSync(
+      path.join(tempDir, ".git", "HEAD"),
+      "2222222222222222222222222222222222222222\n",
+    );
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+    db.upsertSymbol({
+      id: "sym_detached",
+      filePath: path.join(tempDir, "src", "a.ts"),
+      name: "detachedFunc",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+    db.addSymbolsToBranch("2222222", ["sym_detached"]);
+
+    const result = await indexer.getPrImpact({});
+
+    expect(result.directSymbols.map((s) => s.id)).toContain("sym_detached");
+  });
+
   it("detects hub nodes and flags HIGH risk", async () => {
     (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       files: ["src/db.ts"],

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -459,4 +459,73 @@ describe("pr_impact tool", () => {
       "other-branch",
     );
   });
+
+  it("regression: checkConflicts detects overlapping PRs despite cross-branch line drift", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (args: { pr?: number }) => {
+        if (args.pr === 1) return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+        if (args.pr === 2) return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+        return { files: ["src/a.ts"], baseBranch: "main", source: "git" };
+      },
+    );
+
+    (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (
+        cmd: string,
+        args: string[],
+        _opts: unknown,
+        callback: (err: Error | null, result?: { stdout: string }) => void,
+      ) => {
+        if (cmd === "gh" && args[0] === "pr" && args[1] === "view") {
+          callback(null, { stdout: '{"headRefName":"feature-branch"}\n' });
+        } else if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+          callback(null, {
+            stdout: '[{"number":2,"headRefName":"other-branch"}]\n',
+          });
+        } else {
+          callback(new Error("Unexpected execFile: " + cmd + " " + JSON.stringify(args)));
+        }
+      },
+    );
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    const filePath = path.join(tempDir, "src", "a.ts");
+
+    // Symbol on the current branch at line 1.
+    db.upsertSymbol({
+      id: "sym_a_feature",
+      filePath,
+      name: "funcA",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+
+    // Same symbol on the other branch at line 20, producing a different symbolId.
+    db.upsertSymbol({
+      id: "sym_a_other",
+      filePath,
+      name: "funcA",
+      kind: "function",
+      startLine: 20,
+      startCol: 0,
+      endLine: 30,
+      endCol: 0,
+      language: "typescript",
+    });
+
+    db.addSymbolsToBranch("feature-branch", ["sym_a_feature"]);
+    db.addSymbolsToBranch("other-branch", ["sym_a_other"]);
+
+    const result = await indexer.getPrImpact({ pr: 1, checkConflicts: true });
+
+    expect(result.conflictingPRs).toBeDefined();
+    const prNums = result.conflictingPRs!.map((c) => c.pr);
+    expect(prNums).toContain(2);
+  });
 });

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
+import { pr_impact, call_graph, initializeTools } from "../src/tools/index.js";
+import { getChangedFiles } from "../src/tools/changed-files.js";
+import type { Database } from "../src/native/index.js";
+
+vi.mock("../src/tools/changed-files.js", () => ({
+  getChangedFiles: vi.fn(),
+}));
+
+describe("pr_impact tool", () => {
+  let tempDir: string;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let _indexers: Indexer[] = [];
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init?) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = Array.isArray(body.input) ? body.input : [];
+      const data = texts.map((text) => {
+        let seed = 0;
+        for (const ch of text) {
+          seed = (seed * 31 + ch.charCodeAt(0)) % 1000;
+        }
+        const embedding = Array.from({ length: 8 }, (_, idx) => ((seed + idx * 17) % 997) / 997);
+        return { embedding };
+      });
+      return new Response(
+        JSON.stringify({
+          data,
+          usage: { total_tokens: Math.max(1, texts.length * 8) },
+        }),
+        { status: 200 },
+      );
+    });
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pr-impact-test-"));
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, ".git", "refs", "heads"), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+    fs.writeFileSync(path.join(tempDir, ".git", "refs", "heads", "main"), "1111111111111111111111111111111111111111\n");
+    fs.writeFileSync(
+      path.join(tempDir, "src", "placeholder.ts"),
+      "export function placeholder() { return 1; }\n",
+      "utf-8",
+    );
+  });
+
+  afterEach(async () => {
+    await Promise.all(_indexers.map((i) => i.close()));
+    _indexers = [];
+    fetchSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  async function createIndexer(): Promise<Indexer> {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-model",
+        dimensions: 8,
+      },
+      indexing: { watchFiles: false },
+    });
+    initializeTools(tempDir, config);
+    const indexer = new Indexer(tempDir, config);
+    _indexers.push(indexer);
+    await indexer.index();
+    return indexer;
+  }
+
+  async function getDatabase(indexer: Indexer): Promise<Database> {
+    await indexer.getStatus();
+    return (indexer as unknown as { database: Database }).database;
+  }
+
+  it("happy path returns formatted report with expected sections", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: ["src/a.ts"],
+      baseBranch: "main",
+      source: "git",
+    });
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    db.upsertSymbol({
+      id: "sym_a",
+      filePath: path.join(tempDir, "src", "a.ts"),
+      name: "funcA",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_b",
+      filePath: path.join(tempDir, "src", "b.ts"),
+      name: "funcB",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+    db.addSymbolsToBranch("main", ["sym_a", "sym_b"]);
+    db.upsertCallEdge({
+      id: "edge_ba",
+      fromSymbolId: "sym_b",
+      targetName: "funcA",
+      toSymbolId: "sym_a",
+      callType: "Call",
+      confidence: "Direct",
+      line: 5,
+      col: 0,
+      isResolved: true,
+    });
+
+    const result = await pr_impact.execute({ branch: "main" }, { worktree: tempDir });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Files changed:");
+    expect(result).toContain("src/a.ts");
+    expect(result).toContain("Symbols affected:");
+    expect(result).toContain("Communities touched:");
+    expect(result).toContain("Risk:");
+  });
+
+  it("returns graceful error when branch has no indexed symbols", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: ["src/a.ts"],
+      baseBranch: "main",
+      source: "git",
+    });
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+    db.addSymbolsToBranch("main", []);
+
+    const result = await pr_impact.execute({ branch: "feature" }, { worktree: tempDir });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Error analyzing PR impact");
+    expect(result).toContain("Run index_codebase first");
+  });
+
+  it("detects hub nodes and flags HIGH risk", async () => {
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: ["src/db.ts"],
+      baseBranch: "main",
+      source: "git",
+    });
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    db.upsertSymbol({
+      id: "sym_hub",
+      filePath: path.join(tempDir, "src", "db.ts"),
+      name: "DatabasePool",
+      kind: "class",
+      startLine: 1,
+      startCol: 0,
+      endLine: 20,
+      endCol: 0,
+      language: "typescript",
+    });
+
+    const callerSymbols: string[] = [];
+    for (let i = 1; i <= 25; i++) {
+      const id = `sym_caller_${i}`;
+      callerSymbols.push(id);
+      db.upsertSymbol({
+        id,
+        filePath: path.join(tempDir, "src", `caller${i}.ts`),
+        name: `caller${i}`,
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 10,
+        endCol: 0,
+        language: "typescript",
+      });
+      db.upsertCallEdge({
+        id: `edge_${i}`,
+        fromSymbolId: id,
+        targetName: "DatabasePool",
+        toSymbolId: "sym_hub",
+        callType: "Call",
+        confidence: "Direct",
+        line: 5,
+        col: 0,
+        isResolved: true,
+      });
+    }
+
+    db.addSymbolsToBranch("main", ["sym_hub", ...callerSymbols]);
+
+    const result = await pr_impact.execute({ branch: "main" }, { worktree: tempDir });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("Risk: HIGH");
+    expect(result).toContain("DatabasePool");
+    expect(result).toContain("Hub nodes in change scope:");
+  });
+
+  it("regression: call_graph tool still works", async () => {
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    db.upsertSymbol({
+      id: "sym_x",
+      filePath: path.join(tempDir, "src", "x.ts"),
+      name: "funcX",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_y",
+      filePath: path.join(tempDir, "src", "y.ts"),
+      name: "funcY",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+    db.addSymbolsToBranch("main", ["sym_x", "sym_y"]);
+    db.upsertCallEdge({
+      id: "edge_yx",
+      fromSymbolId: "sym_y",
+      targetName: "funcX",
+      toSymbolId: "sym_x",
+      callType: "Call",
+      confidence: "Direct",
+      line: 5,
+      col: 0,
+      isResolved: true,
+    });
+
+    const result = await call_graph.execute(
+      { name: "funcX", direction: "callers" },
+      { worktree: tempDir },
+    );
+    expect(typeof result).toBe("string");
+    expect(result).toContain("funcY");
+  });
+
+  it("direction callers only returns upstream callers", async () => {
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    // Build: X -> A -> B (X calls A, A calls B)
+    db.upsertSymbol({
+      id: "sym_x", filePath: path.join(tempDir, "src", "x.ts"), name: "funcX",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_a", filePath: path.join(tempDir, "src", "a.ts"), name: "funcA",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_b", filePath: path.join(tempDir, "src", "b.ts"), name: "funcB",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.addSymbolsToBranch("main", ["sym_x", "sym_a", "sym_b"]);
+    db.upsertCallEdge({
+      id: "edge_xa", fromSymbolId: "sym_x", targetName: "funcA", toSymbolId: "sym_a",
+      callType: "Call", confidence: "Direct", line: 5, col: 0, isResolved: true,
+    });
+    db.upsertCallEdge({
+      id: "edge_ab", fromSymbolId: "sym_a", targetName: "funcB", toSymbolId: "sym_b",
+      callType: "Call", confidence: "Direct", line: 5, col: 0, isResolved: true,
+    });
+
+    // callers of A should include X (calls A), not B (called by A)
+    const callers = db.getTransitiveReachability(["sym_a"], "main", "callers", 5);
+    const callerIds = callers.map((c) => c.symbolId);
+    expect(callerIds).toContain("sym_x");
+    expect(callerIds).not.toContain("sym_b");
+  });
+
+  it("direction callees only returns downstream callees", async () => {
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    // Build: X -> A -> B
+    db.upsertSymbol({
+      id: "sym_x", filePath: path.join(tempDir, "src", "x.ts"), name: "funcX",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_a", filePath: path.join(tempDir, "src", "a.ts"), name: "funcA",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_b", filePath: path.join(tempDir, "src", "b.ts"), name: "funcB",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.addSymbolsToBranch("main", ["sym_x", "sym_a", "sym_b"]);
+    db.upsertCallEdge({
+      id: "edge_xa", fromSymbolId: "sym_x", targetName: "funcA", toSymbolId: "sym_a",
+      callType: "Call", confidence: "Direct", line: 5, col: 0, isResolved: true,
+    });
+    db.upsertCallEdge({
+      id: "edge_ab", fromSymbolId: "sym_a", targetName: "funcB", toSymbolId: "sym_b",
+      callType: "Call", confidence: "Direct", line: 5, col: 0, isResolved: true,
+    });
+
+    // callees of A should include B (A calls B), not X (calls A)
+    const callees = db.getTransitiveReachability(["sym_a"], "main", "callees", 5);
+    const calleeIds = callees.map((c) => c.symbolId);
+    expect(calleeIds).toContain("sym_b");
+    expect(calleeIds).not.toContain("sym_x");
+  });
+
+  it("direction both returns union of callers and callees", async () => {
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+
+    // Build: X -> A -> B
+    db.upsertSymbol({
+      id: "sym_x", filePath: path.join(tempDir, "src", "x.ts"), name: "funcX",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_a", filePath: path.join(tempDir, "src", "a.ts"), name: "funcA",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.upsertSymbol({
+      id: "sym_b", filePath: path.join(tempDir, "src", "b.ts"), name: "funcB",
+      kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
+    });
+    db.addSymbolsToBranch("main", ["sym_x", "sym_a", "sym_b"]);
+    db.upsertCallEdge({
+      id: "edge_xa", fromSymbolId: "sym_x", targetName: "funcA", toSymbolId: "sym_a",
+      callType: "Call", confidence: "Direct", line: 5, col: 0, isResolved: true,
+    });
+    db.upsertCallEdge({
+      id: "edge_ab", fromSymbolId: "sym_a", targetName: "funcB", toSymbolId: "sym_b",
+      callType: "Call", confidence: "Direct", line: 5, col: 0, isResolved: true,
+    });
+
+    // both: should contain X (caller) and B (callee)
+    const both = db.getTransitiveReachability(["sym_a"], "main", "both", 5);
+    const bothIds = both.map((c) => c.symbolId);
+    expect(bothIds).toContain("sym_x");
+    expect(bothIds).toContain("sym_b");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `pr_impact` tool that analyzes a pull request or branch by following call-graph relationships from changed files to affected symbols, communities, hub-node risk, and optional concurrent-PR conflicts.

## Changes

- Add Rust native functions for transitive call-graph reachability (`callers`, `callees`, and `both`), deterministic label-propagation community detection, and degree centrality in `native/src/community.rs`.
- Add `getSymbolsForBranch` and `getSymbolsForFiles` database helpers and wire them through NAPI.
- Add `Indexer.getPrImpact()` with risk-level classification (LOW / MEDIUM / HIGH), community grouping, hub-node detection, and optional `gh`-based conflict detection.
- Add OpenCode `pr_impact` tool, MCP server registration, and `/pr-impact` slash command.
- Add `changed-files.ts` helper supporting `git diff`, `gh pr view`, and fallback paths.
- Add TypeScript and Rust unit tests covering direction handling, community detection, hub-node flagging, and changed-files behavior.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #115
