### PR TITLE
fix(call-graph): index exported TS symbols

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -51,6 +51,7 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "function_declaration",
   "function",
   "arrow_function",
+  "export_statement",
   "method_definition",
   "class_declaration",
   "interface_declaration",


### PR DESCRIPTION
## Summary

Ensure exported TypeScript/JavaScript declarations are indexed as call-graph symbols.

## Changes

- include `export_statement` in `CALL_GRAPH_SYMBOL_CHUNK_TYPES`
- restore symbol persistence for exported functions during indexing
- unblock `call_graph`, `call_graph_path`, and `pr_impact` on fresh repos

## Testing

How were these changes tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [ ] Tests pass (`npm run test:run`)
- [ ] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #
