### PR TITLE
fix: align Pi call graph output with host adapters

### DIFF
--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -2,7 +2,15 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { formatCostEstimate } from "../utils/cost.js";
-import { formatDefinitionLookup, formatHealthCheck, formatIndexStats, formatStatus } from "../tools/utils.js";
+import {
+  formatCallGraphCallees,
+  formatCallGraphCallers,
+  formatCallGraphPath,
+  formatDefinitionLookup,
+  formatHealthCheck,
+  formatIndexStats,
+  formatStatus,
+} from "../tools/utils.js";
 import { formatPrImpact } from "../tools/format-pr-impact.js";
 import {
   findSimilarCode,
@@ -220,25 +228,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
           return { content: [{ type: "text", text: "Error: 'symbolId' is required when direction is 'callees'." }] };
         }
         const { callees } = await getCallGraphData(runtime.projectRoot, runtime.host, args);
-        if (callees.length === 0) {
-          return { content: [{ type: "text", text: `No callees found for symbol ${args.symbolId}${args.relationshipType ? ` with type ${args.relationshipType}` : ""}.` }] };
-        }
-        const formatted = callees.map((e, i) => {
-          const conf = e.confidence !== "Direct" ? ` [${e.confidence.toLowerCase()}]` : "";
-          return `[${i + 1}] \u2192 ${e.targetName} (${e.callType})${conf} at line ${e.line}${e.isResolved ? ` [resolved: ${e.toSymbolId}]` : " [unresolved]"}`;
-        });
-        return { content: [{ type: "text", text: `Callees (${callees.length}):\n\n${formatted.join("\n")}` }] };
+        return { content: [{ type: "text", text: formatCallGraphCallees(args.symbolId, callees, args.relationshipType) }] };
       }
 
       const { callers } = await getCallGraphData(runtime.projectRoot, runtime.host, args);
-      if (callers.length === 0) {
-        return { content: [{ type: "text", text: `No callers found for "${args.name}"${args.relationshipType ? ` with type ${args.relationshipType}` : ""}.` }] };
-      }
-      const formatted = callers.map((e, i) => {
-        const conf = e.confidence !== "Direct" ? ` [${e.confidence.toLowerCase()}]` : "";
-        return `[${i + 1}] \u2190 from ${e.fromSymbolName ?? "<unknown>"} in ${e.fromSymbolFilePath ?? "<unknown file>"} [${e.fromSymbolId}] (${e.callType})${conf} at line ${e.line}${e.isResolved ? " [resolved]" : " [unresolved]"}`;
-      });
-      return { content: [{ type: "text", text: `"${args.name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}` }] };
+      return { content: [{ type: "text", text: formatCallGraphCallers(args.name, callers, args.relationshipType) }] };
     },
   );
 
@@ -252,15 +246,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     },
     async (args) => {
       const path = await getCallGraphPath(runtime.projectRoot, runtime.host, args.from, args.to, args.maxDepth);
-      if (path.length === 0) {
-        return { content: [{ type: "text", text: `No path found between "${args.from}" and "${args.to}". They may be in disconnected components, or the call graph index needs updating.` }] };
-      }
-      const formatted = path.map((hop, i) => {
-        const prefix = i === 0 ? "[start]" : `--${hop.callType}-->`;
-        const location = hop.filePath ? ` (${hop.filePath}:${hop.line})` : "";
-        return `${prefix} ${hop.symbolName}${location}`;
-      });
-      return { content: [{ type: "text", text: `Path (${path.length} hops):\n${formatted.join("\n")}` }] };
+      return { content: [{ type: "text", text: formatCallGraphPath(args.from, args.to, path) }] };
     },
   );
   server.tool(

--- a/src/pi-call-graph.ts
+++ b/src/pi-call-graph.ts
@@ -1,0 +1,66 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+import { getCallGraphData, getCallGraphPath } from "./tools/operations.js";
+import { formatCallGraphCallees, formatCallGraphCallers, formatCallGraphPath } from "./tools/utils.js";
+
+const HOST = "pi" as const;
+
+const RelationshipType = Type.Union([
+  Type.Literal("Call"),
+  Type.Literal("MethodCall"),
+  Type.Literal("Constructor"),
+  Type.Literal("Import"),
+  Type.Literal("Inherits"),
+  Type.Literal("Implements"),
+]);
+
+function text(text: string, details?: unknown) {
+  return { content: [{ type: "text" as const, text }], details };
+}
+
+function projectRoot(ctx: { cwd?: string } | undefined): string | undefined {
+  return ctx?.cwd ?? process.cwd();
+}
+
+export function registerPiCallGraphTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "call_graph",
+    label: "Call Graph",
+    description: "Find callers or callees of a function/method in the indexed call graph.",
+    parameters: Type.Object({
+      name: Type.String(),
+      direction: Type.Optional(Type.Union([Type.Literal("callers"), Type.Literal("callees")])),
+      symbolId: Type.Optional(Type.String()),
+      relationshipType: Type.Optional(RelationshipType),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const result = await getCallGraphData(projectRoot(ctx), HOST, params);
+      if (result.direction === "callees") {
+        return text(
+          params.symbolId
+            ? formatCallGraphCallees(params.symbolId, result.callees, params.relationshipType)
+            : "Error: 'symbolId' is required when direction is 'callees'.",
+          result,
+        );
+      }
+
+      return text(formatCallGraphCallers(params.name, result.callers, params.relationshipType), result);
+    },
+  });
+
+  pi.registerTool({
+    name: "call_graph_path",
+    label: "Call Graph Path",
+    description: "Find a call path between two functions/methods.",
+    parameters: Type.Object({
+      from: Type.String(),
+      to: Type.String(),
+      maxDepth: Type.Optional(Type.Number({ default: 10 })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const result = await getCallGraphPath(projectRoot(ctx), HOST, params.from, params.to, params.maxDepth);
+      return text(formatCallGraphPath(params.from, params.to, result), result);
+    },
+  });
+}

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -6,8 +6,6 @@ import { formatPrImpact } from "./tools/format-pr-impact.js";
 import {
   addKnowledgeBase,
   findSimilarCode,
-  getCallGraphData,
-  getCallGraphPath,
   getIndexHealthCheck,
   getIndexLogs,
   getIndexMetrics,
@@ -26,6 +24,7 @@ import {
   formatSearchResults,
   formatStatus,
 } from "./tools/utils.js";
+import { registerPiCallGraphTools } from "./pi-call-graph.js";
 
 const HOST = "pi" as const;
 
@@ -37,15 +36,6 @@ const ChunkType = Type.Union([
   Type.Literal("type"),
   Type.Literal("module"),
   Type.Literal("block"),
-]);
-
-const RelationshipType = Type.Union([
-  Type.Literal("Call"),
-  Type.Literal("MethodCall"),
-  Type.Literal("Constructor"),
-  Type.Literal("Import"),
-  Type.Literal("Inherits"),
-  Type.Literal("Implements"),
 ]);
 
 function text(text: string, details?: unknown) {
@@ -198,36 +188,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
     },
   });
 
-  pi.registerTool({
-    name: "call_graph",
-    label: "Call Graph",
-    description: "Find callers or callees of a function/method in the indexed call graph.",
-    parameters: Type.Object({
-      name: Type.String(),
-      direction: Type.Optional(Type.Union([Type.Literal("callers"), Type.Literal("callees")])),
-      symbolId: Type.Optional(Type.String()),
-      relationshipType: Type.Optional(RelationshipType),
-    }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await getCallGraphData(projectRoot(ctx), HOST, params);
-      return text(JSON.stringify(result, null, 2), result);
-    },
-  });
-
-  pi.registerTool({
-    name: "call_graph_path",
-    label: "Call Graph Path",
-    description: "Find a call path between two functions/methods.",
-    parameters: Type.Object({
-      from: Type.String(),
-      to: Type.String(),
-      maxDepth: Type.Optional(Type.Number({ default: 10 })),
-    }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await getCallGraphPath(projectRoot(ctx), HOST, params.from, params.to, params.maxDepth);
-      return text(JSON.stringify(result, null, 2), result);
-    },
-  });
+  registerPiCallGraphTools(pi);
 
   pi.registerTool({
     name: "pr_impact",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,9 @@ import type { Indexer } from "../indexer/index.js";
 import { formatCostEstimate } from "../utils/cost.js";
 import {
   formatCodebasePeek,
+  formatCallGraphCallees,
+  formatCallGraphCallers,
+  formatCallGraphPath,
   formatDefinitionLookup,
   formatHealthCheck,
   formatIndexStats,
@@ -242,23 +245,11 @@ export const call_graph: ToolDefinition = tool({
         return "Error: 'symbolId' is required when direction is 'callees'. First use direction='callers' to find the symbol ID.";
       }
       const { callees } = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
-      if (callees.length === 0) {
-        return `No callees found for symbol ${args.symbolId}${args.relationshipType ? ` with type ${args.relationshipType}` : ""}. The function may not call any other tracked functions.`;
-      }
-      return callees.map((edge, index) => {
-        const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
-        return `[${index + 1}] \u2192 ${edge.targetName} (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? ` [resolved: ${edge.toSymbolId}]` : " [unresolved]"}`;
-      }).join("\n");
+      return formatCallGraphCallees(args.symbolId, callees, args.relationshipType);
     }
 
     const { callers } = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
-    if (callers.length === 0) {
-      return `No callers found for "${args.name}"${args.relationshipType ? ` with type ${args.relationshipType}` : ""}. It may not be called by any tracked function, or the index needs updating.`;
-    }
-    return callers.map((edge, index) => {
-      const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
-      return `[${index + 1}] \u2190 from ${edge.fromSymbolName ?? "<unknown>"} in ${edge.fromSymbolFilePath ?? "<unknown file>"} [${edge.fromSymbolId}] (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? " [resolved]" : " [unresolved]"}`;
-    }).join("\n");
+    return formatCallGraphCallers(args.name, callers, args.relationshipType);
   },
 });
 
@@ -272,15 +263,7 @@ export const call_graph_path: ToolDefinition = tool({
   },
   async execute(args, context) {
     const path = await getCallGraphPath(context?.worktree, DEFAULT_HOST, args.from, args.to, args.maxDepth);
-    if (path.length === 0) {
-      return `No path found between "${args.from}" and "${args.to}". They may be in disconnected components, or the call graph index needs updating.`;
-    }
-    const formatted = path.map((hop, index) => {
-      const prefix = index === 0 ? "[start]" : `--${hop.callType}-->`;
-      const location = hop.filePath ? ` (${hop.filePath}:${hop.line})` : "";
-      return `${prefix} ${hop.symbolName}${location}`;
-    });
-    return `Path (${path.length} hops):\n${formatted.join("\n")}`;
+    return formatCallGraphPath(args.from, args.to, path);
   },
 });
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,4 +1,5 @@
 import { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../indexer/index.js";
+import type { CallEdgeData, PathHopData } from "../native/index.js";
 import type { LogEntry } from "../utils/logger.js";
 
 const MAX_CONTENT_LINES = 30;
@@ -233,6 +234,44 @@ export function formatLogs(logs: LogEntry[]): string {
     const dataStr = l.data ? ` ${JSON.stringify(l.data)}` : "";
     return `[${l.timestamp}] [${l.level.toUpperCase()}] [${l.category}] ${l.message}${dataStr}`;
   }).join("\n");
+}
+
+export function formatCallGraphCallers(name: string, callers: CallEdgeData[], relationshipType?: string): string {
+  if (callers.length === 0) {
+    return `No callers found for "${name}"${relationshipType ? ` with type ${relationshipType}` : ""}. It may not be called by any tracked function, or the index needs updating.`;
+  }
+
+  const formatted = callers.map((edge, index) => {
+    const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
+    return `[${index + 1}] \u2190 from ${edge.fromSymbolName ?? "<unknown>"} in ${edge.fromSymbolFilePath ?? "<unknown file>"} [${edge.fromSymbolId}] (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? " [resolved]" : " [unresolved]"}`;
+  });
+
+  return `"${name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}`;
+}
+
+export function formatCallGraphCallees(symbolId: string, callees: CallEdgeData[], relationshipType?: string): string {
+  if (callees.length === 0) {
+    return `No callees found for symbol ${symbolId}${relationshipType ? ` with type ${relationshipType}` : ""}. The function may not call any other tracked functions.`;
+  }
+
+  return callees.map((edge, index) => {
+    const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
+    return `[${index + 1}] \u2192 ${edge.targetName} (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? ` [resolved: ${edge.toSymbolId}]` : " [unresolved]"}`;
+  }).join("\n");
+}
+
+export function formatCallGraphPath(from: string, to: string, path: PathHopData[]): string {
+  if (path.length === 0) {
+    return `No path found between "${from}" and "${to}". They may be in disconnected components, or the call graph index needs updating.`;
+  }
+
+  const formatted = path.map((hop, index) => {
+    const prefix = index === 0 ? "[start]" : `--${hop.callType}-->`;
+    const location = hop.filePath ? ` (${hop.filePath}:${hop.line})` : "";
+    return `${prefix} ${hop.symbolName}${location}`;
+  });
+
+  return `Path (${path.length} hops):\n${formatted.join("\n")}`;
 }
 
 function formatResultHeader(result: SearchResult, index: number): string {

--- a/tests/host-paths.test.ts
+++ b/tests/host-paths.test.ts
@@ -1,0 +1,71 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HostMode } from "../src/config/host.js";
+import {
+  getHostProjectConfigRelativePath,
+  getHostProjectIndexRelativePath,
+  resolveProjectConfigPath,
+  resolveProjectIndexPath,
+} from "../src/config/paths.js";
+
+const gitMocks = vi.hoisted(() => ({
+  resolveWorktreeMainRepoRoot: vi.fn<() => string | null>(() => null),
+}));
+
+vi.mock("../src/git/index.js", () => gitMocks);
+
+describe("host path conformance", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "host-paths-"));
+    gitMocks.resolveWorktreeMainRepoRoot.mockReset();
+    gitMocks.resolveWorktreeMainRepoRoot.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses host-native project config and index paths", () => {
+    const cases: ReadonlyArray<{
+      readonly host: HostMode;
+      readonly configPath: string;
+      readonly indexPath: string;
+    }> = [
+      { host: "opencode", configPath: path.join(".opencode", "codebase-index.json"), indexPath: path.join(".opencode", "index") },
+      { host: "claude", configPath: path.join(".claude", "codebase-index.json"), indexPath: path.join(".claude", "index") },
+      { host: "codex", configPath: path.join(".codebase-index", "config.json"), indexPath: path.join(".codebase-index", "index") },
+      { host: "pi", configPath: path.join(".codebase-index", "config.json"), indexPath: path.join(".codebase-index", "index") },
+    ];
+
+    for (const entry of cases) {
+      expect(getHostProjectConfigRelativePath(entry.host)).toBe(entry.configPath);
+      expect(getHostProjectIndexRelativePath(entry.host)).toBe(entry.indexPath);
+      expect(resolveProjectConfigPath(tempDir, entry.host)).toBe(path.join(tempDir, entry.configPath));
+      expect(resolveProjectIndexPath(tempDir, "project", entry.host)).toBe(path.join(tempDir, entry.indexPath));
+    }
+  });
+
+  it("lets non-OpenCode hosts reuse legacy OpenCode state until host config exists", () => {
+    const legacyConfig = path.join(tempDir, ".opencode", "codebase-index.json");
+    const legacyIndex = path.join(tempDir, ".opencode", "index");
+    fs.mkdirSync(path.dirname(legacyConfig), { recursive: true });
+    fs.mkdirSync(legacyIndex, { recursive: true });
+    fs.writeFileSync(legacyConfig, "{}", "utf-8");
+
+    expect(resolveProjectConfigPath(tempDir, "codex")).toBe(legacyConfig);
+    expect(resolveProjectIndexPath(tempDir, "project", "codex")).toBe(legacyIndex);
+
+    const codexConfig = path.join(tempDir, ".codebase-index", "config.json");
+    fs.mkdirSync(path.dirname(codexConfig), { recursive: true });
+    fs.writeFileSync(codexConfig, "{}", "utf-8");
+
+    expect(resolveProjectConfigPath(tempDir, "codex")).toBe(codexConfig);
+    expect(resolveProjectIndexPath(tempDir, "project", "codex")).toBe(path.join(tempDir, ".codebase-index", "index"));
+  });
+});

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const operationMocks = vi.hoisted(() => ({
+  getCallGraphData: vi.fn(),
+  getCallGraphPath: vi.fn(),
+}));
+
+vi.mock("../src/tools/operations.js", () => ({
+  addKnowledgeBase: vi.fn(() => "Added knowledge base"),
+  findSimilarCode: vi.fn(() => []),
+  getCallGraphData: operationMocks.getCallGraphData,
+  getCallGraphPath: operationMocks.getCallGraphPath,
+  getIndexHealthCheck: vi.fn(),
+  getIndexLogs: vi.fn(() => ({ text: "" })),
+  getIndexMetrics: vi.fn(() => ({ text: "" })),
+  getIndexStatus: vi.fn(),
+  getPrImpact: vi.fn(),
+  implementationLookup: vi.fn(() => []),
+  listKnowledgeBases: vi.fn(() => "No knowledge bases configured."),
+  removeKnowledgeBase: vi.fn(() => "Removed knowledge base"),
+  runIndexCodebase: vi.fn(),
+  searchCodebase: vi.fn(() => []),
+}));
+
+interface RegisteredTool {
+  readonly name: string;
+  readonly execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal,
+    onUpdate: () => void,
+    ctx?: { readonly cwd?: string },
+  ) => Promise<{ readonly content: ReadonlyArray<{ readonly type: "text"; readonly text: string }>; readonly details?: unknown }>;
+}
+
+async function registerPiTools(): Promise<Map<string, RegisteredTool>> {
+  const tools = new Map<string, RegisteredTool>();
+  const { default: codebaseIndexPiExtension } = await import("../src/pi-extension.js");
+
+  const pi = {
+    registerTool(tool) {
+      tools.set(tool.name, tool);
+    },
+  } satisfies Pick<ExtensionAPI, "registerTool">;
+
+  codebaseIndexPiExtension(pi);
+
+  return tools;
+}
+
+describe("Pi adapter conformance", () => {
+  beforeEach(() => {
+    operationMocks.getCallGraphData.mockReset();
+    operationMocks.getCallGraphPath.mockReset();
+  });
+
+  it("formats caller results like other host adapters", async () => {
+    operationMocks.getCallGraphData.mockResolvedValue({
+      direction: "callers",
+      callers: [{
+        fromSymbolName: "entryPoint",
+        fromSymbolFilePath: "src/app.ts",
+        fromSymbolId: "sym_entry",
+        callType: "Call",
+        confidence: "Direct",
+        line: 12,
+        isResolved: true,
+      }],
+      callees: [],
+    });
+    const tools = await registerPiTools();
+
+    const result = await tools.get("call_graph")?.execute(
+      "tool-call",
+      { name: "validateToken", direction: "callers" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(result?.content[0]?.text).toContain("\"validateToken\" is called by 1 function(s)");
+    expect(result?.content[0]?.text).toContain("entryPoint in src/app.ts");
+    expect(result?.details).toEqual(expect.objectContaining({ direction: "callers" }));
+  });
+
+  it("formats callee results like other host adapters", async () => {
+    operationMocks.getCallGraphData.mockResolvedValue({
+      direction: "callees",
+      callers: [],
+      callees: [{
+        targetName: "validateToken",
+        toSymbolId: "sym_validate",
+        callType: "Call",
+        confidence: "Direct",
+        line: 21,
+        isResolved: true,
+      }],
+    });
+    const tools = await registerPiTools();
+
+    const result = await tools.get("call_graph")?.execute(
+      "tool-call",
+      { name: "entryPoint", direction: "callees", symbolId: "sym_entry" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(result?.content[0]?.text).toContain("[1] \u2192 validateToken (Call) at line 21 [resolved: sym_validate]");
+    expect(result?.details).toEqual(expect.objectContaining({ direction: "callees" }));
+  });
+
+  it("formats call path results like other host adapters", async () => {
+    operationMocks.getCallGraphPath.mockResolvedValue([
+      { symbolName: "createOrder", filePath: "src/order.ts", line: 10, callType: "Call" },
+      { symbolName: "chargeCard", filePath: "src/pay.ts", line: 33, callType: "MethodCall" },
+    ]);
+    const tools = await registerPiTools();
+
+    const result = await tools.get("call_graph_path")?.execute(
+      "tool-call",
+      { from: "createOrder", to: "chargeCard" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(result?.content[0]?.text).toContain("Path (2 hops):");
+    expect(result?.content[0]?.text).toContain("[start] createOrder (src/order.ts:10)");
+    expect(result?.content[0]?.text).toContain("--MethodCall--> chargeCard (src/pay.ts:33)");
+    expect(result?.details).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Align Pi call graph output with the other host adapters and add host conformance coverage so Codex, Claude, OpenCode, and Pi path/output contracts stay in sync.

## Changes

- Added host path conformance tests for OpenCode, Claude, Codex, and Pi project config/index paths plus legacy OpenCode fallback.
- Centralized call graph/call path text formatting and reused it from OpenCode, MCP, and Pi adapters.
- Split Pi call graph registration into a focused module and added Pi adapter tests for callers, callees, and call paths.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional checks:

- `npx vitest run tests/mcp-server.test.ts tests/pi-package.test.ts tests/codex-plugin.test.ts tests/claude-plugin.test.ts tests/host-paths.test.ts tests/pi-conformance.test.ts`
- `NODE_PATH=/Users/kenneth/dev/git/opencode-codebase-index/node_modules bun run /Users/kenneth/.codex/plugins/cache/sisyphuslabs/omo/4.15.1/skills/programming/scripts/typescript/check-no-excuse-rules.ts src/tools/utils.ts src/tools/index.ts src/mcp-server/register-tools.ts src/pi-extension.ts src/pi-call-graph.ts tests/host-paths.test.ts tests/pi-conformance.test.ts`

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

N/A
