### PR TITLE
security(deps): bump hono override to 4.12.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4835,9 +4835,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "brace-expansion": "5.0.6",
     "express-rate-limit": "8.5.2",
     "fast-uri": "3.1.2",
-    "hono": "4.12.23",
+    "hono": "4.12.25",
     "ip-address": "10.2.0",
     "postcss": "8.5.15",
     "qs": "6.15.2",


### PR DESCRIPTION
## Summary

Bump the transitive Hono override used by the MCP SDK dependency tree to the patched 4.12.25 release.

## Changes

- Update the root npm override for hono from 4.12.23 to 4.12.25
- Refresh package-lock.json for the patched Hono tarball and integrity
- Resolve the five open Dependabot alerts for Hono < 4.12.25

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional verification:

- [x] `npm audit --audit-level=low` reports 0 vulnerabilities
- [x] `node -e` check confirms installed `hono` is 4.12.25

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Resolves Dependabot alerts #6, #7, #8, #9, and #10.