### PR TITLE
chore: prepare v0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-08
+
+### Added
+
+- **Bash call graph support**: Added tree-sitter call extraction for Bash scripts so shell functions and invocations participate in call graph indexing.
+- **Git blame metadata**: Added git blame details to indexed chunks so search results can include authorship and recency context.
+
+### Fixed
+
+- **Pi call graph output**: Aligned Pi call graph formatting with the host adapters.
+- **Bash parser linting**: Resolved Rust clippy warnings in the Bash parser merge guard.
+
 ## [0.13.2] - 2026-07-04
 
 ### Fixed
@@ -382,7 +394,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.2...v0.14.0
+[0.13.2]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.7.0...v0.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package metadata to 0.14.0
- update changelog for Bash call graph support and git blame metadata
- refresh changelog comparison links through v0.14.0

## Verification
- npm run typecheck
- npm run lint
- npm run build
- npm run test:run