### PR TITLE
feat: add git blame metadata to indexed chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ The plugin exposes these tools to the OpenCode agent:
 - **Use for**: Discovery, understanding flows, finding logic when you don't know the names.
 - **Example**: `"find the middleware that sanitizes input"`
 - **Ranking path**: hybrid retrieval → fusion (`search.fusionStrategy`) → deterministic rerank (`search.rerankTopN`) → filters
+- **Blame filters**: when `indexing.gitBlame.enabled` is `true`, filter with `blameAuthor`, `blameSha`, or `blameSince`.
 
 **Writing good queries:**
 
@@ -411,6 +412,7 @@ The plugin exposes these tools to the OpenCode agent:
 - **Example output**:
   ```
   [1] function "validatePayment" at src/billing.ts:45-67 (score: 0.92)
+      abc1234 | Jane Doe | 2025-03-14 | billing: validate payment state
   [2] class "PaymentProcessor" at src/processor.ts:12-89 (score: 0.87)
 
   Use Read tool to examine specific files.
@@ -786,6 +788,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `maxDepth` | `5` | Max directory traversal depth. `-1` = unlimited, `0` = only files in root dir, `1` = one level of subdirectories, etc. |
 | `maxFilesPerDirectory` | `100` | Max files to index per directory. Always picks the smallest files first. |
 | `fallbackToTextOnMaxChunks` | `true` | When a file exceeds `maxChunksPerFile`, fallback to text-based (line-by-line) chunking instead of skipping the rest of the file. |
+| `gitBlame.enabled` | `false` | Annotate changed chunks with `git blame` commit SHA, author, author email, commit timestamp, and summary. Enables `blameAuthor`, `blameSha`, and `blameSince` filters. |
 | **search** | | |
 | `maxResults` | `20` | Maximum results to return |
 | `minScore` | `0.1` | Minimum similarity score (0-1). Lower = more results |

--- a/commands/peek.md
+++ b/commands/peek.md
@@ -11,6 +11,9 @@ The first part is the search query. Look for optional parameters:
 - `type=X` or mentions "functions"/"classes"/"methods" → set chunkType
 - `dir=X` or "in folder X" → set directory filter
 - File extensions like ".ts", "typescript", ".py" → set fileType
+- `author=X` or `blameAuthor=X` → set blameAuthor filter
+- `sha=X` or `blameSha=X` → set blameSha filter
+- `since=YYYY-MM-DD` or `blameSince=YYYY-MM-DD` → set blameSince filter
 
 Call `codebase_peek` with the parsed arguments.
 
@@ -18,6 +21,7 @@ Examples:
 - `/peek authentication logic` → query="authentication logic"
 - `/peek error handling limit=5` → query="error handling", limit=5
 - `/peek validation functions` → query="validation", chunkType="function"
+- `/peek auth logic author=jane@example.com since=2025-01-01` → query="auth logic", blameAuthor="jane@example.com", blameSince="2025-01-01"
 
 If the index doesn't exist, run `index_codebase` first.
 

--- a/commands/search.md
+++ b/commands/search.md
@@ -11,6 +11,9 @@ The first part is the search query. Look for optional parameters:
 - `type=X` or mentions "functions"/"classes"/"methods" → set chunkType
 - `dir=X` or "in folder X" → set directory filter
 - File extensions like ".ts", "typescript", ".py" → set fileType
+- `author=X` or `blameAuthor=X` → set blameAuthor filter
+- `sha=X` or `blameSha=X` → set blameSha filter
+- `since=YYYY-MM-DD` or `blameSince=YYYY-MM-DD` → set blameSince filter
 
 Call `codebase_search` with the parsed arguments.
 
@@ -18,6 +21,7 @@ Examples:
 - `/search authentication logic` → query="authentication logic"
 - `/search error handling limit=5` → query="error handling", limit=5
 - `/search validation functions` → query="validation", chunkType="function"
+- `/search auth logic author=jane@example.com since=2025-01-01` → query="auth logic", blameAuthor="jane@example.com", blameSince="2025-01-01"
 
 If the index doesn't exist, run `index_codebase` first.
 

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -13,7 +13,7 @@ pub enum DbError {
 pub type DbResult<T> = Result<T, DbError>;
 
 /// Schema version for migrations
-const SCHEMA_VERSION: i32 = 5;
+const SCHEMA_VERSION: i32 = 6;
 
 /// Maximum number of SQL bind parameters per query.
 /// SQLite defaults to 999 (SQLITE_MAX_VARIABLE_NUMBER). We use 900 to stay safely under.
@@ -81,7 +81,12 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
                 end_line INTEGER NOT NULL,
                 node_type TEXT,
                 name TEXT,
-                language TEXT NOT NULL
+                language TEXT NOT NULL,
+                blame_sha TEXT,
+                blame_author TEXT,
+                blame_author_email TEXT,
+                blame_committed_at INTEGER,
+                blame_summary TEXT
             );
 
             -- Branch catalog: which chunks exist on which branch
@@ -228,6 +233,23 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
         conn.execute_batch(
             r#"
             ALTER TABLE call_edges ADD COLUMN confidence TEXT NOT NULL DEFAULT 'Direct';
+            "#,
+        )?;
+
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
+            params![SCHEMA_VERSION.to_string()],
+        )?;
+    }
+
+    if (1..6).contains(&from_version) {
+        conn.execute_batch(
+            r#"
+            ALTER TABLE chunks ADD COLUMN blame_sha TEXT;
+            ALTER TABLE chunks ADD COLUMN blame_author TEXT;
+            ALTER TABLE chunks ADD COLUMN blame_author_email TEXT;
+            ALTER TABLE chunks ADD COLUMN blame_committed_at INTEGER;
+            ALTER TABLE chunks ADD COLUMN blame_summary TEXT;
             "#,
         )?;
 
@@ -389,7 +411,7 @@ pub fn get_missing_embeddings(
 
 /// Insert or update a chunk
 #[allow(clippy::too_many_arguments)]
-pub fn upsert_chunk(
+pub fn upsert_chunk_with_blame(
     conn: &Connection,
     chunk_id: &str,
     content_hash: &str,
@@ -399,11 +421,16 @@ pub fn upsert_chunk(
     node_type: Option<&str>,
     name: Option<&str>,
     language: &str,
+    blame_sha: Option<&str>,
+    blame_author: Option<&str>,
+    blame_author_email: Option<&str>,
+    blame_committed_at: Option<i64>,
+    blame_summary: Option<&str>,
 ) -> DbResult<()> {
     conn.execute(
         r#"
-        INSERT INTO chunks (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO chunks (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(chunk_id) DO UPDATE SET
             content_hash = excluded.content_hash,
             file_path = excluded.file_path,
@@ -411,9 +438,28 @@ pub fn upsert_chunk(
             end_line = excluded.end_line,
             node_type = excluded.node_type,
             name = excluded.name,
-            language = excluded.language
+            language = excluded.language,
+            blame_sha = excluded.blame_sha,
+            blame_author = excluded.blame_author,
+            blame_author_email = excluded.blame_author_email,
+            blame_committed_at = excluded.blame_committed_at,
+            blame_summary = excluded.blame_summary
         "#,
-        params![chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language],
+        params![
+            chunk_id,
+            content_hash,
+            file_path,
+            start_line,
+            end_line,
+            node_type,
+            name,
+            language,
+            blame_sha,
+            blame_author,
+            blame_author_email,
+            blame_committed_at,
+            blame_summary
+        ],
     )?;
     Ok(())
 }
@@ -428,8 +474,8 @@ pub fn upsert_chunks_batch(conn: &mut Connection, chunks: &[ChunkRow]) -> DbResu
     {
         let mut stmt = tx.prepare(
             r#"
-            INSERT INTO chunks (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO chunks (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(chunk_id) DO UPDATE SET
                 content_hash = excluded.content_hash,
                 file_path = excluded.file_path,
@@ -437,7 +483,12 @@ pub fn upsert_chunks_batch(conn: &mut Connection, chunks: &[ChunkRow]) -> DbResu
                 end_line = excluded.end_line,
                 node_type = excluded.node_type,
                 name = excluded.name,
-                language = excluded.language
+                language = excluded.language,
+                blame_sha = excluded.blame_sha,
+                blame_author = excluded.blame_author,
+                blame_author_email = excluded.blame_author_email,
+                blame_committed_at = excluded.blame_committed_at,
+                blame_summary = excluded.blame_summary
             "#,
         )?;
 
@@ -450,7 +501,12 @@ pub fn upsert_chunks_batch(conn: &mut Connection, chunks: &[ChunkRow]) -> DbResu
                 chunk.end_line,
                 chunk.node_type,
                 chunk.name,
-                chunk.language
+                chunk.language,
+                chunk.blame_sha,
+                chunk.blame_author,
+                chunk.blame_author_email,
+                chunk.blame_committed_at,
+                chunk.blame_summary
             ])?;
         }
     }
@@ -463,7 +519,7 @@ pub fn get_chunk(conn: &Connection, chunk_id: &str) -> DbResult<Option<ChunkRow>
     let result = conn
         .query_row(
             r#"
-            SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language
+            SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary
             FROM chunks WHERE chunk_id = ?
             "#,
             params![chunk_id],
@@ -477,6 +533,11 @@ pub fn get_chunk(conn: &Connection, chunk_id: &str) -> DbResult<Option<ChunkRow>
                     node_type: row.get(5)?,
                     name: row.get(6)?,
                     language: row.get(7)?,
+                    blame_sha: row.get(8)?,
+                    blame_author: row.get(9)?,
+                    blame_author_email: row.get(10)?,
+                    blame_committed_at: row.get(11)?,
+                    blame_summary: row.get(12)?,
                 })
             },
         )
@@ -488,7 +549,7 @@ pub fn get_chunk(conn: &Connection, chunk_id: &str) -> DbResult<Option<ChunkRow>
 pub fn get_chunks_by_file(conn: &Connection, file_path: &str) -> DbResult<Vec<ChunkRow>> {
     let mut stmt = conn.prepare(
         r#"
-        SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language
+        SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary
         FROM chunks WHERE file_path = ?
         ORDER BY start_line
         "#,
@@ -504,6 +565,11 @@ pub fn get_chunks_by_file(conn: &Connection, file_path: &str) -> DbResult<Vec<Ch
             node_type: row.get(5)?,
             name: row.get(6)?,
             language: row.get(7)?,
+            blame_sha: row.get(8)?,
+            blame_author: row.get(9)?,
+            blame_author_email: row.get(10)?,
+            blame_committed_at: row.get(11)?,
+            blame_summary: row.get(12)?,
         })
     })?;
 
@@ -517,7 +583,7 @@ pub fn get_chunks_by_file(conn: &Connection, file_path: &str) -> DbResult<Vec<Ch
 pub fn get_chunks_by_name(conn: &Connection, name: &str) -> DbResult<Vec<ChunkRow>> {
     let mut stmt = conn.prepare(
         r#"
-        SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language
+        SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary
         FROM chunks WHERE name = ?
         "#,
     )?;
@@ -532,6 +598,11 @@ pub fn get_chunks_by_name(conn: &Connection, name: &str) -> DbResult<Vec<ChunkRo
             node_type: row.get(5)?,
             name: row.get(6)?,
             language: row.get(7)?,
+            blame_sha: row.get(8)?,
+            blame_author: row.get(9)?,
+            blame_author_email: row.get(10)?,
+            blame_committed_at: row.get(11)?,
+            blame_summary: row.get(12)?,
         })
     })?;
 
@@ -545,7 +616,7 @@ pub fn get_chunks_by_name(conn: &Connection, name: &str) -> DbResult<Vec<ChunkRo
 pub fn get_chunks_by_name_ci(conn: &Connection, name: &str) -> DbResult<Vec<ChunkRow>> {
     let mut stmt = conn.prepare(
         r#"
-        SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language
+        SELECT chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary
         FROM chunks WHERE lower(name) = lower(?)
         "#,
     )?;
@@ -560,6 +631,11 @@ pub fn get_chunks_by_name_ci(conn: &Connection, name: &str) -> DbResult<Vec<Chun
             node_type: row.get(5)?,
             name: row.get(6)?,
             language: row.get(7)?,
+            blame_sha: row.get(8)?,
+            blame_author: row.get(9)?,
+            blame_author_email: row.get(10)?,
+            blame_committed_at: row.get(11)?,
+            blame_summary: row.get(12)?,
         })
     })?;
 
@@ -604,6 +680,11 @@ pub struct ChunkRow {
     pub node_type: Option<String>,
     pub name: Option<String>,
     pub language: String,
+    pub blame_sha: Option<String>,
+    pub blame_author: Option<String>,
+    pub blame_author_email: Option<String>,
+    pub blame_committed_at: Option<i64>,
+    pub blame_summary: Option<String>,
 }
 
 // ============================================================================
@@ -2028,6 +2109,36 @@ mod tests {
         (temp_dir, conn)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn upsert_chunk(
+        conn: &Connection,
+        chunk_id: &str,
+        content_hash: &str,
+        file_path: &str,
+        start_line: u32,
+        end_line: u32,
+        node_type: Option<&str>,
+        name: Option<&str>,
+        language: &str,
+    ) -> DbResult<()> {
+        upsert_chunk_with_blame(
+            conn,
+            chunk_id,
+            content_hash,
+            file_path,
+            start_line,
+            end_line,
+            node_type,
+            name,
+            language,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
     #[test]
     fn test_init_db() {
         let (_temp_dir, conn) = setup_test_db();
@@ -2038,7 +2149,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
     }
 
     #[test]
@@ -2608,7 +2719,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(schema_version, "5");
+        assert_eq!(schema_version, "6");
 
         let on_delete: String = conn
             .query_row("PRAGMA foreign_key_list(call_edges)", [], |row| row.get(6))

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -381,6 +381,11 @@ pub struct ChunkData {
     pub node_type: Option<String>,
     pub name: Option<String>,
     pub language: String,
+    pub blame_sha: Option<String>,
+    pub blame_author: Option<String>,
+    pub blame_author_email: Option<String>,
+    pub blame_committed_at: Option<i64>,
+    pub blame_summary: Option<String>,
 }
 
 #[napi(object)]
@@ -498,7 +503,7 @@ impl Database {
     #[napi]
     pub fn upsert_chunk(&self, chunk: ChunkData) -> Result<()> {
         self.with_conn(|conn| {
-            db::upsert_chunk(
+            db::upsert_chunk_with_blame(
                 conn,
                 &chunk.chunk_id,
                 &chunk.content_hash,
@@ -508,6 +513,11 @@ impl Database {
                 chunk.node_type.as_deref(),
                 chunk.name.as_deref(),
                 &chunk.language,
+                chunk.blame_sha.as_deref(),
+                chunk.blame_author.as_deref(),
+                chunk.blame_author_email.as_deref(),
+                chunk.blame_committed_at,
+                chunk.blame_summary.as_deref(),
             )
             .map_err(|e| Error::from_reason(e.to_string()))
         })
@@ -527,6 +537,11 @@ impl Database {
                 node_type: row.node_type,
                 name: row.name,
                 language: row.language,
+                blame_sha: row.blame_sha,
+                blame_author: row.blame_author,
+                blame_author_email: row.blame_author_email,
+                blame_committed_at: row.blame_committed_at,
+                blame_summary: row.blame_summary,
             }))
         })
     }
@@ -547,6 +562,11 @@ impl Database {
                     node_type: row.node_type,
                     name: row.name,
                     language: row.language,
+                    blame_sha: row.blame_sha,
+                    blame_author: row.blame_author,
+                    blame_author_email: row.blame_author_email,
+                    blame_committed_at: row.blame_committed_at,
+                    blame_summary: row.blame_summary,
                 })
                 .collect())
         })
@@ -568,6 +588,11 @@ impl Database {
                     node_type: row.node_type,
                     name: row.name,
                     language: row.language,
+                    blame_sha: row.blame_sha,
+                    blame_author: row.blame_author,
+                    blame_author_email: row.blame_author_email,
+                    blame_committed_at: row.blame_committed_at,
+                    blame_summary: row.blame_summary,
                 })
                 .collect())
         })
@@ -589,6 +614,11 @@ impl Database {
                     node_type: row.node_type,
                     name: row.name,
                     language: row.language,
+                    blame_sha: row.blame_sha,
+                    blame_author: row.blame_author,
+                    blame_author_email: row.blame_author_email,
+                    blame_committed_at: row.blame_committed_at,
+                    blame_summary: row.blame_summary,
                 })
                 .collect())
         })
@@ -651,6 +681,11 @@ impl Database {
                 node_type: c.node_type,
                 name: c.name,
                 language: c.language,
+                blame_sha: c.blame_sha,
+                blame_author: c.blame_author,
+                blame_author_email: c.blame_author_email,
+                blame_committed_at: c.blame_committed_at,
+                blame_summary: c.blame_summary,
             })
             .collect();
         self.with_conn_mut(|conn| {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -69,6 +69,7 @@ Find WHERE code is. Returns metadata only (file, line, name, type).
 
 ```
 codebase_peek(query="validation logic", chunkType="function", directory="src/utils")
+codebase_peek(query="authentication flow", blameAuthor="jane@example.com")
 ```
 
 ### `codebase_search`
@@ -76,6 +77,7 @@ Find code with full content. Use when you need to see implementation.
 
 ```
 codebase_search(query="error handling middleware", fileType="ts", contextLines=2)
+codebase_search(query="rate limiter", blameSince="2025-01-01")
 ```
 
 ### `find_similar`
@@ -132,3 +134,6 @@ remove_knowledge_base(path="/path/to/docs")
 | `chunkType` | `function`, `class`, `interface`, `type`, `method` |
 | `directory` | `"src/api"`, `"tests"` |
 | `fileType` | `"ts"`, `"py"`, `"rs"` |
+| `blameAuthor` | `"jane@example.com"` or `"Jane Doe"` |
+| `blameSha` | `"abc1234"` |
+| `blameSince` | `"2025-01-01"` |

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -21,6 +21,7 @@ export function getDefaultIndexingConfig(): IndexingConfig {
     maxDepth: 5,
     maxFilesPerDirectory: 100,
     fallbackToTextOnMaxChunks: true,
+    gitBlame: { enabled: false },
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -54,6 +54,9 @@ export interface IndexingConfig {
    * instead of skipping the rest of the file. Default: true
    */
   fallbackToTextOnMaxChunks: boolean;
+  gitBlame: {
+    enabled: boolean;
+  };
 }
 
 export interface SearchConfig {
@@ -180,6 +183,11 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     maxDepth: typeof rawIndexing.maxDepth === "number" ? (rawIndexing.maxDepth < -1 ? -1 : rawIndexing.maxDepth) : defaultIndexing.maxDepth,
     maxFilesPerDirectory: typeof rawIndexing.maxFilesPerDirectory === "number" ? Math.max(1, rawIndexing.maxFilesPerDirectory) : defaultIndexing.maxFilesPerDirectory,
     fallbackToTextOnMaxChunks: typeof rawIndexing.fallbackToTextOnMaxChunks === "boolean" ? rawIndexing.fallbackToTextOnMaxChunks : defaultIndexing.fallbackToTextOnMaxChunks,
+    gitBlame: {
+      enabled: rawIndexing.gitBlame && typeof rawIndexing.gitBlame === "object" && typeof (rawIndexing.gitBlame as Record<string, unknown>).enabled === "boolean"
+        ? (rawIndexing.gitBlame as { enabled: boolean }).enabled
+        : defaultIndexing.gitBlame.enabled,
+    },
   };
 
   const rawSearch = (input.search && typeof input.search === "object" ? input.search : {}) as Record<string, unknown>;

--- a/src/indexer/git-blame.ts
+++ b/src/indexer/git-blame.ts
@@ -1,0 +1,82 @@
+import { execFile } from "child_process";
+import * as path from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+export interface GitBlameMetadata {
+  readonly sha: string;
+  readonly author: string;
+  readonly authorEmail: string;
+  readonly committedAt: number;
+  readonly summary: string;
+}
+
+interface MutableBlameMetadata {
+  sha: string;
+  author: string;
+  authorEmail: string;
+  committedAt: number;
+  summary: string;
+  lines: number;
+}
+
+export function parseGitBlamePorcelain(output: string): GitBlameMetadata | undefined {
+  const commits = new Map<string, MutableBlameMetadata>();
+  let current: MutableBlameMetadata | undefined;
+
+  for (const line of output.split("\n")) {
+    if (/^[0-9a-f]{40} /.test(line)) {
+      const sha = line.slice(0, 40);
+      current = commits.get(sha) ?? {
+        sha,
+        author: "",
+        authorEmail: "",
+        committedAt: 0,
+        summary: "",
+        lines: 0,
+      };
+      commits.set(sha, current);
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (line.startsWith("author ")) {
+      current.author = line.slice("author ".length);
+    } else if (line.startsWith("author-mail ")) {
+      current.authorEmail = line.slice("author-mail ".length).replace(/^<|>$/g, "");
+    } else if (line.startsWith("author-time ")) {
+      current.committedAt = Number.parseInt(line.slice("author-time ".length), 10);
+    } else if (line.startsWith("summary ")) {
+      current.summary = line.slice("summary ".length);
+    } else if (line.startsWith("\t")) {
+      current.lines += 1;
+    }
+  }
+
+  return Array.from(commits.values())
+    .filter((commit) => commit.lines > 0)
+    .sort((a, b) => b.lines - a.lines || b.committedAt - a.committedAt)[0];
+}
+
+export async function getChunkGitBlame(
+  projectRoot: string,
+  filePath: string,
+  startLine: number,
+  endLine: number
+): Promise<GitBlameMetadata | undefined> {
+  const relativePath = path.relative(projectRoot, filePath);
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["blame", "--line-porcelain", "-L", `${startLine},${endLine}`, "--", relativePath],
+      { cwd: projectRoot, timeout: 30000 }
+    );
+    return parseGitBlamePorcelain(stdout);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -40,6 +40,7 @@ import type { HostMode } from "../config/host.js";
 import { getHostProjectIndexRelativePath, resolveProjectIndexPath } from "../config/paths.js";
 import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
+import { getChunkGitBlame, type GitBlameMetadata } from "./git-blame.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash"]);
 // Languages whose identifiers are case-insensitive at the language level.
@@ -166,6 +167,7 @@ export interface SearchResult {
   score: number;
   chunkType: string;
   name?: string;
+  blame?: GitBlameMetadata;
 }
 
 export interface HealthCheckResult {
@@ -245,6 +247,60 @@ interface SerializedFailedBatch {
 }
 
 type RankedCandidate = { id: string; score: number; metadata: ChunkMetadata };
+type SearchFilterOptions = {
+  fileType?: string;
+  directory?: string;
+  chunkType?: string;
+  blameAuthor?: string;
+  blameSha?: string;
+  blameSince?: string;
+};
+
+function metadataFromBlame(blame: GitBlameMetadata | undefined): Partial<ChunkMetadata> {
+  if (!blame) {
+    return {};
+  }
+
+  return {
+    blameSha: blame.sha,
+    blameAuthor: blame.author,
+    blameAuthorEmail: blame.authorEmail,
+    blameCommittedAt: blame.committedAt,
+    blameSummary: blame.summary,
+  };
+}
+
+function blameFromChunkData(chunk: ChunkData | null): GitBlameMetadata | undefined {
+  if (!chunk?.blameSha || !chunk.blameAuthor || !chunk.blameAuthorEmail || chunk.blameCommittedAt === undefined || !chunk.blameSummary) {
+    return undefined;
+  }
+
+  return {
+    sha: chunk.blameSha,
+    author: chunk.blameAuthor,
+    authorEmail: chunk.blameAuthorEmail,
+    committedAt: chunk.blameCommittedAt,
+    summary: chunk.blameSummary,
+  };
+}
+
+function blameFromMetadata(metadata: ChunkMetadata): GitBlameMetadata | undefined {
+  if (!metadata.blameSha || !metadata.blameAuthor || !metadata.blameAuthorEmail || metadata.blameCommittedAt === undefined || !metadata.blameSummary) {
+    return undefined;
+  }
+
+  return {
+    sha: metadata.blameSha,
+    author: metadata.blameAuthor,
+    authorEmail: metadata.blameAuthorEmail,
+    committedAt: metadata.blameCommittedAt,
+    summary: metadata.blameSummary,
+  };
+}
+
+function hasBlameMetadata(metadata: ChunkMetadata): boolean {
+  return blameFromMetadata(metadata) !== undefined;
+}
 
 interface RerankDocumentPayload {
   id: string;
@@ -1418,6 +1474,7 @@ function promoteIdentifierMatches(
             name: chunk.name ?? undefined,
             language: chunk.language,
             hash: chunk.contentHash,
+            ...metadataFromBlame(blameFromChunkData(chunk)),
           };
 
           const baselineScore = existing?.score ?? 0.5;
@@ -1534,6 +1591,7 @@ function buildSymbolDefinitionLane(
           name: chunk.name ?? undefined,
           language: chunk.language,
           hash: chunk.contentHash,
+          ...metadataFromBlame(blameFromChunkData(chunk)),
         },
       });
     }
@@ -1745,11 +1803,7 @@ export function mergeTieredResults(
 
 function matchesSearchFilters(
   candidate: RankedCandidate,
-  options: {
-    fileType?: string;
-    directory?: string;
-    chunkType?: string;
-  } | undefined,
+  options: SearchFilterOptions | undefined,
   minScore: number
 ): boolean {
   if (candidate.score < minScore) return false;
@@ -1767,6 +1821,24 @@ function matchesSearchFilters(
 
   if (options?.chunkType && candidate.metadata.chunkType !== options.chunkType) {
     return false;
+  }
+
+  if (options?.blameAuthor) {
+    const author = options.blameAuthor.toLowerCase();
+    const candidateAuthor = candidate.metadata.blameAuthor?.toLowerCase();
+    const candidateEmail = candidate.metadata.blameAuthorEmail?.toLowerCase();
+    if (candidateAuthor !== author && candidateEmail !== author) return false;
+  }
+
+  if (options?.blameSha && !candidate.metadata.blameSha?.toLowerCase().startsWith(options.blameSha.toLowerCase())) {
+    return false;
+  }
+
+  if (options?.blameSince) {
+    const sinceMs = Date.parse(options.blameSince);
+    if (Number.isNaN(sinceMs)) return false;
+    const committedAt = candidate.metadata.blameCommittedAt;
+    if (committedAt === undefined || committedAt < Math.floor(sinceMs / 1000)) return false;
   }
 
   return true;
@@ -3249,6 +3321,7 @@ export class Indexer {
 
     const existingChunks = new Map<string, string>();
     const existingChunksByFile = new Map<string, Set<string>>();
+    const existingMetadataById = new Map<string, ChunkMetadata>();
     for (const { key, metadata } of store.getAllMetadata()) {
       if (scopedRoots && !this.isFileInCurrentScope(metadata.filePath, scopedRoots)) {
         continue;
@@ -3257,6 +3330,7 @@ export class Indexer {
         continue;
       }
       existingChunks.set(key, metadata.hash);
+      existingMetadataById.set(key, metadata);
       const fileChunks = existingChunksByFile.get(metadata.filePath) || new Set();
       fileChunks.add(key);
       existingChunksByFile.set(metadata.filePath, fileChunks);
@@ -3265,6 +3339,8 @@ export class Indexer {
     const currentChunkIds = new Set<string>();
     const currentFilePaths = new Set<string>();
     const pendingChunks: PendingChunk[] = [];
+    const gitBlameEnabled = this.config.indexing.gitBlame.enabled && isGitRepo(this.projectRoot);
+    let backfilledBlameMetadata = false;
 
     for (const filePath of unchangedFilePaths) {
       currentFilePaths.add(filePath);
@@ -3277,6 +3353,56 @@ export class Indexer {
     }
 
     const chunkDataBatch: ChunkData[] = [];
+
+    if (gitBlameEnabled) {
+      const backfillItems: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }> = [];
+
+      for (const chunkId of currentChunkIds) {
+        const metadata = existingMetadataById.get(chunkId);
+        if (!metadata || hasBlameMetadata(metadata)) {
+          continue;
+        }
+
+        const chunk = database.getChunk(chunkId);
+        if (!chunk) {
+          continue;
+        }
+
+        const blame = await getChunkGitBlame(this.projectRoot, chunk.filePath, chunk.startLine, chunk.endLine);
+        const blameMetadata = metadataFromBlame(blame);
+        if (!blameMetadata.blameSha) {
+          continue;
+        }
+
+        chunkDataBatch.push({
+          ...chunk,
+          blameSha: blameMetadata.blameSha,
+          blameAuthor: blameMetadata.blameAuthor,
+          blameAuthorEmail: blameMetadata.blameAuthorEmail,
+          blameCommittedAt: blameMetadata.blameCommittedAt,
+          blameSummary: blameMetadata.blameSummary,
+        });
+
+        const embeddingBuffer = database.getEmbedding(chunk.contentHash);
+        if (!embeddingBuffer) {
+          continue;
+        }
+
+        backfillItems.push({
+          id: chunkId,
+          vector: Array.from(bufferToFloat32Array(embeddingBuffer)),
+          metadata: {
+            ...metadata,
+            ...blameMetadata,
+          },
+        });
+      }
+
+      if (backfillItems.length > 0) {
+        store.addBatch(backfillItems);
+        backfilledBlameMetadata = true;
+      }
+    }
 
     for (const parsed of parsedFiles) {
       currentFilePaths.add(parsed.path);
@@ -3308,6 +3434,12 @@ export class Indexer {
 
         const id = generateChunkId(parsed.path, chunk);
         const contentHash = generateChunkHash(chunk);
+        const existingContentHash = existingChunks.get(id);
+        const existingChunk = gitBlameEnabled ? database.getChunk(id) : null;
+        const blame = gitBlameEnabled && existingContentHash !== contentHash
+          ? await getChunkGitBlame(this.projectRoot, parsed.path, chunk.startLine, chunk.endLine)
+          : blameFromChunkData(existingChunk);
+        const blameMetadata = metadataFromBlame(blame);
         currentChunkIds.add(id);
 
         chunkDataBatch.push({
@@ -3319,9 +3451,14 @@ export class Indexer {
           nodeType: chunk.chunkType,
           name: chunk.name,
           language: chunk.language,
+          blameSha: blameMetadata.blameSha,
+          blameAuthor: blameMetadata.blameAuthor,
+          blameAuthorEmail: blameMetadata.blameAuthorEmail,
+          blameCommittedAt: blameMetadata.blameCommittedAt,
+          blameSummary: blameMetadata.blameSummary,
         });
 
-        if (existingChunks.get(id) === contentHash) {
+        if (existingContentHash === contentHash) {
           fileChunkCount++;
           continue;
         }
@@ -3338,6 +3475,7 @@ export class Indexer {
           name: chunk.name,
           language: chunk.language,
           hash: contentHash,
+          ...blameMetadata,
         };
 
         pendingChunks.push({
@@ -3514,6 +3652,9 @@ export class Indexer {
       database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
       database.clearBranchSymbols(branchCatalogKey);
       database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
+      if (backfilledBlameMetadata) {
+        store.save();
+      }
       if (scopedRoots) {
         this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
         this.clearScopedFailedBatches(scopedRoots);
@@ -3995,6 +4136,9 @@ export class Indexer {
       filterByBranch?: boolean;
       metadataOnly?: boolean;
       definitionIntent?: boolean;
+      blameAuthor?: string;
+      blameSha?: string;
+      blameSince?: string;
     }
   ): Promise<SearchResult[]> {
     const { store, provider, database } = await this.ensureInitialized();
@@ -4218,6 +4362,7 @@ export class Indexer {
           score: r.score,
           chunkType: r.metadata.chunkType,
           name: r.metadata.name,
+          blame: blameFromMetadata(r.metadata),
         };
       })
     );
@@ -4860,6 +5005,7 @@ export class Indexer {
           score: r.score,
           chunkType: r.metadata.chunkType,
           name: r.metadata.name,
+          blame: blameFromMetadata(r.metadata),
         };
       })
     );

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -6,9 +6,11 @@ import {
   formatCallGraphCallees,
   formatCallGraphCallers,
   formatCallGraphPath,
+  formatCodebasePeek,
   formatDefinitionLookup,
   formatHealthCheck,
   formatIndexStats,
+  formatSearchResults,
   formatStatus,
 } from "../tools/utils.js";
 import { formatPrImpact } from "../tools/format-pr-impact.js";
@@ -25,7 +27,7 @@ import {
   runIndexCodebase,
   searchCodebase,
 } from "../tools/operations.js";
-import { CHUNK_TYPE_ENUM, type McpServerRuntime, truncateContent } from "./shared.js";
+import { CHUNK_TYPE_ENUM, type McpServerRuntime } from "./shared.js";
 
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
@@ -38,6 +40,9 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
       chunkType: z.enum(CHUNK_TYPE_ENUM).optional().describe("Filter by code chunk type"),
       contextLines: z.number().optional().describe("Number of extra lines to include before/after each match (default: 0)"),
+      blameAuthor: z.string().optional().describe("Filter by git blame author name or email"),
+      blameSha: z.string().optional().describe("Filter by git blame commit SHA or prefix"),
+      blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date"),
     },
     async (args) => {
       const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
@@ -46,20 +51,16 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         directory: args.directory,
         chunkType: args.chunkType,
         contextLines: args.contextLines,
+        blameAuthor: args.blameAuthor,
+        blameSha: args.blameSha,
+        blameSince: args.blameSince,
       });
 
       if (results.length === 0) {
         return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
       }
 
-      const formatted = results.map((r, idx) => {
-        const header = r.name
-          ? `[${idx + 1}] ${r.chunkType} "${r.name}" in ${r.filePath}:${r.startLine}-${r.endLine}`
-          : `[${idx + 1}] ${r.chunkType} in ${r.filePath}:${r.startLine}-${r.endLine}`;
-        return `${header} (score: ${r.score.toFixed(2)})\n\`\`\`\n${truncateContent(r.content)}\n\`\`\``;
-      });
-
-      return { content: [{ type: "text", text: `Found ${results.length} results for "${args.query}":\n\n${formatted.join("\n\n")}` }] };
+      return { content: [{ type: "text", text: `Found ${results.length} results for "${args.query}":\n\n${formatSearchResults(results, "score")}` }] };
     },
   );
 
@@ -72,6 +73,9 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
       directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
       chunkType: z.enum(CHUNK_TYPE_ENUM).optional().describe("Filter by code chunk type"),
+      blameAuthor: z.string().optional().describe("Filter by git blame author name or email"),
+      blameSha: z.string().optional().describe("Filter by git blame commit SHA or prefix"),
+      blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date"),
     },
     async (args) => {
       const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
@@ -80,19 +84,16 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         directory: args.directory,
         chunkType: args.chunkType,
         metadataOnly: true,
+        blameAuthor: args.blameAuthor,
+        blameSha: args.blameSha,
+        blameSince: args.blameSince,
       });
 
       if (results.length === 0) {
         return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
       }
 
-      const formatted = results.map((r, idx) => {
-        const location = `${r.filePath}:${r.startLine}-${r.endLine}`;
-        const name = r.name ? `"${r.name}"` : "(anonymous)";
-        return `[${idx + 1}] ${r.chunkType} ${name} at ${location} (score: ${r.score.toFixed(2)})`;
-      });
-
-      return { content: [{ type: "text", text: `Found ${results.length} locations for "${args.query}":\n\n${formatted.join("\n")}\n\nUse Read tool to examine specific files.` }] };
+      return { content: [{ type: "text", text: `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}\n\nUse Read tool to examine specific files.` }] };
     },
   );
 
@@ -181,14 +182,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         return { content: [{ type: "text", text: "No similar code found. Try a different snippet or run index_codebase first." }] };
       }
 
-      const formatted = results.map((r, idx) => {
-        const header = r.name
-          ? `[${idx + 1}] ${r.chunkType} "${r.name}" in ${r.filePath}:${r.startLine}-${r.endLine}`
-          : `[${idx + 1}] ${r.chunkType} in ${r.filePath}:${r.startLine}-${r.endLine}`;
-        return `${header} (similarity: ${(r.score * 100).toFixed(1)}%)\n\`\`\`\n${truncateContent(r.content)}\n\`\`\``;
-      });
-
-      return { content: [{ type: "text", text: `Found ${results.length} similar code blocks:\n\n${formatted.join("\n\n")}` }] };
+      return { content: [{ type: "text", text: `Found ${results.length} similar code blocks:\n\n${formatSearchResults(results)}` }] };
     },
   );
 

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -214,6 +214,11 @@ export interface ChunkMetadata {
   name?: string;
   language: string;
   hash: string;
+  blameSha?: string;
+  blameAuthor?: string;
+  blameAuthorEmail?: string;
+  blameCommittedAt?: number;
+  blameSummary?: string;
 }
 
 export function parseFile(filePath: string, content: string): CodeChunk[] {
@@ -704,6 +709,11 @@ export interface ChunkData {
   nodeType?: string;
   name?: string;
   language: string;
+  blameSha?: string;
+  blameAuthor?: string;
+  blameAuthorEmail?: string;
+  blameCommittedAt?: number;
+  blameSummary?: string;
 }
 
 export interface BranchDelta {

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -58,6 +58,9 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       directory: Type.Optional(Type.String({ description: "Filter by directory path" })),
       chunkType: Type.Optional(ChunkType),
       contextLines: Type.Optional(Type.Number({ description: "Extra lines around each match" })),
+      blameAuthor: Type.Optional(Type.String({ description: "Filter by git blame author name or email" })),
+      blameSha: Type.Optional(Type.String({ description: "Filter by git blame commit SHA or prefix" })),
+      blameSince: Type.Optional(Type.String({ description: "Filter to chunks last changed on or after this date" })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const results = await searchCodebase(projectRoot(ctx), HOST, params.query, params);
@@ -75,6 +78,9 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       fileType: Type.Optional(Type.String()),
       directory: Type.Optional(Type.String()),
       chunkType: Type.Optional(ChunkType),
+      blameAuthor: Type.Optional(Type.String()),
+      blameSha: Type.Optional(Type.String()),
+      blameSince: Type.Optional(Type.String()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const results = await searchCodebase(projectRoot(ctx), HOST, params.query, { ...params, metadataOnly: true });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -78,6 +78,9 @@ export const codebase_peek: ToolDefinition = tool({
     fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
     directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
     chunkType: z.enum(CHUNK_TYPE_VALUES).optional().describe("Filter by code chunk type"),
+    blameAuthor: z.string().optional().describe("Filter by git blame author name or email"),
+    blameSha: z.string().optional().describe("Filter by git blame commit SHA or prefix"),
+    blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date (e.g., 2025-01-01)"),
   },
   async execute(args, context) {
     const results = await searchCodebase(context?.worktree, DEFAULT_HOST, args.query, {
@@ -86,6 +89,9 @@ export const codebase_peek: ToolDefinition = tool({
       directory: args.directory,
       chunkType: args.chunkType,
       metadataOnly: true,
+      blameAuthor: args.blameAuthor,
+      blameSha: args.blameSha,
+      blameSince: args.blameSince,
     });
 
     return formatCodebasePeek(results);
@@ -189,6 +195,9 @@ export const codebase_search: ToolDefinition = tool({
     directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
     chunkType: z.enum(CHUNK_TYPE_VALUES).optional().describe("Filter by code chunk type"),
     contextLines: z.number().optional().describe("Number of extra lines to include before/after each match (default: 0)"),
+    blameAuthor: z.string().optional().describe("Filter by git blame author name or email"),
+    blameSha: z.string().optional().describe("Filter by git blame commit SHA or prefix"),
+    blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date (e.g., 2025-01-01)"),
   },
   async execute(args, context) {
     const results = await searchCodebase(context?.worktree, DEFAULT_HOST, args.query, {
@@ -197,6 +206,9 @@ export const codebase_search: ToolDefinition = tool({
       directory: args.directory,
       chunkType: args.chunkType,
       contextLines: args.contextLines,
+      blameAuthor: args.blameAuthor,
+      blameSha: args.blameSha,
+      blameSince: args.blameSince,
     });
 
     if (results.length === 0) {

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -108,6 +108,9 @@ export async function searchCodebase(
     contextLines?: number;
     metadataOnly?: boolean;
     definitionIntent?: boolean;
+    blameAuthor?: string;
+    blameSha?: string;
+    blameSince?: string;
   } = {},
 ): Promise<SearchResult[]> {
   const indexer = getIndexerForProject(projectRoot, host);
@@ -118,6 +121,9 @@ export async function searchCodebase(
     contextLines: options.contextLines,
     metadataOnly: options.metadataOnly,
     definitionIntent: options.definitionIntent,
+    blameAuthor: options.blameAuthor,
+    blameSha: options.blameSha,
+    blameSince: options.blameSince,
   });
 }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -181,7 +181,7 @@ export function formatCodebasePeek(results: SearchResult[]): string {
   const formatted = results.map((r, idx) => {
     const location = `${r.filePath}:${r.startLine}-${r.endLine}`;
     const name = r.name ? `"${r.name}"` : "(anonymous)";
-    return `[${idx + 1}] ${r.chunkType} ${name} at ${location} (score: ${r.score.toFixed(2)})`;
+    return `[${idx + 1}] ${r.chunkType} ${name} at ${location} (score: ${r.score.toFixed(2)})${formatBlame(r)}`;
   });
 
   return formatted.join("\n");
@@ -280,6 +280,15 @@ function formatResultHeader(result: SearchResult, index: number): string {
     : `[${index + 1}] ${result.chunkType} in ${result.filePath}:${result.startLine}-${result.endLine}`;
 }
 
+function formatBlame(result: SearchResult): string {
+  if (!result.blame) {
+    return "";
+  }
+
+  const date = new Date(result.blame.committedAt * 1000).toISOString().slice(0, 10);
+  return `\n    ${result.blame.sha.slice(0, 7)} | ${result.blame.author} | ${date} | ${result.blame.summary}`;
+}
+
 export function formatDefinitionLookup(results: SearchResult[], query: string): string {
   if (results.length === 0) {
     return `No definition found for "${query}". Try codebase_search for broader discovery, or verify the symbol name.`;
@@ -287,7 +296,7 @@ export function formatDefinitionLookup(results: SearchResult[], query: string): 
 
   const formatted = results.map((r, idx) => {
     const header = formatResultHeader(r, idx);
-    return `${header} (score: ${r.score.toFixed(2)})\n\`\`\`\n${truncateContent(r.content)}\n\`\`\``;
+    return `${header} (score: ${r.score.toFixed(2)})${formatBlame(r)}\n\`\`\`\n${truncateContent(r.content)}\n\`\`\``;
   });
 
   return formatted.join("\n\n");
@@ -303,7 +312,7 @@ export function formatSearchResults(results: SearchResult[], scoreFormat: ScoreF
       ? `(similarity: ${(r.score * 100).toFixed(1)}%)`
       : `(score: ${r.score.toFixed(2)})`;
 
-    return `${header} ${scoreLabel}\n\`\`\`\n${truncateContent(r.content)}\n\`\`\``;
+    return `${header} ${scoreLabel}${formatBlame(r)}\n\`\`\`\n${truncateContent(r.content)}\n\`\`\``;
   });
 
   return formatted.join("\n\n");

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -207,6 +207,7 @@ Final line.`;
       const peekCmd = commands.get("peek")!;
       expect(peekCmd.description).toBe("Quickly find likely code locations without returning full code");
       expect(peekCmd.template).toContain("codebase_peek");
+      expect(peekCmd.template).toContain("blameAuthor");
 
       const reindexCmd = commands.get("reindex")!;
       expect(reindexCmd.description).toBe("Fully rebuild the codebase index from scratch");
@@ -216,6 +217,11 @@ Final line.`;
       expect(callGraphCmd.description).toBe("Trace callers, callees, or paths using the call graph");
       expect(callGraphCmd.template).toContain("call_graph");
       expect(callGraphCmd.template).toContain("call_graph_path");
+
+      const searchCmd = commands.get("search")!;
+      expect(searchCmd.template).toContain("blameAuthor");
+      expect(searchCmd.template).toContain("blameSha");
+      expect(searchCmd.template).toContain("blameSince");
     });
   });
 });

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -544,6 +544,31 @@ describe("Database", () => {
       expect(db.getStats().chunkCount).toBe(0);
     });
 
+    it("should persist git blame metadata on chunks", () => {
+      db.upsertChunksBatch([{
+        chunkId: "blamed_chunk",
+        contentHash: "hash_blame",
+        filePath: "/auth.ts",
+        startLine: 1,
+        endLine: 5,
+        nodeType: "function",
+        name: "validateSession",
+        language: "typescript",
+        blameSha: "abc123456789",
+        blameAuthor: "Jane Doe",
+        blameAuthorEmail: "jane@example.com",
+        blameCommittedAt: 1741953600,
+        blameSummary: "auth: add session validation",
+      }]);
+
+      const chunk = db.getChunk("blamed_chunk");
+      expect(chunk?.blameSha).toBe("abc123456789");
+      expect(chunk?.blameAuthor).toBe("Jane Doe");
+      expect(chunk?.blameAuthorEmail).toBe("jane@example.com");
+      expect(chunk?.blameCommittedAt).toBe(1741953600);
+      expect(chunk?.blameSummary).toBe("auth: add session validation");
+    });
+
     it("should add chunks to branch in batch", () => {
       const chunks: ChunkData[] = [
         { chunkId: "c1", contentHash: "h1", filePath: "/f.ts", startLine: 1, endLine: 5, language: "ts" },

--- a/tests/pi-package.test.ts
+++ b/tests/pi-package.test.ts
@@ -30,11 +30,11 @@ describe("Pi package integration", () => {
   });
 
   it("registers first-class Pi tools", () => {
-    const tools: Array<{ name: string }> = [];
+    const tools: Array<{ name: string; parameters?: unknown }> = [];
 
     codebaseIndexPiExtension({
       registerTool(tool) {
-        tools.push({ name: tool.name });
+        tools.push({ name: tool.name, parameters: tool.parameters });
       },
     } as Parameters<typeof codebaseIndexPiExtension>[0]);
 
@@ -55,5 +55,13 @@ describe("Pi package integration", () => {
       "knowledge_base_add",
       "knowledge_base_remove",
     ]));
+
+    const searchParams = JSON.stringify(tools.find((tool) => tool.name === "codebase_search")?.parameters);
+    const peekParams = JSON.stringify(tools.find((tool) => tool.name === "codebase_peek")?.parameters);
+    for (const params of [searchParams, peekParams]) {
+      expect(params).toContain("blameAuthor");
+      expect(params).toContain("blameSha");
+      expect(params).toContain("blameSince");
+    }
   });
 });

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { execFileSync } from "child_process";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -111,6 +112,128 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(topPaths[0]).toContain(path.join("app", "indexer", "index.ts"));
     expect(topPaths).not.toContain(path.join("tests", "fixtures", "call-graph", "same-file-refs.ts"));
     expect(topPaths).not.toContain(path.join("benchmarks", "run.ts"));
+  });
+
+  it("annotates indexed chunks with git blame and filters by blame author", async () => {
+    const authoredDir = fs.mkdtempSync(path.join(os.tmpdir(), "search-blame-"));
+    try {
+      execFileSync("git", ["init"], { cwd: authoredDir });
+      execFileSync("git", ["config", "user.name", "Default User"], { cwd: authoredDir });
+      execFileSync("git", ["config", "user.email", "default@example.com"], { cwd: authoredDir });
+
+      fs.writeFileSync(
+        path.join(authoredDir, "auth.ts"),
+        `export function validateSession() { return "auth session token"; }\n`,
+        "utf-8"
+      );
+      execFileSync("git", ["add", "auth.ts"], { cwd: authoredDir });
+      execFileSync("git", ["commit", "-m", "auth: add session validation"], {
+        cwd: authoredDir,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Jane Doe",
+          GIT_AUTHOR_EMAIL: "jane@example.com",
+          GIT_AUTHOR_DATE: "2025-03-14T12:00:00Z",
+          GIT_COMMITTER_NAME: "Jane Doe",
+          GIT_COMMITTER_EMAIL: "jane@example.com",
+          GIT_COMMITTER_DATE: "2025-03-14T12:00:00Z",
+        },
+      });
+
+      fs.writeFileSync(
+        path.join(authoredDir, "payments.ts"),
+        `export function chargeCard() { return "payment flow"; }\n`,
+        "utf-8"
+      );
+      execFileSync("git", ["add", "payments.ts"], { cwd: authoredDir });
+      execFileSync("git", ["commit", "-m", "payments: add card charge"], {
+        cwd: authoredDir,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Alex Roe",
+          GIT_AUTHOR_EMAIL: "alex@example.com",
+          GIT_AUTHOR_DATE: "2025-04-01T12:00:00Z",
+          GIT_COMMITTER_NAME: "Alex Roe",
+          GIT_COMMITTER_EMAIL: "alex@example.com",
+          GIT_COMMITTER_DATE: "2025-04-01T12:00:00Z",
+        },
+      });
+
+      const disabledConfig = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-embedding-model",
+          dimensions: 8,
+        },
+        indexing: {
+          watchFiles: false,
+          gitBlame: { enabled: false },
+        },
+        search: {
+          maxResults: 10,
+          minScore: 0,
+        },
+      });
+      const disabledIndexer = new Indexer(authoredDir, disabledConfig);
+      await disabledIndexer.index();
+      await disabledIndexer.close();
+
+      const config = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-embedding-model",
+          dimensions: 8,
+        },
+        indexing: {
+          watchFiles: false,
+          gitBlame: { enabled: true },
+        },
+        search: {
+          maxResults: 10,
+          minScore: 0,
+        },
+      });
+
+      const indexer = new Indexer(authoredDir, config);
+      _indexers.push(indexer);
+      await indexer.index();
+
+      const janeResults = await indexer.search("session token", 5, {
+        metadataOnly: true,
+        filterByBranch: false,
+        blameAuthor: "jane@example.com",
+      });
+
+      expect(janeResults).toHaveLength(1);
+      expect(janeResults[0]?.filePath).toContain("auth.ts");
+      expect(janeResults[0]?.blame?.authorEmail).toBe("jane@example.com");
+      expect(janeResults[0]?.blame?.summary).toBe("auth: add session validation");
+
+      const blameSha = janeResults[0]?.blame?.sha.slice(0, 8);
+      if (!blameSha) {
+        throw new Error("expected blame SHA");
+      }
+
+      const shaResults = await indexer.search("session token", 5, {
+        metadataOnly: true,
+        filterByBranch: false,
+        blameSha,
+      });
+      expect(shaResults).toHaveLength(1);
+      expect(shaResults[0]?.filePath).toContain("auth.ts");
+
+      const sinceResults = await indexer.search("payment flow", 5, {
+        metadataOnly: true,
+        filterByBranch: false,
+        blameSince: "2025-03-20",
+      });
+      expect(sinceResults).toHaveLength(1);
+      expect(sinceResults[0]?.filePath).toContain("payments.ts");
+    } finally {
+      fs.rmSync(authoredDir, { recursive: true, force: true });
+    }
   });
 
   it("prefers documentation paths for doc-intent phrasing with 'where is'", async () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -468,6 +468,27 @@ describe("tools utils", () => {
       expect(result).toContain("a.ts:1-2");
       expect(result).toContain("0.5");
     });
+
+    it("should include git blame annotation when present", () => {
+      const result = formatCodebasePeek([{
+        filePath: "src/auth.ts",
+        startLine: 45,
+        endLine: 67,
+        content: "",
+        score: 0.92,
+        chunkType: "function",
+        name: "validateSession",
+        blame: {
+          sha: "abc123456789",
+          author: "Jane Doe",
+          authorEmail: "jane@example.com",
+          committedAt: 1741953600,
+          summary: "auth: add session validation",
+        },
+      }]);
+
+      expect(result).toContain("abc1234 | Jane Doe | 2025-03-14 | auth: add session validation");
+    });
   });
 
   describe("formatHealthCheck", () => {
@@ -726,6 +747,28 @@ describe("tools utils", () => {
 
       expect(result).toContain("(similarity: 92.0%)");
       expect(result).not.toContain("(score:");
+    });
+
+    it("should include git blame annotation with full search results", () => {
+      const result = formatSearchResults([{
+        filePath: "src/auth.ts",
+        startLine: 45,
+        endLine: 67,
+        content: "export function validateSession() { return true; }",
+        score: 0.92,
+        chunkType: "function",
+        name: "validateSession",
+        blame: {
+          sha: "abc123456789",
+          author: "Jane Doe",
+          authorEmail: "jane@example.com",
+          committedAt: 1741953600,
+          summary: "auth: add session validation",
+        },
+      }]);
+
+      expect(result).toContain("abc1234 | Jane Doe | 2025-03-14 | auth: add session validation");
+      expect(result).toContain("export function validateSession()");
     });
   });
 });


### PR DESCRIPTION
## Summary

Enrich indexed code chunks with optional git blame metadata so search results can show who last touched code and why.

## Changes

- Add `indexing.gitBlame.enabled` and schema v6 blame columns on `chunks`.
- Compute and backfill per-chunk git blame metadata, then expose `blameAuthor`, `blameSha`, and `blameSince` filters across OpenCode, MCP/Codex/Claude, and Pi.
- Annotate search/peek/find-similar/definition result formatting with `sha | author | date | summary` when blame metadata is available.
- Update README, slash commands, skill guidance, and regression tests for DB persistence, filters, host parity, docs, and formatting.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional checks run:

- `cd native && cargo test` — 93 passed
- `npx vitest run tests/search-integration.test.ts tests/database.test.ts tests/pi-package.test.ts tests/commands.test.ts tests/tools-utils.test.ts` — 119 passed
- Formatter smoke check for blame annotation output

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Fixes #122
