### PR TITLE
feat(codex): add marketplace-backed plugin integration

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "helweg-plugins",
+  "interface": {
+    "displayName": "Helweg Plugins"
+  },
+  "plugins": [
+    {
+      "name": "codebase-index",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "codebase-index",
+  "version": "0.12.0",
+  "description": "Semantic code search and codebase graph tools for Codex",
+  "author": {
+    "name": "Kenneth",
+    "email": "kenneth@example.com",
+    "url": "https://github.com/Helweg/opencode-codebase-index"
+  },
+  "homepage": "https://github.com/Helweg/opencode-codebase-index",
+  "repository": "https://github.com/Helweg/opencode-codebase-index",
+  "license": "MIT",
+  "keywords": [
+    "codebase-index",
+    "semantic search",
+    "opencode",
+    "codex",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
+  "id": "codebase-index",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Codebase Index",
+    "shortDescription": "Navigate large codebases with semantic search and graph tools",
+    "longDescription": "Install this plugin to get semantic search tools in Codex. The skill layer gives usage guidance, and MCP tools provide searchable context for large repos.",
+    "developerName": "Kenneth",
+    "category": "Productivity",
+    "capabilities": [
+      "Instructions",
+      "MCP Tools",
+      "Search"
+    ],
+    "websiteURL": "https://github.com/Helweg/opencode-codebase-index",
+    "privacyPolicyURL": "https://github.com/Helweg/opencode-codebase-index/blob/main/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/Helweg/opencode-codebase-index/blob/main/LICENSE",
+    "brandColor": "#3B82F6",
+    "defaultPrompt": [
+      "Use codebase-search skills and MCP tools to find local implementation context before edits."
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "codebase-index": {
+      "command": "node",
+      "args": ["${PLUGIN_ROOT}/dist/cli.js", "--host", "codex"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## 📌 Quick Navigation
 
 - [⚡ Quick Start](#-quick-start)
+- [🧩 Codex Plugin](#-codex-plugin)
 - [🌐 MCP Server (Cursor, Claude Code, Windsurf, etc.)](#-mcp-server-cursor-claude-code-windsurf-etc)
 - [🎯 When to Use What](#-when-to-use-what)
 - [🧭 OMO CodeGraph Compatibility](#-omo-codegraph-compatibility)
@@ -62,6 +63,20 @@
 4. **Start Searching**
    Ask:
    > "Find the function that handles credit card validation errors"
+## 🧩 Codex Plugin
+Install once for Codex threads and get skill guidance plus MCP tools in one manifest.
+
+1. **Install the plugin from the marketplace**
+   ```bash
+   codex plugin add codebase-index
+   ```
+2. **Restart or open a new thread** in the target workspace.
+3. Use MCP tools (`index_codebase`, `index_status`, `codebase_search`, etc.) and the `codebase-search` skill guidance.
+
+The plugin includes:
+- `skills/` guidance for local workflows
+- `hooks/hooks.json` lightweight session-start guidance
+- `.mcp.json` with `--host codex`
 
 ### Provider selection notes
 
@@ -543,6 +558,21 @@ Any OpenAI-compatible reranking endpoint. Examples:
 - **Local models**: Any server implementing `/v1/rerank` format
 
 ## ⚙️ Configuration
+
+### Storage Paths (OpenCode + Codex)
+OpenCode default (existing behavior):
+- project config: `.opencode/codebase-index.json`
+- project index: `.opencode/index`
+- global config: `~/.config/opencode/codebase-index.json`
+- global index: `~/.opencode/global-index`
+
+Codex host mode (new plugin default):
+- project config: `.codebase-index/config.json`
+- project index: `.codebase-index/index`
+- global config: `~/.config/codebase-index/config.json`
+- global index: `~/.codebase-index/global-index`
+
+Codex reads legacy OpenCode paths when codex-native paths are absent, so existing state continues to work.
 
 Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-index.json`:
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,22 @@
 ## 🧩 Codex Plugin
 Install once for Codex threads and get skill guidance plus MCP tools in one manifest.
 
-1. **Install the plugin from the marketplace**
+1. **Add this repo as a marketplace source**
    ```bash
-   codex plugin add codebase-index
+   codex plugin marketplace add Helweg/opencode-codebase-index
    ```
-2. **Restart or open a new thread** in the target workspace.
-3. Use MCP tools (`index_codebase`, `index_status`, `codebase_search`, etc.) and the `codebase-search` skill guidance.
+2. **Install the plugin**
+   ```bash
+   codex plugin add codebase-index@helweg-plugins
+   ```
+3. **Restart or open a new thread** in the target workspace.
+4. Use MCP tools (`index_codebase`, `index_status`, `codebase_search`, etc.) and the `codebase-search` skill guidance.
 
 The plugin includes:
 - `skills/` guidance for local workflows
 - `hooks/hooks.json` lightweight session-start guidance
 - `.mcp.json` with `--host codex`
+- `.agents/plugins/marketplace.json` so this repo can act as a Codex marketplace source
 
 ### Provider selection notes
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '\nUse codebase_peek for quick location discovery, then codebase_search for implementation details. Use index_status before searching on first run.\\n'",
+            "commandWindows": "Write-Output 'Use codebase_peek for quick location discovery, then codebase_search for implementation details. Use index_status before searching on first run.'",
+            "statusMessage": "Codebase Index ready"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,11 @@
     "dist",
     "native/*.node",
     "skill",
-    "commands"
+    "commands",
+    ".codex-plugin",
+    ".mcp.json",
+    "skills",
+    "hooks"
   ],
   "napi": {
     "binaryName": "codebase-index-native",

--- a/skills/codebase-search/SKILL.md
+++ b/skills/codebase-search/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: codebase-search
+description: Semantic code and documentation search by meaning for Codex workflows. Use codebase_peek to find WHERE code is first, then codebase_search for implementation details.
+---
+
+# Codebase Search Skill
+
+Use this skill when you need local repository knowledge before web lookup.
+
+## Core workflow
+
+1. `codebase_peek(query, ...)` to find likely locations quickly with metadata-only results.
+2. `codebase_search(query, ...)` when you need full code context.
+3. `call_graph(name, direction)` when you need callers/callees after locating a symbol.
+4. `find_similar(code)` for duplicate patterns and refactor planning.
+5. `implementation_lookup(query)` when you need the authoritative definition location.
+
+If results are weak, run `index_status` (check readiness) and `index_codebase`.
+
+## Tool Priority
+
+- `codebase_peek` for discovery (fastest, cheap tokens).
+- `codebase_search` for exact implementation review.
+- `find_similar` for pattern matching and duplication.
+- `call_graph` and `call_graph_path` for execution flow.
+- `index_codebase` (force/estimate/verbose) for first-time or stale indexes.
+- `index_status`, `index_health_check`, `index_metrics`, `index_logs` for operational checks.
+
+## Suggested Commands
+
+1. `codebase_peek("payment processing flow")`
+2. `codebase_search("payment processing flow")`
+3. `call_graph("chargeCard", "callees")`
+4. `find_similar("function validate(data)")`
+5. `implementation_lookup("validate")`
+
+## Additional Notes
+
+- Use `grep` for exact identifiers and tiny, deterministic lookups.
+- Use `websearch` only when local tools return no results and docs are likely missing.
+- Prefer `codebase_peek` before `codebase_search` to avoid high token usage.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,6 +158,7 @@ async function main(): Promise<void> {
       args.project,
       config,
       args.host,
+      args.config ? { configPath: args.config } : {},
     );
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,12 +161,12 @@ async function main(): Promise<void> {
 
 main().catch((error: unknown) => {
   if (error instanceof Error && error.message.startsWith("Invalid host mode")) {
-    console.error(error.message);
+    console.error("Invalid host mode. Allowed values: opencode, codex.");
     process.exit(1);
   }
 
   if (error instanceof Error) {
-    console.error(error.message);
+    console.error("Failed to start MCP server. Check config and network.");
     process.exit(1);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import * as os from "os";
 import * as path from "path";
 
 import { parseConfig } from "./config/schema.js";
@@ -7,6 +8,9 @@ import { parseHostMode, type HostMode } from "./config/host.js";
 import { handleEvalCommand } from "./eval/cli.js";
 import { createMcpServer } from "./mcp-server.js";
 import { loadMergedConfig } from "./config/merger.js";
+import { getIndexerForProject } from "./tools/operations.js";
+import { hasProjectMarker } from "./utils/files.js";
+import { createWatcherWithIndexer, type CombinedWatcher } from "./watcher/index.js";
 
 function parseArgs(argv: string[]): { project: string; config?: string; host: HostMode } {
   let project = process.cwd();
@@ -43,7 +47,27 @@ async function main(): Promise<void> {
 
   await server.connect(transport);
 
+  let watcher: CombinedWatcher | null = null;
+  const isHomeDir = path.resolve(args.project) === path.resolve(os.homedir());
+  const isValidProject = !isHomeDir && (!config.indexing.requireProjectMarker || hasProjectMarker(args.project));
+
+  if (config.indexing.autoIndex && isValidProject) {
+    const indexer = getIndexerForProject(args.project, args.host);
+    indexer.initialize().then(() => {
+      indexer.index().catch(() => {});
+    }).catch(() => {});
+  }
+
+  if (config.indexing.watchFiles && isValidProject) {
+    watcher = createWatcherWithIndexer(
+      () => getIndexerForProject(args.project, args.host),
+      args.project,
+      config,
+    );
+  }
+
   const shutdown = (): void => {
+    watcher?.stop();
     server.close().catch(() => {});
     process.exit(0);
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,23 +3,29 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import * as path from "path";
 
 import { parseConfig } from "./config/schema.js";
+import { parseHostMode, type HostMode } from "./config/host.js";
 import { handleEvalCommand } from "./eval/cli.js";
 import { createMcpServer } from "./mcp-server.js";
 import { loadMergedConfig } from "./config/merger.js";
 
-function parseArgs(argv: string[]): { project: string; config?: string } {
+function parseArgs(argv: string[]): { project: string; config?: string; host: HostMode } {
   let project = process.cwd();
   let config: string | undefined;
+  let host: HostMode = "opencode";
 
   for (let i = 2; i < argv.length; i++) {
     if (argv[i] === "--project" && argv[i + 1]) {
       project = path.resolve(argv[++i]);
     } else if (argv[i] === "--config" && argv[i + 1]) {
       config = path.resolve(argv[++i]);
+    } else if (argv[i] === "--host" && argv[i + 1]) {
+      host = parseHostMode(argv[++i]);
+    } else if (argv[i] === "--host") {
+      host = parseHostMode(undefined);
     }
   }
 
-  return { project, config };
+  return { project, config, host };
 }
 
 async function main(): Promise<void> {
@@ -29,10 +35,10 @@ async function main(): Promise<void> {
   }
 
   const args = parseArgs(process.argv);
-  const rawConfig = loadMergedConfig(args.project);
+  const rawConfig = loadMergedConfig(args.project, args.host);
   const config = parseConfig(rawConfig);
 
-  const server = createMcpServer(args.project, config);
+  const server = createMcpServer(args.project, config, args.host);
   const transport = new StdioServerTransport();
 
   await server.connect(transport);
@@ -46,7 +52,17 @@ async function main(): Promise<void> {
   process.on("SIGTERM", shutdown);
 }
 
-main().catch((_error: unknown) => {
-  console.error("Fatal: failed to start MCP server (check config and network)");
+main().catch((error: unknown) => {
+  if (error instanceof Error && error.message.startsWith("Invalid host mode")) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  if (error instanceof Error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  console.error("Fatal: failed to start MCP server");
   process.exit(1);
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,18 +3,25 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
+import { pathToFileURL } from "url";
 
 import { parseConfig } from "./config/schema.js";
 import { parseHostMode, type HostMode } from "./config/host.js";
 import { handleEvalCommand } from "./eval/cli.js";
 import { Indexer } from "./indexer/index.js";
 import { createMcpServer } from "./mcp-server.js";
-import { loadMergedConfig } from "./config/merger.js";
+import { loadConfigFile, loadMergedConfig } from "./config/merger.js";
 import { getIndexerForProject } from "./tools/operations.js";
 import { hasProjectMarker } from "./utils/files.js";
 import { createWatcherWithIndexer, type CombinedWatcher } from "./watcher/index.js";
 import { attachRecentActivity } from "./tools/visualize/activity.js";
 import { generateVisualizationHtml, transformForVisualization } from "./tools/visualize/index.js";
+
+export interface CliArgs {
+  project: string;
+  config?: string;
+  host: HostMode;
+}
 
 interface VisualizeArgs {
   directory?: string;
@@ -23,7 +30,7 @@ interface VisualizeArgs {
   project: string;
 }
 
-function parseArgs(argv: string[]): { project: string; config?: string; host: HostMode } {
+export function parseArgs(argv: string[]): CliArgs {
   let project = process.cwd();
   let config: string | undefined;
   let host: HostMode = "opencode";
@@ -41,6 +48,10 @@ function parseArgs(argv: string[]): { project: string; config?: string; host: Ho
   }
 
   return { project, config, host };
+}
+
+export function loadCliRawConfig(args: CliArgs): unknown {
+  return args.config ? loadConfigFile(args.config) : loadMergedConfig(args.project, args.host);
 }
 
 function parseVisualizeArgs(argv: string[], cwd: string): VisualizeArgs {
@@ -122,7 +133,7 @@ async function main(): Promise<void> {
   }
 
   const args = parseArgs(process.argv);
-  const rawConfig = loadMergedConfig(args.project, args.host);
+  const rawConfig = loadCliRawConfig(args);
   const config = parseConfig(rawConfig);
 
   const server = createMcpServer(args.project, config, args.host);
@@ -146,6 +157,7 @@ async function main(): Promise<void> {
       () => getIndexerForProject(args.project, args.host),
       args.project,
       config,
+      args.host,
     );
   }
 
@@ -159,7 +171,7 @@ async function main(): Promise<void> {
   process.on("SIGTERM", shutdown);
 }
 
-main().catch((error: unknown) => {
+function handleMainError(error: unknown): never {
   if (error instanceof Error && error.message.startsWith("Invalid host mode")) {
     console.error("Invalid host mode. Allowed values: opencode, codex.");
     process.exit(1);
@@ -172,4 +184,8 @@ main().catch((error: unknown) => {
 
   console.error("Fatal: failed to start MCP server");
   process.exit(1);
-});
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch(handleMainError);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { createMcpServer } from "./mcp-server.js";
 import { loadConfigFile, loadMergedConfig } from "./config/merger.js";
 import { getIndexerForProject } from "./tools/operations.js";
 import { hasProjectMarker } from "./utils/files.js";
+import { startAutoIndex } from "./utils/auto-index.js";
 import { createWatcherWithIndexer, type CombinedWatcher } from "./watcher/index.js";
 import { attachRecentActivity } from "./tools/visualize/activity.js";
 import { generateVisualizationHtml, transformForVisualization } from "./tools/visualize/index.js";
@@ -147,9 +148,7 @@ async function main(): Promise<void> {
 
   if (config.indexing.autoIndex && isValidProject) {
     const indexer = getIndexerForProject(args.project, args.host);
-    indexer.initialize().then(() => {
-      indexer.index().catch(() => {});
-    }).catch(() => {});
+    startAutoIndex(indexer, args.project);
   }
 
   if (config.indexing.watchFiles && isValidProject) {

--- a/src/config/host.ts
+++ b/src/config/host.ts
@@ -1,0 +1,17 @@
+export type HostMode = "opencode" | "codex";
+
+export const HOST_MODES: ReadonlyArray<HostMode> = ["opencode", "codex"];
+
+export function parseHostMode(value: string | undefined): HostMode {
+  const normalized = (value ?? "").toLowerCase();
+
+  if (normalized === "opencode" || normalized === "codex") {
+    return normalized;
+  }
+
+  throw new Error(`Invalid host mode: ${value ?? "(none)"}. Allowed values: opencode, codex.`);
+}
+
+export function isSupportedHostMode(value: string): value is HostMode {
+  return value === "opencode" || value === "codex";
+}

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as path from "path";
 
-import { getGlobalConfigPath, resolveProjectConfigPath, resolveWritableProjectConfigPath } from "./paths.js";
+import { resolveGlobalConfigPath, resolveProjectConfigPath, resolveWritableProjectConfigPath } from "./paths.js";
 import type { HostMode } from "./host.js";
 import { resolveInheritedKnowledgeBaseEntries } from "./rebase.js";
 
@@ -155,7 +155,7 @@ export function loadProjectConfigLayer(projectRoot: string, host: HostMode = "op
  * - For include/exclude: project overrides global if set, otherwise load global
  */
 export function loadMergedConfig(projectRoot: string, host: HostMode = "opencode"): unknown {
-  const globalConfigPath = getGlobalConfigPath(host);
+  const globalConfigPath = resolveGlobalConfigPath(host);
   const projectConfigPath = resolveProjectConfigPath(projectRoot, host);
   let globalConfig: Record<string, unknown> | null = null;
   let globalConfigError: Error | null = null;

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -111,6 +111,10 @@ function loadJsonFile(filePath: string): unknown {
 
 }
 
+export function loadConfigFile(filePath: string): unknown {
+  return loadJsonFile(filePath);
+}
+
 export function materializeLocalProjectConfig(
   projectRoot: string,
   config: unknown,

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -1,8 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import * as os from "os";
 import * as path from "path";
 
-import { resolveProjectConfigPath } from "./paths.js";
+import { getGlobalConfigPath, resolveProjectConfigPath, resolveWritableProjectConfigPath } from "./paths.js";
+import type { HostMode } from "./host.js";
 import { resolveInheritedKnowledgeBaseEntries } from "./rebase.js";
 
 const PROJECT_OVERRIDE_KEYS = [
@@ -109,18 +109,21 @@ function loadJsonFile(filePath: string): unknown {
     throw new Error(`Failed to load config file ${filePath}: ${message}`);
   }
 
-  return null;
 }
 
-export function materializeLocalProjectConfig(projectRoot: string, config: unknown): string {
-  const localConfigPath = path.join(projectRoot, ".opencode", "codebase-index.json");
+export function materializeLocalProjectConfig(
+  projectRoot: string,
+  config: unknown,
+  host: HostMode = "opencode",
+): string {
+  const localConfigPath = resolveWritableProjectConfigPath(projectRoot, host);
   mkdirSync(path.dirname(localConfigPath), { recursive: true });
   writeFileSync(localConfigPath, JSON.stringify(config, null, 2), "utf-8");
   return localConfigPath;
 }
 
-export function loadProjectConfigLayer(projectRoot: string): Record<string, unknown> {
-  const projectConfigPath = resolveProjectConfigPath(projectRoot);
+export function loadProjectConfigLayer(projectRoot: string, host: HostMode = "opencode"): Record<string, unknown> {
+  const projectConfigPath = resolveProjectConfigPath(projectRoot, host);
   const projectConfig = loadJsonFile(projectConfigPath) as Record<string, unknown> | null;
 
   if (!projectConfig) {
@@ -151,9 +154,9 @@ export function loadProjectConfigLayer(projectRoot: string): Record<string, unkn
  * - For additionalInclude: merge arrays (union, deduplicated)
  * - For include/exclude: project overrides global if set, otherwise load global
  */
-export function loadMergedConfig(projectRoot: string): unknown {
-  const globalConfigPath = os.homedir() + "/.config/opencode/codebase-index.json";
-  const projectConfigPath = resolveProjectConfigPath(projectRoot);
+export function loadMergedConfig(projectRoot: string, host: HostMode = "opencode"): unknown {
+  const globalConfigPath = getGlobalConfigPath(host);
+  const projectConfigPath = resolveProjectConfigPath(projectRoot, host);
   let globalConfig: Record<string, unknown> | null = null;
   let globalConfigError: Error | null = null;
 
@@ -164,7 +167,7 @@ export function loadMergedConfig(projectRoot: string): unknown {
   }
 
   const projectConfig = loadJsonFile(projectConfigPath) as Record<string, unknown> | null;
-  const normalizedProjectConfig = loadProjectConfigLayer(projectRoot);
+  const normalizedProjectConfig = loadProjectConfigLayer(projectRoot, host);
 
   if (globalConfigError) {
     if (!projectConfig) {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -79,6 +79,38 @@ export function getGlobalConfigPath(host: HostMode = "opencode"): string {
   return path.join(os.homedir(), ".config", "codebase-index", "config.json");
 }
 
+export function resolveGlobalConfigPath(host: HostMode = "opencode"): string {
+  const hostConfigPath = getGlobalConfigPath(host);
+  if (existsSync(hostConfigPath)) {
+    return hostConfigPath;
+  }
+
+  if (host !== "opencode") {
+    const legacyConfigPath = getGlobalConfigPath("opencode");
+    if (existsSync(legacyConfigPath)) {
+      return legacyConfigPath;
+    }
+  }
+
+  return hostConfigPath;
+}
+
+export function resolveGlobalIndexPath(host: HostMode = "opencode"): string {
+  const hostIndexPath = getGlobalIndexPath(host);
+  if (existsSync(hostIndexPath)) {
+    return hostIndexPath;
+  }
+
+  if (host !== "opencode") {
+    const legacyIndexPath = getGlobalIndexPath("opencode");
+    if (existsSync(legacyIndexPath)) {
+      return legacyIndexPath;
+    }
+  }
+
+  return hostIndexPath;
+}
+
 export function resolveProjectConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
   const hostConfigPath = path.join(projectRoot, getProjectConfigRelativePath(host));
   if (existsSync(hostConfigPath)) {
@@ -117,7 +149,7 @@ export function resolveProjectIndexPath(
   host: HostMode = "opencode",
 ): string {
   if (scope === "global") {
-    return getGlobalIndexPath(host);
+    return resolveGlobalIndexPath(host);
   }
 
   const localIndexPath = path.join(projectRoot, getProjectIndexRelativePath(host));

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -50,17 +50,8 @@ export function getHostProjectIndexRelativePath(host: HostMode): string {
   return getProjectIndexRelativePath(host);
 }
 
-function hasProjectConfig(projectRoot: string, host: HostMode): boolean {
-  const primaryPath = path.join(projectRoot, getProjectConfigRelativePath(host));
-  if (existsSync(primaryPath)) {
-    return true;
-  }
-
-  if (host !== "opencode") {
-    return existsSync(path.join(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH));
-  }
-
-  return false;
+function hasHostProjectConfig(projectRoot: string, host: HostMode): boolean {
+  return existsSync(path.join(projectRoot, getProjectConfigRelativePath(host)));
 }
 
 export function getGlobalIndexPath(host: HostMode = "opencode"): string {
@@ -157,7 +148,14 @@ export function resolveProjectIndexPath(
     return localIndexPath;
   }
 
-  if (hasProjectConfig(projectRoot, host)) {
+  if (host !== "opencode") {
+    const legacyIndexPath = path.join(projectRoot, OPENCODE_PROJECT_INDEX_RELATIVE_PATH);
+    if (existsSync(legacyIndexPath) && !hasHostProjectConfig(projectRoot, host)) {
+      return legacyIndexPath;
+    }
+  }
+
+  if (hasHostProjectConfig(projectRoot, host)) {
     return localIndexPath;
   }
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -2,10 +2,22 @@ import { existsSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
+import type { HostMode } from "./host.js";
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
 
-const PROJECT_CONFIG_RELATIVE_PATH = path.join(".opencode", "codebase-index.json");
-const PROJECT_INDEX_RELATIVE_PATH = path.join(".opencode", "index");
+const OPENCODE_PROJECT_CONFIG_RELATIVE_PATH = path.join(".opencode", "codebase-index.json");
+const OPENCODE_PROJECT_INDEX_RELATIVE_PATH = path.join(".opencode", "index");
+const CODEBASE_INDEX_DIR = ".codebase-index";
+const CODEBASE_PROJECT_CONFIG_RELATIVE_PATH = path.join(CODEBASE_INDEX_DIR, "config.json");
+const CODEBASE_PROJECT_INDEX_RELATIVE_PATH = path.join(CODEBASE_INDEX_DIR, "index");
+
+function getProjectConfigRelativePath(host: HostMode): string {
+  return host === "opencode" ? OPENCODE_PROJECT_CONFIG_RELATIVE_PATH : CODEBASE_PROJECT_CONFIG_RELATIVE_PATH;
+}
+
+function getProjectIndexRelativePath(host: HostMode): string {
+  return host === "opencode" ? OPENCODE_PROJECT_INDEX_RELATIVE_PATH : CODEBASE_PROJECT_INDEX_RELATIVE_PATH;
+}
 
 function resolveWorktreeFallbackPath(projectRoot: string, relativePath: string): string | null {
   const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
@@ -17,40 +29,117 @@ function resolveWorktreeFallbackPath(projectRoot: string, relativePath: string):
   return existsSync(fallbackPath) ? fallbackPath : null;
 }
 
-function hasProjectConfig(projectRoot: string): boolean {
-  return existsSync(path.join(projectRoot, PROJECT_CONFIG_RELATIVE_PATH));
-}
-
-export function getGlobalIndexPath(): string {
-  return path.join(os.homedir(), ".opencode", "global-index");
-}
-
-export function resolveProjectConfigPath(projectRoot: string): string {
-  const localConfigPath = path.join(projectRoot, PROJECT_CONFIG_RELATIVE_PATH);
-  if (existsSync(localConfigPath)) {
-    return localConfigPath;
+export function resolveWorktreeFallbackProjectIndexPath(projectRoot: string, host: HostMode): string | null {
+  const inheritedHostPath = resolveWorktreeFallbackPath(projectRoot, getProjectIndexRelativePath(host));
+  if (inheritedHostPath) {
+    return inheritedHostPath;
   }
 
-  return resolveWorktreeFallbackPath(projectRoot, PROJECT_CONFIG_RELATIVE_PATH) ?? localConfigPath;
+  if (host !== "opencode") {
+    return resolveWorktreeFallbackPath(projectRoot, OPENCODE_PROJECT_INDEX_RELATIVE_PATH);
+  }
+
+  return null;
 }
 
-export function resolveWritableProjectConfigPath(projectRoot: string): string {
-  return path.join(projectRoot, PROJECT_CONFIG_RELATIVE_PATH);
+export function getHostProjectConfigRelativePath(host: HostMode): string {
+  return getProjectConfigRelativePath(host);
 }
 
-export function resolveProjectIndexPath(projectRoot: string, scope: "project" | "global"): string {
+export function getHostProjectIndexRelativePath(host: HostMode): string {
+  return getProjectIndexRelativePath(host);
+}
+
+function hasProjectConfig(projectRoot: string, host: HostMode): boolean {
+  const primaryPath = path.join(projectRoot, getProjectConfigRelativePath(host));
+  if (existsSync(primaryPath)) {
+    return true;
+  }
+
+  if (host !== "opencode") {
+    return existsSync(path.join(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH));
+  }
+
+  return false;
+}
+
+export function getGlobalIndexPath(host: HostMode = "opencode"): string {
+  if (host === "opencode") {
+    return path.join(os.homedir(), ".opencode", "global-index");
+  }
+
+  return path.join(os.homedir(), ".codebase-index", "global-index");
+}
+
+export function getGlobalConfigPath(host: HostMode = "opencode"): string {
+  if (host === "opencode") {
+    return path.join(os.homedir(), ".config", "opencode", "codebase-index.json");
+  }
+
+  return path.join(os.homedir(), ".config", "codebase-index", "config.json");
+}
+
+export function resolveProjectConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
+  const hostConfigPath = path.join(projectRoot, getProjectConfigRelativePath(host));
+  if (existsSync(hostConfigPath)) {
+    return hostConfigPath;
+  }
+
+  if (host !== "opencode") {
+    const legacyConfigPath = path.join(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH);
+    if (existsSync(legacyConfigPath)) {
+      return legacyConfigPath;
+    }
+  }
+
+  const hostFallback = resolveWorktreeFallbackPath(projectRoot, getProjectConfigRelativePath(host));
+  if (hostFallback) {
+    return hostFallback;
+  }
+
+  if (host !== "opencode") {
+    const legacyFallback = resolveWorktreeFallbackPath(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH);
+    if (legacyFallback) {
+      return legacyFallback;
+    }
+  }
+
+  return hostConfigPath;
+}
+
+export function resolveWritableProjectConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
+  return path.join(projectRoot, getProjectConfigRelativePath(host));
+}
+
+export function resolveProjectIndexPath(
+  projectRoot: string,
+  scope: "project" | "global",
+  host: HostMode = "opencode",
+): string {
   if (scope === "global") {
-    return getGlobalIndexPath();
+    return getGlobalIndexPath(host);
   }
 
-  const localIndexPath = path.join(projectRoot, PROJECT_INDEX_RELATIVE_PATH);
+  const localIndexPath = path.join(projectRoot, getProjectIndexRelativePath(host));
   if (existsSync(localIndexPath)) {
     return localIndexPath;
   }
 
-  if (hasProjectConfig(projectRoot)) {
+  if (hasProjectConfig(projectRoot, host)) {
     return localIndexPath;
   }
 
-  return resolveWorktreeFallbackPath(projectRoot, PROJECT_INDEX_RELATIVE_PATH) ?? localIndexPath;
+  const hostFallback = resolveWorktreeFallbackPath(projectRoot, getProjectIndexRelativePath(host));
+  if (hostFallback) {
+    return hostFallback;
+  }
+
+  if (host !== "opencode") {
+    const legacyFallback = resolveWorktreeFallbackPath(projectRoot, OPENCODE_PROJECT_INDEX_RELATIVE_PATH);
+    if (legacyFallback) {
+      return legacyFallback;
+    }
+  }
+
+  return localIndexPath;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
 } from "./tools/index.js";
 import { loadCommandsFromDirectory } from "./commands/loader.js";
 import { RoutingHintController } from "./routing-hints.js";
+import { startAutoIndex } from "./utils/auto-index.js";
 import { hasProjectMarker } from "./utils/files.js";
 import type { CombinedWatcher } from "./watcher/index.js";
 
@@ -110,9 +111,7 @@ const plugin: Plugin = async ({ directory, worktree }) => {
 
     if (config.indexing.autoIndex && isValidProject) {
       const indexer = getProjectIndexer();
-      indexer.initialize().then(() => {
-        indexer.index().catch(() => {});
-      }).catch(() => {});
+      startAutoIndex(indexer, projectRoot);
     }
 
     if (config.indexing.watchFiles && isValidProject) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ const plugin: Plugin = async ({ directory, worktree }) => {
     }
 
     if (config.indexing.watchFiles && isValidProject) {
-      replaceActiveWatcher(projectRoot, createWatcherWithIndexer(getProjectIndexer, projectRoot, config));
+      replaceActiveWatcher(projectRoot, createWatcherWithIndexer(getProjectIndexer, projectRoot, config, "opencode"));
     } else {
       replaceActiveWatcher(projectRoot, null);
     }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4338,8 +4338,15 @@ export class Indexer {
       return;
     }
 
-    const localProjectIndexPath = path.join(this.projectRoot, getHostProjectIndexRelativePath(this.host));
-    if (path.resolve(this.indexPath) !== path.resolve(localProjectIndexPath)) {
+    const localProjectIndexPaths = [path.join(this.projectRoot, getHostProjectIndexRelativePath(this.host))];
+    if (this.host !== "opencode") {
+      localProjectIndexPaths.push(path.join(this.projectRoot, getHostProjectIndexRelativePath("opencode")));
+    }
+
+    const isLocalProjectIndex = localProjectIndexPaths.some(
+      (localPath) => path.resolve(this.indexPath) === path.resolve(localPath)
+    );
+    if (!isLocalProjectIndex) {
       throw new Error(
         "Project-scoped force rebuild is unsafe while using an inherited worktree index. " +
         "Create a local project config boundary before clearing the index."

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -36,7 +36,8 @@ import {
 } from "../native/index.js";
 import type { SymbolData, CallEdgeData, PathHopData, ReachabilityData, CommunityData, CentralityData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
-import { resolveProjectIndexPath } from "../config/paths.js";
+import type { HostMode } from "../config/host.js";
+import { getHostProjectIndexRelativePath, resolveProjectIndexPath } from "../config/paths.js";
 import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
 
@@ -1789,6 +1790,7 @@ function unionCandidates(
 }
 
 export class Indexer {
+  private readonly host: HostMode;
   private config: ParsedCodebaseIndexConfig;
   private projectRoot: string;
   private indexPath: string;
@@ -1811,9 +1813,10 @@ export class Indexer {
   private indexCompatibility: IndexCompatibility | null = null;
   private indexingLockPath: string = "";
 
-  constructor(projectRoot: string, config: ParsedCodebaseIndexConfig) {
+  constructor(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode") {
     this.projectRoot = projectRoot;
     this.config = config;
+    this.host = host;
     this.indexPath = this.getIndexPath();
     this.fileHashCachePath = path.join(this.indexPath, "file-hashes.json");
     this.failedBatchesPath = path.join(this.indexPath, "failed-batches.json");
@@ -1822,7 +1825,7 @@ export class Indexer {
   }
 
   private getIndexPath(): string {
-    return resolveProjectIndexPath(this.projectRoot, this.config.scope);
+    return resolveProjectIndexPath(this.projectRoot, this.config.scope, this.host);
   }
 
   private loadFileHashCache(): void {
@@ -4335,7 +4338,7 @@ export class Indexer {
       return;
     }
 
-    const localProjectIndexPath = path.join(this.projectRoot, ".opencode", "index");
+    const localProjectIndexPath = path.join(this.projectRoot, getHostProjectIndexRelativePath(this.host));
     if (path.resolve(this.indexPath) !== path.resolve(localProjectIndexPath)) {
       throw new Error(
         "Project-scoped force rebuild is unsafe while using an inherited worktree index. " +

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,55 +1,36 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import * as path from "path";
-import { existsSync } from "fs";
+import { readFileSync } from "fs";
 
-import { Indexer } from "./indexer/index.js";
 import type { ParsedCodebaseIndexConfig } from "./config/schema.js";
-import { resolveWorktreeMainRepoRoot } from "./git/index.js";
+import type { HostMode } from "./config/host.js";
 import { registerMcpPrompts } from "./mcp-server/register-prompts.js";
 import { registerMcpTools } from "./mcp-server/register-tools.js";
+import { initializeTools } from "./tools/operations.js";
 
-export function createMcpServer(projectRoot: string, config: ParsedCodebaseIndexConfig): McpServer {
+function getPackageVersion(): string {
+  const raw = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as unknown;
+  if (raw && typeof raw === "object" && "version" in raw && typeof raw.version === "string") {
+    return raw.version;
+  }
+
+  return "0.0.0";
+}
+
+export function createMcpServer(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode = "opencode",
+): McpServer {
   const server = new McpServer({
     name: "opencode-codebase-index",
-    version: "0.5.1",
+    version: getPackageVersion(),
   });
 
-  let indexer = new Indexer(projectRoot, config);
-  let initialized = false;
-
-  function refreshIndexerFromConfig(): void {
-    indexer = new Indexer(projectRoot, config);
-    initialized = false;
-  }
-
-  function shouldForceLocalizeProjectIndex(): boolean {
-    if (config.scope !== "project") {
-      return false;
-    }
-
-    const localIndexPath = path.join(projectRoot, ".opencode", "index");
-    const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
-    if (!mainRepoRoot) {
-      return false;
-    }
-
-    const inheritedIndexPath = path.join(mainRepoRoot, ".opencode", "index");
-    return !existsSync(localIndexPath) && existsSync(inheritedIndexPath);
-  }
-
-  async function ensureInitialized(): Promise<void> {
-    if (!initialized) {
-      await indexer.initialize();
-      initialized = true;
-    }
-  }
+  initializeTools(projectRoot, config, host);
 
   registerMcpTools(server, {
     projectRoot,
-    ensureInitialized,
-    getIndexer: () => indexer,
-    refreshIndexerFromConfig,
-    shouldForceLocalizeProjectIndex,
+    host,
   });
 
   registerMcpPrompts(server);

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -1,12 +1,22 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
-import type { LogLevel } from "../config/schema.js";
 import { formatCostEstimate } from "../utils/cost.js";
-import type { LogEntry } from "../utils/logger.js";
 import { formatDefinitionLookup, formatHealthCheck, formatIndexStats, formatStatus } from "../tools/utils.js";
 import { formatPrImpact } from "../tools/format-pr-impact.js";
+import {
+  findSimilarCode,
+  getCallGraphData,
+  getCallGraphPath,
+  getIndexHealthCheck,
+  getIndexLogs,
+  getIndexMetrics,
+  getIndexStatus,
+  getPrImpact,
+  implementationLookup,
+  runIndexCodebase,
+  searchCodebase,
+} from "../tools/operations.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime, truncateContent } from "./shared.js";
 
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
@@ -22,8 +32,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       contextLines: z.number().optional().describe("Number of extra lines to include before/after each match (default: 0)"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const results = await runtime.getIndexer().search(args.query, args.limit ?? 5, {
+      const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
+        limit: args.limit ?? 5,
         fileType: args.fileType,
         directory: args.directory,
         chunkType: args.chunkType,
@@ -56,8 +66,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       chunkType: z.enum(CHUNK_TYPE_ENUM).optional().describe("Filter by code chunk type"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const results = await runtime.getIndexer().search(args.query, args.limit ?? 10, {
+      const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
+        limit: args.limit ?? 10,
         fileType: args.fileType,
         directory: args.directory,
         chunkType: args.chunkType,
@@ -87,27 +97,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       verbose: z.boolean().optional().default(false).describe("Show detailed info about skipped files and parsing failures"),
     },
     async (args) => {
-      if (args.estimateOnly) {
-        await runtime.ensureInitialized();
-        const estimate = await runtime.getIndexer().estimateCost();
-        return { content: [{ type: "text", text: formatCostEstimate(estimate) }] };
-      }
-
-      if (args.force) {
-        if (runtime.shouldForceLocalizeProjectIndex()) {
-          materializeLocalProjectConfig(runtime.projectRoot, loadProjectConfigLayer(runtime.projectRoot));
-          runtime.refreshIndexerFromConfig();
-        }
-        await runtime.ensureInitialized();
-        await runtime.getIndexer().clearIndex();
-        runtime.refreshIndexerFromConfig();
-        await runtime.ensureInitialized();
-      } else {
-        await runtime.ensureInitialized();
-      }
-
-      const stats = await runtime.getIndexer().index();
-      return { content: [{ type: "text", text: formatIndexStats(stats, args.verbose ?? false) }] };
+      const result = await runIndexCodebase(runtime.projectRoot, runtime.host, args);
+      const text = result.kind === "estimate"
+        ? formatCostEstimate(result.estimate)
+        : formatIndexStats(result.stats, args.verbose ?? false);
+      return { content: [{ type: "text", text }] };
     },
   );
 
@@ -116,8 +110,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Check the status of the codebase index. Shows whether the codebase is indexed, how many chunks are stored, and the embedding provider being used.",
     {},
     async () => {
-      await runtime.ensureInitialized();
-      const status = await runtime.getIndexer().getStatus();
+      const status = await getIndexStatus(runtime.projectRoot, runtime.host);
       return { content: [{ type: "text", text: formatStatus(status) }] };
     },
   );
@@ -127,8 +120,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Check index health and remove stale entries from deleted files. Run this to clean up the index after files have been deleted.",
     {},
     async () => {
-      await runtime.ensureInitialized();
-      const result = await runtime.getIndexer().healthCheck();
+      const result = await getIndexHealthCheck(runtime.projectRoot, runtime.host);
       return { content: [{ type: "text", text: formatHealthCheck(result) }] };
     },
   );
@@ -138,18 +130,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Get metrics and performance statistics for the codebase index. Requires debug.enabled=true and debug.metrics=true in config.",
     {},
     async () => {
-      await runtime.ensureInitialized();
-      const logger = runtime.getIndexer().getLogger();
-
-      if (!logger.isEnabled()) {
-        return { content: [{ type: "text", text: "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```" }] };
-      }
-
-      if (!logger.isMetricsEnabled()) {
-        return { content: [{ type: "text", text: "Metrics collection is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```" }] };
-      }
-
-      return { content: [{ type: "text", text: logger.formatMetrics() }] };
+      const result = await getIndexMetrics(runtime.projectRoot, runtime.host);
+      return { content: [{ type: "text", text: result.text }] };
     },
   );
 
@@ -162,32 +144,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       level: z.enum(["error", "warn", "info", "debug"]).optional().describe("Filter by minimum log level"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const logger = runtime.getIndexer().getLogger();
-
-      if (!logger.isEnabled()) {
-        return { content: [{ type: "text", text: "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true\n  }\n}\n```" }] };
-      }
-
-      let logs: LogEntry[];
-      if (args.category) {
-        logs = logger.getLogsByCategory(args.category, args.limit);
-      } else if (args.level) {
-        logs = logger.getLogsByLevel(args.level as LogLevel, args.limit);
-      } else {
-        logs = logger.getLogs(args.limit);
-      }
-
-      if (logs.length === 0) {
-        return { content: [{ type: "text", text: "No logs recorded yet. Logs are captured during indexing and search operations." }] };
-      }
-
-      const text = logs.map(l => {
-        const dataStr = l.data ? ` ${JSON.stringify(l.data)}` : "";
-        return `[${l.timestamp}] [${l.level.toUpperCase()}] [${l.category}] ${l.message}${dataStr}`;
-      }).join("\n");
-
-      return { content: [{ type: "text", text }] };
+      const result = await getIndexLogs(runtime.projectRoot, runtime.host, args);
+      return { content: [{ type: "text", text: result.text }] };
     },
   );
 
@@ -203,8 +161,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       excludeFile: z.string().optional().describe("Exclude results from this file path"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const results = await runtime.getIndexer().findSimilar(args.code, args.limit ?? 10, {
+      const results = await findSimilarCode(runtime.projectRoot, runtime.host, args.code, {
+        limit: args.limit ?? 10,
         fileType: args.fileType,
         directory: args.directory,
         chunkType: args.chunkType,
@@ -236,11 +194,10 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils')"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const results = await runtime.getIndexer().search(args.query, args.limit ?? 5, {
+      const results = await implementationLookup(runtime.projectRoot, runtime.host, args.query, {
+        limit: args.limit ?? 5,
         fileType: args.fileType,
         directory: args.directory,
-        definitionIntent: true,
       });
 
       return { content: [{ type: "text", text: formatDefinitionLookup(results, args.query) }] };
@@ -258,14 +215,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       relationshipType: z.enum(["Call", "MethodCall", "Constructor", "Import", "Inherits", "Implements"]).optional().describe("Filter by relationship type. Omit to show all."),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const indexer = runtime.getIndexer();
-
       if (args.direction === "callees") {
         if (!args.symbolId) {
           return { content: [{ type: "text", text: "Error: 'symbolId' is required when direction is 'callees'." }] };
         }
-        const callees = await indexer.getCallees(args.symbolId, args.relationshipType);
+        const { callees } = await getCallGraphData(runtime.projectRoot, runtime.host, args);
         if (callees.length === 0) {
           return { content: [{ type: "text", text: `No callees found for symbol ${args.symbolId}${args.relationshipType ? ` with type ${args.relationshipType}` : ""}.` }] };
         }
@@ -276,7 +230,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         return { content: [{ type: "text", text: `Callees (${callees.length}):\n\n${formatted.join("\n")}` }] };
       }
 
-      const callers = await indexer.getCallers(args.name, args.relationshipType);
+      const { callers } = await getCallGraphData(runtime.projectRoot, runtime.host, args);
       if (callers.length === 0) {
         return { content: [{ type: "text", text: `No callers found for "${args.name}"${args.relationshipType ? ` with type ${args.relationshipType}` : ""}.` }] };
       }
@@ -297,9 +251,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       maxDepth: z.number().optional().default(10).describe("Maximum traversal depth (default: 10)"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const indexer = runtime.getIndexer();
-      const path = await indexer.findCallPath(args.from, args.to, args.maxDepth);
+      const path = await getCallGraphPath(runtime.projectRoot, runtime.host, args.from, args.to, args.maxDepth);
       if (path.length === 0) {
         return { content: [{ type: "text", text: `No path found between "${args.from}" and "${args.to}". They may be in disconnected components, or the call graph index needs updating.` }] };
       }
@@ -323,10 +275,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       direction: z.enum(["callers", "callees", "both"]).optional().default("both").describe("Call-graph traversal direction: 'callers' for upstream, 'callees' for downstream, 'both' for union (default: both)"),
     },
     async (args) => {
-      await runtime.ensureInitialized();
-      const indexer = runtime.getIndexer();
       try {
-        const result = await indexer.getPrImpact({
+        const result = await getPrImpact(runtime.projectRoot, runtime.host, {
           pr: args.pr,
           branch: args.branch,
           maxDepth: args.maxDepth,

--- a/src/mcp-server/shared.ts
+++ b/src/mcp-server/shared.ts
@@ -1,4 +1,4 @@
-import type { Indexer } from "../indexer/index.js";
+import type { HostMode } from "../config/host.js";
 
 export const MAX_CONTENT_LINES = 30;
 
@@ -18,8 +18,5 @@ export const CHUNK_TYPE_ENUM = [
 
 export interface McpServerRuntime {
   projectRoot: string;
-  ensureInitialized(): Promise<void>;
-  getIndexer(): Indexer;
-  refreshIndexerFromConfig(): void;
-  shouldForceLocalizeProjectIndex(): boolean;
+  host: HostMode;
 }

--- a/src/tools/config-state.ts
+++ b/src/tools/config-state.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { loadMergedConfig, loadProjectConfigLayer } from "../config/merger.js";
 import { resolveWritableProjectConfigPath } from "../config/paths.js";
 import { resolveConfigPathValue, serializeConfigPathValue } from "./knowledge-base-paths.js";
+import type { HostMode } from "../config/host.js";
 
 function normalizeKnowledgeBasePaths(
   config: Record<string, unknown>,
@@ -28,20 +29,20 @@ function toConfigRecord(rawConfig: unknown): Record<string, unknown> {
   return { ...(rawConfig as Record<string, unknown>) };
 }
 
-export function getConfigPath(projectRoot: string): string {
-  return resolveWritableProjectConfigPath(projectRoot);
+export function getConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
+  return resolveWritableProjectConfigPath(projectRoot, host);
 }
 
-export function loadRuntimeConfig(projectRoot: string): Record<string, unknown> {
-  return normalizeKnowledgeBasePaths(toConfigRecord(loadMergedConfig(projectRoot)), projectRoot);
+export function loadRuntimeConfig(projectRoot: string, host: HostMode = "opencode"): Record<string, unknown> {
+  return normalizeKnowledgeBasePaths(toConfigRecord(loadMergedConfig(projectRoot, host)), projectRoot);
 }
 
-export function loadEditableConfig(projectRoot: string): Record<string, unknown> {
-  return normalizeKnowledgeBasePaths(toConfigRecord(loadProjectConfigLayer(projectRoot)), projectRoot);
+export function loadEditableConfig(projectRoot: string, host: HostMode = "opencode"): Record<string, unknown> {
+  return normalizeKnowledgeBasePaths(toConfigRecord(loadProjectConfigLayer(projectRoot, host)), projectRoot);
 }
 
-export function saveConfig(projectRoot: string, config: Record<string, unknown>): void {
-  const configPath = getConfigPath(projectRoot);
+export function saveConfig(projectRoot: string, config: Record<string, unknown>, host: HostMode = "opencode"): void {
+  const configPath = getConfigPath(projectRoot, host);
   const configDir = path.dirname(configPath);
   const configBaseDir = path.dirname(configDir);
   if (!existsSync(configDir)) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,90 +1,64 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin";
 
-import { parseConfig, type ParsedCodebaseIndexConfig } from "../config/schema.js";
-import { Indexer } from "../indexer/index.js";
+import type { HostMode } from "../config/host.js";
+import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
+import type { Indexer } from "../indexer/index.js";
 import { formatCostEstimate } from "../utils/cost.js";
-import type { LogLevel } from "../config/schema.js";
-import type { LogEntry } from "../utils/logger.js";
 import {
-  formatProgressTitle,
-  formatIndexStats,
-  formatStatus,
-  calculatePercentage,
   formatCodebasePeek,
   formatDefinitionLookup,
   formatHealthCheck,
-  formatLogs,
+  formatIndexStats,
   formatSearchResults,
+  formatStatus,
 } from "./utils.js";
-import { pr_impact } from "./pr-impact.js";
 import {
-  findKnowledgeBasePathIndex,
-  hasMatchingKnowledgeBasePath,
-  resolveKnowledgeBasePath,
-} from "./knowledge-base-paths.js";
-import { existsSync, realpathSync, statSync } from "fs";
-import * as path from "path";
-import { loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
-import { resolveWorktreeMainRepoRoot } from "../git/index.js";
-import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from "./config-state.js";
-import * as os from "os";
-
-function ensureStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? (value as string[]) : [];
-}
+  addKnowledgeBase,
+  findSimilarCode,
+  getCallGraphData,
+  getCallGraphPath,
+  getIndexHealthCheck,
+  getIndexLogs,
+  getIndexMetrics,
+  getIndexerForProject as getOperationIndexerForProject,
+  getIndexStatus,
+  getSharedIndexer as getOperationSharedIndexer,
+  implementationLookup,
+  initializeTools as initializeToolOperations,
+  listKnowledgeBases,
+  removeKnowledgeBase,
+  runIndexCodebase,
+  searchCodebase,
+} from "./operations.js";
+import { pr_impact } from "./pr-impact.js";
 
 const z = tool.schema;
-
-const indexerMap = new Map<string, Indexer>();
-let defaultProjectRoot: string = "";
+const DEFAULT_HOST: HostMode = "opencode";
+const CHUNK_TYPE_VALUES = [
+  "function",
+  "class",
+  "method",
+  "interface",
+  "type",
+  "enum",
+  "struct",
+  "impl",
+  "trait",
+  "module",
+  "other",
+] as const;
+const RELATIONSHIP_TYPE_VALUES = ["Call", "MethodCall", "Constructor", "Import", "Inherits", "Implements"] as const;
 
 export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig): void {
-  defaultProjectRoot = projectRoot;
-  const indexer = new Indexer(projectRoot, config);
-  indexerMap.set(projectRoot, indexer);
+  initializeToolOperations(projectRoot, config, DEFAULT_HOST);
 }
 
 export function getSharedIndexer(): Indexer {
-  return getIndexerForProject(defaultProjectRoot);
-}
-
-function refreshIndexerForDirectory(projectRoot: string): void {
-  if (!projectRoot) {
-    throw new Error("Codebase index tools not initialized. Plugin may not be loaded correctly.");
-  }
-  const indexer = new Indexer(projectRoot, parseConfig(loadRuntimeConfig(projectRoot)));
-  indexerMap.set(projectRoot, indexer);
-}
-
-function shouldForceLocalizeProjectIndex(projectRoot: string): boolean {
-  const currentConfig = parseConfig(loadRuntimeConfig(projectRoot));
-  if (currentConfig.scope !== "project") {
-    return false;
-  }
-
-  const localIndexPath = path.join(projectRoot, ".opencode", "index");
-  const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
-  if (!mainRepoRoot) {
-    return false;
-  }
-
-  const inheritedIndexPath = path.join(mainRepoRoot, ".opencode", "index");
-  return !existsSync(localIndexPath) && existsSync(inheritedIndexPath);
+  return getOperationSharedIndexer(DEFAULT_HOST);
 }
 
 export function getIndexerForProject(directory: string): Indexer {
-  const projectRoot = directory || defaultProjectRoot;
-  if (!projectRoot) {
-    throw new Error("Codebase index tools not initialized. Plugin may not be loaded correctly.");
-  }
-
-  let indexer = indexerMap.get(projectRoot);
-  if (!indexer) {
-    const config = parseConfig(loadRuntimeConfig(projectRoot));
-    indexer = new Indexer(projectRoot, config);
-    indexerMap.set(projectRoot, indexer);
-  }
-  return indexer;
+  return getOperationIndexerForProject(directory, DEFAULT_HOST);
 }
 
 export const codebase_peek: ToolDefinition = tool({
@@ -95,11 +69,11 @@ export const codebase_peek: ToolDefinition = tool({
     limit: z.number().optional().default(10).describe("Maximum number of results to return"),
     fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
     directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
-    chunkType: z.enum(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module", "other"]).optional().describe("Filter by code chunk type"),
+    chunkType: z.enum(CHUNK_TYPE_VALUES).optional().describe("Filter by code chunk type"),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const results = await indexer.search(args.query, args.limit ?? 10, {
+    const results = await searchCodebase(context?.worktree, DEFAULT_HOST, args.query, {
+      limit: args.limit ?? 10,
       fileType: args.fileType,
       directory: args.directory,
       chunkType: args.chunkType,
@@ -119,37 +93,13 @@ export const index_codebase: ToolDefinition = tool({
     verbose: z.boolean().optional().default(false).describe("Show detailed info about skipped files and parsing failures"),
   },
   async execute(args, context) {
-    const projectRoot = context?.worktree || defaultProjectRoot;
-    let indexer = getIndexerForProject(projectRoot);
-
-    if (args.estimateOnly) {
-      const estimate = await indexer.estimateCost();
-      return formatCostEstimate(estimate);
-    }
-
-    if (args.force) {
-      if (shouldForceLocalizeProjectIndex(projectRoot)) {
-        materializeLocalProjectConfig(projectRoot, loadProjectConfigLayer(projectRoot));
-        refreshIndexerForDirectory(projectRoot);
-        indexer = getIndexerForProject(projectRoot);
-      }
-      await indexer.clearIndex();
-    }
-
-    const stats = await indexer.index((progress) => {
-      context.metadata({
-        title: formatProgressTitle(progress),
-        metadata: {
-          phase: progress.phase,
-          filesProcessed: progress.filesProcessed,
-          totalFiles: progress.totalFiles,
-          chunksProcessed: progress.chunksProcessed,
-          totalChunks: progress.totalChunks,
-          percentage: calculatePercentage(progress),
-        },
-      });
+    const result = await runIndexCodebase(context?.worktree, DEFAULT_HOST, args, (title, metadata) => {
+      context.metadata({ title, metadata });
     });
-    return formatIndexStats(stats, args.verbose ?? false);
+
+    return result.kind === "estimate"
+      ? formatCostEstimate(result.estimate)
+      : formatIndexStats(result.stats, args.verbose ?? false);
   },
 });
 
@@ -158,9 +108,7 @@ export const index_status: ToolDefinition = tool({
     "Check the status of the codebase index. Shows whether the codebase is indexed, how many chunks are stored, and the embedding provider being used.",
   args: {},
   async execute(_args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const status = await indexer.getStatus();
-    return formatStatus(status);
+    return formatStatus(await getIndexStatus(context?.worktree, DEFAULT_HOST));
   },
 });
 
@@ -169,10 +117,7 @@ export const index_health_check: ToolDefinition = tool({
     "Check index health and remove stale entries from deleted files. Run this to clean up the index after files have been deleted.",
   args: {},
   async execute(_args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const result = await indexer.healthCheck();
-
-    return formatHealthCheck(result);
+    return formatHealthCheck(await getIndexHealthCheck(context?.worktree, DEFAULT_HOST));
   },
 });
 
@@ -181,18 +126,7 @@ export const index_metrics: ToolDefinition = tool({
     "Get metrics and performance statistics for the codebase index. Shows indexing stats, search timings, cache hit rates, and API usage. Requires debug.enabled=true and debug.metrics=true in config.",
   args: {},
   async execute(_args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const logger = indexer.getLogger();
-
-    if (!logger.isEnabled()) {
-      return "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```";
-    }
-
-    if (!logger.isMetricsEnabled()) {
-      return "Metrics collection is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```";
-    }
-
-    return logger.formatMetrics();
+    return (await getIndexMetrics(context?.worktree, DEFAULT_HOST)).text;
   },
 });
 
@@ -205,23 +139,7 @@ export const index_logs: ToolDefinition = tool({
     level: z.enum(["error", "warn", "info", "debug"]).optional().describe("Filter by minimum log level"),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const logger = indexer.getLogger();
-
-    if (!logger.isEnabled()) {
-      return "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true\n  }\n}\n```";
-    }
-
-    let logs: LogEntry[];
-    if (args.category) {
-      logs = logger.getLogsByCategory(args.category, args.limit);
-    } else if (args.level) {
-      logs = logger.getLogsByLevel(args.level as LogLevel, args.limit);
-    } else {
-      logs = logger.getLogs(args.limit);
-    }
-
-    return formatLogs(logs);
+    return (await getIndexLogs(context?.worktree, DEFAULT_HOST, args)).text;
   },
 });
 
@@ -233,12 +151,12 @@ export const find_similar: ToolDefinition = tool({
     limit: z.number().optional().default(10).describe("Maximum number of results to return"),
     fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
     directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
-    chunkType: z.enum(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module", "other"]).optional().describe("Filter by code chunk type"),
+    chunkType: z.enum(CHUNK_TYPE_VALUES).optional().describe("Filter by code chunk type"),
     excludeFile: z.string().optional().describe("Exclude results from this file path (useful when searching for duplicates of code from a specific file)"),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const results = await indexer.findSimilar(args.code, args.limit, {
+    const results = await findSimilarCode(context?.worktree, DEFAULT_HOST, args.code, {
+      limit: args.limit,
       fileType: args.fileType,
       directory: args.directory,
       chunkType: args.chunkType,
@@ -261,12 +179,12 @@ export const codebase_search: ToolDefinition = tool({
     limit: z.number().optional().default(5).describe("Maximum number of results to return"),
     fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
     directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
-    chunkType: z.enum(["function", "class", "method", "interface", "type", "enum", "struct", "impl", "trait", "module", "other"]).optional().describe("Filter by code chunk type"),
+    chunkType: z.enum(CHUNK_TYPE_VALUES).optional().describe("Filter by code chunk type"),
     contextLines: z.number().optional().describe("Number of extra lines to include before/after each match (default: 0)"),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const results = await indexer.search(args.query, args.limit ?? 5, {
+    const results = await searchCodebase(context?.worktree, DEFAULT_HOST, args.query, {
+      limit: args.limit ?? 5,
       fileType: args.fileType,
       directory: args.directory,
       chunkType: args.chunkType,
@@ -294,11 +212,10 @@ export const implementation_lookup: ToolDefinition = tool({
     directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils')"),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const results = await indexer.search(args.query, args.limit ?? 5, {
+    const results = await implementationLookup(context?.worktree, DEFAULT_HOST, args.query, {
+      limit: args.limit ?? 5,
       fileType: args.fileType,
       directory: args.directory,
-      definitionIntent: true,
     });
     return formatDefinitionLookup(results, args.query);
   },
@@ -312,33 +229,31 @@ export const call_graph: ToolDefinition = tool({
     name: z.string().describe("Function or method name to query"),
     direction: z.enum(["callers", "callees"]).default("callers").describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
     symbolId: z.string().optional().describe("Symbol ID (required for 'callees' direction, returned by previous call_graph queries)"),
-    relationshipType: z.enum(["Call", "MethodCall", "Constructor", "Import", "Inherits", "Implements"]).optional().describe("Filter by relationship type. Omit to show all."),
+    relationshipType: z.enum(RELATIONSHIP_TYPE_VALUES).optional().describe("Filter by relationship type. Omit to show all."),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
     if (args.direction === "callees") {
       if (!args.symbolId) {
         return "Error: 'symbolId' is required when direction is 'callees'. First use direction='callers' to find the symbol ID.";
       }
-      const callees = await indexer.getCallees(args.symbolId, args.relationshipType);
+      const { callees } = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
       if (callees.length === 0) {
         return `No callees found for symbol ${args.symbolId}${args.relationshipType ? ` with type ${args.relationshipType}` : ""}. The function may not call any other tracked functions.`;
       }
-      const formatted = callees.map((e, i) => {
-        const conf = e.confidence !== "Direct" ? ` [${e.confidence.toLowerCase()}]` : "";
-        return `[${i + 1}] \u2192 ${e.targetName} (${e.callType})${conf} at line ${e.line}${e.isResolved ? ` [resolved: ${e.toSymbolId}]` : " [unresolved]"}`;
-      });
-      return formatted.join("\n");
+      return callees.map((edge, index) => {
+        const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
+        return `[${index + 1}] \u2192 ${edge.targetName} (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? ` [resolved: ${edge.toSymbolId}]` : " [unresolved]"}`;
+      }).join("\n");
     }
-    const callers = await indexer.getCallers(args.name, args.relationshipType);
+
+    const { callers } = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
     if (callers.length === 0) {
       return `No callers found for "${args.name}"${args.relationshipType ? ` with type ${args.relationshipType}` : ""}. It may not be called by any tracked function, or the index needs updating.`;
     }
-    const formatted = callers.map((e, i) => {
-      const conf = e.confidence !== "Direct" ? ` [${e.confidence.toLowerCase()}]` : "";
-      return `[${i + 1}] \u2190 from ${e.fromSymbolName ?? "<unknown>"} in ${e.fromSymbolFilePath ?? "<unknown file>"} [${e.fromSymbolId}] (${e.callType})${conf} at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`;
-    });
-    return formatted.join("\n");
+    return callers.map((edge, index) => {
+      const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
+      return `[${index + 1}] \u2190 from ${edge.fromSymbolName ?? "<unknown>"} in ${edge.fromSymbolFilePath ?? "<unknown file>"} [${edge.fromSymbolId}] (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? " [resolved]" : " [unresolved]"}`;
+    }).join("\n");
   },
 });
 
@@ -351,13 +266,12 @@ export const call_graph_path: ToolDefinition = tool({
     maxDepth: z.number().optional().default(10).describe("Maximum traversal depth (default: 10)"),
   },
   async execute(args, context) {
-    const indexer = getIndexerForProject(context?.worktree);
-    const path = await indexer.findCallPath(args.from, args.to, args.maxDepth);
+    const path = await getCallGraphPath(context?.worktree, DEFAULT_HOST, args.from, args.to, args.maxDepth);
     if (path.length === 0) {
       return `No path found between "${args.from}" and "${args.to}". They may be in disconnected components, or the call graph index needs updating.`;
     }
-    const formatted = path.map((hop, i) => {
-      const prefix = i === 0 ? "[start]" : `--${hop.callType}-->`;
+    const formatted = path.map((hop, index) => {
+      const prefix = index === 0 ? "[start]" : `--${hop.callType}-->`;
       const location = hop.filePath ? ` (${hop.filePath}:${hop.line})` : "";
       return `${prefix} ${hop.symbolName}${location}`;
     });
@@ -371,86 +285,10 @@ export const add_knowledge_base: ToolDefinition = tool({
     "The folder will be indexed alongside the main project code. " +
     "Supports absolute paths or relative paths (relative to the project root).",
   args: {
-    path: z.string().describe("Path to the folder to add as a knowledge base (absolute or relative to project root)"),
+    path: z.string().describe("Path to the folder to add as a knowledge base (absolute or relative to the project root)"),
   },
   async execute(args, context) {
-    const projectRoot = context?.worktree || defaultProjectRoot;
-    const inputPath = args.path.trim();
-
-    const normalizedPath = path.resolve(
-      path.isAbsolute(inputPath)
-        ? inputPath
-        : resolveKnowledgeBasePath(inputPath, projectRoot)
-    );
-
-    if (!existsSync(normalizedPath)) {
-      return `Error: Directory does not exist: ${normalizedPath}`;
-    }
-
-    // Resolve symlinks to get the real path for security checks only
-    let realPath: string;
-    try {
-      realPath = realpathSync(normalizedPath);
-    } catch {
-      return `Error: Cannot resolve path: ${normalizedPath}`;
-    }
-
-    // Security: block sensitive system directories (check against real path to prevent symlink bypass)
-    const blockedPrefixes = [
-      "/etc",
-      "/proc",
-      "/sys",
-      "/dev",
-      "/boot",
-      "/root",
-      "/var/run",
-      "/var/log",
-    ];
-    const homeDir = os.homedir();
-    const sensitiveDotDirs = [".ssh", ".gnupg", ".aws", ".config/gcloud", ".docker", ".kube"];
-
-    for (const prefix of blockedPrefixes) {
-      if (realPath === prefix || realPath.startsWith(prefix + "/")) {
-        return `Error: Adding system directory as knowledge base is not allowed: ${normalizedPath}`;
-      }
-    }
-
-    for (const dotDir of sensitiveDotDirs) {
-      const sensitiveDir = path.join(homeDir, dotDir);
-      if (realPath === sensitiveDir || realPath.startsWith(sensitiveDir + "/")) {
-        return `Error: Adding sensitive directory as knowledge base is not allowed: ${normalizedPath}`;
-      }
-    }
-
-    try {
-      const stat = statSync(normalizedPath);
-      if (!stat.isDirectory()) {
-        return `Error: Path is not a directory: ${normalizedPath}`;
-      }
-    } catch (error) {
-      return `Error: Cannot access directory: ${normalizedPath} - ${error instanceof Error ? error.message : String(error)}`;
-    }
-
-    const config = loadEditableConfig(projectRoot);
-    const knowledgeBases: string[] = ensureStringArray(config.knowledgeBases);
-
-    const alreadyExists = hasMatchingKnowledgeBasePath(knowledgeBases, normalizedPath, projectRoot);
-
-    if (alreadyExists) {
-      return `Knowledge base already configured: ${normalizedPath}`;
-    }
-
-    knowledgeBases.push(normalizedPath);
-    config.knowledgeBases = knowledgeBases;
-    saveConfig(projectRoot, config);
-    refreshIndexerForDirectory(projectRoot);
-
-    let result = `${normalizedPath}\n`;
-    result += `Total knowledge bases: ${knowledgeBases.length}\n`;
-    result += `Config saved to: ${getConfigPath(projectRoot)}\n`;
-    result += `\nRun /index to rebuild the index with the new knowledge base.`;
-
-    return result;
+    return addKnowledgeBase(context?.worktree, DEFAULT_HOST, args.path);
   },
 });
 
@@ -459,35 +297,7 @@ export const list_knowledge_bases: ToolDefinition = tool({
     "List all configured knowledge base folders that are indexed alongside the main project.",
   args: {},
   async execute(_args, context) {
-    const projectRoot = context?.worktree || defaultProjectRoot;
-    const config = loadRuntimeConfig(projectRoot);
-    const knowledgeBases: string[] = ensureStringArray(config.knowledgeBases);
-
-    if (knowledgeBases.length === 0) {
-      return "No knowledge bases configured. Use add_knowledge_base to add folders.";
-    }
-
-    let result = `Knowledge Bases (${knowledgeBases.length}):\n\n`;
-
-    for (let i = 0; i < knowledgeBases.length; i++) {
-      const kb = knowledgeBases[i];
-      const resolvedPath = resolveKnowledgeBasePath(kb, projectRoot);
-      const exists = existsSync(resolvedPath);
-
-      result += `[${i + 1}] ${kb}\n`;
-      result += `    Resolved: ${resolvedPath}\n`;
-      result += `    Status: ${exists ? "Exists" : "NOT FOUND"}\n`;
-      if (exists) {
-        try {
-          const stat = statSync(resolvedPath);
-          result += `    Type: ${stat.isDirectory() ? "Directory" : "File"}\n`;
-        } catch { /* ignore */ }
-      }
-      result += "\n";
-    }
-
-    result += `Config file: ${getConfigPath(projectRoot)}`;
-    return result;
+    return listKnowledgeBases(context?.worktree, DEFAULT_HOST);
   },
 });
 
@@ -498,38 +308,8 @@ export const remove_knowledge_base: ToolDefinition = tool({
     path: z.string().describe("Path of the knowledge base to remove (must match the configured path exactly)"),
   },
   async execute(args, context) {
-    const projectRoot = context?.worktree || defaultProjectRoot;
-    const inputPath = args.path.trim();
-
-    const config = loadEditableConfig(projectRoot);
-    const knowledgeBases: string[] = ensureStringArray(config.knowledgeBases);
-
-    if (knowledgeBases.length === 0) {
-      return "No knowledge bases configured.";
-    }
-
-    const index = findKnowledgeBasePathIndex(knowledgeBases, inputPath, projectRoot);
-
-    if (index === -1) {
-      let result = `Knowledge base not found: ${inputPath}\n\n`;
-      result += `Currently configured:\n`;
-      for (const kb of knowledgeBases) {
-        result += `  - ${kb}\n`;
-      }
-      return result;
-    }
-
-    const removed = knowledgeBases.splice(index, 1)[0];
-    config.knowledgeBases = knowledgeBases;
-    saveConfig(projectRoot, config);
-    refreshIndexerForDirectory(projectRoot);
-
-    let result = `Removed: ${removed}\n\n`;
-    result += `Remaining knowledge bases: ${knowledgeBases.length}\n`;
-    result += `Config saved to: ${getConfigPath(projectRoot)}\n`;
-    result += `\nRun /index to rebuild the index without the removed knowledge base.`;
-
-    return result;
+    return removeKnowledgeBase(context?.worktree, DEFAULT_HOST, args.path.trim());
   },
 });
+
 export { pr_impact };

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -1,0 +1,494 @@
+import { existsSync, realpathSync, statSync } from "fs";
+import * as path from "path";
+import { loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
+import { parseConfig, type ParsedCodebaseIndexConfig } from "../config/schema.js";
+import { getHostProjectIndexRelativePath, getHostProjectConfigRelativePath, resolveWorktreeFallbackProjectIndexPath } from "../config/paths.js";
+import type { HostMode } from "../config/host.js";
+import { Indexer } from "../indexer/index.js";
+import { findKnowledgeBasePathIndex, hasMatchingKnowledgeBasePath, resolveKnowledgeBasePath } from "./knowledge-base-paths.js";
+import { calculatePercentage, formatProgressTitle, formatStatus } from "./utils.js";
+import type { LogLevel } from "../config/schema.js";
+import type { LogEntry } from "../utils/logger.js";
+import type { CostEstimate } from "../utils/cost.js";
+import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from "./config-state.js";
+
+type IndexerCacheKey = `${HostMode}::${string}`;
+
+type SearchResult = Awaited<ReturnType<Indexer["search"]>>[number];
+type CallGraphEdge = Awaited<ReturnType<Indexer["getCallers"]>>[number];
+type IndexStats = Awaited<ReturnType<Indexer["index"]>>;
+type StatusResult = Awaited<ReturnType<Indexer["getStatus"]>>;
+type HealthCheckResult = Awaited<ReturnType<Indexer["healthCheck"]>>;
+type PrImpactResult = Awaited<ReturnType<Indexer["getPrImpact"]>>;
+
+type ProgressCb = (title: string, metadata: Record<string, unknown>) => void | Promise<void>;
+
+const indexerCache = new Map<IndexerCacheKey, Indexer>();
+const configCache = new Map<IndexerCacheKey, ParsedCodebaseIndexConfig>();
+const defaultProjectRoots = new Map<HostMode, string>();
+
+function getProjectRoot(projectRoot: string | undefined, host: HostMode): string {
+  if (projectRoot) {
+    return projectRoot;
+  }
+
+  const root = defaultProjectRoots.get(host);
+  if (!root) {
+    throw new Error("Codebase index tools not initialized. Plugin may not be loaded correctly.");
+  }
+
+  return root;
+}
+
+function getIndexerCacheKey(projectRoot: string, host: HostMode): IndexerCacheKey {
+  return `${host}::${projectRoot}`;
+}
+
+function getOrCreateIndexer(projectRoot: string, host: HostMode): Indexer {
+  const key = getIndexerCacheKey(projectRoot, host);
+  const cached = indexerCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const config = parseConfig(loadRuntimeConfig(projectRoot, host));
+  const indexer = new Indexer(projectRoot, config, host);
+  indexerCache.set(key, indexer);
+  configCache.set(key, config);
+  return indexer;
+}
+
+export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode"): void {
+  defaultProjectRoots.set(host, projectRoot);
+  const key = getIndexerCacheKey(projectRoot, host);
+  const indexer = new Indexer(projectRoot, config, host);
+  indexerCache.set(key, indexer);
+  configCache.set(key, config);
+}
+
+export function getSharedIndexer(host: HostMode = "opencode"): Indexer {
+  return getIndexerForProject(undefined, host);
+}
+
+export function getIndexerForProject(projectRoot: string | undefined, host: HostMode = "opencode"): Indexer {
+  const root = getProjectRoot(projectRoot, host);
+  return getOrCreateIndexer(root, host);
+}
+
+export function refreshIndexerForDirectory(
+  projectRoot: string,
+  host: HostMode = "opencode",
+  config: ParsedCodebaseIndexConfig = parseConfig(loadRuntimeConfig(projectRoot, host)),
+): void {
+  const key = getIndexerCacheKey(projectRoot, host);
+  const indexer = new Indexer(projectRoot, config, host);
+  indexerCache.set(key, indexer);
+  configCache.set(key, config);
+}
+
+export function shouldForceLocalizeProjectIndex(projectRoot: string | undefined, host: HostMode = "opencode"): boolean {
+  const root = getProjectRoot(projectRoot, host);
+  const localIndexPath = path.join(root, getHostProjectIndexRelativePath(host));
+  if (existsSync(localIndexPath)) {
+    return false;
+  }
+  const inheritedIndexPath = resolveWorktreeFallbackProjectIndexPath(root, host);
+  return inheritedIndexPath !== null;
+}
+
+export async function searchCodebase(
+  projectRoot: string | undefined,
+  host: HostMode,
+  query: string,
+  options: {
+    limit?: number;
+    fileType?: string;
+    directory?: string;
+    chunkType?: string;
+    contextLines?: number;
+    metadataOnly?: boolean;
+    definitionIntent?: boolean;
+  } = {},
+): Promise<SearchResult[]> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.search(query, options.limit, {
+    fileType: options.fileType,
+    directory: options.directory,
+    chunkType: options.chunkType,
+    contextLines: options.contextLines,
+    metadataOnly: options.metadataOnly,
+    definitionIntent: options.definitionIntent,
+  });
+}
+
+export async function findSimilarCode(
+  projectRoot: string | undefined,
+  host: HostMode,
+  code: string,
+  options: {
+    limit?: number;
+    fileType?: string;
+    directory?: string;
+    chunkType?: string;
+    excludeFile?: string;
+  } = {},
+): Promise<Awaited<ReturnType<Indexer["findSimilar"]>>> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.findSimilar(code, options.limit, {
+    fileType: options.fileType,
+    directory: options.directory,
+    chunkType: options.chunkType,
+    excludeFile: options.excludeFile,
+  });
+}
+
+export async function implementationLookup(
+  projectRoot: string | undefined,
+  host: HostMode,
+  query: string,
+  options: {
+    limit?: number;
+    fileType?: string;
+    directory?: string;
+  } = {},
+): Promise<SearchResult[]> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.search(query, options.limit, {
+    fileType: options.fileType,
+    directory: options.directory,
+    definitionIntent: true,
+  });
+}
+
+export async function getCallGraphData(
+  projectRoot: string | undefined,
+  host: HostMode,
+  params: {
+    name: string;
+    direction?: "callers" | "callees";
+    symbolId?: string;
+    relationshipType?: "Call" | "MethodCall" | "Constructor" | "Import" | "Inherits" | "Implements";
+  },
+): Promise<{ direction: "callers" | "callees"; callers: CallGraphEdge[]; callees: CallGraphEdge[]; }> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  if (params.direction === "callees") {
+    if (!params.symbolId) {
+      return { direction: "callees", callees: [], callers: [] };
+    }
+    const callees = await indexer.getCallees(params.symbolId, params.relationshipType);
+    return { direction: "callees", callees, callers: [] };
+  }
+
+  const callers = await indexer.getCallers(params.name, params.relationshipType);
+  return { direction: "callers", callers, callees: [] };
+}
+
+export async function getCallGraphPath(
+  projectRoot: string | undefined,
+  host: HostMode,
+  from: string,
+  to: string,
+  maxDepth?: number,
+): Promise<Awaited<ReturnType<Indexer["findCallPath"]>>> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.findCallPath(from, to, maxDepth);
+}
+
+export async function runIndexCodebase(
+  projectRoot: string | undefined,
+  host: HostMode,
+  args: { force?: boolean; estimateOnly?: boolean; verbose?: boolean },
+  onProgress?: ProgressCb,
+): Promise<{ kind: "estimate"; estimate: CostEstimate } | { kind: "stats"; stats: IndexStats }> {
+  const root = getProjectRoot(projectRoot, host);
+  const key = getIndexerCacheKey(root, host);
+  const cachedConfig = configCache.get(key);
+  let indexer = getIndexerForProject(root, host);
+
+  if (args.estimateOnly) {
+    return { kind: "estimate", estimate: await indexer.estimateCost() };
+  }
+
+  if (args.force) {
+    if (shouldForceLocalizeProjectIndex(root, host)) {
+      materializeLocalProjectConfig(root, loadProjectConfigLayer(root, host), host);
+      refreshIndexerForDirectory(root, host, cachedConfig);
+      indexer = getIndexerForProject(root, host);
+    }
+    await indexer.clearIndex();
+    refreshIndexerForDirectory(root, host, cachedConfig);
+    indexer = getIndexerForProject(root, host);
+  }
+
+  const stats = await indexer.index((progress) => {
+    if (onProgress) {
+      return onProgress(formatProgressTitle(progress), {
+        phase: progress.phase,
+        filesProcessed: progress.filesProcessed,
+        totalFiles: progress.totalFiles,
+        chunksProcessed: progress.chunksProcessed,
+        totalChunks: progress.totalChunks,
+        percentage: calculatePercentage(progress),
+      });
+    }
+    return Promise.resolve();
+  });
+
+  return { kind: "stats", stats };
+}
+
+export async function getIndexStatus(projectRoot: string | undefined, host: HostMode): Promise<StatusResult> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.getStatus();
+}
+
+export async function getIndexHealthCheck(projectRoot: string | undefined, host: HostMode): Promise<HealthCheckResult> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.healthCheck();
+}
+
+export async function getPrImpact(
+  projectRoot: string | undefined,
+  host: HostMode,
+  params: {
+    pr?: number;
+    branch?: string;
+    maxDepth?: number;
+    hubThreshold?: number;
+    checkConflicts?: boolean;
+    direction?: "callers" | "callees" | "both";
+  },
+): Promise<PrImpactResult> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  return indexer.getPrImpact({
+    pr: params.pr,
+    branch: params.branch,
+    maxDepth: params.maxDepth,
+    hubThreshold: params.hubThreshold,
+    checkConflicts: params.checkConflicts,
+    direction: params.direction,
+  });
+}
+
+export async function getIndexMetrics(projectRoot: string | undefined, host: HostMode): Promise<{ enabled: boolean; metricsEnabled: boolean; text: string }> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  const logger = indexer.getLogger();
+
+  if (!logger.isEnabled()) {
+    return {
+      enabled: false,
+      metricsEnabled: false,
+      text: "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```",
+    };
+  }
+
+  if (!logger.isMetricsEnabled()) {
+    return {
+      enabled: true,
+      metricsEnabled: false,
+      text: "Metrics collection is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```",
+    };
+  }
+
+  return {
+    enabled: true,
+    metricsEnabled: true,
+    text: logger.formatMetrics(),
+  };
+}
+
+export async function getIndexLogs(
+  projectRoot: string | undefined,
+  host: HostMode,
+  args: { limit?: number; category?: string; level?: LogLevel },
+): Promise<{ kind: "disabled"; text: string } | { kind: "entries"; text: string }> {
+  const indexer = getIndexerForProject(projectRoot, host);
+  const logger = indexer.getLogger();
+
+  if (!logger.isEnabled()) {
+    return {
+      kind: "disabled",
+      text: "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true\n  }\n}\n```",
+    };
+  }
+
+  let logs: LogEntry[];
+  if (args.category) {
+    logs = logger.getLogsByCategory(args.category, args.limit);
+  } else if (args.level) {
+    logs = logger.getLogsByLevel(args.level, args.limit);
+  } else {
+    logs = logger.getLogs(args.limit);
+  }
+
+  if (logs.length === 0) {
+    return {
+      kind: "entries",
+      text: "No logs recorded yet. Logs are captured during indexing and search operations.",
+    };
+  }
+
+  const text = logs.map((entry) => {
+    const dataStr = entry.data ? ` ${JSON.stringify(entry.data)}` : "";
+    return `[${entry.timestamp}] [${entry.level.toUpperCase()}] [${entry.category}] ${entry.message}${dataStr}`;
+  }).join("\n");
+
+  return { kind: "entries", text };
+}
+
+export function addKnowledgeBase(
+  projectRoot: string | undefined,
+  host: HostMode,
+  knowledgeBasePath: string,
+): string {
+  const root = getProjectRoot(projectRoot, host);
+  const inputPath = knowledgeBasePath.trim();
+  const normalizedPath = path.resolve(
+    path.isAbsolute(inputPath)
+      ? inputPath
+      : resolveKnowledgeBasePath(inputPath, root),
+  );
+
+  if (!existsSync(normalizedPath)) {
+    return `Error: Directory does not exist: ${normalizedPath}`;
+  }
+
+  let realPath: string;
+  try {
+    realPath = realpathSync(normalizedPath);
+  } catch {
+    return `Error: Cannot resolve path: ${normalizedPath}`;
+  }
+
+  const blockedPrefixes = [
+    "/etc",
+    "/proc",
+    "/sys",
+    "/dev",
+    "/boot",
+    "/root",
+    "/var/run",
+    "/var/log",
+  ];
+  const homeDir = process.platform === "win32" ? process.env.USERPROFILE ?? "" : process.env.HOME ?? "";
+  const sensitiveDotDirs = [
+    ".ssh",
+    ".gnupg",
+    ".aws",
+    ".config/gcloud",
+    ".docker",
+    ".kube",
+  ];
+
+  for (const prefix of blockedPrefixes) {
+    if (realPath === prefix || realPath.startsWith(`${prefix}/`)) {
+      return `Error: Adding sensitive directory as knowledge base is not allowed: ${normalizedPath}`;
+    }
+  }
+
+  for (const dotDir of sensitiveDotDirs) {
+    const sensitiveDir = path.join(homeDir, dotDir);
+    if (sensitiveDir && (realPath === sensitiveDir || realPath.startsWith(`${sensitiveDir}/`))) {
+      return `Error: Adding sensitive directory as knowledge base is not allowed: ${normalizedPath}`;
+    }
+  }
+
+  try {
+    const stat = statSync(normalizedPath);
+    if (!stat.isDirectory()) {
+      return `Error: Path is not a directory: ${normalizedPath}`;
+    }
+  } catch (error: unknown) {
+    return `Error: Cannot access directory: ${normalizedPath} - ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  const config = loadEditableConfig(root, host);
+  const knowledgeBases: string[] = Array.isArray(config.knowledgeBases) ? (config.knowledgeBases as string[]) : [];
+  const alreadyExists = hasMatchingKnowledgeBasePath(knowledgeBases, normalizedPath, root);
+
+  if (alreadyExists) {
+    return `Knowledge base already configured: ${normalizedPath}`;
+  }
+
+  knowledgeBases.push(normalizedPath);
+  config.knowledgeBases = knowledgeBases;
+  saveConfig(root, config, host);
+  refreshIndexerForDirectory(root, host);
+
+  let result = `${normalizedPath}\n`;
+  result += `Total knowledge bases: ${knowledgeBases.length}\n`;
+  result += `Config path: ${getConfigPath(root, host)}\n`;
+  result += `\nRun /index to rebuild the index with the new knowledge base.`;
+  return result;
+}
+
+export function listKnowledgeBases(projectRoot: string | undefined, host: HostMode): string {
+  const root = getProjectRoot(projectRoot, host);
+  const config = loadRuntimeConfig(root, host);
+  const knowledgeBases: string[] = Array.isArray(config.knowledgeBases) ? (config.knowledgeBases as string[]) : [];
+
+  if (knowledgeBases.length === 0) {
+    return "No knowledge bases configured. Use add_knowledge_base to add folders.";
+  }
+
+  let result = `Knowledge Bases (${knowledgeBases.length}):\n\n`;
+
+  for (let i = 0; i < knowledgeBases.length; i++) {
+    const kb = knowledgeBases[i];
+    const resolvedPath = resolveKnowledgeBasePath(kb, root);
+    const exists = existsSync(resolvedPath);
+
+    result += `[${i + 1}] ${kb}\n`;
+    result += `    Resolved: ${resolvedPath}\n`;
+    result += `    Status: ${exists ? "Exists" : "NOT FOUND"}\n`;
+
+    if (exists) {
+      try {
+        const stat = statSync(resolvedPath);
+        result += `    Type: ${stat.isDirectory() ? "Directory" : "File"}\n`;
+      } catch {
+        // ignore
+      }
+    }
+
+    result += "\n";
+  }
+
+  const hasHostConfig = existsSync(path.join(root, getHostProjectConfigRelativePath(host)));
+  if (hasHostConfig) {
+    result += `
+Config sources: 1 file(s).`;
+  }
+
+  result += `\nConfig file: ${getConfigPath(root, host)}`;
+  return result;
+}
+
+export function removeKnowledgeBase(
+  projectRoot: string | undefined,
+  host: HostMode,
+  knowledgeBasePath: string,
+): string {
+  const root = getProjectRoot(projectRoot, host);
+  const config = loadEditableConfig(root, host);
+  const knowledgeBases: string[] = Array.isArray(config.knowledgeBases) ? (config.knowledgeBases as string[]) : [];
+  const index = findKnowledgeBasePathIndex(knowledgeBases, knowledgeBasePath, root);
+
+  if (index === -1) {
+    return `Knowledge base not found: ${knowledgeBasePath}`;
+  }
+
+  const removed = knowledgeBases.splice(index, 1)[0];
+  config.knowledgeBases = knowledgeBases;
+  saveConfig(root, config, host);
+  refreshIndexerForDirectory(root, host);
+
+  let result = `Removed: ${removed}\n\n`;
+  result += `Remaining knowledge bases: ${knowledgeBases.length}\n`;
+  result += `Config saved to: ${getConfigPath(root, host)}\n`;
+  result += `\nRun /index to rebuild the index without the removed knowledge base.`;
+
+  return result;
+}
+
+export { formatStatus };

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -1,0 +1,17 @@
+import type { Indexer } from "../indexer/index.js";
+
+type AutoIndexTarget = Pick<Indexer, "initialize" | "index">;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function startAutoIndex(indexer: AutoIndexTarget, projectRoot: string): void {
+  indexer.initialize().then(() => {
+    indexer.index().catch((error: unknown) => {
+      console.error(`[codebase-index] Auto-index failed for "${projectRoot}": ${getErrorMessage(error)}`);
+    });
+  }).catch((error: unknown) => {
+    console.error(`[codebase-index] Auto-index initialization failed for "${projectRoot}": ${getErrorMessage(error)}`);
+  });
+}

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -19,6 +19,7 @@ const PROJECT_MARKERS = [
   "CMakeLists.txt",
   "Makefile",
   ".opencode",
+  ".codebase-index",
 ];
 
 export function hasProjectMarker(projectRoot: string): boolean {
@@ -55,6 +56,7 @@ export function createIgnoreFilter(projectRoot: string): Ignore {
     "target",
     "vendor",
     ".opencode",
+    ".codebase-index",
     ".*",
     "**/.*",
     "**/.*/**",

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -16,20 +16,26 @@ export interface FileChange {
 
 export type ChangeHandler = (changes: FileChange[]) => Promise<void>;
 
+export interface FileWatcherOptions {
+  configPath?: string;
+}
+
 export class FileWatcher {
   private watcher: FSWatcher | null = null;
   private projectRoot: string;
   private config: CodebaseIndexConfig;
   private host: HostMode;
+  private configPath: string | undefined;
   private pendingChanges: Map<string, FileChangeType> = new Map();
   private debounceTimer: NodeJS.Timeout | null = null;
   private debounceMs = 1000;
   private onChanges: ChangeHandler | null = null;
 
-  constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode = "opencode") {
+  constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode = "opencode", options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
     this.config = config;
     this.host = host;
+    this.configPath = options.configPath;
   }
 
   start(handler: ChangeHandler): void {
@@ -39,8 +45,9 @@ export class FileWatcher {
 
     this.onChanges = handler;
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
+    const watchTargets = this.configPath ? [this.projectRoot, this.configPath] : this.projectRoot;
 
-    this.watcher = chokidar.watch(this.projectRoot, {
+    this.watcher = chokidar.watch(watchTargets, {
       ignored: (filePath: string) => {
         const relativePath = path.relative(this.projectRoot, filePath);
         if (!relativePath) return false;
@@ -123,6 +130,10 @@ export class FileWatcher {
   }
 
   private getProjectConfigRelativePaths(): string[] {
+    if (this.configPath) {
+      return [path.normalize(path.relative(this.projectRoot, this.configPath))];
+    }
+
     return [
       resolveProjectConfigPath(this.projectRoot, this.host),
       resolveWritableProjectConfigPath(this.projectRoot, this.host),

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 
 import type { HostMode } from "../config/host.js";
 import type { CodebaseIndexConfig } from "../config/schema.js";
-import { resolveWritableProjectConfigPath } from "../config/paths.js";
+import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
@@ -111,17 +111,22 @@ export class FileWatcher {
 
   private isProjectConfigPath(filePath: string): boolean {
     const relativePath = path.relative(this.projectRoot, filePath);
-    return path.normalize(relativePath) === this.getProjectConfigRelativePath();
+    const normalizedRelativePath = path.normalize(relativePath);
+    return this.getProjectConfigRelativePaths().some((configPath) => configPath === normalizedRelativePath);
   }
 
   private isProjectConfigPathOrAncestor(relativePath: string): boolean {
     const normalizedRelativePath = path.normalize(relativePath);
-    const configRelativePath = this.getProjectConfigRelativePath();
-    return configRelativePath === normalizedRelativePath || configRelativePath.startsWith(`${normalizedRelativePath}${path.sep}`);
+    return this.getProjectConfigRelativePaths().some(
+      (configPath) => configPath === normalizedRelativePath || configPath.startsWith(`${normalizedRelativePath}${path.sep}`),
+    );
   }
 
-  private getProjectConfigRelativePath(): string {
-    return path.normalize(path.relative(this.projectRoot, resolveWritableProjectConfigPath(this.projectRoot, this.host)));
+  private getProjectConfigRelativePaths(): string[] {
+    return [
+      resolveProjectConfigPath(this.projectRoot, this.host),
+      resolveWritableProjectConfigPath(this.projectRoot, this.host),
+    ].map((configPath) => path.normalize(path.relative(this.projectRoot, configPath)));
   }
 
   private scheduleFlush(): void {

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -1,7 +1,9 @@
 import chokidar, { FSWatcher } from "chokidar";
 import * as path from "path";
 
+import type { HostMode } from "../config/host.js";
 import type { CodebaseIndexConfig } from "../config/schema.js";
+import { resolveWritableProjectConfigPath } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
@@ -18,14 +20,16 @@ export class FileWatcher {
   private watcher: FSWatcher | null = null;
   private projectRoot: string;
   private config: CodebaseIndexConfig;
+  private host: HostMode;
   private pendingChanges: Map<string, FileChangeType> = new Map();
   private debounceTimer: NodeJS.Timeout | null = null;
   private debounceMs = 1000;
   private onChanges: ChangeHandler | null = null;
 
-  constructor(projectRoot: string, config: CodebaseIndexConfig) {
+  constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode = "opencode") {
     this.projectRoot = projectRoot;
     this.config = config;
+    this.host = host;
   }
 
   start(handler: ChangeHandler): void {
@@ -40,6 +44,10 @@ export class FileWatcher {
       ignored: (filePath: string) => {
         const relativePath = path.relative(this.projectRoot, filePath);
         if (!relativePath) return false;
+
+        if (this.isProjectConfigPathOrAncestor(relativePath)) {
+          return false;
+        }
 
         if (hasFilteredPathSegment(relativePath, path.sep)) {
           return true;
@@ -78,6 +86,12 @@ export class FileWatcher {
   }
 
   private handleChange(type: FileChangeType, filePath: string): void {
+    if (this.isProjectConfigPath(filePath)) {
+      this.pendingChanges.set(filePath, type);
+      this.scheduleFlush();
+      return;
+    }
+
     const includePatterns = [...this.config.include, ...(this.config.additionalInclude ?? [])];
     if (
       !shouldIncludeFile(
@@ -93,6 +107,21 @@ export class FileWatcher {
 
     this.pendingChanges.set(filePath, type);
     this.scheduleFlush();
+  }
+
+  private isProjectConfigPath(filePath: string): boolean {
+    const relativePath = path.relative(this.projectRoot, filePath);
+    return path.normalize(relativePath) === this.getProjectConfigRelativePath();
+  }
+
+  private isProjectConfigPathOrAncestor(relativePath: string): boolean {
+    const normalizedRelativePath = path.normalize(relativePath);
+    const configRelativePath = this.getProjectConfigRelativePath();
+    return configRelativePath === normalizedRelativePath || configRelativePath.startsWith(`${normalizedRelativePath}${path.sep}`);
+  }
+
+  private getProjectConfigRelativePath(): string {
+    return path.normalize(path.relative(this.projectRoot, resolveWritableProjectConfigPath(this.projectRoot, this.host)));
   }
 
   private scheduleFlush(): void {

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -1,6 +1,8 @@
 import type { CodebaseIndexConfig } from "../config/schema.js";
+import { parseConfig } from "../config/schema.js";
 import type { HostMode } from "../config/host.js";
 import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
+import { loadConfigFile } from "../config/merger.js";
 import type { Indexer } from "../indexer/index.js";
 import { isGitRepo } from "../git/index.js";
 import { refreshIndexerForDirectory } from "../tools/operations.js";
@@ -16,6 +18,10 @@ export interface CombinedWatcher {
   fileWatcher: FileWatcher;
   gitWatcher: GitHeadWatcher | null;
   stop(): void;
+}
+
+export interface WatcherOptions {
+  configPath?: string;
 }
 
 class BackgroundReindexer {
@@ -66,8 +72,9 @@ export function createWatcherWithIndexer(
   projectRoot: string,
   config: CodebaseIndexConfig,
   host: HostMode = "opencode",
+  options: WatcherOptions = {},
 ): CombinedWatcher {
-  const fileWatcher = new FileWatcher(projectRoot, config, host);
+  const fileWatcher = new FileWatcher(projectRoot, config, host, options);
   const backgroundReindexer = new BackgroundReindexer(async () => {
     await getIndexer().index();
   });
@@ -79,12 +86,10 @@ export function createWatcherWithIndexer(
     const hasDelete = changes.some((c) => c.type === "unlink");
 
     if (hasAddOrChange || hasDelete) {
-      const configPaths = [
-        resolveProjectConfigPath(projectRoot, host),
-        resolveWritableProjectConfigPath(projectRoot, host),
-      ].map((configPath) => pathNormalize(configPath));
+      const configPaths = getConfigPaths(projectRoot, host, options);
       if (changes.some((change) => configPaths.includes(pathNormalize(change.path)))) {
-        refreshIndexerForDirectory(projectRoot, host);
+        const parsedConfig = options.configPath ? parseConfig(loadConfigFile(options.configPath)) : undefined;
+        refreshIndexerForDirectory(projectRoot, host, parsedConfig);
       }
       backgroundReindexer.request();
     }
@@ -113,4 +118,15 @@ export function createWatcherWithIndexer(
 
 function pathNormalize(value: string): string {
   return value.split("\\").join("/");
+}
+
+function getConfigPaths(projectRoot: string, host: HostMode, options: WatcherOptions): string[] {
+  if (options.configPath) {
+    return [pathNormalize(options.configPath)];
+  }
+
+  return [
+    resolveProjectConfigPath(projectRoot, host),
+    resolveWritableProjectConfigPath(projectRoot, host),
+  ].map((configPath) => pathNormalize(configPath));
 }

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -1,6 +1,6 @@
 import type { CodebaseIndexConfig } from "../config/schema.js";
 import type { HostMode } from "../config/host.js";
-import { resolveWritableProjectConfigPath } from "../config/paths.js";
+import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
 import type { Indexer } from "../indexer/index.js";
 import { isGitRepo } from "../git/index.js";
 import { refreshIndexerForDirectory } from "../tools/operations.js";
@@ -79,8 +79,11 @@ export function createWatcherWithIndexer(
     const hasDelete = changes.some((c) => c.type === "unlink");
 
     if (hasAddOrChange || hasDelete) {
-      const configPath = pathNormalize(resolveWritableProjectConfigPath(projectRoot, host));
-      if (changes.some((change) => pathNormalize(change.path) === configPath)) {
+      const configPaths = [
+        resolveProjectConfigPath(projectRoot, host),
+        resolveWritableProjectConfigPath(projectRoot, host),
+      ].map((configPath) => pathNormalize(configPath));
+      if (changes.some((change) => configPaths.includes(pathNormalize(change.path)))) {
         refreshIndexerForDirectory(projectRoot, host);
       }
       backgroundReindexer.request();

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -1,6 +1,9 @@
 import type { CodebaseIndexConfig } from "../config/schema.js";
+import type { HostMode } from "../config/host.js";
+import { resolveWritableProjectConfigPath } from "../config/paths.js";
 import type { Indexer } from "../indexer/index.js";
 import { isGitRepo } from "../git/index.js";
+import { refreshIndexerForDirectory } from "../tools/operations.js";
 import { FileWatcher } from "./file-watcher.js";
 import { GitHeadWatcher } from "./git-head-watcher.js";
 
@@ -61,9 +64,10 @@ class BackgroundReindexer {
 export function createWatcherWithIndexer(
   getIndexer: () => Indexer,
   projectRoot: string,
-  config: CodebaseIndexConfig
+  config: CodebaseIndexConfig,
+  host: HostMode = "opencode",
 ): CombinedWatcher {
-  const fileWatcher = new FileWatcher(projectRoot, config);
+  const fileWatcher = new FileWatcher(projectRoot, config, host);
   const backgroundReindexer = new BackgroundReindexer(async () => {
     await getIndexer().index();
   });
@@ -75,6 +79,10 @@ export function createWatcherWithIndexer(
     const hasDelete = changes.some((c) => c.type === "unlink");
 
     if (hasAddOrChange || hasDelete) {
+      const configPath = pathNormalize(resolveWritableProjectConfigPath(projectRoot, host));
+      if (changes.some((change) => pathNormalize(change.path) === configPath)) {
+        refreshIndexerForDirectory(projectRoot, host);
+      }
       backgroundReindexer.request();
     }
   });
@@ -98,4 +106,8 @@ export function createWatcherWithIndexer(
       gitWatcher?.stop();
     },
   };
+}
+
+function pathNormalize(value: string): string {
+  return value.split("\\").join("/");
 }

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Indexer } from "../src/indexer/index.js";
+import { startAutoIndex } from "../src/utils/auto-index.js";
+
+type AutoIndexMock = Pick<Indexer, "initialize" | "index">;
+
+function createIndexerMock(overrides: {
+  initialize?: ReturnType<typeof vi.fn>;
+  index?: ReturnType<typeof vi.fn>;
+}): AutoIndexMock {
+  return {
+    initialize: overrides.initialize ?? vi.fn().mockResolvedValue(undefined),
+    index: overrides.index ?? vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("startAutoIndex", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs initialization failures", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const indexer = createIndexerMock({
+      initialize: vi.fn().mockRejectedValue(new Error("missing credentials")),
+    });
+
+    startAutoIndex(indexer, "/tmp/project");
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[codebase-index] Auto-index initialization failed for "/tmp/project": missing credentials',
+    );
+  });
+
+  it("indexes after initialization succeeds", async () => {
+    const indexer = createIndexerMock({});
+
+    startAutoIndex(indexer, "/tmp/project");
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalled());
+
+    expect(indexer.initialize).toHaveBeenCalledOnce();
+    expect(indexer.index).toHaveBeenCalledOnce();
+  });
+
+  it("logs indexing failures after initialization succeeds", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const indexer = createIndexerMock({
+      index: vi.fn().mockRejectedValue(new Error("database is malformed")),
+    });
+
+    startAutoIndex(indexer, "/tmp/project");
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(consoleError).toHaveBeenCalledWith(
+      '[codebase-index] Auto-index failed for "/tmp/project": database is malformed',
+    );
+  });
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,35 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadCliRawConfig, parseArgs } from "../src/cli.js";
+
+describe("cli config loading", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "cli-config-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads explicit --config file instead of merged host config", () => {
+    const configPath = path.join(tempDir, "custom-config.json");
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ embeddingProvider: "ollama", include: ["custom/**/*.ts"] }, null, 2),
+      "utf-8",
+    );
+
+    const args = parseArgs(["node", "dist/cli.js", "--project", tempDir, "--host", "codex", "--config", configPath]);
+    const rawConfig = loadCliRawConfig(args) as Record<string, unknown>;
+
+    expect(rawConfig.embeddingProvider).toBe("ollama");
+    expect(rawConfig.include).toEqual(["custom/**/*.ts"]);
+  });
+});

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs";
+
+import { describe, expect, it } from "vitest";
+import { parseHostMode } from "../src/config/host.js";
+
+describe("Codex plugin host mode", () => {
+  it("parses known host modes", () => {
+    expect(parseHostMode("opencode")).toBe("opencode");
+    expect(parseHostMode("codex")).toBe("codex");
+  });
+
+  it("rejects unknown host mode with a clear error", () => {
+    expect(() => parseHostMode("weird"))
+      .toThrow("Invalid host mode: weird. Allowed values: opencode, codex.");
+  });
+
+  it("exposes Codex plugin manifest and MCP command", () => {
+    const pluginManifest = JSON.parse(fs.readFileSync(".codex-plugin/plugin.json", "utf-8")) as {
+      mcpServers?: string;
+      hooks?: string;
+      version: string;
+      name: string;
+    };
+    const mcpManifest = JSON.parse(fs.readFileSync(".mcp.json", "utf-8")) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+
+    expect(pluginManifest.name).toBe("codebase-index");
+    expect(pluginManifest.version).toBe("0.12.0");
+    expect(pluginManifest.mcpServers).toBe("./.mcp.json");
+    expect(pluginManifest.hooks).toBe("./hooks/hooks.json");
+    expect(fs.existsSync("hooks/hooks.json")).toBe(true);
+
+    const codebaseMcp = mcpManifest.mcpServers["codebase-index"];
+    expect(codebaseMcp.command).toBe("node");
+    expect(codebaseMcp.args).toContain("--host");
+    expect(codebaseMcp.args).toContain("codex");
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -10,6 +10,7 @@ import {
   AUTO_DETECT_PROVIDER_ORDER,
   DEFAULT_PROVIDER_MODELS,
   DEFAULT_INCLUDE,
+  DEFAULT_EXCLUDE,
 } from "../src/config/constants.js";
 
 describe("config schema", () => {
@@ -85,7 +86,7 @@ describe("config schema", () => {
       expect(config.embeddingModel).toBeUndefined();
       expect(config.scope).toBe("project");
       expect(config.include).toHaveLength(DEFAULT_INCLUDE.length);
-      expect(config.exclude).toHaveLength(16);
+      expect(config.exclude).toHaveLength(DEFAULT_EXCLUDE.length);
     });
 
     it("should return defaults for null input", () => {

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -5,6 +5,8 @@ import * as path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadMergedConfig } from "../src/config/merger.js";
 import {
+  resolveGlobalConfigPath,
+  resolveGlobalIndexPath,
   resolveProjectConfigPath,
   resolveProjectIndexPath,
   resolveWritableProjectConfigPath,
@@ -87,6 +89,23 @@ describe("host-aware path resolution", () => {
     expect(loaded.knowledgeBases).toEqual(["codex-docs"]);
   });
 
+  it("falls back to legacy global config for codex host when codex-native global config is absent", () => {
+    const homeDir = os.homedir();
+    fs.mkdirSync(path.join(homeDir, ".config", "opencode"), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, ".config", "opencode", "codebase-index.json"),
+      JSON.stringify({ scope: "global", knowledgeBases: ["legacy-global-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    const resolved = resolveGlobalConfigPath("codex");
+    const loaded = loadMergedConfig(mainRepoDir, "codex") as Record<string, unknown>;
+
+    expect(resolved).toBe(path.join(homeDir, ".config", "opencode", "codebase-index.json"));
+    expect(loaded.scope).toBe("global");
+    expect(loaded.knowledgeBases).toEqual(["legacy-global-docs"]);
+  });
+
   it("falls back to legacy worktree index when codex index is absent", () => {
     fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
 
@@ -101,6 +120,16 @@ describe("host-aware path resolution", () => {
 
     expect(resolveProjectIndexPath(worktreeDir, "project", "codex")).toBe(
       path.join(mainRepoDir, ".codebase-index", "index"),
+    );
+  });
+
+  it("falls back to legacy global index for codex host when codex-native global index is absent", () => {
+    const homeDir = os.homedir();
+    fs.mkdirSync(path.join(homeDir, ".opencode", "global-index"), { recursive: true });
+
+    expect(resolveGlobalIndexPath("codex")).toBe(path.join(homeDir, ".opencode", "global-index"));
+    expect(resolveProjectIndexPath(mainRepoDir, "global", "codex")).toBe(
+      path.join(homeDir, ".opencode", "global-index"),
     );
   });
 

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -120,6 +120,33 @@ describe("host-aware path resolution", () => {
     );
   });
 
+  it("falls back to local legacy project index when codex host has only OpenCode project state", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectIndexPath(mainRepoDir, "project", "codex")).toBe(
+      path.join(mainRepoDir, ".opencode", "index"),
+    );
+  });
+
+  it("uses codex project index when codex-native config exists next to a legacy index", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".codebase-index"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".codebase-index", "config.json"),
+      JSON.stringify({ knowledgeBases: ["codex-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectIndexPath(mainRepoDir, "project", "codex")).toBe(
+      path.join(mainRepoDir, ".codebase-index", "index"),
+    );
+  });
+
   it("prefers codex-index inheritance before legacy when both exist", () => {
     fs.mkdirSync(path.join(mainRepoDir, ".codebase-index", "index"), { recursive: true });
     fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadMergedConfig } from "../src/config/merger.js";
+import {
+  resolveProjectConfigPath,
+  resolveProjectIndexPath,
+  resolveWritableProjectConfigPath,
+} from "../src/config/paths.js";
+
+describe("host-aware path resolution", () => {
+  let tempDir: string;
+  let mainRepoDir: string;
+  let worktreeDir: string;
+  let worktreeGitDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "host-mode-paths-"));
+    mainRepoDir = path.join(tempDir, "main-repo");
+    worktreeDir = path.join(tempDir, "worktree-feature");
+    worktreeGitDir = path.join(mainRepoDir, ".git", "worktrees", "feature");
+
+    fs.mkdirSync(path.join(mainRepoDir, ".git", "refs", "heads", "feature", "x"), { recursive: true });
+    fs.mkdirSync(mainRepoDir, { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".git"), { recursive: true });
+    fs.mkdirSync(worktreeGitDir, { recursive: true });
+    fs.mkdirSync(worktreeDir, { recursive: true });
+
+    fs.writeFileSync(path.join(mainRepoDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+    fs.writeFileSync(path.join(mainRepoDir, ".git", "refs", "heads", "main"), "1111111111111111111111111111111111111111\n");
+    fs.writeFileSync(path.join(mainRepoDir, ".git", "refs", "heads", "feature", "x", "y"), "2222222222222222222222222222222222222222\n");
+
+    fs.writeFileSync(path.join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+    fs.writeFileSync(path.join(worktreeGitDir, "HEAD"), "ref: refs/heads/feature/x/y\n");
+    fs.writeFileSync(path.join(worktreeGitDir, "commondir"), "../..\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses host-specific writable config paths", () => {
+    expect(resolveWritableProjectConfigPath(mainRepoDir, "opencode")).toBe(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+    );
+    expect(resolveWritableProjectConfigPath(mainRepoDir, "codex")).toBe(
+      path.join(mainRepoDir, ".codebase-index", "config.json"),
+    );
+  });
+
+  it("reads legacy OpenCode config for codex host when codex-native config is absent", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    const resolved = resolveProjectConfigPath(mainRepoDir, "codex");
+    const loaded = loadMergedConfig(mainRepoDir, "codex") as Record<string, unknown>;
+
+    expect(resolved).toBe(path.join(mainRepoDir, ".opencode", "codebase-index.json"));
+    expect(loaded.knowledgeBases).toEqual(["legacy-docs"]);
+  });
+
+  it("prefers codex-native config for codex host when present", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".codebase-index"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".codebase-index", "config.json"),
+      JSON.stringify({ knowledgeBases: ["codex-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    const resolved = resolveProjectConfigPath(mainRepoDir, "codex");
+    const loaded = loadMergedConfig(mainRepoDir, "codex") as Record<string, unknown>;
+
+    expect(resolved).toBe(path.join(mainRepoDir, ".codebase-index", "config.json"));
+    expect(loaded.knowledgeBases).toEqual(["codex-docs"]);
+  });
+
+  it("falls back to legacy worktree index when codex index is absent", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(worktreeDir, "project", "codex")).toBe(
+      path.join(mainRepoDir, ".opencode", "index"),
+    );
+  });
+
+  it("prefers codex-index inheritance before legacy when both exist", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".codebase-index", "index"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(worktreeDir, "project", "codex")).toBe(
+      path.join(mainRepoDir, ".codebase-index", "index"),
+    );
+  });
+
+  it("keeps OpenCode project index path unchanged", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(mainRepoDir, "project", "opencode")).toBe(
+      path.join(mainRepoDir, ".opencode", "index"),
+    );
+  });
+});

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadMergedConfig } from "../src/config/merger.js";
 import {
   resolveGlobalConfigPath,
@@ -14,15 +14,20 @@ import {
 
 describe("host-aware path resolution", () => {
   let tempDir: string;
+  let homeDir: string;
   let mainRepoDir: string;
   let worktreeDir: string;
   let worktreeGitDir: string;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "host-mode-paths-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "host-mode-home-"));
     mainRepoDir = path.join(tempDir, "main-repo");
     worktreeDir = path.join(tempDir, "worktree-feature");
     worktreeGitDir = path.join(mainRepoDir, ".git", "worktrees", "feature");
+
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("USERPROFILE", homeDir);
 
     fs.mkdirSync(path.join(mainRepoDir, ".git", "refs", "heads", "feature", "x"), { recursive: true });
     fs.mkdirSync(mainRepoDir, { recursive: true });
@@ -40,6 +45,8 @@ describe("host-aware path resolution", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(homeDir, { recursive: true, force: true });
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -90,7 +97,6 @@ describe("host-aware path resolution", () => {
   });
 
   it("falls back to legacy global config for codex host when codex-native global config is absent", () => {
-    const homeDir = os.homedir();
     fs.mkdirSync(path.join(homeDir, ".config", "opencode"), { recursive: true });
     fs.writeFileSync(
       path.join(homeDir, ".config", "opencode", "codebase-index.json"),
@@ -124,7 +130,6 @@ describe("host-aware path resolution", () => {
   });
 
   it("falls back to legacy global index for codex host when codex-native global index is absent", () => {
-    const homeDir = os.homedir();
     fs.mkdirSync(path.join(homeDir, ".opencode", "global-index"), { recursive: true });
 
     expect(resolveGlobalIndexPath("codex")).toBe(path.join(homeDir, ".opencode", "global-index"));

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -211,6 +211,38 @@ describe("indexer clearIndex force rebuild", () => {
     );
   });
 
+  it("allows codex force clearing a local legacy OpenCode project index", async () => {
+    embeddingDimensions = 8;
+    const legacyIndexer = createIndexer(tempDir, 8);
+    const legacyStats = await legacyIndexer.index();
+    expect(legacyStats.failedChunks).toBe(0);
+
+    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+    const seededDb = trackDb(new Database(dbPath));
+    expect(seededDb.getStats().embeddingCount).toBeGreaterThan(0);
+
+    const codexConfig = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-8d",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    });
+    const codexIndexer = trackIndexer(new Indexer(tempDir, codexConfig, "codex"));
+
+    await expect(codexIndexer.clearIndex()).resolves.toBeUndefined();
+
+    const clearedDb = trackDb(new Database(dbPath));
+    expect(clearedDb.getStats().embeddingCount).toBe(0);
+    expect(clearedDb.getStats().chunkCount).toBe(0);
+  });
+
   it("clears only the current project from a shared global index when compatibility is unchanged", async () => {
     vi.stubEnv("HOME", tempHome);
     vi.stubEnv("USERPROFILE", tempHome);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -396,6 +396,7 @@ describe("MCP server tools and prompts", () => {
     expect(mergerMocks.materializeLocalProjectConfig).toHaveBeenCalledWith(
       "/tmp/test-project",
       mergerMocks.loadProjectConfigLayer.mock.results.at(-1)?.value,
+      "opencode",
     );
 
     expect(indexerMockState.constructorArgs.length).toBeGreaterThanOrEqual(3);
@@ -440,6 +441,7 @@ describe("MCP server tools and prompts", () => {
     expect(mergerMocks.materializeLocalProjectConfig).toHaveBeenCalledWith(
       "/tmp/test-project",
       { knowledgeBases: ["docs/reference"] },
+      "opencode",
     );
     expect(indexerMockState.constructorArgs.slice(-2)).toEqual([
       ["/tmp/test-project", runtimeConfig],

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -14,6 +14,7 @@ vi.mock("../src/tools/operations.js", () => ({
 
 vi.mock("../src/git/index.js", () => ({
   isGitRepo: vi.fn(() => false),
+  resolveWorktreeMainRepoRoot: vi.fn(() => null),
 }));
 
 import { parseConfig } from "../src/config/schema.js";
@@ -48,7 +49,7 @@ describe("watcher config refresh", () => {
     writeFileSync(path.join(tempDir, ".codebase-index", "config.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
 
     await vi.waitFor(() => {
-      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex");
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex", undefined);
       expect(indexer.index).toHaveBeenCalledTimes(1);
     }, { timeout: 2500 });
 
@@ -76,9 +77,73 @@ describe("watcher config refresh", () => {
     writeFileSync(path.join(tempDir, ".opencode", "index", "codebase.db"), "index");
 
     await vi.waitFor(() => {
-      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex");
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex", undefined);
       expect(indexer.index).toHaveBeenCalledTimes(1);
     }, { timeout: 2500 });
+
+    watcher.stop();
+  });
+
+  it("refreshes from explicit config path when configured", async () => {
+    const projectRoot = path.join(tempDir, "project");
+    mkdirSync(projectRoot, { recursive: true });
+    const configPath = path.join(tempDir, "custom-config.json");
+    writeFileSync(configPath, JSON.stringify({ include: ["**/*.ts"] }));
+
+    const indexer = {
+      index: vi.fn().mockResolvedValue(undefined),
+    };
+    const watcher = createWatcherWithIndexer(
+      () => indexer,
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { configPath },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    writeFileSync(configPath, JSON.stringify({ include: ["custom/**/*.ts"] }));
+
+    await vi.waitFor(() => {
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(
+        projectRoot,
+        "codex",
+        expect.objectContaining({ include: ["custom/**/*.ts"] }),
+      );
+      expect(indexer.index).toHaveBeenCalledTimes(1);
+    }, { timeout: 2500 });
+
+    watcher.stop();
+  });
+
+  it("does not refresh from project config when explicit config path is configured", async () => {
+    const projectRoot = path.join(tempDir, "project");
+    mkdirSync(projectRoot, { recursive: true });
+    const configPath = path.join(tempDir, "custom-config.json");
+    writeFileSync(configPath, JSON.stringify({ include: ["**/*.ts"] }));
+    mkdirSync(path.join(projectRoot, ".codebase-index"), { recursive: true });
+
+    const indexer = {
+      index: vi.fn().mockResolvedValue(undefined),
+    };
+    const watcher = createWatcherWithIndexer(
+      () => indexer,
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { configPath },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    operationMocks.refreshIndexerForDirectory.mockClear();
+    indexer.index.mockClear();
+
+    writeFileSync(path.join(projectRoot, ".codebase-index", "config.json"), JSON.stringify({ include: ["project/**/*.ts"] }));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    expect(operationMocks.refreshIndexerForDirectory).not.toHaveBeenCalled();
+    expect(indexer.index).not.toHaveBeenCalled();
 
     watcher.stop();
   });

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -54,4 +54,32 @@ describe("watcher config refresh", () => {
 
     watcher.stop();
   });
+
+  it("refreshes the codex indexer cache before reindexing when legacy OpenCode config changes", async () => {
+    mkdirSync(path.join(tempDir, ".opencode"), { recursive: true });
+    writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), JSON.stringify({ include: ["**/*.ts"] }));
+
+    const indexer = {
+      index: vi.fn().mockResolvedValue(undefined),
+    };
+    const watcher = createWatcherWithIndexer(
+      () => indexer,
+      tempDir,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    mkdirSync(path.join(tempDir, ".opencode", "index"), { recursive: true });
+    writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
+    writeFileSync(path.join(tempDir, ".opencode", "index", "codebase.db"), "index");
+
+    await vi.waitFor(() => {
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex");
+      expect(indexer.index).toHaveBeenCalledTimes(1);
+    }, { timeout: 2500 });
+
+    watcher.stop();
+  });
 });

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const operationMocks = vi.hoisted(() => ({
+  refreshIndexerForDirectory: vi.fn(),
+}));
+
+vi.mock("../src/tools/operations.js", () => ({
+  refreshIndexerForDirectory: operationMocks.refreshIndexerForDirectory,
+}));
+
+vi.mock("../src/git/index.js", () => ({
+  isGitRepo: vi.fn(() => false),
+}));
+
+import { parseConfig } from "../src/config/schema.js";
+import { createWatcherWithIndexer } from "../src/watcher/index.js";
+
+describe("watcher config refresh", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "watcher-config-refresh-"));
+    operationMocks.refreshIndexerForDirectory.mockClear();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("refreshes the codex indexer cache before reindexing when codex config changes", async () => {
+    const indexer = {
+      index: vi.fn().mockResolvedValue(undefined),
+    };
+    const watcher = createWatcherWithIndexer(
+      () => indexer,
+      tempDir,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    mkdirSync(path.join(tempDir, ".codebase-index"), { recursive: true });
+    writeFileSync(path.join(tempDir, ".codebase-index", "config.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
+
+    await vi.waitFor(() => {
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex");
+      expect(indexer.index).toHaveBeenCalledTimes(1);
+    }, { timeout: 2500 });
+
+    watcher.stop();
+  });
+});

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -164,6 +164,30 @@ describe("FileWatcher", () => {
 
       expect(changes.some((c) => c.path.includes(path.join(".codebase-index", "index")))).toBe(false);
     });
+
+    it("should watch legacy OpenCode config in codex mode without watching legacy index files", async () => {
+      const changes: FileChange[] = [];
+      fs.mkdirSync(path.join(tempDir, ".opencode"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), "{}");
+      watcher = new FileWatcher(tempDir, createTestConfig({ include: ["**/*.ts"] }), "codex");
+
+      watcher.start(async (c) => {
+        changes.push(...c);
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      fs.mkdirSync(path.join(tempDir, ".opencode", "index"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), "{\"include\":[\"src/**/*.ts\"]}");
+      fs.writeFileSync(path.join(tempDir, ".opencode", "index", "codebase.db"), "index");
+
+      await vi.waitFor(
+        () => expect(changes.some((c) => c.path.endsWith(path.join(".opencode", "codebase-index.json")))).toBe(true),
+        { timeout: 2500 },
+      );
+
+      expect(changes.some((c) => c.path.includes(path.join(".opencode", "index")))).toBe(false);
+    });
   });
 
   describe("createWatcherWithIndexer", () => {

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -142,6 +142,28 @@ describe("FileWatcher", () => {
 
       expect(changes.some((c) => c.path.endsWith("root.ts"))).toBe(true);
     });
+
+    it("should watch codex-native config without watching codex index files", async () => {
+      const changes: FileChange[] = [];
+      watcher = new FileWatcher(tempDir, createTestConfig({ include: ["**/*.ts"] }), "codex");
+
+      watcher.start(async (c) => {
+        changes.push(...c);
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      fs.mkdirSync(path.join(tempDir, ".codebase-index", "index"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, ".codebase-index", "config.json"), "{}");
+      fs.writeFileSync(path.join(tempDir, ".codebase-index", "index", "codebase.db"), "index");
+
+      await vi.waitFor(
+        () => expect(changes.some((c) => c.path.endsWith(path.join(".codebase-index", "config.json")))).toBe(true),
+        { timeout: 2500 },
+      );
+
+      expect(changes.some((c) => c.path.includes(path.join(".codebase-index", "index")))).toBe(false);
+    });
   });
 
   describe("createWatcherWithIndexer", () => {


### PR DESCRIPTION
## Summary

Add first-class Codex plugin support, wire the Codex MCP CLI to auto-index and watch valid projects on startup, and make the repository installable as a Codex marketplace source.

## Changes

- add Codex plugin bundle metadata, host-aware config/index paths, skills/hooks, and MCP wiring
- route Codex/OpenCode tool behavior through shared operations and add Codex-specific tests
- auto-index and start file watching from `dist/cli.js --host codex`, and add a repo marketplace source for installation

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

N/A
