### PR TITLE
feat(routing): add opt-in OMO CodeGraph handoff hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [⚡ Quick Start](#-quick-start)
 - [🌐 MCP Server (Cursor, Claude Code, Windsurf, etc.)](#-mcp-server-cursor-claude-code-windsurf-etc)
 - [🎯 When to Use What](#-when-to-use-what)
+- [🧭 OMO CodeGraph Compatibility](#-omo-codegraph-compatibility)
 - [🧰 Tools Available](#-tools-available)
 - [🎮 Slash Commands](#-slash-commands)
 - [📚 Knowledge Base](#-knowledge-base)
@@ -124,7 +125,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    npx opencode-codebase-index-mcp                            # uses current directory
    ```
 
-The MCP server exposes all 10 tools (`codebase_search`, `codebase_peek`, `find_similar`, `call_graph`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 4 prompts (`search`, `find`, `index`, `status`).
+The MCP server exposes all 12 tools (`codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`).
 
 The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) are optional peer dependencies — they're only needed if you use the MCP server.
 
@@ -156,11 +157,34 @@ src/api/checkout.ts:89      (Route handler for /pay)
 | Just need to find locations | `codebase_peek` | Returns metadata only, saves ~90% tokens |
 | Need the authoritative definition site | `implementation_lookup` | Prioritizes real implementation definitions over docs/tests |
 | Understand code flow | `call_graph` | Find callers/callees of any function |
+| Trace dependency paths | `call_graph_path` | Find the shortest known call path between two symbols |
 | Know exact identifier | `grep` | Faster, finds all occurrences |
 | Need ALL matches | `grep` | Semantic returns top N only |
 | Mixed discovery + precision | `/find` (hybrid) | Best of both worlds |
 
 **Rule of thumb**: `codebase_peek` to find locations → `Read` to examine → `grep` for precision. For symbol-definition questions, use `implementation_lookup` first.
+
+## 🧭 OMO CodeGraph Compatibility
+
+Recent OMO releases include a built-in CodeGraph MCP and make it part of the default agent workflow. This does **not** replace `opencode-codebase-index`; the two tools answer different first questions.
+
+| Need | Prefer | Why |
+|------|--------|-----|
+| Find code by intent, behavior, or natural language | `codebase_peek` / `codebase_search` | Semantic + hybrid retrieval works when you do not know exact names |
+| Jump to the likely implementation site | `implementation_lookup` | Definition-oriented ranking prefers source over tests/docs |
+| Find similar implementations or duplicate patterns | `find_similar` | Embedding similarity compares code shape and meaning |
+| Follow callers, callees, imports, inheritance, or implementations | OMO CodeGraph or `call_graph` | Structural graph tools are best for dependency topology |
+| Find a shortest known relationship chain | `call_graph_path` | Uses this plugin's indexed call edges to connect two symbols |
+| Include external docs, examples, or API references in discovery | `add_knowledge_base` + `codebase_search` | Knowledge bases are indexed into the same retrieval store |
+
+Recommended OMO workflow:
+
+1. Start broad with `codebase_peek` when the prompt is conceptual, such as "where is auth enforced?" or "payment validation flow".
+2. Use `implementation_lookup` once you have a symbol or concept that should resolve to a definition.
+3. Use OMO CodeGraph, `call_graph`, or `call_graph_path` after locating the relevant symbol to check blast radius and dependency flow.
+4. Keep `grep` for exact identifiers and exhaustive text matches.
+
+If OMO reports an uninitialized CodeGraph workspace, follow its `codegraph init` guidance. That setup is independent from this plugin's index under `.opencode/index/`, so `/index` and `codegraph init` may both be useful in the same repository.
 
 ## 📊 Token Usage
 
@@ -363,8 +387,16 @@ Returns recent debug logs with optional filtering.
 Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, and MATLAB.
 
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
-- **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries).
+- **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries), `relationshipType` (optional: `Call`, `MethodCall`, `Constructor`, `Import`, `Inherits`, `Implements`).
 - **Example**: Find who calls `validateToken` → `call_graph(name="validateToken", direction="callers")`
+
+### `call_graph_path`
+
+Find the shortest known call-graph path between two symbols. Use it after `codebase_peek`, `implementation_lookup`, or `call_graph` identifies the important source and target names.
+
+- **Use for**: Blast-radius checks, dependency-chain discovery, explaining how one subsystem reaches another.
+- **Parameters**: `from` (source symbol name), `to` (target symbol name), `maxDepth` (optional, default `10`).
+- **Example**: Trace how `createOrder` reaches `chargeCard` → `call_graph_path(from="createOrder", to="chargeCard")`
 
 ### `pr_impact`
 Analyzes a PR's changed files to determine impact scope within the codebase.
@@ -581,6 +613,7 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "rerankTopN": 20,                         // Deterministic rerank depth
     "contextLines": 0,                        // Extra lines before/after match
     "routingHints": true,                     // Runtime nudges for local discovery/definition queries
+    "routingGraphHandoffHints": false,        // Add opt-in graph/OMO CodeGraph handoff wording
     "routingHintRole": "system"              // system | developer (message role used for hints)
   },
   "reranker": {
@@ -652,6 +685,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `rerankTopN` | `20` | Deterministic rerank depth cap. Applies lightweight name/path/chunk-type rerank to top-N only |
 | `contextLines` | `0` | Extra lines to include before/after each match |
 | `routingHints` | `true` | Inject lightweight runtime hints for local conceptual discovery and definition lookups. Set to `false` to disable plugin-side routing nudges. |
+| `routingGraphHandoffHints` | `false` | When `true`, conceptual discovery hints also say to use graph tools (including OMO CodeGraph) after semantic discovery identifies relevant symbols. |
 | `routingHintRole` | `"system"` | Message role used when injecting routing hints: `"system"` (default) or `"developer"`. |
 | **reranker** | | Optional second-stage model reranker for the top candidate pool |
 | `enabled` | `false` | Turn external reranking on/off |
@@ -683,7 +717,7 @@ These warnings improve observability but do **not** change the recovery behavior
 ### Retrieval ranking behavior
 
 - `codebase_search` and `codebase_peek` use the hybrid path: semantic + keyword retrieval → fusion (`fusionStrategy`) → deterministic rerank (`rerankTopN`) → optional external reranker (`reranker`) → filtering.
-- When `search.routingHints` is enabled (default), the plugin adds tiny per-turn runtime hints for local conceptual discovery and definition queries. Conceptual discovery is nudged toward `codebase_peek` / `codebase_search`, while definition questions are nudged toward `implementation_lookup`. Exact identifier and unrelated operational tasks are left alone. Set `search.routingHintRole` to `"developer"` if your client/runtime expects developer-role guidance instead of system-role guidance.
+- When `search.routingHints` is enabled (default), the plugin adds tiny per-turn runtime hints for local conceptual discovery and definition queries. Conceptual discovery is nudged toward `codebase_peek` / `codebase_search`, while definition questions are nudged toward `implementation_lookup`. Exact identifier and unrelated operational tasks are left alone. Set `search.routingGraphHandoffHints` to `true` to add opt-in graph/OMO CodeGraph handoff wording, and set `search.routingHintRole` to `"developer"` if your client/runtime expects developer-role guidance instead of system-role guidance.
 - `find_similar` stays semantic-only: semantic retrieval + deterministic rerank only (no keyword retrieval, no RRF).
 - For compatibility rollbacks, set `search.fusionStrategy` to `"weighted"` to use the legacy weighted fusion path.
 - When enabled, the external reranker sees path metadata plus a bounded on-disk code snippet for each candidate so it can distinguish real implementations from docs/tests more reliably.

--- a/commands/call-graph.md
+++ b/commands/call-graph.md
@@ -1,24 +1,28 @@
 ---
-description: Trace callers or callees using the call graph
+description: Trace callers, callees, or paths using the call graph
 ---
 
-Trace function dependencies using the `call_graph` tool.
+Trace function dependencies using the `call_graph` and `call_graph_path` tools.
 
 User input: $ARGUMENTS
 
 Interpret input as follows:
+- If input asks for a path, connection, route, chain, or "from X to Y", use `call_graph_path`.
 - Default to `direction="callers"` unless input asks for callees/calls/makes calls.
 - `name=<function>` or plain text function name sets `name`.
 - `symbolId=<id>` is required for `direction="callees"`.
+- For path queries, parse `from=<function>`, `to=<function>`, and optional `maxDepth=<number>`.
 
 Execution flow:
-1. If direction is `callers`, call `call_graph` with `{ name, direction: "callers" }`.
-2. If direction is `callees` and `symbolId` is present, call `call_graph` with `{ name, direction: "callees", symbolId }`.
-3. If direction is `callees` and `symbolId` is missing, first call `call_graph` with `direction="callers"` to get symbol IDs, then ask the user to choose one if multiple are returned.
+1. If input asks for a path and has source/target names, call `call_graph_path` with `{ from, to, maxDepth? }`.
+2. If direction is `callers`, call `call_graph` with `{ name, direction: "callers" }`.
+3. If direction is `callees` and `symbolId` is present, call `call_graph` with `{ name, direction: "callees", symbolId }`.
+4. If direction is `callees` and `symbolId` is missing, first call `call_graph` with `direction="callers"` to get symbol IDs, then ask the user to choose one if multiple are returned.
 
 Examples:
 - `/call-graph Database` → callers for `Database`
 - `/call-graph callers name=Indexer` → callers for `Indexer`
 - `/call-graph callees name=Database symbolId=sym_abc123` → callees for selected symbol
+- `/call-graph path from=createOrder to=chargeCard` → shortest known path between the two symbols
 
 If output says no callers found, suggest running `/index force` first.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -21,6 +21,8 @@ The indexed codebase contains **two types of content**:
 | Need to see actual code | `codebase_search` | Returns full code content |
 | Find duplicates/patterns | `find_similar` | Given code snippet → similar code |
 | Understand code flow | `call_graph` | Find callers/callees of any function |
+| Trace dependency paths | `call_graph_path` | Find a shortest known path between two symbols |
+| Analyze PR blast radius | `pr_impact` | Find affected symbols, communities, hub nodes, and risk |
 | Don't know function/class names | `codebase_peek` or `codebase_search` | Natural language → code |
 | Know exact identifier names | `grep` | Faster, more precise |
 | Need ALL occurrences | `grep` | Semantic returns top N only |
@@ -54,10 +56,11 @@ Suggest: "知识库中未找到相关信息，是否添加相关文档文件夹�
 
 ## Recommended Workflow
 
-1. **Search first**: `codebase_search("ADC channels ESP32")` → check local knowledge
-2. **Locate with peek**: `codebase_peek("authentication flow")` → get file locations
+1. **Locate by meaning first**: `codebase_peek("authentication flow")` → get likely locations before grep or graph tools
+2. **Search with content**: `codebase_search("ADC channels ESP32")` → inspect implementation or knowledge-base matches
 3. **Read what matters**: `Read` the specific files you need
-4. **Drill down with grep**: `grep "validateToken"` for exact matches
+4. **Trace structure after discovery**: `call_graph`, `call_graph_path`, `pr_impact`, or OMO CodeGraph once you know the relevant symbol
+5. **Drill down with grep**: `grep "validateToken"` for exact matches
 
 ## Tools
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -35,6 +35,7 @@ export function getDefaultSearchConfig(): SearchConfig {
     rerankTopN: 20,
     contextLines: 0,
     routingHints: true,
+    routingGraphHandoffHints: false,
     routingHintRole: "system",
   };
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -66,6 +66,7 @@ export interface SearchConfig {
   rerankTopN: number;
   contextLines: number;
   routingHints: boolean;
+  routingGraphHandoffHints: boolean;
   routingHintRole: "system" | "developer";
 }
 
@@ -192,6 +193,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     rerankTopN: typeof rawSearch.rerankTopN === "number" ? Math.min(200, Math.max(0, Math.floor(rawSearch.rerankTopN))) : defaultSearch.rerankTopN,
     contextLines: typeof rawSearch.contextLines === "number" ? Math.min(50, Math.max(0, rawSearch.contextLines)) : defaultSearch.contextLines,
     routingHints: typeof rawSearch.routingHints === "boolean" ? rawSearch.routingHints : defaultSearch.routingHints,
+    routingGraphHandoffHints: typeof rawSearch.routingGraphHandoffHints === "boolean" ? rawSearch.routingGraphHandoffHints : defaultSearch.routingGraphHandoffHints,
     routingHintRole: rawSearch.routingHintRole === "developer" || rawSearch.routingHintRole === "system"
       ? rawSearch.routingHintRole
       : defaultSearch.routingHintRole,

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ const plugin: Plugin = async ({ directory, worktree }) => {
 
     const getProjectIndexer = () => getIndexerForProject(projectRoot);
     const routingHints = config.search.routingHints
-      ? new RoutingHintController(() => getProjectIndexer().getStatus())
+      ? new RoutingHintController(() => getProjectIndexer().getStatus(), 200, config.search.routingGraphHandoffHints)
       : null;
 
     const isHomeDir = path.resolve(projectRoot) === path.resolve(os.homedir());

--- a/src/routing-hints.ts
+++ b/src/routing-hints.ts
@@ -124,6 +124,7 @@ export function assessRoutingIntent(text: string): RoutingAssessment {
 export function buildRoutingHint(
   assessment: RoutingAssessment,
   status: Pick<StatusResult, "indexed" | "compatibility"> | null,
+  includeGraphHandoff: boolean = false,
 ): string | null {
   if (assessment.intent === "definition_lookup") {
     if (!status || !status.indexed || status.compatibility?.compatible === false) {
@@ -138,10 +139,14 @@ export function buildRoutingHint(
   }
 
   if (!status || !status.indexed || status.compatibility?.compatible === false) {
-    return "For this turn, if local code discovery by behavior is needed, check `index_status` first and run `index_codebase` if the index is missing or incompatible. Use `grep` for exact identifiers or exhaustive matches.";
+      const graphHandoff = includeGraphHandoff ? " Use graph tools after semantic discovery identifies relevant symbols." : "";
+      return `For this turn, if local code discovery by behavior is needed, check \`index_status\` first and run \`index_codebase\` if the index is missing or incompatible.${graphHandoff} Use \`grep\` for exact identifiers or exhaustive matches.`;
   }
 
-  return "For this turn, prefer `codebase_peek` for local code discovery by behavior or likely location, then use `codebase_search` when you need implementation content. Use `grep` for exact identifiers or exhaustive matches.";
+  const graphHandoff = includeGraphHandoff
+    ? " before graph tools such as `call_graph`, `call_graph_path`, `pr_impact`, or OMO CodeGraph"
+    : "";
+  return `For this turn, prefer \`codebase_peek\` for local code discovery by behavior or likely location${graphHandoff}. Then use \`codebase_search\` when you need implementation content. Use \`grep\` for exact identifiers or exhaustive matches.`;
 }
 
 export class RoutingHintController {
@@ -150,6 +155,7 @@ export class RoutingHintController {
   constructor(
     private readonly getStatus: () => Promise<Pick<StatusResult, "indexed" | "compatibility">>,
     private readonly maxSessions: number = 200,
+    private readonly includeGraphHandoff: boolean = false,
   ) {}
 
   observeUserMessage(sessionID: string, parts: TextPartLike[]): RoutingAssessment {
@@ -176,7 +182,7 @@ export class RoutingHintController {
     }
 
     const status = await this.safeGetStatus();
-    const hint = buildRoutingHint(state.assessment, status);
+    const hint = buildRoutingHint(state.assessment, status, this.includeGraphHandoff);
 
     return hint ? [hint] : [];
   }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -213,8 +213,9 @@ Final line.`;
       expect(reindexCmd.template).toContain("force=true");
 
       const callGraphCmd = commands.get("call-graph")!;
-      expect(callGraphCmd.description).toBe("Trace callers or callees using the call graph");
+      expect(callGraphCmd.description).toBe("Trace callers, callees, or paths using the call graph");
       expect(callGraphCmd.template).toContain("call_graph");
+      expect(callGraphCmd.template).toContain("call_graph_path");
     });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -304,6 +304,15 @@ describe("config schema", () => {
         expect(parseConfig({ search: { routingHints: "nope" } }).search.routingHints).toBe(true);
       });
 
+      it("should parse routingGraphHandoffHints values", () => {
+        expect(parseConfig({ search: { routingGraphHandoffHints: true } }).search.routingGraphHandoffHints).toBe(true);
+        expect(parseConfig({ search: { routingGraphHandoffHints: false } }).search.routingGraphHandoffHints).toBe(false);
+      });
+
+      it("should fallback routingGraphHandoffHints to default for invalid values", () => {
+        expect(parseConfig({ search: { routingGraphHandoffHints: "nope" } }).search.routingGraphHandoffHints).toBe(false);
+      });
+
       it("should parse routingHintRole values", () => {
         expect(parseConfig({ search: { routingHintRole: "system" } }).search.routingHintRole).toBe("system");
         expect(parseConfig({ search: { routingHintRole: "developer" } }).search.routingHintRole).toBe("developer");

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -4,6 +4,7 @@ const mockState = vi.hoisted(() => ({
   config: {
     search: {
       routingHints: true,
+      routingGraphHandoffHints: false,
       routingHintRole: "system" as "system" | "developer",
     },
     indexing: {
@@ -96,6 +97,7 @@ describe("plugin routing hint hook selection", () => {
     mockState.config = {
       search: {
         routingHints: true,
+        routingGraphHandoffHints: false,
         routingHintRole: "system",
       },
       indexing: {

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -184,7 +184,6 @@ describe("pr_impact tool", () => {
       path.join(tempDir, ".git", "HEAD"),
       "2222222222222222222222222222222222222222\n",
     );
-
     const indexer = await createIndexer();
     const db = await getDatabase(indexer);
     db.upsertSymbol({

--- a/tests/routing-hints.test.ts
+++ b/tests/routing-hints.test.ts
@@ -75,10 +75,12 @@ describe("routing hints", () => {
       const hint = buildRoutingHint(
         assessRoutingIntent("Where is the webhook validation logic?"),
         { indexed: true, compatibility: { compatible: true } },
+        true,
       );
 
       expect(hint).toContain("prefer `codebase_peek`");
       expect(hint).toContain("`codebase_search`");
+      expect(hint).toContain("before graph tools such as `call_graph`, `call_graph_path`, `pr_impact`, or OMO CodeGraph");
       expect(hint).toContain("`grep`");
     });
 
@@ -86,10 +88,12 @@ describe("routing hints", () => {
       const hint = buildRoutingHint(
         assessRoutingIntent("Which file handles retry backoff logic?"),
         { indexed: false, compatibility: null },
+        true,
       );
 
       expect(hint).toContain("check `index_status` first");
       expect(hint).toContain("run `index_codebase`");
+      expect(hint).toContain("Use graph tools after semantic discovery identifies relevant symbols");
     });
 
     it("returns null for non-conceptual intents", () => {
@@ -99,6 +103,17 @@ describe("routing hints", () => {
       );
 
       expect(hint).toBeNull();
+    });
+
+    it("omits graph handoff wording by default", () => {
+      const hint = buildRoutingHint(
+        assessRoutingIntent("Where is the webhook validation logic?"),
+        { indexed: true, compatibility: { compatible: true } },
+      );
+
+      expect(hint).toContain("prefer `codebase_peek`");
+      expect(hint).not.toContain("OMO CodeGraph");
+      expect(hint).not.toContain("Use graph tools after semantic discovery");
     });
 
     it("returns a definition-specific hint when the index is ready", () => {
@@ -127,7 +142,7 @@ describe("routing hints", () => {
       const controller = new RoutingHintController(async () => ({
         indexed: true,
         compatibility: { compatible: true },
-      }));
+      }), 200, true);
 
       controller.observeUserMessage("session-1", [{ type: "text", text: "Where is the auth flow implemented?" }]);
 
@@ -138,6 +153,7 @@ describe("routing hints", () => {
       const hints = await controller.getSystemHints("session-1");
       expect(hints).toHaveLength(1);
       expect(hints[0]).toContain("prefer `codebase_peek`");
+      expect(hints[0]).toContain("OMO CodeGraph");
     });
 
     it("stops nudging after a codebase tool is used", async () => {


### PR DESCRIPTION
## Summary

Add an opt-in graph handoff routing mode so semantic discovery hints can explicitly direct agents to use `codebase_peek` before graph tools such as OMO CodeGraph, `call_graph`, `call_graph_path`, and `pr_impact`.

## Changes

- Add `search.routingGraphHandoffHints` config flag, defaulting to `false`.
- Gate graph/OMO CodeGraph handoff wording behind that config flag while preserving existing semantic routing hints by default.
- Route `/call-graph` path/chain/from-to prompts to `call_graph_path`.
- Refresh README and skill guidance for the OMO CodeGraph workflow and current tool surfaces.
- Carry forward the detached-HEAD `pr_impact` branch-key regression fix from latest `main`.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build:ts`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional verification:

- `npx vitest run tests/config.test.ts tests/routing-hints.test.ts tests/plugin-hooks.test.ts`
- `npx vitest run tests/commands.test.ts tests/pr-impact.test.ts tests/routing-hints.test.ts tests/config.test.ts tests/plugin-hooks.test.ts`
- `npx tsx -e 'import("./src/config/schema.ts").then(({ parseConfig }) => { const off = parseConfig({}).search.routingGraphHandoffHints; const on = parseConfig({ search: { routingGraphHandoffHints: true } }).search.routingGraphHandoffHints; if (off !== false || on !== true) throw new Error("config surface failed"); console.log(`config-surface-ok off=${off} on=${on}`); })'`

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #(issue number)
