### PR TITLE
chore: prepare v0.13.2 release metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.13.1"
+      "version": "0.13.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-04
+
+### Fixed
+
+- **Local plugin development**: Added `npm run dev:link-mcp` so this repository checkout can provide the local `opencode-codebase-index-mcp` bin expected by the standard `npx --package opencode-codebase-index ...` MCP command, without changing the published Codex/Claude manifests.
+- **MCP install docs**: Updated MCP examples to use the published-package `npx -y --package opencode-codebase-index opencode-codebase-index-mcp ...` form and clarified that MCP runtime dependencies ship with the package.
+
 ## [0.13.1] - 2026-07-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ The plugin includes:
 - `.mcp.json` running the published `opencode-codebase-index` CLI via `npx … --host codex`, so a git marketplace install works without a local build
 - `.agents/plugins/marketplace.json` so this repo can act as a Codex marketplace source
 
+For local plugin development from this checkout, build and link the local MCP bin once:
+
+```bash
+npm run build:ts
+npm run dev:link-mcp
+```
+
+After that, the normal `.mcp.json` command also works when Codex starts the plugin from this repository.
+
 ## 🧩 Claude Code Plugin
 Install once for Claude Code sessions and get skill guidance plus MCP tools in one manifest.
 
@@ -155,7 +164,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
      "mcpServers": {
        "codebase-index": {
          "command": "npx",
-         "args": ["opencode-codebase-index-mcp", "--project", "/path/to/your/project"]
+         "args": ["-y", "--package", "opencode-codebase-index", "opencode-codebase-index-mcp", "--project", "/path/to/your/project"]
        }
      }
    }
@@ -167,7 +176,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
      "mcpServers": {
        "codebase-index": {
          "command": "npx",
-         "args": ["opencode-codebase-index-mcp", "--project", "/path/to/your/project"]
+         "args": ["-y", "--package", "opencode-codebase-index", "opencode-codebase-index-mcp", "--project", "/path/to/your/project"]
        }
      }
    }
@@ -175,14 +184,16 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
 
 3. **CLI options**
    ```bash
-   npx opencode-codebase-index-mcp --project /path/to/repo    # specify project root
-   npx opencode-codebase-index-mcp --config /path/to/config   # custom config file
-   npx opencode-codebase-index-mcp                            # uses current directory
+   npx -y --package opencode-codebase-index opencode-codebase-index-mcp --project /path/to/repo
+   npx -y --package opencode-codebase-index opencode-codebase-index-mcp --config /path/to/config
+   npx -y --package opencode-codebase-index opencode-codebase-index-mcp
    ```
 
 The MCP server exposes all 12 tools (`codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`).
 
-The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) are optional peer dependencies — they're only needed if you use the MCP server.
+The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) ship with the package so published `npx --package opencode-codebase-index` launches work in clean MCP clients.
+
+If you are testing the MCP command from inside this repository checkout and see `opencode-codebase-index-mcp: command not found`, run `npm run build:ts && npm run dev:link-mcp`. That adds the local bin shim expected by `npx` without changing the published MCP config.
 
 ## 🔍 See It In Action
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",
@@ -47,6 +47,7 @@
     "eval:ci": "npx tsx src/cli.ts eval run --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:ci:ollama": "npx tsx src/cli.ts eval run --config .github/eval-ollama-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:compare": "npx tsx src/cli.ts eval compare",
+    "dev:link-mcp": "node scripts/link-local-mcp-bin.mjs",
     "test": "vitest",
     "pretest:run": "node scripts/run-build-native-with-rustflags.mjs",
     "test:run": "vitest run",
@@ -61,6 +62,7 @@
     "native/*.node",
     "skill",
     "commands",
+    "scripts/link-local-mcp-bin.mjs",
     ".codex-plugin",
     ".claude-plugin",
     ".mcp.json",

--- a/scripts/link-local-mcp-bin.mjs
+++ b/scripts/link-local-mcp-bin.mjs
@@ -1,0 +1,25 @@
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { dirname, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cliPath = resolve(root, "dist/cli.js");
+const binDir = resolve(root, "node_modules/.bin");
+const binPath = resolve(binDir, "opencode-codebase-index-mcp");
+
+if (!existsSync(cliPath)) {
+  console.error("dist/cli.js is missing. Run `npm run build:ts` first.");
+  process.exit(1);
+}
+
+mkdirSync(binDir, { recursive: true });
+rmSync(binPath, { force: true });
+rmSync(`${binPath}.cmd`, { force: true });
+
+if (process.platform === "win32") {
+  writeFileSync(`${binPath}.cmd`, `@echo off\r\nnode "%~dp0\\..\\..\\dist\\cli.js" %*\r\n`, "utf-8");
+} else {
+  symlinkSync(relative(dirname(binPath), cliPath), binPath);
+}
+
+console.log(`Linked ${binPath} -> ${cliPath}`);

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.13.1");
+    expect(pluginManifest.version).toBe("0.13.2");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -21,9 +21,14 @@ describe("Claude Code plugin", () => {
     // Runs the published npm package, not the uncommitted dist/, so a git
     // marketplace install can start the server without a local build.
     expect(codebaseMcp?.command).toBe("npx");
-    expect(codebaseMcp?.args).toContain("opencode-codebase-index");
-    expect(codebaseMcp?.args).toContain("--host");
-    expect(codebaseMcp?.args).toContain("claude");
+    expect(codebaseMcp?.args).toEqual([
+      "-y",
+      "--package",
+      "opencode-codebase-index",
+      "opencode-codebase-index-mcp",
+      "--host",
+      "claude",
+    ]);
   });
 
   it("exposes a Claude marketplace manifest using owner metadata", () => {
@@ -37,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.13.1",
+      version: "0.13.2",
     }));
   });
 });

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -8,12 +8,14 @@ describe("Codex plugin host mode", () => {
     const packageJson = JSON.parse(fs.readFileSync("package.json", "utf-8")) as {
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
+      scripts?: Record<string, string>;
     };
 
     expect(packageJson.dependencies?.["@modelcontextprotocol/sdk"]).toBeTruthy();
     expect(packageJson.dependencies?.zod).toBeTruthy();
     expect(packageJson.devDependencies?.["@modelcontextprotocol/sdk"]).toBeUndefined();
     expect(packageJson.devDependencies?.zod).toBeUndefined();
+    expect(packageJson.scripts?.["dev:link-mcp"]).toBe("node scripts/link-local-mcp-bin.mjs");
   });
 
   it("parses known host modes", () => {
@@ -40,7 +42,7 @@ describe("Codex plugin host mode", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.13.1");
+    expect(pluginManifest.version).toBe("0.13.2");
     expect(pluginManifest.mcpServers).toBe("./.mcp.json");
     expect(pluginManifest.hooks).toBe("./hooks/hooks.json");
     expect(fs.existsSync("hooks/hooks.json")).toBe(true);


### PR DESCRIPTION
## Summary

Prepare the v0.13.2 patch release for MCP startup reliability and local plugin development.

## Changes

- Bump package, lockfile, Codex plugin, Claude plugin, and marketplace metadata to v0.13.2.
- Add `npm run dev:link-mcp` so local plugin checkouts can provide the `opencode-codebase-index-mcp` bin expected by the standard `npx --package` MCP command.
- Update MCP docs to use the published-package `npx -y --package opencode-codebase-index opencode-codebase-index-mcp ...` form and document the local checkout workflow.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional validation:

- Packed `opencode-codebase-index-0.13.2.tgz` with `npm pack` and confirmed it contains `dist/cli.js`, native binary, and `scripts/link-local-mcp-bin.mjs`.
- Started the packed tarball from a clean temp project through MCP stdio and verified initialize, `listTools` (12 tools), and `index_status`.
- Started the local checkout with the unchanged `.mcp.json` command after `npm run dev:link-mcp` and verified initialize, `listTools` (12 tools), and `index_status`.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #140
