### PR TITLE
chore: prepare v0.13.1 hotfix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.12.0"
+      "version": "0.13.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {
@@ -19,7 +19,6 @@
     "mcp"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
   "mcpServers": {
     "codebase-index": {
       "command": "npx",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-07-03
+
+### Fixed
+
+- **Codex and Claude MCP startup**: Recognize npm `.bin` symlink launches as the CLI entrypoint so `npx --package opencode-codebase-index opencode-codebase-index-mcp --host ...` starts the MCP server instead of exiting before handshake.
+
 ## [0.13.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Install once for Claude Code sessions and get skill guidance plus MCP tools in o
 
 The plugin includes:
 - `skills/` guidance for local workflows
-- `hooks/hooks.json` lightweight session-start guidance
 - inline `mcpServers` (in `.claude-plugin/plugin.json`) running the published `opencode-codebase-index` CLI via `npx … --host claude`, so a git marketplace install works without a local build
 - `.claude-plugin/marketplace.json` so this repo can act as a Claude Code marketplace source
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { writeFileSync } from "fs";
+import { realpathSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
-import { pathToFileURL } from "url";
+import { fileURLToPath } from "url";
 
 import { parseConfig } from "./config/schema.js";
 import { parseHostMode, HOST_MODES, type HostMode } from "./config/host.js";
@@ -53,6 +53,10 @@ export function parseArgs(argv: string[]): CliArgs {
 
 export function loadCliRawConfig(args: CliArgs): unknown {
   return args.config ? loadConfigFile(args.config) : loadMergedConfig(args.project, args.host);
+}
+
+export function isCliEntrypoint(moduleUrl: string, argvPath: string | undefined): boolean {
+  return argvPath !== undefined && realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
 }
 
 function parseVisualizeArgs(argv: string[], cwd: string): VisualizeArgs {
@@ -186,6 +190,6 @@ function handleMainError(error: unknown): never {
   process.exit(1);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
   main().catch(handleMainError);
 }

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,10 +13,9 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.13.0");
-    expect(pluginManifest.hooks).toBe("./hooks/hooks.json");
+    expect(pluginManifest.version).toBe("0.13.1");
+    expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
-    expect(fs.existsSync("hooks/hooks.json")).toBe(true);
 
     const codebaseMcp = pluginManifest.mcpServers?.["codebase-index"];
     // Runs the published npm package, not the uncommitted dist/, so a git
@@ -31,11 +30,14 @@ describe("Claude Code plugin", () => {
     const marketplace = JSON.parse(fs.readFileSync(".claude-plugin/marketplace.json", "utf-8")) as {
       name: string;
       owner: { name: string };
-      plugins: Array<{ name: string; source: string }>;
+      plugins: Array<{ name: string; source: string; version: string }>;
     };
 
     expect(marketplace.name).toBe("helweg-plugins");
     expect(marketplace.owner.name).toBeTruthy();
-    expect(marketplace.plugins.some((plugin) => plugin.name === "codebase-index")).toBe(true);
+    expect(marketplace.plugins).toContainEqual(expect.objectContaining({
+      name: "codebase-index",
+      version: "0.13.1",
+    }));
   });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,10 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
+import { pathToFileURL } from "url";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { loadCliRawConfig, parseArgs } from "../src/cli.js";
+import { isCliEntrypoint, loadCliRawConfig, parseArgs } from "../src/cli.js";
 
 describe("cli config loading", () => {
   let tempDir: string;
@@ -31,5 +32,16 @@ describe("cli config loading", () => {
 
     expect(rawConfig.embeddingProvider).toBe("ollama");
     expect(rawConfig.include).toEqual(["custom/**/*.ts"]);
+  });
+
+  it("recognizes npm bin symlinks as the CLI entrypoint", () => {
+    const realCliPath = path.join(tempDir, "package", "dist", "cli.js");
+    const binPath = path.join(tempDir, ".bin", "opencode-codebase-index-mcp");
+    mkdirSync(path.dirname(realCliPath), { recursive: true });
+    mkdirSync(path.dirname(binPath), { recursive: true });
+    writeFileSync(realCliPath, "#!/usr/bin/env node\n", "utf-8");
+    symlinkSync(realCliPath, binPath);
+
+    expect(isCliEntrypoint(pathToFileURL(realCliPath).href, binPath)).toBe(true);
   });
 });

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -40,7 +40,7 @@ describe("Codex plugin host mode", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.13.0");
+    expect(pluginManifest.version).toBe("0.13.1");
     expect(pluginManifest.mcpServers).toBe("./.mcp.json");
     expect(pluginManifest.hooks).toBe("./hooks/hooks.json");
     expect(fs.existsSync("hooks/hooks.json")).toBe(true);


### PR DESCRIPTION
## Summary

Prepare the `0.13.1` hotfix release for MCP startup through npm package bin symlinks.

## Changes

- Fix CLI entrypoint detection so `npx --package opencode-codebase-index opencode-codebase-index-mcp --host ...` starts the MCP server when launched through npm `.bin` symlinks
- Add a regression test for npm-style bin symlink entrypoints
- Bump package, lockfile, Codex plugin, Claude plugin, and Claude marketplace metadata to `0.13.1`
- Document the hotfix in `CHANGELOG.md` and align Claude plugin README/test expectations with the current manifest

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional manual verification:

- Packed `opencode-codebase-index-0.13.1.tgz`
- Verified `npx --package <tarball> opencode-codebase-index-mcp --host codex` lists 12 MCP tools and runs `index_status` plus `implementation_lookup`
- Verified `npx --package <tarball> opencode-codebase-index-mcp --host claude` lists 12 MCP tools and runs `index_status` plus `implementation_lookup`

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes the Codex/Claude MCP startup failure where the server exited before the `initialize` handshake.
