### PR TITLE
fix(codex): run published CLI via npx

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "codebase-index": {
-      "command": "node",
-      "args": ["${PLUGIN_ROOT}/dist/cli.js", "--host", "codex"]
+      "command": "npx",
+      "args": ["-y", "--package", "opencode-codebase-index", "opencode-codebase-index-mcp", "--host", "codex"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Install once for Codex threads and get skill guidance plus MCP tools in one mani
 The plugin includes:
 - `skills/` guidance for local workflows
 - `hooks/hooks.json` lightweight session-start guidance
-- `.mcp.json` with `--host codex`
+- `.mcp.json` running the published `opencode-codebase-index` CLI via `npx … --host codex`, so a git marketplace install works without a local build
 - `.agents/plugins/marketplace.json` so this repo can act as a Codex marketplace source
 
 ## 🧩 Claude Code Plugin

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -34,8 +34,14 @@ describe("Codex plugin host mode", () => {
     expect(fs.existsSync("hooks/hooks.json")).toBe(true);
 
     const codebaseMcp = mcpManifest.mcpServers["codebase-index"];
-    expect(codebaseMcp.command).toBe("node");
-    expect(codebaseMcp.args).toContain("--host");
-    expect(codebaseMcp.args).toContain("codex");
+    expect(codebaseMcp.command).toBe("npx");
+    expect(codebaseMcp.args).toEqual([
+      "-y",
+      "--package",
+      "opencode-codebase-index",
+      "opencode-codebase-index-mcp",
+      "--host",
+      "codex",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- run the Codex MCP manifest through the published npm CLI with npx
- document the install-safe Codex marketplace behavior
- strengthen the Codex plugin manifest test to lock the full command args

## Verification
- npm run typecheck
- npm run build:ts
- npm run lint
- npm run test:run
- targeted harness tests: tests/codex-plugin.test.ts, tests/claude-plugin.test.ts, tests/host-mode-paths.test.ts, tests/pi-package.test.ts, tests/cli.test.ts, tests/mcp-server.test.ts
