### PR TITLE
feat: add Bash call graph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Returns recent debug logs with optional filtering.
 
 ### `call_graph`
 
-Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, and MATLAB.
+Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, and Bash.
 
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
 - **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries), `relationshipType` (optional: `Call`, `MethodCall`, `Constructor`, `Import`, `Inherits`, `Implements`).
@@ -1175,7 +1175,7 @@ The Rust native module handles performance-critical operations:
 - **usearch**: High-performance vector similarity search with F16 quantization
 - **SQLite**: Persistent storage for embeddings, chunks, branch catalog, symbols, and call edges
 - **BM25 inverted index**: Fast keyword search for hybrid retrieval
-- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB)
+- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash)
 - **xxhash**: Fast content hashing for change detection
 
 Rebuild with: `npm run build:native` (requires Rust toolchain)

--- a/native/queries/bash-calls.scm
+++ b/native/queries/bash-calls.scm
@@ -1,0 +1,3 @@
+; Direct command/function calls: foo, foo arg, echo "hi"
+(command
+  name: (command_name) @callee.name) @call

--- a/native/src/call_extractor.rs
+++ b/native/src/call_extractor.rs
@@ -44,6 +44,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Gdscript => tree_sitter_gdscript::LANGUAGE.into(),
         Language::Matlab => tree_sitter_matlab::LANGUAGE.into(),
         Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
+        Language::Bash => tree_sitter_bash::LANGUAGE.into(),
         _ => return Ok(vec![]),
     };
 
@@ -71,6 +72,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Gdscript => include_str!("../queries/gdscript-calls.scm"),
         Language::Matlab => include_str!("../queries/matlab-calls.scm"),
         Language::Apex => include_str!("../queries/apex-calls.scm"),
+        Language::Bash => include_str!("../queries/bash-calls.scm"),
         _ => return Ok(vec![]),
     };
 

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -146,7 +146,9 @@ fn extract_semantic_nodes(
 
             let content = &source[start_byte..end_byte];
 
-            if content.len() >= MIN_CHUNK_SIZE {
+            if content.len() >= MIN_CHUNK_SIZE
+                || (*language == Language::Bash && node_type == "function_definition")
+            {
                 let name = extract_name(cursor, source);
 
                 let start_line = if leading_comment.is_some() {
@@ -606,6 +608,7 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
             || kind == "property_name"
             || kind == "type_identifier"
             || kind == "name"
+            || kind == "word"
         {
             return Some(source[n.start_byte()..n.end_byte()].to_string());
         }
@@ -757,7 +760,12 @@ fn merge_small_chunks(chunks: &mut Vec<CodeChunk>) {
             continue;
         };
 
-        if cur.content.len() < MIN_CHUNK_SIZE * 2
+        let can_merge_without_losing_symbol = !(cur.language == "bash"
+            && cur.chunk_type == "function_definition")
+            && !(chunk.language == "bash" && chunk.chunk_type == "function_definition");
+
+        if can_merge_without_losing_symbol
+            && cur.content.len() < MIN_CHUNK_SIZE * 2
             && cur.content.len() + chunk.content.len() <= MAX_CHUNK_SIZE
             && cur.end_line + 1 >= chunk.start_line
         {

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -761,8 +761,8 @@ fn merge_small_chunks(chunks: &mut Vec<CodeChunk>) {
         };
 
         let can_merge_without_losing_symbol = !(cur.language == "bash"
-            && cur.chunk_type == "function_definition")
-            && !(chunk.language == "bash" && chunk.chunk_type == "function_definition");
+            && cur.chunk_type == "function_definition"
+            || chunk.language == "bash" && chunk.chunk_type == "function_definition");
 
         if can_merge_without_losing_symbol
             && cur.content.len() < MIN_CHUNK_SIZE * 2

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -41,7 +41,7 @@ import { getHostProjectIndexRelativePath, resolveProjectIndexPath } from "../con
 import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
 
-export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab"]);
+export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash"]);
 // Languages whose identifiers are case-insensitive at the language level.
 // The Rust call_extractor lowercases callee names for these languages (except
 // constructors and imports), so same-file resolution in this file must use

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -691,6 +691,151 @@ const math = @import("math.zig");
     });
   });
 
+  describe("bash call extraction", () => {
+    it("should extract direct command and function calls", () => {
+      const content = `
+#!/usr/bin/env bash
+
+function greet() {
+  echo "Hello, $1"
+}
+
+add() {
+  local left="$1"
+  local right="$2"
+  echo "$(( left + right ))"
+}
+
+main() {
+  local name="World"
+  greet "$name"
+  local total
+  total=$(add 1 2)
+  echo "total: $total"
+}
+`;
+      const calls = extractCalls(content, "bash");
+      const callNames = calls.map((c) => c.calleeName);
+
+      expect(CALL_GRAPH_LANGUAGES.has("bash")).toBe(true);
+      expect(callNames).toContain("greet");
+      expect(callNames).toContain("add");
+    });
+
+    it("should parse Bash function names for call graph symbols", () => {
+      const filePath = "/scripts/build.sh";
+      const content = `
+#!/usr/bin/env bash
+
+function greet() {
+  echo "Hello, $1"
+}
+
+add() {
+  local left="$1"
+  local right="$2"
+  echo "$(( left + right ))"
+}
+
+main() {
+  local name="World"
+  greet "$name"
+  local total
+  total=$(add 1 2)
+  echo "total: $total"
+}
+`;
+      const parsed = parseFiles([{ path: filePath, content }]);
+      const chunks = parsed[0].chunks;
+      const symbolChunks = chunks.filter((chunk) => CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType));
+      const names = symbolChunks.map((chunk) => chunk.name);
+
+      expect(names).toContain("greet");
+      expect(names).toContain("add");
+      expect(names).toContain("main");
+    });
+
+    it("should keep small Bash function chunks for call graph symbols", () => {
+      const filePath = "/scripts/tiny.sh";
+      const content = `
+a(){ b; }
+b(){ echo ok; }
+`;
+      const parsed = parseFiles([{ path: filePath, content }]);
+      const symbolChunks = parsed[0].chunks.filter((chunk) => CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType));
+      const names = symbolChunks.map((chunk) => chunk.name);
+
+      expect(names).toContain("a");
+      expect(names).toContain("b");
+    });
+
+    it("should resolve same-file Bash function calls", () => {
+      const db = openDb();
+      const filePath = "/scripts/build.sh";
+      const content = `
+#!/usr/bin/env bash
+
+helper() {
+  local message="helper"
+  echo "preparing \${message} call"
+  echo "\${message}"
+}
+
+main() {
+  local result="starting"
+  echo "$result"
+  helper
+  echo "done"
+}
+`;
+      const parsed = parseFiles([{ path: filePath, content }]);
+      const fileSymbols: SymbolData[] = [];
+
+      for (const chunk of parsed[0].chunks) {
+        if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
+        fileSymbols.push({
+          id: `sym_${hashContent(filePath + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`,
+          filePath,
+          name: chunk.name,
+          kind: chunk.chunkType,
+          startLine: chunk.startLine,
+          startCol: 0,
+          endLine: chunk.endLine,
+          endCol: 0,
+          language: chunk.language,
+        });
+      }
+
+      db.upsertSymbolsBatch(fileSymbols);
+      const main = fileSymbols.find((symbol) => symbol.name === "main");
+      const helper = fileSymbols.find((symbol) => symbol.name === "helper");
+      expect(main).toBeDefined();
+      expect(helper).toBeDefined();
+
+      const helperCall = extractCalls(content, "bash").find((call) => call.calleeName === "helper");
+      expect(helperCall).toBeDefined();
+
+      const edge: CallEdgeData = {
+        id: "edge_bash_helper",
+        fromSymbolId: main!.id,
+        targetName: helperCall!.calleeName,
+        callType: helperCall!.callType,
+        confidence: "Direct",
+        line: helperCall!.line,
+        col: helperCall!.column,
+        isResolved: false,
+      };
+      db.upsertCallEdgesBatch([edge]);
+      db.resolveCallEdge(edge.id, helper!.id);
+      db.addSymbolsToBranchBatch("test", fileSymbols.map((symbol) => symbol.id));
+
+      const callees = db.getCallees(main!.id, "test");
+      expect(callees.length).toBe(1);
+      expect(callees[0].isResolved).toBe(true);
+      expect(callees[0].toSymbolId).toBe(helper!.id);
+    });
+  });
+
   describe("call graph storage", () => {
     it("should store symbols in database", () => {
       const db = openDb();


### PR DESCRIPTION
## Summary

Add Bash support to the `call_graph` indexing path so Bash files move from semantic parsing only to end-to-end call graph extraction and same-file resolution.

## Changes

- Add a Bash tree-sitter call extraction query and wire it into the native call extractor.
- Include Bash in the TypeScript call graph language allowlist and preserve Bash function symbols during parsing/chunk merging.
- Add focused Bash call graph tests and update README support claims.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Manual smoke check: exercised `extractCalls(..., "bash")` and `parseFiles` for a small Bash file, confirming a `helper` call and Bash `function_definition` symbols for `helper` and `main`.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #123