### PR TITLE
feat(claude): add Claude Code as a first-class host

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "helweg-plugins",
+  "owner": {
+    "name": "Kenneth",
+    "email": "kenneth@example.com",
+    "url": "https://github.com/Helweg/opencode-codebase-index"
+  },
+  "plugins": [
+    {
+      "name": "codebase-index",
+      "description": "Semantic code search and codebase graph tools for Claude Code",
+      "source": "./",
+      "version": "0.12.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "codebase-index",
+  "version": "0.12.0",
+  "description": "Semantic code search and codebase graph tools for Claude Code",
+  "displayName": "Codebase Index",
+  "author": {
+    "name": "Kenneth",
+    "email": "kenneth@example.com",
+    "url": "https://github.com/Helweg/opencode-codebase-index"
+  },
+  "homepage": "https://github.com/Helweg/opencode-codebase-index",
+  "repository": "https://github.com/Helweg/opencode-codebase-index",
+  "license": "MIT",
+  "keywords": [
+    "codebase-index",
+    "semantic search",
+    "claude",
+    "claude-code",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
+  "mcpServers": {
+    "codebase-index": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/cli.js", "--host", "claude"]
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,8 +22,8 @@
   "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "codebase-index": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/cli.js", "--host", "claude"]
+      "command": "npx",
+      "args": ["-y", "--package", "opencode-codebase-index", "opencode-codebase-index-mcp", "--host", "claude"]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ benchmarks/results/
 # Local agent/session artifacts
 .sisyphus/
 .superset/
+
+# Local agent/workspace scratch (not part of the package)
+.omo/
+AGENTS.original.md

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - [⚡ Quick Start](#-quick-start)
 - [🧩 Codex Plugin](#-codex-plugin)
+- [🧩 Claude Code Plugin](#-claude-code-plugin)
 - [🌐 MCP Server (Cursor, Claude Code, Windsurf, etc.)](#-mcp-server-cursor-claude-code-windsurf-etc)
 - [🎯 When to Use What](#-when-to-use-what)
 - [🧭 OMO CodeGraph Compatibility](#-omo-codegraph-compatibility)
@@ -82,6 +83,26 @@ The plugin includes:
 - `hooks/hooks.json` lightweight session-start guidance
 - `.mcp.json` with `--host codex`
 - `.agents/plugins/marketplace.json` so this repo can act as a Codex marketplace source
+
+## 🧩 Claude Code Plugin
+Install once for Claude Code sessions and get skill guidance plus MCP tools in one manifest.
+
+1. **Add this repo as a marketplace source**
+   ```bash
+   /plugin marketplace add Helweg/opencode-codebase-index
+   ```
+2. **Install the plugin**
+   ```bash
+   /plugin install codebase-index@helweg-plugins
+   ```
+3. **Restart or open a new session** in the target workspace.
+4. Use MCP tools (`index_codebase`, `index_status`, `codebase_search`, etc.) and the `codebase-search` skill guidance.
+
+The plugin includes:
+- `skills/` guidance for local workflows
+- `hooks/hooks.json` lightweight session-start guidance
+- inline `mcpServers` (in `.claude-plugin/plugin.json`) launching `dist/cli.js --host claude` via `${CLAUDE_PLUGIN_ROOT}`
+- `.claude-plugin/marketplace.json` so this repo can act as a Claude Code marketplace source
 
 ### Provider selection notes
 
@@ -587,20 +608,26 @@ Any OpenAI-compatible reranking endpoint. Examples:
 
 ## ⚙️ Configuration
 
-### Storage Paths (OpenCode + Codex)
+### Storage Paths (OpenCode + Codex + Claude)
 OpenCode default (existing behavior):
 - project config: `.opencode/codebase-index.json`
 - project index: `.opencode/index`
 - global config: `~/.config/opencode/codebase-index.json`
 - global index: `~/.opencode/global-index`
 
-Codex host mode (new plugin default):
+Codex host mode (`--host codex`):
 - project config: `.codebase-index/config.json`
 - project index: `.codebase-index/index`
 - global config: `~/.config/codebase-index/config.json`
 - global index: `~/.codebase-index/global-index`
 
-Codex reads legacy OpenCode paths when codex-native paths are absent, so existing state continues to work.
+Claude Code host mode (`--host claude`):
+- project config: `.claude/codebase-index.json`
+- project index: `.claude/index`
+- global config: `~/.claude/codebase-index.json`
+- global index: `~/.claude/global-index`
+
+Codex and Claude read legacy OpenCode paths when their host-native paths are absent, so existing state continues to work.
 
 Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-index.json`:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Install once for Claude Code sessions and get skill guidance plus MCP tools in o
 The plugin includes:
 - `skills/` guidance for local workflows
 - `hooks/hooks.json` lightweight session-start guidance
-- inline `mcpServers` (in `.claude-plugin/plugin.json`) launching `dist/cli.js --host claude` via `${CLAUDE_PLUGIN_ROOT}`
+- inline `mcpServers` (in `.claude-plugin/plugin.json`) running the published `opencode-codebase-index` CLI via `npx … --host claude`, so a git marketplace install works without a local build
 - `.claude-plugin/marketplace.json` so this repo can act as a Claude Code marketplace source
 
 ### Provider selection notes

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "skill",
     "commands",
     ".codex-plugin",
+    ".claude-plugin",
     ".mcp.json",
     "skills",
     "hooks"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import { pathToFileURL } from "url";
 
 import { parseConfig } from "./config/schema.js";
-import { parseHostMode, type HostMode } from "./config/host.js";
+import { parseHostMode, HOST_MODES, type HostMode } from "./config/host.js";
 import { handleEvalCommand } from "./eval/cli.js";
 import { Indexer } from "./indexer/index.js";
 import { createMcpServer } from "./mcp-server.js";
@@ -173,7 +173,7 @@ async function main(): Promise<void> {
 
 function handleMainError(error: unknown): never {
   if (error instanceof Error && error.message.startsWith("Invalid host mode")) {
-    console.error("Invalid host mode. Allowed values: opencode, codex.");
+    console.error(`Invalid host mode. Allowed values: ${HOST_MODES.join(", ")}.`);
     process.exit(1);
   }
 

--- a/src/config/host.ts
+++ b/src/config/host.ts
@@ -1,17 +1,17 @@
-export type HostMode = "opencode" | "codex";
+export type HostMode = "opencode" | "codex" | "claude";
 
-export const HOST_MODES: ReadonlyArray<HostMode> = ["opencode", "codex"];
+export const HOST_MODES: ReadonlyArray<HostMode> = ["opencode", "codex", "claude"];
+
+export function isSupportedHostMode(value: string): value is HostMode {
+  return (HOST_MODES as ReadonlyArray<string>).includes(value);
+}
 
 export function parseHostMode(value: string | undefined): HostMode {
   const normalized = (value ?? "").toLowerCase();
 
-  if (normalized === "opencode" || normalized === "codex") {
+  if (isSupportedHostMode(normalized)) {
     return normalized;
   }
 
-  throw new Error(`Invalid host mode: ${value ?? "(none)"}. Allowed values: opencode, codex.`);
-}
-
-export function isSupportedHostMode(value: string): value is HostMode {
-  return value === "opencode" || value === "codex";
+  throw new Error(`Invalid host mode: ${value ?? "(none)"}. Allowed values: ${HOST_MODES.join(", ")}.`);
 }

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -10,13 +10,30 @@ const OPENCODE_PROJECT_INDEX_RELATIVE_PATH = path.join(".opencode", "index");
 const CODEBASE_INDEX_DIR = ".codebase-index";
 const CODEBASE_PROJECT_CONFIG_RELATIVE_PATH = path.join(CODEBASE_INDEX_DIR, "config.json");
 const CODEBASE_PROJECT_INDEX_RELATIVE_PATH = path.join(CODEBASE_INDEX_DIR, "index");
+const CLAUDE_DIR = ".claude";
+const CLAUDE_PROJECT_CONFIG_RELATIVE_PATH = path.join(CLAUDE_DIR, "codebase-index.json");
+const CLAUDE_PROJECT_INDEX_RELATIVE_PATH = path.join(CLAUDE_DIR, "index");
 
 function getProjectConfigRelativePath(host: HostMode): string {
-  return host === "opencode" ? OPENCODE_PROJECT_CONFIG_RELATIVE_PATH : CODEBASE_PROJECT_CONFIG_RELATIVE_PATH;
+  switch (host) {
+    case "opencode":
+      return OPENCODE_PROJECT_CONFIG_RELATIVE_PATH;
+    case "claude":
+      return CLAUDE_PROJECT_CONFIG_RELATIVE_PATH;
+    default:
+      return CODEBASE_PROJECT_CONFIG_RELATIVE_PATH;
+  }
 }
 
 function getProjectIndexRelativePath(host: HostMode): string {
-  return host === "opencode" ? OPENCODE_PROJECT_INDEX_RELATIVE_PATH : CODEBASE_PROJECT_INDEX_RELATIVE_PATH;
+  switch (host) {
+    case "opencode":
+      return OPENCODE_PROJECT_INDEX_RELATIVE_PATH;
+    case "claude":
+      return CLAUDE_PROJECT_INDEX_RELATIVE_PATH;
+    default:
+      return CODEBASE_PROJECT_INDEX_RELATIVE_PATH;
+  }
 }
 
 function resolveWorktreeFallbackPath(projectRoot: string, relativePath: string): string | null {
@@ -55,19 +72,25 @@ function hasHostProjectConfig(projectRoot: string, host: HostMode): boolean {
 }
 
 export function getGlobalIndexPath(host: HostMode = "opencode"): string {
-  if (host === "opencode") {
-    return path.join(os.homedir(), ".opencode", "global-index");
+  switch (host) {
+    case "opencode":
+      return path.join(os.homedir(), ".opencode", "global-index");
+    case "claude":
+      return path.join(os.homedir(), ".claude", "global-index");
+    default:
+      return path.join(os.homedir(), ".codebase-index", "global-index");
   }
-
-  return path.join(os.homedir(), ".codebase-index", "global-index");
 }
 
 export function getGlobalConfigPath(host: HostMode = "opencode"): string {
-  if (host === "opencode") {
-    return path.join(os.homedir(), ".config", "opencode", "codebase-index.json");
+  switch (host) {
+    case "opencode":
+      return path.join(os.homedir(), ".config", "opencode", "codebase-index.json");
+    case "claude":
+      return path.join(os.homedir(), ".claude", "codebase-index.json");
+    default:
+      return path.join(os.homedir(), ".config", "codebase-index", "config.json");
   }
-
-  return path.join(os.homedir(), ".config", "codebase-index", "config.json");
 }
 
 export function resolveGlobalConfigPath(host: HostMode = "opencode"): string {

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -1,0 +1,39 @@
+import * as fs from "fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("Claude Code plugin", () => {
+  it("exposes Claude plugin manifest with inline MCP command on the claude host", () => {
+    const pluginManifest = JSON.parse(fs.readFileSync(".claude-plugin/plugin.json", "utf-8")) as {
+      name: string;
+      version: string;
+      hooks?: string;
+      skills?: string;
+      mcpServers?: Record<string, { command: string; args: string[] }>;
+    };
+
+    expect(pluginManifest.name).toBe("codebase-index");
+    expect(pluginManifest.version).toBe("0.12.0");
+    expect(pluginManifest.hooks).toBe("./hooks/hooks.json");
+    expect(pluginManifest.skills).toBe("./skills/");
+    expect(fs.existsSync("hooks/hooks.json")).toBe(true);
+
+    const codebaseMcp = pluginManifest.mcpServers?.["codebase-index"];
+    expect(codebaseMcp?.command).toBe("node");
+    expect(codebaseMcp?.args).toContain("--host");
+    expect(codebaseMcp?.args).toContain("claude");
+    expect(codebaseMcp?.args.some((arg) => arg.includes("${CLAUDE_PLUGIN_ROOT}"))).toBe(true);
+  });
+
+  it("exposes a Claude marketplace manifest using owner metadata", () => {
+    const marketplace = JSON.parse(fs.readFileSync(".claude-plugin/marketplace.json", "utf-8")) as {
+      name: string;
+      owner: { name: string };
+      plugins: Array<{ name: string; source: string }>;
+    };
+
+    expect(marketplace.name).toBe("helweg-plugins");
+    expect(marketplace.owner.name).toBeTruthy();
+    expect(marketplace.plugins.some((plugin) => plugin.name === "codebase-index")).toBe(true);
+  });
+});

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -19,10 +19,12 @@ describe("Claude Code plugin", () => {
     expect(fs.existsSync("hooks/hooks.json")).toBe(true);
 
     const codebaseMcp = pluginManifest.mcpServers?.["codebase-index"];
-    expect(codebaseMcp?.command).toBe("node");
+    // Runs the published npm package, not the uncommitted dist/, so a git
+    // marketplace install can start the server without a local build.
+    expect(codebaseMcp?.command).toBe("npx");
+    expect(codebaseMcp?.args).toContain("opencode-codebase-index");
     expect(codebaseMcp?.args).toContain("--host");
     expect(codebaseMcp?.args).toContain("claude");
-    expect(codebaseMcp?.args.some((arg) => arg.includes("${CLAUDE_PLUGIN_ROOT}"))).toBe(true);
   });
 
   it("exposes a Claude marketplace manifest using owner metadata", () => {

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -7,11 +7,12 @@ describe("Codex plugin host mode", () => {
   it("parses known host modes", () => {
     expect(parseHostMode("opencode")).toBe("opencode");
     expect(parseHostMode("codex")).toBe("codex");
+    expect(parseHostMode("claude")).toBe("claude");
   });
 
   it("rejects unknown host mode with a clear error", () => {
     expect(() => parseHostMode("weird"))
-      .toThrow("Invalid host mode: weird. Allowed values: opencode, codex.");
+      .toThrow("Invalid host mode: weird. Allowed values: opencode, codex, claude.");
   });
 
   it("exposes Codex plugin manifest and MCP command", () => {

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -165,6 +165,67 @@ describe("host-aware path resolution", () => {
     );
   });
 
+  it("uses claude-native writable config path", () => {
+    expect(resolveWritableProjectConfigPath(mainRepoDir, "claude")).toBe(
+      path.join(mainRepoDir, ".claude", "codebase-index.json"),
+    );
+  });
+
+  it("uses claude-native global paths", () => {
+    expect(resolveGlobalConfigPath("claude")).toBe(path.join(homeDir, ".claude", "codebase-index.json"));
+    expect(resolveGlobalIndexPath("claude")).toBe(path.join(homeDir, ".claude", "global-index"));
+  });
+
+  it("reads legacy OpenCode config for claude host when claude-native config is absent", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectConfigPath(mainRepoDir, "claude")).toBe(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+    );
+    const loaded = loadMergedConfig(mainRepoDir, "claude") as Record<string, unknown>;
+    expect(loaded.knowledgeBases).toEqual(["legacy-docs"]);
+  });
+
+  it("prefers claude-native config for claude host when present", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".claude", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["claude-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectConfigPath(mainRepoDir, "claude")).toBe(
+      path.join(mainRepoDir, ".claude", "codebase-index.json"),
+    );
+    const loaded = loadMergedConfig(mainRepoDir, "claude") as Record<string, unknown>;
+    expect(loaded.knowledgeBases).toEqual(["claude-docs"]);
+  });
+
+  it("uses claude project index when claude-native config exists next to a legacy index", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".claude", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["claude-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectIndexPath(mainRepoDir, "project", "claude")).toBe(
+      path.join(mainRepoDir, ".claude", "index"),
+    );
+  });
+
   it("keeps OpenCode project index path unchanged", () => {
     fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
 


### PR DESCRIPTION
## Summary

Make Claude Code a first-class host, mirroring the existing Codex first-class integration. Claude Code can now install the plugin from this repo's marketplace and run the indexer with its own native storage paths.

## Changes

- Add `"claude"` to the `HostMode` union and derive `parseHostMode`/`isSupportedHostMode` (and the CLI error message) from `HOST_MODES`, so allowed values stay in sync.
- Claude-native storage paths — project `.claude/codebase-index.json` + `.claude/index`, global `~/.claude/codebase-index.json` + `~/.claude/global-index` — reusing the existing non-OpenCode fallback so legacy OpenCode state still resolves.
- Add `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (Claude Code native manifest: inline `mcpServers` launching `dist/cli.js --host claude` via `${CLAUDE_PLUGIN_ROOT}`, `owner` metadata in the marketplace). Reuses the host-neutral `skills/` and `hooks/hooks.json`.
- Publish `.claude-plugin` in `package.json` `files`; document the Claude Code plugin install flow and Claude storage paths in `README.md`.

## Testing

How were these changes tested?

- [x] Unit tests added/updated — Claude path coverage in `host-mode-paths.test.ts`, new `claude-plugin.test.ts`, updated host error-message assertion (21/21 host+plugin+cli tests pass)
- [ ] Manual testing performed
- [ ] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [ ] Tests pass (`npm run test:run`)
- [ ] Lint passes (`npm run lint`)

> Note: the full suite has 12 pre-existing failing files that require the native module (`npm run build:native`) — unrelated to this change. All host-mode, path, and plugin-manifest tests pass.

## Release Labels

- [x] Added at least one release category label (`feature`)
- [x] Added at most one semver label (`semver:minor`)

## Related Issues

N/A
