### PR TITLE
fix: serialize index mutations across processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ opencode-codebase-index
 
 # Local index data
 .opencode/
+.codebase-index/
 
 # Test files
 test-*.cjs

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -1,4 +1,4 @@
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use std::path::Path;
 use thiserror::Error;
 
@@ -8,6 +8,8 @@ pub enum DbError {
     Sqlite(#[from] rusqlite::Error),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Read-only database schema error: {0}")]
+    ReadOnlySchema(String),
 }
 
 pub type DbResult<T> = Result<T, DbError>;
@@ -48,6 +50,49 @@ pub fn init_db(db_path: &Path) -> DbResult<Connection> {
         migrate_schema(&conn, current_version)?;
     }
 
+    Ok(conn)
+}
+
+/// Ouvre une base publiée sans créer de fichier ni exécuter de migration.
+pub fn open_db_read_only(db_path: &Path) -> DbResult<Connection> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+
+    conn.execute_batch("PRAGMA query_only = ON; PRAGMA foreign_keys = ON;")?;
+
+    let stored_version: String = conn
+        .query_row(
+            "SELECT value FROM metadata WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|error| {
+            DbError::ReadOnlySchema(format!(
+                "cannot read schema version (expected {SCHEMA_VERSION}): {error}"
+            ))
+        })?;
+    let current_version = stored_version.parse::<i32>().map_err(|error| {
+        DbError::ReadOnlySchema(format!(
+            "invalid schema version {stored_version:?} (expected {SCHEMA_VERSION}): {error}"
+        ))
+    })?;
+
+    if current_version != SCHEMA_VERSION {
+        return Err(DbError::ReadOnlySchema(format!(
+            "found version {current_version}, expected {SCHEMA_VERSION}; a writer must migrate the index"
+        )));
+    }
+
+    Ok(conn)
+}
+
+/// Crée un catalogue vide en mémoire, puis le verrouille en lecture seule.
+pub fn create_empty_read_only_db() -> DbResult<Connection> {
+    let conn = Connection::open_in_memory()?;
+    migrate_schema(&conn, 0)?;
+    conn.execute_batch("PRAGMA query_only = ON; PRAGMA foreign_keys = ON;")?;
     Ok(conn)
 }
 

--- a/native/src/hasher.rs
+++ b/native/src/hasher.rs
@@ -1,15 +1,26 @@
 use anyhow::Result;
 use std::fs;
+use std::io::{BufReader, Read};
 use std::path::Path;
-use xxhash_rust::xxh3::xxh3_64;
+use xxhash_rust::xxh3::{xxh3_64, Xxh3};
 
 pub fn xxhash_content(content: &str) -> String {
     format!("{:016x}", xxh3_64(content.as_bytes()))
 }
 
 pub fn xxhash_file(file_path: &str) -> Result<String> {
-    let content = fs::read(Path::new(file_path))?;
-    Ok(format!("{:016x}", xxh3_64(&content)))
+    let file = fs::File::open(Path::new(file_path))?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Xxh3::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:016x}", hasher.digest()))
 }
 
 #[cfg(test)]

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -119,7 +119,7 @@ impl VectorStore {
     }
 
     #[napi]
-    pub fn save(&self) -> Result<()> {
+    pub fn save(&mut self) -> Result<()> {
         self.inner
             .save()
             .map_err(|e| Error::from_reason(e.to_string()))
@@ -130,6 +130,18 @@ impl VectorStore {
         self.inner
             .load()
             .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn load_strict(&mut self) -> Result<()> {
+        self.inner
+            .load_strict()
+            .map_err(|e| Error::from_reason(e.to_string()))
+    }
+
+    #[napi]
+    pub fn has_fingerprint(&self) -> bool {
+        self.inner.has_fingerprint()
     }
 
     #[napi]

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -414,13 +414,31 @@ pub struct DatabaseStats {
 
 #[napi]
 impl Database {
+    fn from_connection(conn: rusqlite::Connection) -> Self {
+        Self {
+            conn: std::sync::Mutex::new(Some(conn)),
+        }
+    }
+
     #[napi(constructor)]
     pub fn new(db_path: String) -> Result<Self> {
         let conn = db::init_db(std::path::Path::new(&db_path))
             .map_err(|e| Error::from_reason(e.to_string()))?;
-        Ok(Self {
-            conn: std::sync::Mutex::new(Some(conn)),
-        })
+        Ok(Self::from_connection(conn))
+    }
+
+    #[napi(factory)]
+    pub fn open_read_only(db_path: String) -> Result<Self> {
+        let conn = db::open_db_read_only(std::path::Path::new(&db_path))
+            .map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(Self::from_connection(conn))
+    }
+
+    #[napi(factory)]
+    pub fn create_empty_read_only() -> Result<Self> {
+        let conn =
+            db::create_empty_read_only_db().map_err(|e| Error::from_reason(e.to_string()))?;
+        Ok(Self::from_connection(conn))
     }
 
     fn closed_error() -> Error {

--- a/native/src/store.rs
+++ b/native/src/store.rs
@@ -1,10 +1,17 @@
-use crate::SearchResult;
+use crate::{hasher::xxhash_file, SearchResult};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
 use usearch::{new_index, Index, IndexOptions, MetricKind, ScalarKind};
+use xxhash_rust::xxh3::Xxh3;
+
+// The usearch loader accepts trailing bytes. Embedding the metadata digest here
+// makes the vector artifact carry the other half of the publication binding.
+const METADATA_BINDING_PREFIX: &[u8] = b"\nOCBI_METADATA_XXH3:";
+const METADATA_BINDING_SUFFIX: &[u8] = b"\n";
 
 #[derive(Serialize, Deserialize, Default)]
 struct StoredMetadata {
@@ -12,6 +19,8 @@ struct StoredMetadata {
     key_to_id: HashMap<String, u64>,
     metadata: HashMap<String, String>,
     next_id: u64,
+    #[serde(default)]
+    vector_fingerprint: Option<String>,
 }
 
 pub struct VectorStoreInner {
@@ -22,33 +31,105 @@ pub struct VectorStoreInner {
     dimensions: usize,
 }
 
-impl VectorStoreInner {
-    pub fn new(index_path: PathBuf, dimensions: usize) -> Result<Self> {
-        let options = IndexOptions {
-            dimensions,
-            metric: MetricKind::Cos,
-            quantization: ScalarKind::F16,
-            connectivity: 16,
-            expansion_add: 128,
-            expansion_search: 64,
-            multi: false,
-        };
+fn create_vector_index(dimensions: usize) -> Result<Index> {
+    let options = IndexOptions {
+        dimensions,
+        metric: MetricKind::Cos,
+        quantization: ScalarKind::F16,
+        connectivity: 16,
+        expansion_add: 128,
+        expansion_search: 64,
+        multi: false,
+    };
+    Ok(new_index(&options)?)
+}
 
-        let index = new_index(&options)?;
+impl VectorStoreInner {
+    fn update_fingerprint_bytes(hasher: &mut Xxh3, value: &[u8]) {
+        hasher.update(&(value.len() as u64).to_le_bytes());
+        hasher.update(value);
+    }
+
+    fn metadata_binding(stored: &StoredMetadata) -> String {
+        let mut hasher = Xxh3::new();
+
+        let mut id_to_key: Vec<_> = stored.id_to_key.iter().collect();
+        id_to_key.sort_unstable_by_key(|(id, _)| **id);
+        Self::update_fingerprint_bytes(&mut hasher, b"id_to_key");
+        hasher.update(&(id_to_key.len() as u64).to_le_bytes());
+        for (id, key) in id_to_key {
+            hasher.update(&id.to_le_bytes());
+            Self::update_fingerprint_bytes(&mut hasher, key.as_bytes());
+        }
+
+        let mut key_to_id: Vec<_> = stored.key_to_id.iter().collect();
+        key_to_id.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        Self::update_fingerprint_bytes(&mut hasher, b"key_to_id");
+        hasher.update(&(key_to_id.len() as u64).to_le_bytes());
+        for (key, id) in key_to_id {
+            Self::update_fingerprint_bytes(&mut hasher, key.as_bytes());
+            hasher.update(&id.to_le_bytes());
+        }
+
+        let mut metadata: Vec<_> = stored.metadata.iter().collect();
+        metadata.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        Self::update_fingerprint_bytes(&mut hasher, b"metadata");
+        hasher.update(&(metadata.len() as u64).to_le_bytes());
+        for (key, value) in metadata {
+            Self::update_fingerprint_bytes(&mut hasher, key.as_bytes());
+            Self::update_fingerprint_bytes(&mut hasher, value.as_bytes());
+        }
+
+        Self::update_fingerprint_bytes(&mut hasher, b"next_id");
+        hasher.update(&stored.next_id.to_le_bytes());
+        format!("{:016x}", hasher.digest())
+    }
+
+    fn append_metadata_binding(index_path: &Path, binding: &str) -> Result<()> {
+        let mut index_file = fs::OpenOptions::new().append(true).open(index_path)?;
+        index_file.write_all(METADATA_BINDING_PREFIX)?;
+        index_file.write_all(binding.as_bytes())?;
+        index_file.write_all(METADATA_BINDING_SUFFIX)?;
+        Ok(())
+    }
+
+    fn verify_metadata_binding(index_path: &Path, stored: &StoredMetadata) -> Result<()> {
+        let binding = Self::metadata_binding(stored);
+        let expected = [
+            METADATA_BINDING_PREFIX,
+            binding.as_bytes(),
+            METADATA_BINDING_SUFFIX,
+        ]
+        .concat();
+        let mut index_file = fs::File::open(index_path)?;
+        if index_file.metadata()?.len() < expected.len() as u64 {
+            return Err(anyhow!(
+                "Vector fingerprint mismatch: vectors and vectors.meta.json do not belong to the same publication"
+            ));
+        }
+        index_file.seek(SeekFrom::End(-(expected.len() as i64)))?;
+        let mut actual = vec![0; expected.len()];
+        index_file.read_exact(&mut actual)?;
+        if actual != expected {
+            return Err(anyhow!(
+                "Vector fingerprint mismatch: vectors and vectors.meta.json do not belong to the same publication"
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn new(index_path: PathBuf, dimensions: usize) -> Result<Self> {
+        let index = create_vector_index(dimensions)?;
 
         let metadata_path = index_path.with_extension("meta.json");
 
-        let mut store = Self {
+        let store = Self {
             index,
             index_path,
             metadata_path,
             stored: StoredMetadata::default(),
             dimensions,
         };
-
-        if store.index_path.exists() {
-            let _ = store.load();
-        }
 
         Ok(store)
     }
@@ -200,7 +281,10 @@ impl VectorStoreInner {
         }
     }
 
-    pub fn save(&self) -> Result<()> {
+    pub fn save(&mut self) -> Result<()> {
+        self.validate_structure()?;
+        self.stored.vector_fingerprint = None;
+
         if let Some(parent) = self.index_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -210,27 +294,164 @@ impl VectorStoreInner {
             .to_str()
             .ok_or_else(|| anyhow!("Index path contains invalid UTF-8: {:?}", self.index_path))?;
         self.index.save(index_path_str)?;
+        let metadata_binding = Self::metadata_binding(&self.stored);
+        Self::append_metadata_binding(&self.index_path, &metadata_binding)?;
+        let fingerprint = xxhash_file(index_path_str)?;
 
-        let metadata_json = serde_json::to_string(&self.stored)?;
-        fs::write(&self.metadata_path, metadata_json)?;
+        self.stored.vector_fingerprint = Some(fingerprint);
+        let publication = (|| -> Result<()> {
+            let metadata_json = serde_json::to_string(&self.stored)?;
+            fs::write(&self.metadata_path, metadata_json)?;
+            Ok(())
+        })();
+        if let Err(error) = publication {
+            self.stored.vector_fingerprint = None;
+            return Err(error);
+        }
 
         Ok(())
     }
 
     pub fn load(&mut self) -> Result<()> {
-        if self.index_path.exists() {
-            let index_path_str = self.index_path.to_str().ok_or_else(|| {
-                anyhow!("Index path contains invalid UTF-8: {:?}", self.index_path)
-            })?;
-            self.index.load(index_path_str)?;
+        self.load_with_fingerprint_requirement(false)
+    }
+
+    pub fn load_strict(&mut self) -> Result<()> {
+        self.load_with_fingerprint_requirement(true)
+    }
+
+    fn load_with_fingerprint_requirement(&mut self, require_fingerprint: bool) -> Result<()> {
+        let index_exists = self.index_path.exists();
+        let metadata_exists = self.metadata_path.exists();
+        if index_exists != metadata_exists {
+            return Err(anyhow!(
+                "Incomplete vector publication: vectors and vectors.meta.json must both exist"
+            ));
+        }
+        if !index_exists {
+            if require_fingerprint {
+                return Err(anyhow!(
+                    "Missing vector fingerprint: a leased writer must publish this legacy vector pair before readers can load it"
+                ));
+            }
+            self.index = create_vector_index(self.dimensions)?;
+            self.stored = StoredMetadata::default();
+            return Ok(());
         }
 
-        if self.metadata_path.exists() {
-            let metadata_json = fs::read_to_string(&self.metadata_path)?;
-            self.stored = serde_json::from_str(&metadata_json)?;
+        let metadata_json = Some(fs::read_to_string(&self.metadata_path)?);
+        let stored: StoredMetadata = metadata_json
+            .as_deref()
+            .map(serde_json::from_str)
+            .transpose()?
+            .unwrap_or_default();
+
+        if stored.vector_fingerprint.is_none() {
+            if require_fingerprint {
+                return Err(anyhow!(
+                    "Missing vector fingerprint: a leased writer must publish this legacy vector pair before readers can load it"
+                ));
+            }
+
+            // Structural validation cannot prove that an unfingerprinted legacy pair is
+            // semantically matched. A leased writer may only establish a new baseline.
+        }
+
+        let index_path_str = self
+            .index_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Index path contains invalid UTF-8: {:?}", self.index_path))?;
+        let vector_fingerprint_before = xxhash_file(index_path_str)?;
+        if let Some(expected) = stored.vector_fingerprint.as_deref() {
+            Self::verify_metadata_binding(&self.index_path, &stored)?;
+            if vector_fingerprint_before != expected {
+                return Err(anyhow!(
+                    "Vector fingerprint mismatch: vectors and vectors.meta.json do not belong to the same publication"
+                ));
+            }
+        }
+
+        let index = create_vector_index(self.dimensions)?;
+        index.load(index_path_str)?;
+
+        let vector_fingerprint_after = xxhash_file(index_path_str)?;
+        if vector_fingerprint_before != vector_fingerprint_after {
+            return Err(anyhow!(
+                "Vector publication changed while it was being loaded; retry after the active writer finishes"
+            ));
+        }
+        if let Some(metadata_before) = metadata_json.as_deref() {
+            let metadata_after = fs::read_to_string(&self.metadata_path)?;
+            if metadata_after != metadata_before {
+                return Err(anyhow!(
+                    "Vector metadata changed while it was being loaded; retry after the active writer finishes"
+                ));
+            }
+        }
+
+        Self::validate_structure_parts(&index, &stored)?;
+        self.index = index;
+        self.stored = stored;
+
+        Ok(())
+    }
+
+    fn validate_structure(&self) -> Result<()> {
+        Self::validate_structure_parts(&self.index, &self.stored)
+    }
+
+    fn validate_structure_parts(index: &Index, stored: &StoredMetadata) -> Result<()> {
+        let vector_count = index.size();
+        let id_count = stored.id_to_key.len();
+        let key_count = stored.key_to_id.len();
+        let metadata_count = stored.metadata.len();
+        if vector_count != id_count || id_count != key_count || key_count != metadata_count {
+            return Err(anyhow!(
+                "Vector store structure mismatch: vectors={}, ids={}, keys={}, metadata={}",
+                vector_count,
+                id_count,
+                key_count,
+                metadata_count
+            ));
+        }
+
+        for (&id, key) in &stored.id_to_key {
+            if stored.key_to_id.get(key) != Some(&id) {
+                return Err(anyhow!(
+                    "Vector store structure mismatch: key '{}' does not map back to ID {}",
+                    key,
+                    id
+                ));
+            }
+            if !index.contains(id) {
+                return Err(anyhow!(
+                    "Vector store structure mismatch: vector ID {} is missing from the index",
+                    id
+                ));
+            }
+            if !stored.metadata.contains_key(key) {
+                return Err(anyhow!(
+                    "Vector store structure mismatch: metadata is missing for key '{}'",
+                    key
+                ));
+            }
+        }
+
+        if let Some(max_id) = stored.id_to_key.keys().max() {
+            if stored.next_id <= *max_id {
+                return Err(anyhow!(
+                    "Vector store structure mismatch: next ID {} is not greater than persisted ID {}",
+                    stored.next_id,
+                    max_id
+                ));
+            }
         }
 
         Ok(())
+    }
+
+    pub fn has_fingerprint(&self) -> bool {
+        self.stored.vector_fingerprint.is_some()
     }
 
     pub fn count(&self) -> usize {
@@ -238,17 +459,7 @@ impl VectorStoreInner {
     }
 
     pub fn clear(&mut self) -> Result<()> {
-        let options = IndexOptions {
-            dimensions: self.dimensions,
-            metric: MetricKind::Cos,
-            quantization: ScalarKind::F16,
-            connectivity: 16,
-            expansion_add: 128,
-            expansion_search: 64,
-            multi: false,
-        };
-
-        self.index = new_index(&options)?;
+        self.index = create_vector_index(self.dimensions)?;
         self.stored = StoredMetadata::default();
 
         if self.index_path.exists() {

--- a/native/src/store.rs
+++ b/native/src/store.rs
@@ -63,7 +63,7 @@ impl VectorStoreInner {
         }
 
         let mut key_to_id: Vec<_> = stored.key_to_id.iter().collect();
-        key_to_id.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        key_to_id.sort_unstable_by_key(|(key, _)| *key);
         Self::update_fingerprint_bytes(&mut hasher, b"key_to_id");
         hasher.update(&(key_to_id.len() as u64).to_le_bytes());
         for (key, id) in key_to_id {
@@ -72,7 +72,7 @@ impl VectorStoreInner {
         }
 
         let mut metadata: Vec<_> = stored.metadata.iter().collect();
-        metadata.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        metadata.sort_unstable_by_key(|(key, _)| *key);
         Self::update_fingerprint_bytes(&mut hasher, b"metadata");
         hasher.update(&(metadata.len() as u64).to_le_bytes());
         for (key, value) in metadata {
@@ -346,15 +346,13 @@ impl VectorStoreInner {
             .transpose()?
             .unwrap_or_default();
 
-        if stored.vector_fingerprint.is_none() {
-            if require_fingerprint {
-                return Err(anyhow!(
-                    "Missing vector fingerprint: a leased writer must publish this legacy vector pair before readers can load it"
-                ));
-            }
-
-            // Structural validation cannot prove that an unfingerprinted legacy pair is
-            // semantically matched. A leased writer may only establish a new baseline.
+        // Structural validation cannot prove that an unfingerprinted legacy pair is
+        // semantically matched. A leased writer may only establish a new baseline,
+        // while readers require an existing fingerprint.
+        if stored.vector_fingerprint.is_none() && require_fingerprint {
+            return Err(anyhow!(
+                "Missing vector fingerprint: a leased writer must publish this legacy vector pair before readers can load it"
+            ));
         }
 
         let index_path_str = self

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^9.39.4",
         "tsup": "^8.1.0",
+        "tsx": "^4.23.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.0",
         "vitest": "^4.1.2"
@@ -8592,6 +8593,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typanion": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^9.39.4",
     "tsup": "^8.1.0",
+    "tsx": "^4.23.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.2"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,14 +165,22 @@ async function main(): Promise<void> {
     );
   }
 
-  const shutdown = (): void => {
-    watcher?.stop();
-    server.close().catch(() => {});
-    process.exit(0);
+  let shuttingDown = false;
+  const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await watcher?.stop();
+      await server.close();
+      process.exit(0);
+    } catch (error) {
+      console.error("Failed to stop MCP server cleanly:", error);
+      process.exit(1);
+    }
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", () => { void shutdown(); });
+  process.on("SIGTERM", () => { void shutdown(); });
 }
 
 function handleMainError(error: unknown): never {

--- a/src/indexer/index-lock.ts
+++ b/src/indexer/index-lock.ts
@@ -1,0 +1,556 @@
+import { randomUUID } from "crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export type IndexMutationOperation =
+  | "initialize"
+  | "index"
+  | "force-index"
+  | "clear"
+  | "health-check"
+  | "retry-failed-batches"
+  | "recovery";
+
+export interface IndexLockOwner {
+  pid: number;
+  hostname: string;
+  startedAt: string;
+  operation: IndexMutationOperation;
+  token: string;
+}
+
+export interface IndexLockRecovery {
+  owner: IndexLockOwner;
+  markerPath: string;
+}
+
+export interface IndexLockLease {
+  canonicalIndexPath: string;
+  lockPath: string;
+  owner: IndexLockOwner;
+  recoveries: IndexLockRecovery[];
+}
+
+type OwnerLiveness = "alive" | "dead" | "unknown";
+
+interface ReclaimOwner {
+  pid: number;
+  hostname: string;
+  startedAt: string;
+  token: string;
+  expectedOwnerToken: string;
+}
+
+const OWNER_FILE_NAME = "owner.json";
+const RECLAIM_DIRECTORY_NAME = "reclaiming";
+const RECOVERY_MARKER_PREFIX = "indexing.lock.recovery.";
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const VALID_OPERATIONS = new Set<IndexMutationOperation>([
+  "initialize",
+  "index",
+  "force-index",
+  "clear",
+  "health-check",
+  "retry-failed-batches",
+  "recovery",
+]);
+
+let temporaryCounter = 0;
+
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function retryTransientFilesystemOperation(operation: () => void): void {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      operation();
+      return;
+    } catch (error) {
+      lastError = error;
+      const code = getErrorCode(error);
+      if (code !== "EBUSY" && code !== "EPERM") throw error;
+      if (attempt < 2) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, (attempt + 1) * 10);
+      }
+    }
+  }
+  throw lastError;
+}
+
+function parseOwner(value: unknown): IndexLockOwner | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<IndexLockOwner>;
+  if (!Number.isInteger(candidate.pid) || (candidate.pid ?? 0) <= 0) return null;
+  if (typeof candidate.hostname !== "string" || candidate.hostname.length === 0) return null;
+  if (typeof candidate.startedAt !== "string" || Number.isNaN(Date.parse(candidate.startedAt))) return null;
+  if (typeof candidate.operation !== "string" || !VALID_OPERATIONS.has(candidate.operation as IndexMutationOperation)) return null;
+  if (typeof candidate.token !== "string" || !UUID_PATTERN.test(candidate.token)) return null;
+  return candidate as IndexLockOwner;
+}
+
+function parseReclaimOwner(value: unknown): ReclaimOwner | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<ReclaimOwner>;
+  if (!Number.isInteger(candidate.pid) || (candidate.pid ?? 0) <= 0) return null;
+  if (typeof candidate.hostname !== "string" || candidate.hostname.length === 0) return null;
+  if (typeof candidate.startedAt !== "string" || Number.isNaN(Date.parse(candidate.startedAt))) return null;
+  if (typeof candidate.token !== "string" || !UUID_PATTERN.test(candidate.token)) return null;
+  if (typeof candidate.expectedOwnerToken !== "string" || !UUID_PATTERN.test(candidate.expectedOwnerToken)) return null;
+  return candidate as ReclaimOwner;
+}
+
+function readJsonDirectory<T>(directoryPath: string, parser: (value: unknown) => T | null): T | null {
+  try {
+    return parser(JSON.parse(readFileSync(path.join(directoryPath, OWNER_FILE_NAME), "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+function readDirectoryOwner(lockPath: string): IndexLockOwner | null {
+  return readJsonDirectory(lockPath, parseOwner);
+}
+
+function readReclaimOwner(markerPath: string): ReclaimOwner | null {
+  return readJsonDirectory(markerPath, parseReclaimOwner);
+}
+
+function readRecoveryOwner(markerPath: string): IndexLockOwner | null {
+  return readDirectoryOwner(markerPath);
+}
+
+function readLegacyOwner(lockPath: string): IndexLockOwner | null {
+  try {
+    const parsed = JSON.parse(readFileSync(lockPath, "utf-8")) as {
+      pid?: unknown;
+      startedAt?: unknown;
+      hostname?: unknown;
+      operation?: unknown;
+      token?: unknown;
+    };
+    if (!Number.isInteger(parsed.pid) || Number(parsed.pid) <= 0) return null;
+    if (typeof parsed.startedAt !== "string" || Number.isNaN(Date.parse(parsed.startedAt))) return null;
+    return {
+      pid: Number(parsed.pid),
+      hostname: typeof parsed.hostname === "string" ? parsed.hostname : os.hostname(),
+      startedAt: parsed.startedAt,
+      operation: typeof parsed.operation === "string" && VALID_OPERATIONS.has(parsed.operation as IndexMutationOperation)
+        ? parsed.operation as IndexMutationOperation
+        : "index",
+      token: typeof parsed.token === "string" ? parsed.token : "legacy-v0.14.0",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getOwnerLiveness(owner: Pick<IndexLockOwner, "pid" | "hostname">): OwnerLiveness {
+  if (owner.hostname !== os.hostname()) return "unknown";
+  try {
+    process.kill(owner.pid, 0);
+    return "alive";
+  } catch (error) {
+    const code = getErrorCode(error);
+    if (code === "ESRCH") return "dead";
+    if (code === "EPERM") return "alive";
+    return "unknown";
+  }
+}
+
+function sameOwner(left: IndexLockOwner, right: IndexLockOwner): boolean {
+  return left.pid === right.pid && left.hostname === right.hostname && left.token === right.token;
+}
+
+function sameReclaimOwner(left: ReclaimOwner, right: ReclaimOwner): boolean {
+  return left.pid === right.pid
+    && left.hostname === right.hostname
+    && left.token === right.token
+    && left.expectedOwnerToken === right.expectedOwnerToken;
+}
+
+function publishJsonDirectory(finalPath: string, value: IndexLockOwner | ReclaimOwner): boolean {
+  const candidatePath = `${finalPath}.candidate.${process.pid}.${randomUUID()}`;
+  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    writeFileSync(path.join(candidatePath, OWNER_FILE_NAME), JSON.stringify(value), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    if (existsSync(finalPath)) return false;
+    try {
+      renameSync(candidatePath, finalPath);
+      return true;
+    } catch (error) {
+      if (existsSync(finalPath)) return false;
+      throw error;
+    }
+  } finally {
+    if (existsSync(candidatePath)) rmSync(candidatePath, { recursive: true, force: true });
+  }
+}
+
+function createOwner(operation: IndexMutationOperation): IndexLockOwner {
+  return {
+    pid: process.pid,
+    hostname: os.hostname(),
+    startedAt: new Date().toISOString(),
+    operation,
+    token: randomUUID(),
+  };
+}
+
+function recoveryMarkerPath(indexPath: string, owner: IndexLockOwner): string {
+  return path.join(indexPath, `${RECOVERY_MARKER_PREFIX}${owner.token}`);
+}
+
+function publishRecoveryMarker(indexPath: string, owner: IndexLockOwner): string {
+  const markerPath = recoveryMarkerPath(indexPath, owner);
+  if (!publishJsonDirectory(markerPath, owner)) {
+    const markerOwner = readRecoveryOwner(markerPath);
+    if (!markerOwner || !sameOwner(markerOwner, owner)) {
+      throw new IndexLockContentionError(markerPath, markerOwner, "unknown-owner");
+    }
+  }
+  return markerPath;
+}
+
+function getPendingRecoveries(indexPath: string): IndexLockRecovery[] {
+  const recoveries: IndexLockRecovery[] = [];
+  const markerNames = readdirSync(indexPath).filter((name) => {
+    if (!name.startsWith(RECOVERY_MARKER_PREFIX)) return false;
+    return UUID_PATTERN.test(name.slice(RECOVERY_MARKER_PREFIX.length));
+  }).sort();
+  for (const markerName of markerNames) {
+    const markerPath = path.join(indexPath, markerName);
+    const markerToken = markerName.slice(RECOVERY_MARKER_PREFIX.length);
+    let markerStats;
+    try {
+      markerStats = lstatSync(markerPath);
+    } catch (error) {
+      if (getErrorCode(error) === "ENOENT") continue;
+      throw error;
+    }
+    if (!markerStats.isDirectory()) {
+      throw new IndexLockContentionError(markerPath, null, "unknown-owner");
+    }
+    const owner = readRecoveryOwner(markerPath);
+    if (!owner || owner.token !== markerToken || getOwnerLiveness(owner) !== "dead") {
+      throw new IndexLockContentionError(markerPath, owner, "unknown-owner");
+    }
+    recoveries.push({ owner, markerPath });
+  }
+  recoveries.sort((left, right) => {
+    const byTimestamp = left.owner.startedAt.localeCompare(right.owner.startedAt);
+    return byTimestamp !== 0 ? byTimestamp : left.markerPath.localeCompare(right.markerPath);
+  });
+  return recoveries;
+}
+
+function cleanupDeadPublicationCandidates(indexPath: string): void {
+  const candidatePattern = /^indexing\.lock(?:\.recovery\.[0-9a-f-]{36})?\.candidate\.(\d+)\.[0-9a-f-]{36}$/i;
+  for (const entry of readdirSync(indexPath)) {
+    const match = candidatePattern.exec(entry);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    if (getOwnerLiveness({ pid, hostname: os.hostname() }) !== "dead") continue;
+    rmSync(path.join(indexPath, entry), { recursive: true, force: true });
+  }
+}
+
+function removeDeadReclaimMarker(lockPath: string, expectedOwner: IndexLockOwner): boolean {
+  const markerPath = path.join(lockPath, RECLAIM_DIRECTORY_NAME);
+  const marker = readReclaimOwner(markerPath);
+  if (!marker || marker.expectedOwnerToken !== expectedOwner.token || getOwnerLiveness(marker) !== "dead") {
+    return false;
+  }
+
+  const currentOwner = readDirectoryOwner(lockPath);
+  if (!currentOwner || !sameOwner(currentOwner, expectedOwner) || getOwnerLiveness(currentOwner) !== "dead") {
+    return false;
+  }
+
+  const claimedMarkerPath = `${markerPath}.stale.${marker.pid}.${marker.token}.${randomUUID()}`;
+  try {
+    renameSync(markerPath, claimedMarkerPath);
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+
+  const claimedMarker = readReclaimOwner(claimedMarkerPath);
+  const ownerAfterClaim = readDirectoryOwner(lockPath);
+  if (!claimedMarker
+    || !sameReclaimOwner(claimedMarker, marker)
+    || !ownerAfterClaim
+    || !sameOwner(ownerAfterClaim, expectedOwner)
+    || getOwnerLiveness(ownerAfterClaim) !== "dead") {
+    if (!existsSync(markerPath) && existsSync(claimedMarkerPath)) {
+      renameSync(claimedMarkerPath, markerPath);
+    }
+    return false;
+  }
+
+  rmSync(claimedMarkerPath, { recursive: true, force: true });
+  return true;
+}
+
+function reclaimDeadOwner(indexPath: string, lockPath: string, expectedOwner: IndexLockOwner): boolean {
+  const reclaimPath = path.join(lockPath, RECLAIM_DIRECTORY_NAME);
+  const reclaimOwner: ReclaimOwner = {
+    pid: process.pid,
+    hostname: os.hostname(),
+    startedAt: new Date().toISOString(),
+    token: randomUUID(),
+    expectedOwnerToken: expectedOwner.token,
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (publishJsonDirectory(reclaimPath, reclaimOwner)) break;
+    if (attempt === 0 && removeDeadReclaimMarker(lockPath, expectedOwner)) continue;
+    return false;
+  }
+
+  try {
+    const currentReclaimer = readReclaimOwner(reclaimPath);
+    const currentOwner = readDirectoryOwner(lockPath);
+    if (!currentReclaimer
+      || !sameReclaimOwner(currentReclaimer, reclaimOwner)
+      || !currentOwner
+      || !sameOwner(currentOwner, expectedOwner)
+      || getOwnerLiveness(currentOwner) !== "dead") {
+      return false;
+    }
+
+    publishRecoveryMarker(indexPath, expectedOwner);
+
+    const ownerBeforeQuarantine = readDirectoryOwner(lockPath);
+    const reclaimerBeforeQuarantine = readReclaimOwner(reclaimPath);
+    if (!ownerBeforeQuarantine
+      || !sameOwner(ownerBeforeQuarantine, expectedOwner)
+      || getOwnerLiveness(ownerBeforeQuarantine) !== "dead"
+      || !reclaimerBeforeQuarantine
+      || !sameReclaimOwner(reclaimerBeforeQuarantine, reclaimOwner)) {
+      return false;
+    }
+
+    const quarantinePath = `${lockPath}.stale.${expectedOwner.token}.${reclaimOwner.token}`;
+    renameSync(lockPath, quarantinePath);
+    rmSync(quarantinePath, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export class IndexLockContentionError extends Error {
+  readonly code = "INDEX_BUSY";
+
+  constructor(
+    readonly lockPath: string,
+    readonly owner: IndexLockOwner | null,
+    readonly reason: "active" | "unknown-owner" | "legacy-lock" | "reclaiming",
+  ) {
+    const ownerDescription = owner
+      ? `PID ${owner.pid} on ${owner.hostname}, operation ${owner.operation}, since ${owner.startedAt}`
+      : "an unreadable owner";
+    super(`Index mutation already in progress: ${ownerDescription}`);
+    this.name = "IndexLockContentionError";
+  }
+}
+
+export function isIndexLockContentionError(error: unknown): error is IndexLockContentionError {
+  return error instanceof IndexLockContentionError
+    || (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "INDEX_BUSY");
+}
+
+export function isTransientIndexLockContention(error: unknown): boolean {
+  if (!isIndexLockContentionError(error) || !("reason" in error)) return false;
+  return error.reason === "active" || error.reason === "reclaiming";
+}
+
+export function acquireIndexLock(indexPath: string, operation: IndexMutationOperation): IndexLockLease {
+  mkdirSync(indexPath, { recursive: true });
+  const canonicalIndexPath = realpathSync.native(indexPath);
+  const lockPath = path.join(canonicalIndexPath, "indexing.lock");
+  cleanupDeadPublicationCandidates(canonicalIndexPath);
+
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const owner = createOwner(operation);
+    if (publishJsonDirectory(lockPath, owner)) {
+      const lease: IndexLockLease = {
+        canonicalIndexPath,
+        lockPath,
+        owner,
+        recoveries: [],
+      };
+      try {
+        lease.recoveries = getPendingRecoveries(canonicalIndexPath);
+        return lease;
+      } catch (error) {
+        releaseIndexLock(lease);
+        throw error;
+      }
+    }
+
+    let stats;
+    try {
+      stats = lstatSync(lockPath);
+    } catch (error) {
+      if (getErrorCode(error) === "ENOENT") continue;
+      throw error;
+    }
+
+    if (!stats.isDirectory()) {
+      const legacyOwner = readLegacyOwner(lockPath);
+      throw new IndexLockContentionError(lockPath, legacyOwner, "legacy-lock");
+    }
+
+    const existingOwner = readDirectoryOwner(lockPath);
+    if (!existingOwner) {
+      throw new IndexLockContentionError(lockPath, null, "unknown-owner");
+    }
+
+    const liveness = getOwnerLiveness(existingOwner);
+    if (liveness !== "dead") {
+      throw new IndexLockContentionError(lockPath, existingOwner, liveness === "alive" ? "active" : "unknown-owner");
+    }
+
+    if (!reclaimDeadOwner(canonicalIndexPath, lockPath, existingOwner)) {
+      throw new IndexLockContentionError(lockPath, existingOwner, "reclaiming");
+    }
+  }
+
+  throw new IndexLockContentionError(lockPath, null, "reclaiming");
+}
+
+export function releaseIndexLock(lease: IndexLockLease): boolean {
+  const currentOwner = readDirectoryOwner(lease.lockPath);
+  if (!currentOwner || !sameOwner(currentOwner, lease.owner)) return false;
+
+  const releasePath = `${lease.lockPath}.release.${lease.owner.pid}.${lease.owner.token}`;
+  try {
+    retryTransientFilesystemOperation(() => renameSync(lease.lockPath, releasePath));
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+
+  const claimedOwner = readDirectoryOwner(releasePath);
+  if (!claimedOwner || !sameOwner(claimedOwner, lease.owner)) {
+    if (!existsSync(lease.lockPath) && existsSync(releasePath)) {
+      renameSync(releasePath, lease.lockPath);
+    }
+    return false;
+  }
+
+  try {
+    retryTransientFilesystemOperation(() => rmSync(releasePath, { recursive: true, force: true }));
+  } catch (error) {
+    console.error(`[codebase-index] Lease released but tombstone cleanup failed: ${releasePath}`, error);
+  }
+  return true;
+}
+
+export async function withIndexLock<T>(
+  indexPath: string,
+  operation: IndexMutationOperation,
+  callback: (lease: IndexLockLease) => Promise<T> | T,
+  options: { completeRecoveries?: boolean } = {},
+): Promise<T> {
+  const lease = acquireIndexLock(indexPath, operation);
+  let result: T | undefined;
+  let callbackError: unknown;
+  let callbackFailed = false;
+  try {
+    result = await callback(lease);
+  } catch (error) {
+    callbackFailed = true;
+    callbackError = error;
+  }
+  if (!callbackFailed && options.completeRecoveries !== false) {
+    try {
+      completeLeaseRecovery(lease);
+    } catch (error) {
+      callbackFailed = true;
+      callbackError = error;
+    }
+  }
+
+  let releaseError: unknown;
+  try {
+    if (!releaseIndexLock(lease)) {
+      releaseError = new Error(`Lost ownership of index mutation lease ${lease.owner.token}`);
+    }
+  } catch (error) {
+    releaseError = error;
+  }
+  if (releaseError !== undefined) {
+    if (callbackFailed) throw new AggregateError([callbackError, releaseError], "Index mutation and lease release both failed");
+    throw releaseError;
+  }
+  if (callbackFailed) throw callbackError;
+  return result as T;
+}
+
+export function createLeaseTemporaryPath(
+  targetPath: string,
+  owner: IndexLockOwner,
+  kind: "tmp" | "bak" = "tmp",
+): string {
+  if (kind === "bak") return `${targetPath}.bak.${owner.pid}.${owner.token}`;
+  temporaryCounter += 1;
+  return `${targetPath}.tmp.${owner.pid}.${owner.token}.${temporaryCounter}`;
+}
+
+export function removeLeaseTemporaryPath(temporaryPath: string): void {
+  if (existsSync(temporaryPath)) rmSync(temporaryPath, { recursive: true, force: true });
+}
+
+export function recoverLeaseArtifacts(
+  indexPath: string,
+  owner: IndexLockOwner,
+  backupTargets: string[],
+): void {
+  for (const targetPath of backupTargets) {
+    const backupPath = createLeaseTemporaryPath(targetPath, owner, "bak");
+    if (!existsSync(backupPath)) continue;
+    if (existsSync(targetPath)) rmSync(targetPath, { recursive: true, force: true });
+    renameSync(backupPath, targetPath);
+  }
+
+  const temporaryOwnerMarker = `.tmp.${owner.pid}.${owner.token}.`;
+  for (const entry of readdirSync(indexPath)) {
+    if (!entry.includes(temporaryOwnerMarker)) continue;
+    rmSync(path.join(indexPath, entry), { recursive: true, force: true });
+  }
+}
+
+export function completeLeaseRecovery(lease: IndexLockLease): void {
+  for (const recovery of lease.recoveries) {
+    const markerOwner = readRecoveryOwner(recovery.markerPath);
+    if (!markerOwner || !sameOwner(markerOwner, recovery.owner)) {
+      throw new Error(`Recovery marker ownership changed: ${recovery.markerPath}`);
+    }
+  }
+  for (const recovery of lease.recoveries) {
+    rmSync(recovery.markerPath, { recursive: true, force: true });
+  }
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2802,9 +2802,24 @@ export class Indexer {
   }
 
   async initialize(): Promise<void> {
-    await this.withIndexMutationLease("initialize", async (recoveredOwners) => {
-      await this.ensureInitializedUnlocked(recoveredOwners);
+    if (this.initializationPromise) {
+      await this.initializationPromise;
+      return;
+    }
+    if (this.store && this.provider && this.invertedIndex && this.configuredProviderInfo && this.database) {
+      return;
+    }
+    await this.initializeOnce([], { skipAutoGc: true });
+  }
+
+  private async initializeOnce(
+    recoveredOwners: readonly IndexLockOwner[],
+    options: { skipAutoGc?: boolean },
+  ): Promise<void> {
+    this.initializationPromise ??= this.initializeUnlocked(recoveredOwners, options).finally(() => {
+      this.initializationPromise = null;
     });
+    await this.initializationPromise;
   }
 
   private async initializeUnlocked(
@@ -3308,11 +3323,11 @@ export class Indexer {
     configuredProviderInfo: ConfiguredProviderInfo;
     database: Database;
   }> {
-    if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
-      this.initializationPromise ??= this.initialize().finally(() => {
-        this.initializationPromise = null;
-      });
+    if (this.initializationPromise) {
       await this.initializationPromise;
+    }
+    if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
+      await this.initialize();
     }
     return {
       store: this.store!,
@@ -3330,13 +3345,20 @@ export class Indexer {
     configuredProviderInfo: ConfiguredProviderInfo;
     database: Database;
   }> {
+    if (this.initializationPromise) {
+      await this.initializationPromise;
+    }
+
     if (recoveredOwners.length > 0) {
       this.resetLoadedIndexState();
-      await this.initializeUnlocked(recoveredOwners);
+      await this.initializeOnce(recoveredOwners, { skipAutoGc: true });
     } else if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
-      await this.initializeUnlocked();
+      await this.initializeOnce([], { skipAutoGc: true });
     } else {
       this.refreshLoadedIndexState();
+    }
+    if (this.config.indexing.autoGc) {
+      await this.maybeRunAutoGc();
     }
     return this.requireLoadedIndexState();
   }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fsPromises } from "fs";
+import { existsSync, readFileSync, statSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fsPromises } from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
 import { execFile } from "child_process";
@@ -41,6 +41,17 @@ import { getHostProjectIndexRelativePath, resolveProjectIndexPath } from "../con
 import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
 import { getChunkGitBlame, type GitBlameMetadata } from "./git-blame.js";
+import {
+  acquireIndexLock,
+  completeLeaseRecovery,
+  createLeaseTemporaryPath,
+  recoverLeaseArtifacts,
+  releaseIndexLock,
+  removeLeaseTemporaryPath,
+  type IndexLockLease,
+  type IndexLockOwner,
+  type IndexMutationOperation,
+} from "./index-lock.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash"]);
 // Languages whose identifiers are case-insensitive at the language level.
@@ -1883,7 +1894,8 @@ export class Indexer {
   private readonly queryCacheTtlMs = 5 * 60 * 1000;
   private readonly querySimilarityThreshold = 0.85;
   private indexCompatibility: IndexCompatibility | null = null;
-  private indexingLockPath: string = "";
+  private activeIndexLease: IndexLockLease | null = null;
+  private initializationPromise: Promise<void> | null = null;
 
   constructor(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode") {
     this.projectRoot = projectRoot;
@@ -1892,12 +1904,100 @@ export class Indexer {
     this.indexPath = this.getIndexPath();
     this.fileHashCachePath = path.join(this.indexPath, "file-hashes.json");
     this.failedBatchesPath = path.join(this.indexPath, "failed-batches.json");
-    this.indexingLockPath = path.join(this.indexPath, "indexing.lock");
     this.logger = initializeLogger(config.debug);
   }
 
   private getIndexPath(): string {
     return resolveProjectIndexPath(this.projectRoot, this.config.scope, this.host);
+  }
+
+  private isLocalProjectIndexPath(): boolean {
+    const localProjectIndexPaths = [path.join(this.projectRoot, getHostProjectIndexRelativePath(this.host))];
+    if (this.host !== "opencode") {
+      localProjectIndexPaths.push(path.join(this.projectRoot, getHostProjectIndexRelativePath("opencode")));
+    }
+
+    return localProjectIndexPaths.some((localPath) => {
+      if (!existsSync(localPath) || !existsSync(this.indexPath)) {
+        return path.resolve(this.indexPath) === path.resolve(localPath);
+      }
+      const indexStats = statSync(this.indexPath);
+      const localStats = statSync(localPath);
+      return indexStats.dev === localStats.dev && indexStats.ino === localStats.ino;
+    });
+  }
+
+  private resetLoadedIndexState(): void {
+    this.database?.close();
+    this.store = null;
+    this.invertedIndex = null;
+    this.database = null;
+    this.provider = null;
+    this.configuredProviderInfo = null;
+    this.reranker = null;
+    this.indexCompatibility = null;
+    this.fileHashCache.clear();
+  }
+
+  private refreshLoadedIndexState(): void {
+    if (!this.store || !this.invertedIndex || !this.configuredProviderInfo) return;
+    this.store.load();
+    this.invertedIndex.load();
+    this.fileHashCache.clear();
+    this.loadFileHashCache();
+    this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
+  }
+
+  private async withIndexMutationLease<T>(
+    operation: IndexMutationOperation,
+    callback: (recoveredOwners: readonly IndexLockOwner[]) => Promise<T>,
+  ): Promise<T> {
+    const lease = acquireIndexLock(this.indexPath, operation);
+    this.activeIndexLease = lease;
+
+    let result: T | undefined;
+    let callbackError: unknown;
+    let callbackFailed = false;
+    try {
+      result = await callback(lease.recoveries.map(({ owner }) => owner));
+    } catch (error) {
+      callbackFailed = true;
+      callbackError = error;
+    }
+    if (!callbackFailed) {
+      try {
+        completeLeaseRecovery(lease);
+      } catch (error) {
+        callbackFailed = true;
+        callbackError = error;
+      }
+    }
+    let releaseError: unknown;
+    try {
+      if (!releaseIndexLock(lease)) {
+        releaseError = new Error(`Lost ownership of index mutation lease ${lease.owner.token}`);
+      } else if (this.activeIndexLease?.owner.token === lease.owner.token) {
+        this.activeIndexLease = null;
+      }
+    } catch (error) {
+      releaseError = error;
+      if (!existsSync(lease.lockPath) && this.activeIndexLease?.owner.token === lease.owner.token) {
+        this.activeIndexLease = null;
+      }
+    }
+    if (releaseError !== undefined) {
+      if (callbackFailed) throw new AggregateError([callbackError, releaseError], "Index mutation and lease release both failed");
+      throw releaseError;
+    }
+    if (callbackFailed) throw callbackError;
+    return result as T;
+  }
+
+  private requireActiveLease(): IndexLockLease {
+    if (!this.activeIndexLease) {
+      throw new Error("Index mutation attempted without an active interprocess lease");
+    }
+    return this.activeIndexLease;
   }
 
   private loadFileHashCache(): void {
@@ -1928,10 +2028,15 @@ export class Indexer {
   }
 
   private atomicWriteSync(targetPath: string, data: string): void {
-    const tempPath = `${targetPath}.tmp`;
+    const lease = this.requireActiveLease();
+    const tempPath = createLeaseTemporaryPath(targetPath, lease.owner, "tmp");
     mkdirSync(path.dirname(targetPath), { recursive: true });
-    writeFileSync(tempPath, data);
-    renameSync(tempPath, targetPath);
+    try {
+      writeFileSync(tempPath, data);
+      renameSync(tempPath, targetPath);
+    } finally {
+      removeLeaseTemporaryPath(tempPath);
+    }
   }
 
   private getScopedRoots(): string[] {
@@ -2364,33 +2469,23 @@ export class Indexer {
     };
   }
 
-  private checkForInterruptedIndexing(): boolean {
-    return existsSync(this.indexingLockPath);
-  }
-
-  private acquireIndexingLock(): void {
-    const lockData = {
-      startedAt: new Date().toISOString(),
-      pid: process.pid,
-    };
-    writeFileSync(this.indexingLockPath, JSON.stringify(lockData));
-  }
-
-  private releaseIndexingLock(): void {
-    if (existsSync(this.indexingLockPath)) {
-      unlinkSync(this.indexingLockPath);
-    }
-  }
-
-  private async recoverFromInterruptedIndexing(): Promise<void> {
-    this.logger.warn("Detected interrupted indexing session, recovering...");
-
-    if (existsSync(this.fileHashCachePath)) {
-      unlinkSync(this.fileHashCachePath);
+  private async recoverFromInterruptedIndexingUnlocked(owners: readonly IndexLockOwner[]): Promise<void> {
+    for (const owner of owners) {
+      this.logger.warn("Detected interrupted indexing session, recovering...", {
+        pid: owner.pid,
+        hostname: owner.hostname,
+        operation: owner.operation,
+        startedAt: owner.startedAt,
+      });
     }
 
-    await this.healthCheck();
-    this.releaseIndexingLock();
+    if (this.config.scope === "global") {
+      if (existsSync(this.fileHashCachePath)) {
+        unlinkSync(this.fileHashCachePath);
+      }
+
+      await this.healthCheckUnlocked();
+    }
 
     this.logger.info("Recovery complete, next index will re-process all files");
   }
@@ -2451,7 +2546,7 @@ export class Indexer {
       }
       return;
     }
-    writeFileSync(this.failedBatchesPath, JSON.stringify(batches, null, 2));
+    this.atomicWriteSync(this.failedBatchesPath, JSON.stringify(batches, null, 2));
   }
 
   private collectRetryableFailedChunks(
@@ -2704,6 +2799,15 @@ export class Indexer {
   }
 
   async initialize(): Promise<void> {
+    await this.withIndexMutationLease("initialize", async (recoveredOwners) => {
+      await this.ensureInitializedUnlocked(recoveredOwners);
+    });
+  }
+
+  private async initializeUnlocked(
+    recoveredOwners: readonly IndexLockOwner[] = [],
+    options: { skipAutoGc?: boolean } = {},
+  ): Promise<void> {
     if (this.config.embeddingProvider === 'custom') {
       if (!this.config.customProvider) {
         throw new Error("embeddingProvider is 'custom' but customProvider config is missing.");
@@ -2749,9 +2853,24 @@ export class Indexer {
 
     const dimensions = this.configuredProviderInfo.modelInfo.dimensions;
     const storePath = path.join(this.indexPath, "vectors");
+    if (recoveredOwners.length > 0 && this.config.scope === "project" && !this.isLocalProjectIndexPath()) {
+      throw new Error(
+        "Interrupted indexing recovery is unsafe while using an inherited worktree index. " +
+        "Run index_codebase with force=true to create a local project index boundary."
+      );
+    }
+    for (const recoveredOwner of recoveredOwners) {
+      recoverLeaseArtifacts(this.indexPath, recoveredOwner, [
+        storePath,
+        `${storePath}.meta.json`,
+      ]);
+    }
+    if (recoveredOwners.length > 0 && this.config.scope === "project") {
+      await this.resetLocalIndexArtifacts();
+    }
     this.store = new VectorStore(storePath, dimensions);
 
-    const indexFilePath = path.join(this.indexPath, "vectors.usearch");
+    const indexFilePath = storePath;
     if (existsSync(indexFilePath)) {
       this.store.load();
     }
@@ -2795,12 +2914,10 @@ export class Indexer {
       this.logger.branch("debug", "Not a git repository, using default branch");
     }
 
-    // Recover from interrupted indexing AFTER store, invertedIndex, and database
-    // are all initialized. healthCheck() calls ensureInitialized() which checks
-    // these fields — if they're not set, it re-enters initialize() causing infinite
-    // recursion and 70GB+ memory usage.
-    if (this.checkForInterruptedIndexing()) {
-      await this.recoverFromInterruptedIndexing();
+    // La récupération reste dans le lease nouvellement acquis et ne dépend
+    // jamais de la simple présence d'un verrou appartenant à un processus vivant.
+    if (recoveredOwners.length > 0) {
+      await this.recoverFromInterruptedIndexingUnlocked(recoveredOwners);
     }
 
     if (dbIsNew && this.store.count() > 0) {
@@ -2819,7 +2936,7 @@ export class Indexer {
     }
 
     // Auto-GC: Run garbage collection if enabled and interval has elapsed
-    if (this.config.indexing.autoGc) {
+    if (this.config.indexing.autoGc && !options.skipAutoGc) {
       await this.maybeRunAutoGc();
     }
   }
@@ -2843,7 +2960,7 @@ export class Indexer {
     }
 
     if (shouldRunGc) {
-      const result = await this.healthCheck();
+      const result = await this.healthCheckUnlocked();
       if (result.warning) {
         this.database.setMetadata(STARTUP_WARNING_METADATA_KEY, result.warning);
       } else {
@@ -2894,10 +3011,11 @@ export class Indexer {
       .filter(({ key }) => !excludedSet.has(key));
 
     const storeBasePath = path.join(this.indexPath, "vectors");
-    const storeIndexPath = `${storeBasePath}.usearch`;
+    const storeIndexPath = storeBasePath;
     const storeMetadataPath = `${storeBasePath}.meta.json`;
-    const backupIndexPath = `${storeIndexPath}.bak`;
-    const backupMetadataPath = `${storeMetadataPath}.bak`;
+    const lease = this.requireActiveLease();
+    const backupIndexPath = createLeaseTemporaryPath(storeIndexPath, lease.owner, "bak");
+    const backupMetadataPath = createLeaseTemporaryPath(storeMetadataPath, lease.owner, "bak");
 
     let backedUpIndex = false;
     let backedUpMetadata = false;
@@ -2992,6 +3110,30 @@ export class Indexer {
     return `Detected a corrupted local SQLite index at ${dbPath} and reset the local index. Run index_codebase to rebuild search data.`;
   }
 
+  private async resetLocalIndexArtifacts(): Promise<void> {
+    this.store = null;
+    this.invertedIndex = null;
+    this.database?.close();
+    this.database = null;
+    this.indexCompatibility = null;
+    this.fileHashCache.clear();
+
+    const resetPaths = [
+      path.join(this.indexPath, "codebase.db"),
+      path.join(this.indexPath, "codebase.db-shm"),
+      path.join(this.indexPath, "codebase.db-wal"),
+      path.join(this.indexPath, "vectors"),
+      path.join(this.indexPath, "vectors.usearch"),
+      path.join(this.indexPath, "vectors.meta.json"),
+      path.join(this.indexPath, "inverted-index.json"),
+      path.join(this.indexPath, "file-hashes.json"),
+      path.join(this.indexPath, "failed-batches.json"),
+    ];
+
+    await Promise.all(resetPaths.map((targetPath) => fsPromises.rm(targetPath, { recursive: true, force: true })));
+    await fsPromises.mkdir(this.indexPath, { recursive: true });
+  }
+
   private async tryResetCorruptedIndex(stage: string, error: unknown): Promise<boolean> {
     if (!isSqliteCorruptionError(error)) {
       return false;
@@ -3016,34 +3158,7 @@ export class Indexer {
       error: errorMessage,
     });
 
-    this.store = null;
-    this.invertedIndex = null;
-    this.database?.close();
-    this.database = null;
-    this.indexCompatibility = null;
-    this.fileHashCache.clear();
-
-    const resetPaths = [
-      path.join(this.indexPath, "codebase.db"),
-      path.join(this.indexPath, "codebase.db-shm"),
-      path.join(this.indexPath, "codebase.db-wal"),
-      path.join(this.indexPath, "vectors.usearch"),
-      path.join(this.indexPath, "inverted-index.json"),
-      path.join(this.indexPath, "file-hashes.json"),
-      path.join(this.indexPath, "failed-batches.json"),
-      path.join(this.indexPath, "indexing.lock"),
-      path.join(this.indexPath, "vectors"),
-    ];
-
-    await Promise.all(resetPaths.map(async (targetPath) => {
-      try {
-        await fsPromises.rm(targetPath, { recursive: true, force: true });
-      } catch {
-        // Best-effort cleanup. The follow-up reinitialization will recreate what it needs.
-      }
-    }));
-
-    await fsPromises.mkdir(this.indexPath, { recursive: true });
+    await this.resetLocalIndexArtifacts();
     return true;
   }
 
@@ -3191,7 +3306,10 @@ export class Indexer {
     database: Database;
   }> {
     if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
-      await this.initialize();
+      this.initializationPromise ??= this.initialize().finally(() => {
+        this.initializationPromise = null;
+      });
+      await this.initializationPromise;
     }
     return {
       store: this.store!,
@@ -3199,6 +3317,43 @@ export class Indexer {
       invertedIndex: this.invertedIndex!,
       configuredProviderInfo: this.configuredProviderInfo!,
       database: this.database!,
+    };
+  }
+
+  private async ensureInitializedUnlocked(recoveredOwners: readonly IndexLockOwner[] = []): Promise<{
+    store: VectorStore;
+    provider: EmbeddingProviderInterface;
+    invertedIndex: InvertedIndex;
+    configuredProviderInfo: ConfiguredProviderInfo;
+    database: Database;
+  }> {
+    if (recoveredOwners.length > 0) {
+      this.resetLoadedIndexState();
+      await this.initializeUnlocked(recoveredOwners);
+    } else if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
+      await this.initializeUnlocked();
+    } else {
+      this.refreshLoadedIndexState();
+    }
+    return this.requireLoadedIndexState();
+  }
+
+  private requireLoadedIndexState(): {
+    store: VectorStore;
+    provider: EmbeddingProviderInterface;
+    invertedIndex: InvertedIndex;
+    configuredProviderInfo: ConfiguredProviderInfo;
+    database: Database;
+  } {
+    if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
+      throw new Error("Index state is not initialized");
+    }
+    return {
+      store: this.store,
+      provider: this.provider,
+      invertedIndex: this.invertedIndex,
+      configuredProviderInfo: this.configuredProviderInfo,
+      database: this.database,
     };
   }
 
@@ -3219,7 +3374,19 @@ export class Indexer {
   }
 
   async index(onProgress?: ProgressCallback): Promise<IndexStats> {
-    const { store, provider, invertedIndex, database, configuredProviderInfo } = await this.ensureInitialized();
+    return this.withIndexMutationLease("index", async (recoveredOwners) => {
+      return this.indexUnlocked(onProgress, recoveredOwners);
+    });
+  }
+
+  private async indexUnlocked(
+    onProgress?: ProgressCallback,
+    recoveredOwners: readonly IndexLockOwner[] = [],
+    stateReady = false,
+  ): Promise<IndexStats> {
+    const { store, provider, invertedIndex, database, configuredProviderInfo } = stateReady
+      ? this.requireLoadedIndexState()
+      : await this.ensureInitializedUnlocked(recoveredOwners);
     const scopedRoots = this.config.scope === "global" ? this.getScopedRoots() : null;
     const branchCatalogKey = this.getBranchCatalogKey();
     const forceScopedReembed = scopedRoots !== null && database.getMetadata(this.getProjectForceReembedMetadataKey()) === "true";
@@ -3232,7 +3399,6 @@ export class Indexer {
       );
     }
 
-    this.acquireIndexingLock();
     this.logger.recordIndexingStart();
     this.logger.info("Starting indexing", { projectRoot: this.projectRoot });
 
@@ -3673,7 +3839,6 @@ export class Indexer {
         chunksProcessed: 0,
         totalChunks: 0,
       });
-      this.releaseIndexingLock();
       return stats;
     }
 
@@ -3702,7 +3867,6 @@ export class Indexer {
         chunksProcessed: 0,
         totalChunks: 0,
       });
-      this.releaseIndexingLock();
       return stats;
     }
 
@@ -4035,7 +4199,6 @@ export class Indexer {
       totalChunks: pendingChunks.length,
     });
 
-    this.releaseIndexingLock();
     return stats;
   }
 
@@ -4415,8 +4578,23 @@ export class Indexer {
     };
   }
 
+  async forceIndex(onProgress?: ProgressCallback): Promise<IndexStats> {
+    return this.withIndexMutationLease("force-index", async (recoveredOwners) => {
+      await this.ensureInitializedUnlocked(recoveredOwners);
+      await this.clearIndexUnlocked();
+      return this.indexUnlocked(onProgress, [], true);
+    });
+  }
+
   async clearIndex(): Promise<void> {
-    const { store, invertedIndex, database } = await this.ensureInitialized();
+    await this.withIndexMutationLease("clear", async (recoveredOwners) => {
+      await this.ensureInitializedUnlocked(recoveredOwners);
+      await this.clearIndexUnlocked();
+    });
+  }
+
+  private async clearIndexUnlocked(): Promise<void> {
+    const { store, invertedIndex, database } = this.requireLoadedIndexState();
 
     if (this.config.scope === "global") {
       store.load();
@@ -4483,15 +4661,7 @@ export class Indexer {
       return;
     }
 
-    const localProjectIndexPaths = [path.join(this.projectRoot, getHostProjectIndexRelativePath(this.host))];
-    if (this.host !== "opencode") {
-      localProjectIndexPaths.push(path.join(this.projectRoot, getHostProjectIndexRelativePath("opencode")));
-    }
-
-    const isLocalProjectIndex = localProjectIndexPaths.some(
-      (localPath) => path.resolve(this.indexPath) === path.resolve(localPath)
-    );
-    if (!isLocalProjectIndex) {
+    if (!this.isLocalProjectIndexPath()) {
       throw new Error(
         "Project-scoped force rebuild is unsafe while using an inherited worktree index. " +
         "Create a local project config boundary before clearing the index."
@@ -4526,7 +4696,14 @@ export class Indexer {
   }
 
   async healthCheck(): Promise<HealthCheckResult> {
-    const { store, invertedIndex, database } = await this.ensureInitialized();
+    return this.withIndexMutationLease("health-check", async (recoveredOwners) => {
+      await this.ensureInitializedUnlocked(recoveredOwners);
+      return this.healthCheckUnlocked();
+    });
+  }
+
+  private async healthCheckUnlocked(): Promise<HealthCheckResult> {
+    const { store, invertedIndex, database } = this.requireLoadedIndexState();
 
     this.logger.gc("info", "Starting health check");
 
@@ -4591,7 +4768,7 @@ export class Indexer {
         throw error;
       }
 
-      await this.ensureInitialized();
+      await this.initializeUnlocked(undefined, { skipAutoGc: true });
 
       return {
         removed: 0,
@@ -4617,7 +4794,14 @@ export class Indexer {
   }
 
   async retryFailedBatches(): Promise<{ succeeded: number; failed: number; remaining: number }> {
-    const { store, provider, invertedIndex, database, configuredProviderInfo } = await this.ensureInitialized();
+    return this.withIndexMutationLease("retry-failed-batches", async (recoveredOwners) => {
+      await this.ensureInitializedUnlocked(recoveredOwners);
+      return this.retryFailedBatchesUnlocked();
+    });
+  }
+
+  private async retryFailedBatchesUnlocked(): Promise<{ succeeded: number; failed: number; remaining: number }> {
+    const { store, provider, invertedIndex, database, configuredProviderInfo } = this.requireLoadedIndexState();
     const maxChunkTokens = getSafeEmbeddingChunkTokenLimit(configuredProviderInfo);
     const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1953,6 +1953,9 @@ export class Indexer {
     callback: (recoveredOwners: readonly IndexLockOwner[]) => Promise<T>,
   ): Promise<T> {
     const lease = acquireIndexLock(this.indexPath, operation);
+    this.indexPath = lease.canonicalIndexPath;
+    this.fileHashCachePath = path.join(this.indexPath, "file-hashes.json");
+    this.failedBatchesPath = path.join(this.indexPath, "failed-batches.json");
     this.activeIndexLease = lease;
 
     let result: T | undefined;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3181,6 +3181,7 @@ export class Indexer {
 
     const dimensions = this.configuredProviderInfo.modelInfo.dimensions;
     const storePath = path.join(this.indexPath, "vectors");
+    const vectorMetadataPath = `${storePath}.meta.json`;
     const invertedIndexPath = path.join(this.indexPath, "inverted-index.json");
     const dbPath = path.join(this.indexPath, "codebase.db");
     let dbIsNew = !existsSync(dbPath);
@@ -3209,7 +3210,7 @@ export class Indexer {
       }
 
       this.store = new VectorStore(storePath, dimensions);
-      if (existsSync(storePath)) {
+      if (existsSync(storePath) || existsSync(vectorMetadataPath)) {
         this.store.load();
       }
 
@@ -3237,7 +3238,6 @@ export class Indexer {
       }
     } else {
       this.store = new VectorStore(storePath, dimensions);
-      const vectorMetadataPath = `${storePath}.meta.json`;
       const vectorStoreExists = existsSync(storePath);
       const vectorMetadataExists = existsSync(vectorMetadataPath);
       const vectorReadFailureMessage = this.getVectorReadIssueMessage();

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1916,6 +1916,7 @@ export class Indexer {
   private readIssues: IndexReadIssue[] = [];
   private retiredDatabases: Database[] = [];
   private readerArtifactFingerprint: ReaderArtifactFingerprint | null = null;
+  private writerArtifactFingerprint: ReaderArtifactFingerprint | null = null;
   private readerArtifactRetryAfter = new Map<IndexReadIssue["component"], number>();
 
   constructor(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode") {
@@ -1966,6 +1967,7 @@ export class Indexer {
     this.initializationMode = "none";
     this.readIssues = [];
     this.readerArtifactFingerprint = null;
+    this.writerArtifactFingerprint = null;
     this.readerArtifactRetryAfter.clear();
     this.fileHashCache.clear();
   }
@@ -1977,6 +1979,8 @@ export class Indexer {
     this.fileHashCache.clear();
     this.loadFileHashCache();
     this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
+    this.readIssues = [];
+    this.readerArtifactRetryAfter.clear();
   }
 
   private async withIndexMutationLease<T>(
@@ -2001,6 +2005,7 @@ export class Indexer {
     if (!callbackFailed) {
       try {
         completeLeaseRecovery(lease);
+        this.writerArtifactFingerprint = this.captureReaderArtifactFingerprint();
       } catch (error) {
         callbackFailed = true;
         callbackError = error;
@@ -2010,11 +2015,16 @@ export class Indexer {
     try {
       if (!releaseIndexLock(lease)) {
         releaseError = new Error(`Lost ownership of index mutation lease ${lease.owner.token}`);
+        this.writerArtifactFingerprint = null;
+        if (this.activeIndexLease?.owner.token === lease.owner.token) {
+          this.activeIndexLease = null;
+        }
       } else if (this.activeIndexLease?.owner.token === lease.owner.token) {
         this.activeIndexLease = null;
       }
     } catch (error) {
       releaseError = error;
+      this.writerArtifactFingerprint = null;
       if (!existsSync(lease.lockPath) && this.activeIndexLease?.owner.token === lease.owner.token) {
         this.activeIndexLease = null;
       }
@@ -2919,12 +2929,12 @@ export class Indexer {
 
   private getVectorReadIssueMessage(): string {
     if (this.config.scope === "global") {
-      return "Shared vector index could not be read. Restore or repair the complete shared vector artifacts; automatic reset is disabled for global scope.";
+      return "Shared vector index could not be read. Restore or repair the complete fingerprinted shared vector artifacts; automatic reset is disabled for global scope.";
     }
     if (!this.isLocalProjectIndexPath()) {
-      return "Vector index could not be read from an inherited project index. Restore or repair it from the checkout that owns the index; do not remove or rebuild it from this worktree.";
+      return "Vector index could not be read from an inherited project index. Restore or fingerprint it from the checkout that owns the index; do not remove or rebuild it from this worktree.";
     }
-    return "Vector index could not be read. Restore a complete published vector pair, or, after the active writer finishes, remove this checkout's local index directory and run index_codebase to rebuild it.";
+    return "Vector index could not be read. Run index_codebase after the active writer finishes to fingerprint a structurally valid legacy pair, or remove this checkout's local index directory and run index_codebase to rebuild it.";
   }
 
   private getKeywordReadIssueMessage(): string {
@@ -3019,7 +3029,7 @@ export class Indexer {
       if (vectorStoreExists && vectorMetadataExists) {
         try {
           const store = new VectorStore(storePath, this.configuredProviderInfo.modelInfo.dimensions);
-          store.load();
+          store.loadStrict();
           this.store = store;
           issues.delete("vectors");
           this.readerArtifactRetryAfter.delete("vectors");
@@ -3085,6 +3095,43 @@ export class Indexer {
     this.readerArtifactFingerprint = currentFingerprint;
   }
 
+  private refreshInactiveWriterArtifacts(): boolean {
+    if (this.initializationMode !== "writer" || this.activeIndexLease) {
+      return true;
+    }
+
+    const previousFingerprint = this.writerArtifactFingerprint;
+    const currentFingerprint = this.captureReaderArtifactFingerprint();
+    const retryDue = this.readIssues.some((issue) =>
+      Date.now() >= (this.readerArtifactRetryAfter.get(issue.component) ?? 0)
+    );
+    const artifactsChanged = !previousFingerprint ||
+      currentFingerprint.vectors !== previousFingerprint.vectors ||
+      currentFingerprint.keyword !== previousFingerprint.keyword ||
+      currentFingerprint.database !== previousFingerprint.database ||
+      currentFingerprint.databaseIdentity !== previousFingerprint.databaseIdentity;
+    if (!artifactsChanged && !retryDue) {
+      return true;
+    }
+    if (
+      !previousFingerprint ||
+      currentFingerprint.databaseIdentity !== previousFingerprint.databaseIdentity
+    ) {
+      return false;
+    }
+
+    this.initializationMode = "reader";
+    this.readerArtifactFingerprint = previousFingerprint;
+    try {
+      this.refreshReaderArtifacts();
+      this.writerArtifactFingerprint = this.readerArtifactFingerprint ?? currentFingerprint;
+    } finally {
+      this.readerArtifactFingerprint = null;
+      this.initializationMode = "writer";
+    }
+    return true;
+  }
+
   private async initializeUnlocked(
     mode: Exclude<InitializationMode, "none">,
     recoveredOwners: readonly IndexLockOwner[] = [],
@@ -3144,7 +3191,7 @@ export class Indexer {
     if (mode === "writer") {
       await fsPromises.mkdir(this.indexPath, { recursive: true });
 
-      // La récupération interrompue reste entièrement sous le lease writer.
+      // Interrupted recovery remains entirely under the writer lease.
       if (recoveredOwners.length > 0 && this.config.scope === "project" && !this.isLocalProjectIndexPath()) {
         throw new Error(
           "Interrupted indexing recovery is unsafe while using an inherited worktree index. " +
@@ -3198,7 +3245,7 @@ export class Indexer {
         this.recordReadIssue("vectors", vectorReadFailureMessage);
       } else if (vectorStoreExists) {
         try {
-          this.store.load();
+          this.store.loadStrict();
         } catch (error) {
           this.recordReadIssue("vectors", vectorReadFailureMessage, error);
           this.store = new VectorStore(storePath, dimensions);
@@ -3461,6 +3508,7 @@ export class Indexer {
     this.initializationMode = "none";
     this.readIssues = [];
     this.readerArtifactFingerprint = null;
+    this.writerArtifactFingerprint = null;
     this.readerArtifactRetryAfter.clear();
     this.fileHashCache.clear();
 
@@ -3662,6 +3710,18 @@ export class Indexer {
         await this.initialize();
         initializedReader = true;
         continue;
+      }
+      if (
+        this.initializationMode === "writer" &&
+        !this.activeIndexLease &&
+        !initializedReader
+      ) {
+        if (!this.refreshInactiveWriterArtifacts()) {
+          this.resetLoadedIndexState(true);
+          await this.initialize();
+          initializedReader = true;
+          continue;
+        }
       }
       if (
         this.initializationMode === "reader" &&
@@ -4195,7 +4255,11 @@ export class Indexer {
       database.addChunksToBranchBatch(branchCatalogKey, Array.from(currentChunkIds));
       database.clearBranchSymbols(branchCatalogKey);
       database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
-      if (backfilledBlameMetadata) {
+      const vectorPath = path.join(this.indexPath, "vectors");
+      const shouldFingerprintLegacyPair = !store.hasFingerprint() &&
+        existsSync(vectorPath) &&
+        existsSync(`${vectorPath}.meta.json`);
+      if (backfilledBlameMetadata || shouldFingerprintLegacyPair) {
         store.save();
       }
       if (scopedRoots) {
@@ -4701,6 +4765,10 @@ export class Indexer {
     const maxResults = limit ?? this.config.search.maxResults;
     const hybridWeight = options?.hybridWeight ?? this.config.search.hybridWeight;
     const fusionStrategy = this.config.search.fusionStrategy;
+    const effectiveHybridWeight = fusionStrategy === "weighted" &&
+      readIssues.some((issue) => issue.component === "keyword")
+      ? 0
+      : hybridWeight;
     const rrfK = this.config.search.rrfK;
     const rerankTopN = this.config.search.rerankTopN;
     const filterByBranch = options?.filterByBranch ?? true;
@@ -4710,7 +4778,7 @@ export class Indexer {
     this.logger.search("debug", "Starting search", {
       query,
       maxResults,
-      hybridWeight,
+      hybridWeight: effectiveHybridWeight,
       fusionStrategy,
       rrfK,
       rerankTopN,
@@ -4779,7 +4847,7 @@ export class Indexer {
       rrfK,
       rerankTopN,
       limit: maxResults,
-      hybridWeight,
+      hybridWeight: effectiveHybridWeight,
       prioritizeSourcePaths: sourceIntent,
     });
     const rerankedCombined = await this.rerankCandidatesWithApi(query, combined, {
@@ -5944,6 +6012,7 @@ export class Indexer {
     this.initializationMode = "none";
     this.readIssues = [];
     this.readerArtifactFingerprint = null;
+    this.writerArtifactFingerprint = null;
     this.readerArtifactRetryAfter.clear();
   }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -206,7 +206,23 @@ export interface StatusResult {
   warning?: string;
 }
 
+type InitializationMode = "none" | "reader" | "writer";
+
+interface IndexReadIssue {
+  component: "vectors" | "keyword" | "database";
+  message: string;
+  blocking: boolean;
+}
+
+interface ReaderArtifactFingerprint {
+  vectors: string;
+  keyword: string;
+  database: string;
+  databaseIdentity: string;
+}
+
 const STARTUP_WARNING_METADATA_KEY = "index.startupWarning";
+const READER_ARTIFACT_RETRY_INTERVAL_MS = 1_000;
 
 export interface IndexProgress {
   phase: "scanning" | "parsing" | "embedding" | "storing" | "complete";
@@ -1896,6 +1912,11 @@ export class Indexer {
   private indexCompatibility: IndexCompatibility | null = null;
   private activeIndexLease: IndexLockLease | null = null;
   private initializationPromise: Promise<void> | null = null;
+  private initializationMode: InitializationMode = "none";
+  private readIssues: IndexReadIssue[] = [];
+  private retiredDatabases: Database[] = [];
+  private readerArtifactFingerprint: ReaderArtifactFingerprint | null = null;
+  private readerArtifactRetryAfter = new Map<IndexReadIssue["component"], number>();
 
   constructor(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode") {
     this.projectRoot = projectRoot;
@@ -1927,8 +1948,14 @@ export class Indexer {
     });
   }
 
-  private resetLoadedIndexState(): void {
-    this.database?.close();
+  private resetLoadedIndexState(retireDatabase = false): void {
+    if (this.database) {
+      if (retireDatabase) {
+        this.retiredDatabases.push(this.database);
+      } else {
+        this.database.close();
+      }
+    }
     this.store = null;
     this.invertedIndex = null;
     this.database = null;
@@ -1936,6 +1963,10 @@ export class Indexer {
     this.configuredProviderInfo = null;
     this.reranker = null;
     this.indexCompatibility = null;
+    this.initializationMode = "none";
+    this.readIssues = [];
+    this.readerArtifactFingerprint = null;
+    this.readerArtifactRetryAfter.clear();
     this.fileHashCache.clear();
   }
 
@@ -2040,6 +2071,13 @@ export class Indexer {
     } finally {
       removeLeaseTemporaryPath(tempPath);
     }
+  }
+
+  private saveInvertedIndex(invertedIndex: InvertedIndex): void {
+    this.atomicWriteSync(
+      path.join(this.indexPath, "inverted-index.json"),
+      invertedIndex.serialize(),
+    );
   }
 
   private getScopedRoots(): string[] {
@@ -2464,7 +2502,7 @@ export class Indexer {
     database.gcOrphanChunks();
 
     store.save();
-    invertedIndex.save();
+    this.saveInvertedIndex(invertedIndex);
 
     return {
       removedChunkIds: removedChunkIdList,
@@ -2804,28 +2842,260 @@ export class Indexer {
   async initialize(): Promise<void> {
     if (this.initializationPromise) {
       await this.initializationPromise;
+    }
+    if (this.isInitializedFor("reader")) {
       return;
     }
-    if (this.store && this.provider && this.invertedIndex && this.configuredProviderInfo && this.database) {
-      return;
-    }
-    await this.initializeOnce([], { skipAutoGc: true });
+    await this.initializeOnce("reader", [], { skipAutoGc: true });
   }
 
   private async initializeOnce(
+    mode: Exclude<InitializationMode, "none">,
     recoveredOwners: readonly IndexLockOwner[],
     options: { skipAutoGc?: boolean },
   ): Promise<void> {
-    this.initializationPromise ??= this.initializeUnlocked(recoveredOwners, options).finally(() => {
-      this.initializationPromise = null;
-    });
-    await this.initializationPromise;
+    if (this.initializationPromise) {
+      await this.initializationPromise;
+      if (this.isInitializedFor(mode)) {
+        return;
+      }
+      return this.initializeOnce(mode, recoveredOwners, options);
+    }
+
+    if (this.isInitializedFor(mode)) {
+      return;
+    }
+
+    const initialization = this.initializeUnlocked(mode, recoveredOwners, options)
+      .catch((error) => {
+        this.resetLoadedIndexState();
+        throw error;
+      })
+      .finally(() => {
+        if (this.initializationPromise === initialization) {
+          this.initializationPromise = null;
+        }
+      });
+    this.initializationPromise = initialization;
+    await initialization;
+  }
+
+  private isInitializedFor(mode: Exclude<InitializationMode, "none">): boolean {
+    const hasState = Boolean(
+      this.store &&
+      this.provider &&
+      this.invertedIndex &&
+      this.configuredProviderInfo &&
+      this.database,
+    );
+    if (!hasState) {
+      return false;
+    }
+    return mode === "reader"
+      ? this.initializationMode !== "none"
+      : this.initializationMode === "writer";
+  }
+
+  private recordReadIssue(
+    component: IndexReadIssue["component"],
+    message: string,
+    error?: unknown,
+  ): void {
+    this.readIssues.push(this.createReadIssue(component, message));
+    this.readerArtifactRetryAfter.set(component, Date.now() + READER_ARTIFACT_RETRY_INTERVAL_MS);
+    this.logger.warn(message, error === undefined ? undefined : { error: getErrorMessage(error) });
+  }
+
+  private createReadIssue(
+    component: IndexReadIssue["component"],
+    message: string,
+  ): IndexReadIssue {
+    return {
+      component,
+      message,
+      blocking: component !== "keyword",
+    };
+  }
+
+  private getVectorReadIssueMessage(): string {
+    if (this.config.scope === "global") {
+      return "Shared vector index could not be read. Restore or repair the complete shared vector artifacts; automatic reset is disabled for global scope.";
+    }
+    if (!this.isLocalProjectIndexPath()) {
+      return "Vector index could not be read from an inherited project index. Restore or repair it from the checkout that owns the index; do not remove or rebuild it from this worktree.";
+    }
+    return "Vector index could not be read. Restore a complete published vector pair, or, after the active writer finishes, remove this checkout's local index directory and run index_codebase to rebuild it.";
+  }
+
+  private getKeywordReadIssueMessage(): string {
+    if (this.config.scope === "global") {
+      return "Shared keyword index could not be read; semantic search remains available. Restore or repair the shared keyword artifact; automatic reset is disabled for global scope.";
+    }
+    if (!this.isLocalProjectIndexPath()) {
+      return "Keyword index could not be read from an inherited project index; semantic search remains available. Restore or repair it from the checkout that owns the index; do not rebuild it from this worktree.";
+    }
+    return "Keyword index could not be read; semantic search remains available. Restore a readable published keyword index, or run index_codebase with force=true after the active writer finishes.";
+  }
+
+  private getDatabaseReadIssueMessage(): string {
+    if (this.config.scope === "global") {
+      return "Shared index database could not be read. Restore or repair the shared SQLite database; automatic reset is disabled for global scope.";
+    }
+    if (!this.isLocalProjectIndexPath()) {
+      return "Index database could not be read from an inherited project index. Restore or repair it from the checkout that owns the index; do not migrate or rebuild it from this worktree.";
+    }
+    return "Index database could not be read. Run index_codebase after the active writer finishes to repair or migrate it under the writer lease.";
+  }
+
+  private getReaderFileFingerprint(filePath: string, identityOnly = false): string {
+    try {
+      const stats = statSync(filePath);
+      if (identityOnly) {
+        return `${stats.dev}:${stats.ino}`;
+      }
+      return `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeMs}:${stats.ctimeMs}`;
+    } catch (error) {
+      return `unavailable:${getErrorMessage(error)}`;
+    }
+  }
+
+  private captureReaderArtifactFingerprint(): ReaderArtifactFingerprint {
+    const storePath = path.join(this.indexPath, "vectors");
+    return {
+      vectors: `${this.getReaderFileFingerprint(storePath)}|${this.getReaderFileFingerprint(`${storePath}.meta.json`)}`,
+      keyword: this.getReaderFileFingerprint(path.join(this.indexPath, "inverted-index.json")),
+      database: this.getReaderFileFingerprint(path.join(this.indexPath, "codebase.db")),
+      databaseIdentity: this.getReaderFileFingerprint(path.join(this.indexPath, "codebase.db"), true),
+    };
+  }
+
+  private refreshReaderArtifacts(): void {
+    if (this.initializationMode !== "reader" || !this.configuredProviderInfo) {
+      return;
+    }
+
+    const previousFingerprint = this.readerArtifactFingerprint;
+    const currentFingerprint = this.captureReaderArtifactFingerprint();
+    const issues = new Map(this.readIssues.map((issue) => [issue.component, issue]));
+    const retryDue = (component: IndexReadIssue["component"]): boolean =>
+      issues.has(component) && Date.now() >= (this.readerArtifactRetryAfter.get(component) ?? 0);
+    const vectorsChanged = !previousFingerprint || currentFingerprint.vectors !== previousFingerprint.vectors;
+    const keywordChanged = !previousFingerprint || currentFingerprint.keyword !== previousFingerprint.keyword;
+    const databaseChanged = !previousFingerprint || currentFingerprint.database !== previousFingerprint.database;
+    const databaseReplaced = !previousFingerprint || currentFingerprint.databaseIdentity !== previousFingerprint.databaseIdentity;
+    if (
+      previousFingerprint &&
+      !vectorsChanged &&
+      !keywordChanged &&
+      !databaseChanged &&
+      !Array.from(issues.keys()).some(retryDue)
+    ) {
+      return;
+    }
+
+    const setIssue = (
+      component: IndexReadIssue["component"],
+      message: string,
+      error?: unknown,
+    ): void => {
+      if (!issues.has(component)) {
+        this.logger.warn(message, error === undefined ? undefined : { error: getErrorMessage(error) });
+      }
+      issues.set(component, this.createReadIssue(component, message));
+      this.readerArtifactRetryAfter.set(component, Date.now() + READER_ARTIFACT_RETRY_INTERVAL_MS);
+    };
+
+    const storePath = path.join(this.indexPath, "vectors");
+    const vectorMetadataPath = `${storePath}.meta.json`;
+    const invertedIndexPath = path.join(this.indexPath, "inverted-index.json");
+    const dbPath = path.join(this.indexPath, "codebase.db");
+
+    if (
+      vectorsChanged ||
+      retryDue("vectors")
+    ) {
+      const vectorStoreExists = existsSync(storePath);
+      const vectorMetadataExists = existsSync(vectorMetadataPath);
+      if (vectorStoreExists && vectorMetadataExists) {
+        try {
+          const store = new VectorStore(storePath, this.configuredProviderInfo.modelInfo.dimensions);
+          store.load();
+          this.store = store;
+          issues.delete("vectors");
+          this.readerArtifactRetryAfter.delete("vectors");
+        } catch (error) {
+          setIssue("vectors", this.getVectorReadIssueMessage(), error);
+        }
+      } else if (vectorStoreExists !== vectorMetadataExists || issues.has("vectors")) {
+        setIssue("vectors", this.getVectorReadIssueMessage());
+      }
+    }
+
+    if (
+      keywordChanged ||
+      retryDue("keyword") ||
+      (!existsSync(invertedIndexPath) && (this.store?.count() ?? 0) > 0)
+    ) {
+      if (existsSync(invertedIndexPath)) {
+        try {
+          const invertedIndex = new InvertedIndex(invertedIndexPath);
+          invertedIndex.load();
+          this.invertedIndex = invertedIndex;
+          issues.delete("keyword");
+          this.readerArtifactRetryAfter.delete("keyword");
+        } catch (error) {
+          setIssue("keyword", this.getKeywordReadIssueMessage(), error);
+        }
+      } else if ((this.store?.count() ?? 0) > 0 || issues.has("keyword")) {
+        setIssue("keyword", this.getKeywordReadIssueMessage());
+      }
+    }
+
+    if (
+      databaseReplaced ||
+      (databaseChanged && issues.has("database")) ||
+      retryDue("database")
+    ) {
+      if (existsSync(dbPath)) {
+        try {
+          const database = Database.openReadOnly(dbPath);
+          if (this.database) {
+            this.retiredDatabases.push(this.database);
+          }
+          this.database = database;
+          issues.delete("database");
+          this.readerArtifactRetryAfter.delete("database");
+        } catch (error) {
+          setIssue("database", this.getDatabaseReadIssueMessage(), error);
+        }
+      } else if ((this.store?.count() ?? 0) > 0 || issues.has("database")) {
+        setIssue("database", this.getDatabaseReadIssueMessage());
+      }
+    }
+
+    if (!issues.has("database")) {
+      try {
+        this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo);
+      } catch (error) {
+        setIssue("database", this.getDatabaseReadIssueMessage(), error);
+      }
+    }
+
+    this.readIssues = Array.from(issues.values());
+    this.readerArtifactFingerprint = currentFingerprint;
   }
 
   private async initializeUnlocked(
+    mode: Exclude<InitializationMode, "none">,
     recoveredOwners: readonly IndexLockOwner[] = [],
     options: { skipAutoGc?: boolean } = {},
   ): Promise<void> {
+    if (mode === "writer") {
+      this.requireActiveLease();
+    }
+    this.readIssues = [];
+    this.readerArtifactRetryAfter.clear();
+
     if (this.config.embeddingProvider === 'custom') {
       if (!this.config.customProvider) {
         throw new Error("embeddingProvider is 'custom' but customProvider config is missing.");
@@ -2862,61 +3132,115 @@ export class Indexer {
       }
     }
 
-    await fsPromises.mkdir(this.indexPath, { recursive: true });
-
-    // NOTE: Interrupted indexing recovery is deferred until after store,
-    // invertedIndex, and database are initialized (see below). Running it here
-    // would cause infinite recursion: recovery → healthCheck → ensureInitialized
-    // → initialize (store not yet set) → recovery → ...
-
     const dimensions = this.configuredProviderInfo.modelInfo.dimensions;
     const storePath = path.join(this.indexPath, "vectors");
-    if (recoveredOwners.length > 0 && this.config.scope === "project" && !this.isLocalProjectIndexPath()) {
-      throw new Error(
-        "Interrupted indexing recovery is unsafe while using an inherited worktree index. " +
-        "Run index_codebase with force=true to create a local project index boundary."
-      );
-    }
-    for (const recoveredOwner of recoveredOwners) {
-      recoverLeaseArtifacts(this.indexPath, recoveredOwner, [
-        storePath,
-        `${storePath}.meta.json`,
-      ]);
-    }
-    if (recoveredOwners.length > 0 && this.config.scope === "project") {
-      await this.resetLocalIndexArtifacts();
-    }
-    this.store = new VectorStore(storePath, dimensions);
-
-    const indexFilePath = storePath;
-    if (existsSync(indexFilePath)) {
-      this.store.load();
-    }
-
     const invertedIndexPath = path.join(this.indexPath, "inverted-index.json");
-    this.invertedIndex = new InvertedIndex(invertedIndexPath);
-    try {
-      this.invertedIndex.load();
-    } catch {
-      if (existsSync(invertedIndexPath)) {
-        await fsPromises.unlink(invertedIndexPath);
-      }
-      this.invertedIndex = new InvertedIndex(invertedIndexPath);
-    }
-
     const dbPath = path.join(this.indexPath, "codebase.db");
     let dbIsNew = !existsSync(dbPath);
-    try {
-      this.database = new Database(dbPath);
-    } catch (error) {
-      if (!(await this.tryResetCorruptedIndex("initializing index database", error))) {
-        throw error;
+    const readerArtifactFingerprint = mode === "reader"
+      ? this.captureReaderArtifactFingerprint()
+      : null;
+
+    if (mode === "writer") {
+      await fsPromises.mkdir(this.indexPath, { recursive: true });
+
+      // La récupération interrompue reste entièrement sous le lease writer.
+      if (recoveredOwners.length > 0 && this.config.scope === "project" && !this.isLocalProjectIndexPath()) {
+        throw new Error(
+          "Interrupted indexing recovery is unsafe while using an inherited worktree index. " +
+          "Run index_codebase with force=true to create a local project index boundary."
+        );
+      }
+      for (const recoveredOwner of recoveredOwners) {
+        recoverLeaseArtifacts(this.indexPath, recoveredOwner, [
+          storePath,
+          `${storePath}.meta.json`,
+        ]);
+      }
+      if (recoveredOwners.length > 0 && this.config.scope === "project") {
+        await this.resetLocalIndexArtifacts();
       }
 
       this.store = new VectorStore(storePath, dimensions);
+      if (existsSync(storePath)) {
+        this.store.load();
+      }
+
       this.invertedIndex = new InvertedIndex(invertedIndexPath);
-      this.database = new Database(dbPath);
-      dbIsNew = true;
+      try {
+        this.invertedIndex.load();
+      } catch {
+        if (existsSync(invertedIndexPath)) {
+          await fsPromises.unlink(invertedIndexPath);
+        }
+        this.invertedIndex = new InvertedIndex(invertedIndexPath);
+      }
+
+      try {
+        this.database = new Database(dbPath);
+      } catch (error) {
+        if (!(await this.tryResetCorruptedIndex("initializing index database", error))) {
+          throw error;
+        }
+
+        this.store = new VectorStore(storePath, dimensions);
+        this.invertedIndex = new InvertedIndex(invertedIndexPath);
+        this.database = new Database(dbPath);
+        dbIsNew = true;
+      }
+    } else {
+      this.store = new VectorStore(storePath, dimensions);
+      const vectorMetadataPath = `${storePath}.meta.json`;
+      const vectorStoreExists = existsSync(storePath);
+      const vectorMetadataExists = existsSync(vectorMetadataPath);
+      const vectorReadFailureMessage = this.getVectorReadIssueMessage();
+      if (vectorStoreExists !== vectorMetadataExists) {
+        this.recordReadIssue("vectors", vectorReadFailureMessage);
+      } else if (vectorStoreExists) {
+        try {
+          this.store.load();
+        } catch (error) {
+          this.recordReadIssue("vectors", vectorReadFailureMessage, error);
+          this.store = new VectorStore(storePath, dimensions);
+        }
+      }
+
+      this.invertedIndex = new InvertedIndex(invertedIndexPath);
+      if (existsSync(invertedIndexPath)) {
+        try {
+          this.invertedIndex.load();
+        } catch (error) {
+          this.recordReadIssue(
+            "keyword",
+            this.getKeywordReadIssueMessage(),
+            error,
+          );
+          this.invertedIndex = new InvertedIndex(invertedIndexPath);
+        }
+      } else if (this.store.count() > 0) {
+        this.recordReadIssue("keyword", this.getKeywordReadIssueMessage());
+      }
+
+      if (existsSync(dbPath)) {
+        try {
+          this.database = Database.openReadOnly(dbPath);
+        } catch (error) {
+          this.recordReadIssue(
+            "database",
+            this.getDatabaseReadIssueMessage(),
+            error,
+          );
+          this.database = Database.createEmptyReadOnly();
+        }
+      } else {
+        this.database = Database.createEmptyReadOnly();
+        if (this.store.count() > 0) {
+          this.recordReadIssue(
+            "database",
+            `Index database is missing for the published vectors. ${this.getDatabaseReadIssueMessage()}`,
+          );
+        }
+      }
     }
 
     if (isGitRepo(this.projectRoot)) {
@@ -2932,13 +3256,11 @@ export class Indexer {
       this.logger.branch("debug", "Not a git repository, using default branch");
     }
 
-    // La récupération reste dans le lease nouvellement acquis et ne dépend
-    // jamais de la simple présence d'un verrou appartenant à un processus vivant.
-    if (recoveredOwners.length > 0) {
+    if (mode === "writer" && recoveredOwners.length > 0) {
       await this.recoverFromInterruptedIndexingUnlocked(recoveredOwners);
     }
 
-    if (dbIsNew && this.store.count() > 0) {
+    if (mode === "writer" && dbIsNew && this.store.count() > 0) {
       this.migrateFromLegacyIndex();
     }
 
@@ -2953,10 +3275,12 @@ export class Indexer {
       });
     }
 
-    // Auto-GC: Run garbage collection if enabled and interval has elapsed
-    if (this.config.indexing.autoGc && !options.skipAutoGc) {
+    if (mode === "writer" && this.config.indexing.autoGc && !options.skipAutoGc) {
       await this.maybeRunAutoGc();
     }
+
+    this.initializationMode = mode;
+    this.readerArtifactFingerprint = readerArtifactFingerprint;
   }
 
   private async maybeRunAutoGc(): Promise<void> {
@@ -3134,6 +3458,10 @@ export class Indexer {
     this.database?.close();
     this.database = null;
     this.indexCompatibility = null;
+    this.initializationMode = "none";
+    this.readIssues = [];
+    this.readerArtifactFingerprint = null;
+    this.readerArtifactRetryAfter.clear();
     this.fileHashCache.clear();
 
     const resetPaths = [
@@ -3322,20 +3650,32 @@ export class Indexer {
     invertedIndex: InvertedIndex;
     configuredProviderInfo: ConfiguredProviderInfo;
     database: Database;
+    readIssues: readonly IndexReadIssue[];
+    compatibility: IndexCompatibility;
   }> {
-    if (this.initializationPromise) {
-      await this.initializationPromise;
+    let initializedReader = false;
+    while (true) {
+      if (this.initializationPromise) {
+        await this.initializationPromise;
+      }
+      if (!this.isInitializedFor("reader")) {
+        await this.initialize();
+        initializedReader = true;
+        continue;
+      }
+      if (
+        this.initializationMode === "reader" &&
+        !initializedReader
+      ) {
+        this.refreshReaderArtifacts();
+      }
+      const state = this.requireLoadedIndexState();
+      return {
+        ...state,
+        readIssues: [...this.readIssues],
+        compatibility: this.indexCompatibility ?? this.validateIndexCompatibility(state.configuredProviderInfo),
+      };
     }
-    if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
-      await this.initialize();
-    }
-    return {
-      store: this.store!,
-      provider: this.provider!,
-      invertedIndex: this.invertedIndex!,
-      configuredProviderInfo: this.configuredProviderInfo!,
-      database: this.database!,
-    };
   }
 
   private async ensureInitializedUnlocked(recoveredOwners: readonly IndexLockOwner[] = []): Promise<{
@@ -3345,15 +3685,16 @@ export class Indexer {
     configuredProviderInfo: ConfiguredProviderInfo;
     database: Database;
   }> {
+    this.requireActiveLease();
+
     if (this.initializationPromise) {
       await this.initializationPromise;
     }
 
-    if (recoveredOwners.length > 0) {
-      this.resetLoadedIndexState();
-      await this.initializeOnce(recoveredOwners, { skipAutoGc: true });
-    } else if (!this.store || !this.provider || !this.invertedIndex || !this.configuredProviderInfo || !this.database) {
-      await this.initializeOnce([], { skipAutoGc: true });
+    if (recoveredOwners.length > 0 || !this.isInitializedFor("writer")) {
+      const retireReaderDatabase = this.initializationMode === "reader";
+      this.resetLoadedIndexState(retireReaderDatabase);
+      await this.initializeOnce("writer", recoveredOwners, { skipAutoGc: true });
     } else {
       this.refreshLoadedIndexState();
     }
@@ -3361,6 +3702,17 @@ export class Indexer {
       await this.maybeRunAutoGc();
     }
     return this.requireLoadedIndexState();
+  }
+
+  private requireReadableComponents(
+    readIssues: readonly IndexReadIssue[],
+    ...components: IndexReadIssue["component"][]
+  ): void {
+    const componentSet = new Set(components);
+    const issues = readIssues.filter((issue) => issue.blocking && componentSet.has(issue.component));
+    if (issues.length > 0) {
+      throw new Error(issues.map((issue) => issue.message).join(" "));
+    }
   }
 
   private requireLoadedIndexState(): {
@@ -3873,7 +4225,7 @@ export class Indexer {
       database.clearBranchSymbols(branchCatalogKey);
       database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
       store.save();
-      invertedIndex.save();
+      this.saveInvertedIndex(invertedIndex);
       if (scopedRoots) {
         this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
         this.clearScopedFailedBatches(scopedRoots);
@@ -4163,7 +4515,7 @@ export class Indexer {
     database.addSymbolsToBranchBatch(branchCatalogKey, Array.from(allSymbolIds));
 
     store.save();
-    invertedIndex.save();
+    this.saveInvertedIndex(invertedIndex);
     if (scopedRoots) {
       this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
     } else {
@@ -4329,9 +4681,9 @@ export class Indexer {
       blameSince?: string;
     }
   ): Promise<SearchResult[]> {
-    const { store, provider, database } = await this.ensureInitialized();
+    const { store, provider, invertedIndex, database, readIssues, compatibility } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "vectors", "database");
 
-    const compatibility = this.checkCompatibility();
     if (!compatibility.compatible) {
       throw new Error(
         `${compatibility.reason ?? "Index is incompatible with current embedding provider."} ` +
@@ -4375,7 +4727,7 @@ export class Indexer {
     const vectorMs = performance.now() - vectorStartTime;
 
     const keywordStartTime = performance.now();
-    const keywordResults = await this.keywordSearch(query, maxResults * 4);
+    const keywordResults = await this.keywordSearch(query, maxResults * 4, store, invertedIndex);
     const keywordMs = performance.now() - keywordStartTime;
 
     let branchChunkIds: Set<string> | null = null;
@@ -4558,9 +4910,10 @@ export class Indexer {
 
   private async keywordSearch(
     query: string,
-    limit: number
+    limit: number,
+    store: VectorStore,
+    invertedIndex: InvertedIndex,
   ): Promise<Array<{ id: string; score: number; metadata: ChunkMetadata }>> {
-    const { store, invertedIndex } = await this.ensureInitialized();
     const scores = invertedIndex.search(query);
 
     if (scores.size === 0) {
@@ -4585,21 +4938,38 @@ export class Indexer {
   }
 
   async getStatus(): Promise<StatusResult> {
-    const { store, configuredProviderInfo, database } = await this.ensureInitialized();
+    const { store, configuredProviderInfo, database, readIssues, compatibility } = await this.ensureInitialized();
     const failedBatchesCount = this.getFailedBatchesCount();
+    const vectorCount = store.count();
+    const statusReadIssues = [...readIssues];
+    let startupWarning = "";
+    if (!statusReadIssues.some((issue) => issue.component === "database")) {
+      try {
+        startupWarning = database.getMetadata(STARTUP_WARNING_METADATA_KEY) ?? "";
+      } catch (error) {
+        const message = this.getDatabaseReadIssueMessage();
+        statusReadIssues.push(this.createReadIssue("database", message));
+        if (!this.readIssues.some((issue) => issue.component === "database")) {
+          this.recordReadIssue("database", message, error);
+        }
+      }
+    }
+    const readWarning = statusReadIssues.map((issue) => issue.message).join(" ");
+    const warning = [readWarning, startupWarning].filter((message) => message.length > 0).join(" ");
+    const hasBlockingReadIssue = statusReadIssues.some((issue) => issue.blocking);
 
     return {
-      indexed: store.count() > 0,
-      vectorCount: store.count(),
+      indexed: vectorCount > 0 && !hasBlockingReadIssue,
+      vectorCount,
       provider: configuredProviderInfo.provider,
       model: configuredProviderInfo.modelInfo.model,
       indexPath: this.indexPath,
       currentBranch: this.currentBranch,
       baseBranch: this.baseBranch,
-      compatibility: this.indexCompatibility,
+      compatibility,
       failedBatchesCount,
       failedBatchesPath: failedBatchesCount > 0 ? this.failedBatchesPath : undefined,
-      warning: database.getMetadata(STARTUP_WARNING_METADATA_KEY) ?? undefined,
+      warning: warning || undefined,
     };
   }
 
@@ -4656,7 +5026,7 @@ export class Indexer {
         store.clear();
         store.save();
         invertedIndex.clear();
-        invertedIndex.save();
+        this.saveInvertedIndex(invertedIndex);
 
         this.fileHashCache.clear();
         this.saveFileHashCache();
@@ -4696,7 +5066,7 @@ export class Indexer {
     store.clear();
     store.save();
     invertedIndex.clear();
-    invertedIndex.save();
+    this.saveInvertedIndex(invertedIndex);
 
     // Clear file hash cache so all files are re-parsed
     this.fileHashCache.clear();
@@ -4775,7 +5145,7 @@ export class Indexer {
 
     if (removedCount > 0) {
       store.save();
-      invertedIndex.save();
+      this.saveInvertedIndex(invertedIndex);
     }
 
     let gcOrphanEmbeddings: number;
@@ -4793,7 +5163,7 @@ export class Indexer {
         throw error;
       }
 
-      await this.initializeUnlocked(undefined, { skipAutoGc: true });
+      await this.initializeUnlocked("writer", [], { skipAutoGc: true });
 
       return {
         removed: 0,
@@ -5020,7 +5390,7 @@ export class Indexer {
 
     if (succeeded > 0) {
       store.save();
-      invertedIndex.save();
+      this.saveInvertedIndex(invertedIndex);
     }
 
     if (roots && succeeded > 0 && persistedStillFailing.length === 0 && this.hasProjectForceReembedPending()) {
@@ -5055,7 +5425,8 @@ export class Indexer {
   }
 
   async getDatabaseStats(): Promise<{ embeddingCount: number; chunkCount: number; branchChunkCount: number; branchCount: number } | null> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     return database.getStats();
   }
 
@@ -5074,9 +5445,9 @@ export class Indexer {
       filterByBranch?: boolean;
     }
   ): Promise<SearchResult[]> {
-    const { store, provider, database } = await this.ensureInitialized();
+    const { store, provider, database, readIssues, compatibility } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "vectors", "database");
 
-    const compatibility = this.checkCompatibility();
     if (!compatibility.compatible) {
       throw new Error(
         `${compatibility.reason ?? "Index is incompatible with current embedding provider."} ` +
@@ -5221,7 +5592,8 @@ export class Indexer {
   }
 
   async getCallers(targetName: string, callTypeFilter?: string): Promise<CallEdgeData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const seen = new Set<string>();
     const results: CallEdgeData[] = [];
 
@@ -5238,7 +5610,8 @@ export class Indexer {
   }
 
   async getCallees(symbolId: string, callTypeFilter?: string): Promise<CallEdgeData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const seen = new Set<string>();
     const results: CallEdgeData[] = [];
 
@@ -5255,7 +5628,8 @@ export class Indexer {
   }
 
   async findCallPath(fromName: string, toName: string, maxDepth?: number): Promise<PathHopData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     let shortest: PathHopData[] = [];
 
     for (const branchKey of this.getBranchCatalogKeys()) {
@@ -5269,13 +5643,15 @@ export class Indexer {
   }
 
   async getSymbolsForBranch(branch?: string): Promise<SymbolData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
     return database.getSymbolsForBranch(resolvedBranch);
   }
 
   async getSymbolsForFiles(filePaths: string[], branch?: string): Promise<SymbolData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
     return database.getSymbolsForFiles(filePaths, resolvedBranch);
   }
@@ -5285,19 +5661,22 @@ export class Indexer {
     direction: "callers" | "callees",
     maxDepth?: number
   ): Promise<ReachabilityData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const branch = this.getBranchCatalogKey();
     return database.getTransitiveReachability(rootSymbolIds, branch, direction, maxDepth);
   }
 
   async detectCommunities(branch?: string, symbolIds?: string[]): Promise<CommunityData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
     return database.detectCommunities(resolvedBranch, symbolIds);
   }
 
   async computeCentrality(branch?: string): Promise<CentralityData[]> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
     return database.computeCentrality(resolvedBranch);
   }
@@ -5310,7 +5689,8 @@ export class Indexer {
     checkConflicts?: boolean;
     direction?: "callers" | "callees" | "both";
   }): Promise<PrImpactResult> {
-    const { database } = await this.ensureInitialized();
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
     const execFileAsync = promisify(execFile);
 
     const changedFilesResult = await getChangedFiles({
@@ -5493,7 +5873,8 @@ export class Indexer {
     symbols: SymbolData[];
     edges: CallEdgeData[];
   }> {
-    const { database, store } = await this.ensureInitialized();
+    const { database, store, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "vectors", "database");
     const seenSymbols = new Map<string, SymbolData>();
     const seenEdges = new Map<string, CallEdgeData>();
 
@@ -5548,11 +5929,21 @@ export class Indexer {
   }
 
   async close(): Promise<void> {
-    await this.database?.close();
+    this.database?.close();
+    for (const database of this.retiredDatabases) {
+      database.close();
+    }
+    this.retiredDatabases = [];
     this.database = null;
     this.store = null;
     this.invertedIndex = null;
     this.provider = null;
     this.reranker = null;
+    this.configuredProviderInfo = null;
+    this.indexCompatibility = null;
+    this.initializationMode = "none";
+    this.readIssues = [];
+    this.readerArtifactFingerprint = null;
+    this.readerArtifactRetryAfter.clear();
   }
 }

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -18,13 +18,13 @@ import {
   findSimilarCode,
   getCallGraphData,
   getCallGraphPath,
-  getIndexHealthCheck,
   getIndexLogs,
   getIndexMetrics,
   getIndexStatus,
   getPrImpact,
   implementationLookup,
   runIndexCodebase,
+  runIndexHealthCheck,
   searchCodebase,
 } from "../tools/operations.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime } from "./shared.js";
@@ -132,8 +132,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Check index health and remove stale entries from deleted files. Run this to clean up the index after files have been deleted.",
     {},
     async () => {
-      const result = await getIndexHealthCheck(runtime.projectRoot, runtime.host);
-      return { content: [{ type: "text", text: formatHealthCheck(result) }] };
+      const result = await runIndexHealthCheck(runtime.projectRoot, runtime.host);
+      if (result.kind === "busy") {
+        return { content: [{ type: "text" as const, text: result.text }], isError: true };
+      }
+      return { content: [{ type: "text" as const, text: formatHealthCheck(result.health) }] };
     },
   );
 

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -107,10 +107,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     },
     async (args) => {
       const result = await runIndexCodebase(runtime.projectRoot, runtime.host, args);
-      const text = result.kind === "estimate"
-        ? formatCostEstimate(result.estimate)
-        : formatIndexStats(result.stats, args.verbose ?? false);
-      return { content: [{ type: "text", text }] };
+      if (result.kind === "estimate") {
+        return { content: [{ type: "text", text: formatCostEstimate(result.estimate) }] };
+      }
+      if (result.kind === "busy") {
+        return { content: [{ type: "text", text: result.text }], isError: true };
+      }
+      return { content: [{ type: "text", text: formatIndexStats(result.stats, args.verbose ?? false) }] };
     },
   );
 

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -326,6 +326,14 @@ export class VectorStore {
     this.inner.load();
   }
 
+  loadStrict(): void {
+    this.inner.loadStrict();
+  }
+
+  hasFingerprint(): boolean {
+    return this.inner.hasFingerprint();
+  }
+
   count(): number {
     return this.inner.count();
   }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -77,6 +77,8 @@ function createMockNativeBinding() {
     },
     Database: class {
       constructor() { throw error; }
+      static openReadOnly() { throw error; }
+      static createEmptyReadOnly() { throw error; }
       close() { throw error; }
       getTransitiveReachability() { throw error; }
       detectCommunities() { throw error; }
@@ -736,6 +738,21 @@ export class Database {
 
   constructor(dbPath: string) {
     this.inner = new native.Database(dbPath);
+  }
+
+  private static fromNative(inner: any): Database {
+    const database = Object.create(Database.prototype) as Database;
+    database.inner = inner;
+    database.closed = false;
+    return database;
+  }
+
+  static openReadOnly(dbPath: string): Database {
+    return Database.fromNative(native.Database.openReadOnly(dbPath));
+  }
+
+  static createEmptyReadOnly(): Database {
+    return Database.fromNative(native.Database.createEmptyReadOnly());
   }
 
   private throwIfClosed(): void {

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -133,9 +133,9 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const result = await runIndexCodebase(projectRoot(ctx), HOST, params);
-      return result.kind === "estimate"
-        ? text(formatCostEstimate(result.estimate), result.estimate)
-        : text(formatIndexStats(result.stats, params.verbose ?? false), result.stats);
+      if (result.kind === "estimate") return text(formatCostEstimate(result.estimate), result.estimate);
+      if (result.kind === "busy") return text(result.text, { code: "INDEX_BUSY" });
+      return text(formatIndexStats(result.stats, params.verbose ?? false), result.stats);
     },
   });
 

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -6,7 +6,6 @@ import { formatPrImpact } from "./tools/format-pr-impact.js";
 import {
   addKnowledgeBase,
   findSimilarCode,
-  getIndexHealthCheck,
   getIndexLogs,
   getIndexMetrics,
   getIndexStatus,
@@ -15,6 +14,7 @@ import {
   listKnowledgeBases,
   removeKnowledgeBase,
   runIndexCodebase,
+  runIndexHealthCheck,
   searchCodebase,
 } from "./tools/operations.js";
 import {
@@ -156,8 +156,9 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
     description: "Garbage collect orphaned embeddings/chunks and report health.",
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-      const result = await getIndexHealthCheck(projectRoot(ctx), HOST);
-      return text(formatHealthCheck(result), result);
+      const result = await runIndexHealthCheck(projectRoot(ctx), HOST);
+      if (result.kind === "busy") return text(result.text, { code: "INDEX_BUSY" });
+      return text(formatHealthCheck(result.health), result.health);
     },
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -111,9 +111,9 @@ export const index_codebase: ToolDefinition = tool({
       context.metadata({ title, metadata });
     });
 
-    return result.kind === "estimate"
-      ? formatCostEstimate(result.estimate)
-      : formatIndexStats(result.stats, args.verbose ?? false);
+    if (result.kind === "estimate") return formatCostEstimate(result.estimate);
+    if (result.kind === "busy") return result.text;
+    return formatIndexStats(result.stats, args.verbose ?? false);
   },
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,7 +20,6 @@ import {
   findSimilarCode,
   getCallGraphData,
   getCallGraphPath,
-  getIndexHealthCheck,
   getIndexLogs,
   getIndexMetrics,
   getIndexerForProject as getOperationIndexerForProject,
@@ -31,6 +30,7 @@ import {
   listKnowledgeBases,
   removeKnowledgeBase,
   runIndexCodebase,
+  runIndexHealthCheck,
   searchCodebase,
 } from "./operations.js";
 import { pr_impact } from "./pr-impact.js";
@@ -131,7 +131,9 @@ export const index_health_check: ToolDefinition = tool({
     "Check index health and remove stale entries from deleted files. Run this to clean up the index after files have been deleted.",
   args: {},
   async execute(_args, context) {
-    return formatHealthCheck(await getIndexHealthCheck(context?.worktree, DEFAULT_HOST));
+    const result = await runIndexHealthCheck(context?.worktree, DEFAULT_HOST);
+    if (result.kind === "busy") return result.text;
+    return formatHealthCheck(result.health);
   },
 });
 

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -21,12 +21,35 @@ type IndexStats = Awaited<ReturnType<Indexer["index"]>>;
 type StatusResult = Awaited<ReturnType<Indexer["getStatus"]>>;
 type HealthCheckResult = Awaited<ReturnType<Indexer["healthCheck"]>>;
 type PrImpactResult = Awaited<ReturnType<Indexer["getPrImpact"]>>;
+type IndexBusyResult = { kind: "busy"; text: string };
 
 type ProgressCb = (title: string, metadata: Record<string, unknown>) => void | Promise<void>;
 
 const indexerCache = new Map<IndexerCacheKey, Indexer>();
 const configCache = new Map<IndexerCacheKey, ParsedCodebaseIndexConfig>();
 const defaultProjectRoots = new Map<HostMode, string>();
+
+function getIndexBusyResult(error: unknown): IndexBusyResult | null {
+  if (!isIndexLockContentionError(error)) return null;
+
+  const owner = error.owner;
+  const ownerText = owner
+    ? `PID ${owner.pid}, opération ${owner.operation}, depuis ${owner.startedAt}`
+    : "propriétaire non lisible";
+  if (error.reason === "legacy-lock") {
+    return {
+      kind: "busy",
+      text: `INDEX_BUSY : ancien format de verrou détecté (${ownerText}). Vérifiez le PID et retirez ce verrou manuellement uniquement s'il est obsolète.`,
+    };
+  }
+  if (error.reason === "unknown-owner") {
+    return {
+      kind: "busy",
+      text: `INDEX_BUSY : propriétaire du verrou illisible ou distant (${ownerText}). Reprise automatique refusée ; une vérification manuelle est nécessaire.`,
+    };
+  }
+  return { kind: "busy", text: `INDEX_BUSY : indexation déjà en cours (${ownerText}).` };
+}
 
 function getProjectRoot(projectRoot: string | undefined, host: HostMode): string {
   if (projectRoot) {
@@ -209,7 +232,7 @@ export async function runIndexCodebase(
 ): Promise<
   | { kind: "estimate"; estimate: CostEstimate }
   | { kind: "stats"; stats: IndexStats }
-  | { kind: "busy"; text: string }
+  | IndexBusyResult
 > {
   const root = getProjectRoot(projectRoot, host);
   const key = getIndexerCacheKey(root, host);
@@ -253,24 +276,9 @@ export async function runIndexCodebase(
 
     return { kind: "stats", stats };
   } catch (error) {
-    if (!isIndexLockContentionError(error)) throw error;
-    const owner = error.owner;
-    const ownerText = owner
-      ? `PID ${owner.pid}, opération ${owner.operation}, depuis ${owner.startedAt}`
-      : "propriétaire non lisible";
-    if (error.reason === "legacy-lock") {
-      return {
-        kind: "busy",
-        text: `INDEX_BUSY : ancien format de verrou détecté (${ownerText}). Vérifiez le PID et retirez ce verrou manuellement uniquement s'il est obsolète.`,
-      };
-    }
-    if (error.reason === "unknown-owner") {
-      return {
-        kind: "busy",
-        text: `INDEX_BUSY : propriétaire du verrou illisible ou distant (${ownerText}). Reprise automatique refusée ; une vérification manuelle est nécessaire.`,
-      };
-    }
-    return { kind: "busy", text: `INDEX_BUSY : indexation déjà en cours (${ownerText}).` };
+    const busyResult = getIndexBusyResult(error);
+    if (!busyResult) throw error;
+    return busyResult;
   }
 }
 
@@ -282,6 +290,19 @@ export async function getIndexStatus(projectRoot: string | undefined, host: Host
 export async function getIndexHealthCheck(projectRoot: string | undefined, host: HostMode): Promise<HealthCheckResult> {
   const indexer = getIndexerForProject(projectRoot, host);
   return indexer.healthCheck();
+}
+
+export async function runIndexHealthCheck(
+  projectRoot: string | undefined,
+  host: HostMode,
+): Promise<{ kind: "health"; health: HealthCheckResult } | IndexBusyResult> {
+  try {
+    return { kind: "health", health: await getIndexHealthCheck(projectRoot, host) };
+  } catch (error) {
+    const busyResult = getIndexBusyResult(error);
+    if (!busyResult) throw error;
+    return busyResult;
+  }
 }
 
 export async function getPrImpact(

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -2,9 +2,10 @@ import { existsSync, realpathSync, statSync } from "fs";
 import * as path from "path";
 import { loadProjectConfigLayer, materializeLocalProjectConfig } from "../config/merger.js";
 import { parseConfig, type ParsedCodebaseIndexConfig } from "../config/schema.js";
-import { getHostProjectIndexRelativePath, getHostProjectConfigRelativePath, resolveWorktreeFallbackProjectIndexPath } from "../config/paths.js";
+import { getHostProjectIndexRelativePath, getHostProjectConfigRelativePath, resolveProjectIndexPath, resolveWorktreeFallbackProjectIndexPath } from "../config/paths.js";
 import type { HostMode } from "../config/host.js";
 import { Indexer } from "../indexer/index.js";
+import { isIndexLockContentionError, withIndexLock } from "../indexer/index-lock.js";
 import { findKnowledgeBasePathIndex, hasMatchingKnowledgeBasePath, resolveKnowledgeBasePath } from "./knowledge-base-paths.js";
 import { calculatePercentage, formatProgressTitle, formatStatus } from "./utils.js";
 import type { LogLevel } from "../config/schema.js";
@@ -205,42 +206,72 @@ export async function runIndexCodebase(
   host: HostMode,
   args: { force?: boolean; estimateOnly?: boolean; verbose?: boolean },
   onProgress?: ProgressCb,
-): Promise<{ kind: "estimate"; estimate: CostEstimate } | { kind: "stats"; stats: IndexStats }> {
+): Promise<
+  | { kind: "estimate"; estimate: CostEstimate }
+  | { kind: "stats"; stats: IndexStats }
+  | { kind: "busy"; text: string }
+> {
   const root = getProjectRoot(projectRoot, host);
   const key = getIndexerCacheKey(root, host);
-  const cachedConfig = configCache.get(key);
   let indexer = getIndexerForProject(root, host);
+  const runtimeConfig = configCache.get(key)!;
 
-  if (args.estimateOnly) {
-    return { kind: "estimate", estimate: await indexer.estimateCost() };
-  }
-
-  if (args.force) {
-    if (shouldForceLocalizeProjectIndex(root, host)) {
-      materializeLocalProjectConfig(root, loadProjectConfigLayer(root, host), host);
-      refreshIndexerForDirectory(root, host, cachedConfig);
-      indexer = getIndexerForProject(root, host);
+  try {
+    if (args.estimateOnly) {
+      return { kind: "estimate", estimate: await indexer.estimateCost() };
     }
-    await indexer.clearIndex();
-    refreshIndexerForDirectory(root, host, cachedConfig);
-    indexer = getIndexerForProject(root, host);
-  }
 
-  const stats = await indexer.index((progress) => {
-    if (onProgress) {
-      return onProgress(formatProgressTitle(progress), {
-        phase: progress.phase,
-        filesProcessed: progress.filesProcessed,
-        totalFiles: progress.totalFiles,
-        chunksProcessed: progress.chunksProcessed,
-        totalChunks: progress.totalChunks,
-        percentage: calculatePercentage(progress),
+    const runIndex = async (target: Indexer): Promise<IndexStats> => {
+      const operation = args.force ? target.forceIndex.bind(target) : target.index.bind(target);
+      return operation((progress) => {
+        if (onProgress) {
+          return onProgress(formatProgressTitle(progress), {
+            phase: progress.phase,
+            filesProcessed: progress.filesProcessed,
+            totalFiles: progress.totalFiles,
+            chunksProcessed: progress.chunksProcessed,
+            totalChunks: progress.totalChunks,
+            percentage: calculatePercentage(progress),
+          });
+        }
+        return Promise.resolve();
       });
-    }
-    return Promise.resolve();
-  });
+    };
 
-  return { kind: "stats", stats };
+    let stats: IndexStats;
+    if (args.force && shouldForceLocalizeProjectIndex(root, host)) {
+      const inheritedIndexPath = resolveProjectIndexPath(root, runtimeConfig.scope, host);
+      stats = await withIndexLock(inheritedIndexPath, "force-index", async () => {
+        materializeLocalProjectConfig(root, loadProjectConfigLayer(root, host), host);
+        refreshIndexerForDirectory(root, host, runtimeConfig);
+        indexer = getIndexerForProject(root, host);
+        return runIndex(indexer);
+      }, { completeRecoveries: false });
+    } else {
+      stats = await runIndex(indexer);
+    }
+
+    return { kind: "stats", stats };
+  } catch (error) {
+    if (!isIndexLockContentionError(error)) throw error;
+    const owner = error.owner;
+    const ownerText = owner
+      ? `PID ${owner.pid}, opération ${owner.operation}, depuis ${owner.startedAt}`
+      : "propriétaire non lisible";
+    if (error.reason === "legacy-lock") {
+      return {
+        kind: "busy",
+        text: `INDEX_BUSY : ancien format de verrou détecté (${ownerText}). Vérifiez le PID et retirez ce verrou manuellement uniquement s'il est obsolète.`,
+      };
+    }
+    if (error.reason === "unknown-owner") {
+      return {
+        kind: "busy",
+        text: `INDEX_BUSY : propriétaire du verrou illisible ou distant (${ownerText}). Reprise automatique refusée ; une vérification manuelle est nécessaire.`,
+      };
+    }
+    return { kind: "busy", text: `INDEX_BUSY : indexation déjà en cours (${ownerText}).` };
+  }
 }
 
 export async function getIndexStatus(projectRoot: string | undefined, host: HostMode): Promise<StatusResult> {

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -34,21 +34,21 @@ function getIndexBusyResult(error: unknown): IndexBusyResult | null {
 
   const owner = error.owner;
   const ownerText = owner
-    ? `PID ${owner.pid}, opération ${owner.operation}, depuis ${owner.startedAt}`
-    : "propriétaire non lisible";
+    ? `PID ${owner.pid}, operation ${owner.operation}, since ${owner.startedAt}`
+    : "unreadable owner";
   if (error.reason === "legacy-lock") {
     return {
       kind: "busy",
-      text: `INDEX_BUSY : ancien format de verrou détecté (${ownerText}). Vérifiez le PID et retirez ce verrou manuellement uniquement s'il est obsolète.`,
+      text: `INDEX_BUSY: legacy lock format detected (${ownerText}). Verify the PID and remove this lock manually only if it is stale.`,
     };
   }
   if (error.reason === "unknown-owner") {
     return {
       kind: "busy",
-      text: `INDEX_BUSY : propriétaire du verrou illisible ou distant (${ownerText}). Reprise automatique refusée ; une vérification manuelle est nécessaire.`,
+      text: `INDEX_BUSY: unreadable or remote lock owner (${ownerText}). Automatic recovery was refused; manual verification is required.`,
     };
   }
-  return { kind: "busy", text: `INDEX_BUSY : indexation déjà en cours (${ownerText}).` };
+  return { kind: "busy", text: `INDEX_BUSY: another index operation is already in progress (${ownerText}).` };
 }
 
 function getProjectRoot(projectRoot: string | undefined, host: HostMode): string {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -120,6 +120,11 @@ export function formatStatus(status: StatusResult): string {
     }
   }
 
+  if (status.warning) {
+    lines.push("");
+    lines.push(`INDEX WARNING: ${status.warning}`);
+  }
+
   if (status.compatibility && !status.compatibility.compatible) {
     lines.push("");
     lines.push(`COMPATIBILITY WARNING: ${status.compatibility.reason}`);

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -3,13 +3,43 @@ import { isTransientIndexLockContention } from "../indexer/index-lock.js";
 
 type AutoIndexTarget = Pick<Indexer, "index">;
 
+interface AutoIndexState {
+  retryDelayMs: number;
+}
+
+const INITIAL_RETRY_DELAY_MS = 50;
+const MAX_RETRY_DELAY_MS = 500;
+const autoIndexStates = new WeakMap<AutoIndexTarget, AutoIndexState>();
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function startAutoIndex(indexer: AutoIndexTarget, projectRoot: string): void {
-  indexer.index().catch((error: unknown) => {
-    if (isTransientIndexLockContention(error)) return;
-    console.error(`[codebase-index] Auto-index failed for "${projectRoot}": ${getErrorMessage(error)}`);
+function runAutoIndex(indexer: AutoIndexTarget, projectRoot: string, state: AutoIndexState): void {
+  void indexer.index().then(() => {
+    autoIndexStates.delete(indexer);
+  }).catch((error: unknown) => {
+    if (!isTransientIndexLockContention(error)) {
+      autoIndexStates.delete(indexer);
+      console.error(`[codebase-index] Auto-index failed for "${projectRoot}": ${getErrorMessage(error)}`);
+      return;
+    }
+
+    const retryDelayMs = state.retryDelayMs;
+    state.retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_DELAY_MS);
+    const retryTimer = setTimeout(() => {
+      runAutoIndex(indexer, projectRoot, state);
+    }, retryDelayMs);
+    retryTimer.unref?.();
   });
+}
+
+export function startAutoIndex(indexer: AutoIndexTarget, projectRoot: string): void {
+  if (autoIndexStates.has(indexer)) return;
+
+  const state: AutoIndexState = {
+    retryDelayMs: INITIAL_RETRY_DELAY_MS,
+  };
+  autoIndexStates.set(indexer, state);
+  runAutoIndex(indexer, projectRoot, state);
 }

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -1,17 +1,15 @@
 import type { Indexer } from "../indexer/index.js";
+import { isTransientIndexLockContention } from "../indexer/index-lock.js";
 
-type AutoIndexTarget = Pick<Indexer, "initialize" | "index">;
+type AutoIndexTarget = Pick<Indexer, "index">;
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 export function startAutoIndex(indexer: AutoIndexTarget, projectRoot: string): void {
-  indexer.initialize().then(() => {
-    indexer.index().catch((error: unknown) => {
-      console.error(`[codebase-index] Auto-index failed for "${projectRoot}": ${getErrorMessage(error)}`);
-    });
-  }).catch((error: unknown) => {
-    console.error(`[codebase-index] Auto-index initialization failed for "${projectRoot}": ${getErrorMessage(error)}`);
+  indexer.index().catch((error: unknown) => {
+    if (isTransientIndexLockContention(error)) return;
+    console.error(`[codebase-index] Auto-index failed for "${projectRoot}": ${getErrorMessage(error)}`);
   });
 }

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -30,6 +30,8 @@ export class FileWatcher {
   private debounceTimer: NodeJS.Timeout | null = null;
   private debounceMs = 1000;
   private onChanges: ChangeHandler | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private resolveReady: (() => void) | null = null;
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode = "opencode", options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -76,6 +78,13 @@ export class FileWatcher {
         stabilityThreshold: 300,
         pollInterval: 100,
       },
+    });
+    this.readyPromise = new Promise<void>((resolve) => {
+      this.resolveReady = resolve;
+    });
+    this.watcher.once("ready", () => {
+      this.resolveReady?.();
+      this.resolveReady = null;
     });
 
     this.watcher.on("error", (error: unknown) => {
@@ -168,16 +177,21 @@ export class FileWatcher {
     }
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
 
     if (this.watcher) {
-      this.watcher.close();
+      const watcher = this.watcher;
       this.watcher = null;
+      await watcher.close();
     }
+
+    this.resolveReady?.();
+    this.resolveReady = null;
+    this.readyPromise = null;
 
     this.pendingChanges.clear();
     this.onChanges = null;
@@ -185,5 +199,9 @@ export class FileWatcher {
 
   isRunning(): boolean {
     return this.watcher !== null;
+  }
+
+  async waitUntilReady(): Promise<void> {
+    await (this.readyPromise ?? Promise.resolve());
   }
 }

--- a/src/watcher/git-head-watcher.ts
+++ b/src/watcher/git-head-watcher.ts
@@ -82,15 +82,16 @@ export class GitHeadWatcher {
     return this.currentBranch;
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
 
     if (this.watcher) {
-      this.watcher.close();
+      const watcher = this.watcher;
       this.watcher = null;
+      await watcher.close();
     }
 
     this.onBranchChange = null;

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -4,6 +4,7 @@ import type { HostMode } from "../config/host.js";
 import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
 import { loadConfigFile } from "../config/merger.js";
 import type { Indexer } from "../indexer/index.js";
+import { isTransientIndexLockContention } from "../indexer/index-lock.js";
 import { isGitRepo } from "../git/index.js";
 import { refreshIndexerForDirectory } from "../tools/operations.js";
 import { FileWatcher } from "./file-watcher.js";
@@ -17,7 +18,8 @@ export type { BranchChangeHandler } from "./git-head-watcher.js";
 export interface CombinedWatcher {
   fileWatcher: FileWatcher;
   gitWatcher: GitHeadWatcher | null;
-  stop(): void;
+  whenReady(): Promise<void>;
+  stop(): Promise<void>;
 }
 
 export interface WatcherOptions {
@@ -28,6 +30,8 @@ class BackgroundReindexer {
   private running = false;
   private pending = false;
   private stopped = false;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private retryDelayMs = 50;
 
   constructor(private readonly runIndex: () => Promise<void>) {}
 
@@ -43,10 +47,14 @@ class BackgroundReindexer {
   stop(): void {
     this.stopped = true;
     this.pending = false;
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
   }
 
   private drain(): void {
-    if (this.stopped || this.running || !this.pending) {
+    if (this.stopped || this.running || this.retryTimer || !this.pending) {
       return;
     }
 
@@ -56,13 +64,29 @@ class BackgroundReindexer {
   }
 
   private async run(): Promise<void> {
+    let retryAfterContention = false;
     try {
       await this.runIndex();
+      this.retryDelayMs = 50;
     } catch (error) {
-      console.error("[codebase-index] Background reindex failed:", error);
+      if (isTransientIndexLockContention(error)) {
+        this.pending = true;
+        retryAfterContention = true;
+      } else {
+        console.error("[codebase-index] Background reindex failed:", error);
+      }
     } finally {
       this.running = false;
-      this.drain();
+      if (retryAfterContention && !this.stopped) {
+        const delay = this.retryDelayMs;
+        this.retryDelayMs = Math.min(this.retryDelayMs * 2, 500);
+        this.retryTimer = setTimeout(() => {
+          this.retryTimer = null;
+          this.drain();
+        }, delay);
+      } else {
+        this.drain();
+      }
     }
   }
 }
@@ -108,10 +132,12 @@ export function createWatcherWithIndexer(
   return {
     fileWatcher,
     gitWatcher,
-    stop() {
+    whenReady() {
+      return fileWatcher.waitUntilReady();
+    },
+    async stop() {
       backgroundReindexer.stop();
-      fileWatcher.stop();
-      gitWatcher?.stop();
+      await Promise.all([fileWatcher.stop(), gitWatcher?.stop()]);
     },
   };
 }

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -16,6 +16,7 @@ function createIndexerMock(overrides: {
 
 describe("startAutoIndex", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -28,7 +29,8 @@ describe("startAutoIndex", () => {
     expect(indexer.index).toHaveBeenCalledOnce();
   });
 
-  it("coalesces INDEX_BUSY without logging an error", async () => {
+  it.each(["active", "reclaiming"] as const)("coalesces and retries %s INDEX_BUSY", async (reason) => {
+    vi.useFakeTimers();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const owner = {
       pid: process.pid,
@@ -38,13 +40,21 @@ describe("startAutoIndex", () => {
       token: "busy-owner",
     };
     const indexer = createIndexerMock({
-      index: vi.fn().mockRejectedValue(new IndexLockContentionError("/tmp/indexing.lock", owner, "active")),
+      index: vi.fn()
+        .mockRejectedValueOnce(new IndexLockContentionError("/tmp/indexing.lock", owner, reason))
+        .mockResolvedValueOnce(undefined),
     });
 
     startAutoIndex(indexer, "/tmp/project");
-    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    startAutoIndex(indexer, "/tmp/project");
+    expect(indexer.index).toHaveBeenCalledOnce();
+    await Promise.resolve();
     await Promise.resolve();
 
+    expect(indexer.index).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(indexer.index).toHaveBeenCalledTimes(2);
     expect(consoleError).not.toHaveBeenCalled();
   });
 

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -1,16 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Indexer } from "../src/indexer/index.js";
+import { IndexLockContentionError } from "../src/indexer/index-lock.js";
 import { startAutoIndex } from "../src/utils/auto-index.js";
 
-type AutoIndexMock = Pick<Indexer, "initialize" | "index">;
+type AutoIndexMock = Pick<Indexer, "index">;
 
 function createIndexerMock(overrides: {
-  initialize?: ReturnType<typeof vi.fn>;
   index?: ReturnType<typeof vi.fn>;
 }): AutoIndexMock {
   return {
-    initialize: overrides.initialize ?? vi.fn().mockResolvedValue(undefined),
     index: overrides.index ?? vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -20,31 +19,57 @@ describe("startAutoIndex", () => {
     vi.restoreAllMocks();
   });
 
-  it("logs initialization failures", async () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    const indexer = createIndexerMock({
-      initialize: vi.fn().mockRejectedValue(new Error("missing credentials")),
-    });
-
-    startAutoIndex(indexer, "/tmp/project");
-    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
-
-    expect(consoleError).toHaveBeenCalledWith(
-      '[codebase-index] Auto-index initialization failed for "/tmp/project": missing credentials',
-    );
-  });
-
-  it("indexes after initialization succeeds", async () => {
+  it("indexes through the single lease that also initializes", async () => {
     const indexer = createIndexerMock({});
 
     startAutoIndex(indexer, "/tmp/project");
     await vi.waitFor(() => expect(indexer.index).toHaveBeenCalled());
 
-    expect(indexer.initialize).toHaveBeenCalledOnce();
     expect(indexer.index).toHaveBeenCalledOnce();
   });
 
-  it("logs indexing failures after initialization succeeds", async () => {
+  it("coalesces INDEX_BUSY without logging an error", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const owner = {
+      pid: process.pid,
+      hostname: "local-test",
+      startedAt: new Date().toISOString(),
+      operation: "index" as const,
+      token: "busy-owner",
+    };
+    const indexer = createIndexerMock({
+      index: vi.fn().mockRejectedValue(new IndexLockContentionError("/tmp/indexing.lock", owner, "active")),
+    });
+
+    startAutoIndex(indexer, "/tmp/project");
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    await Promise.resolve();
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("logs non-transient lock states that require intervention", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const owner = {
+      pid: process.pid,
+      hostname: "local-test",
+      startedAt: new Date().toISOString(),
+      operation: "index" as const,
+      token: "legacy-owner",
+    };
+    const indexer = createIndexerMock({
+      index: vi.fn().mockRejectedValue(new IndexLockContentionError("/tmp/indexing.lock", owner, "legacy-lock")),
+    });
+
+    startAutoIndex(indexer, "/tmp/project");
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalledOnce());
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Auto-index failed"),
+    );
+  });
+
+  it("logs real indexing failures", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const indexer = createIndexerMock({
       index: vi.fn().mockRejectedValue(new Error("database is malformed")),

--- a/tests/crash-recovery.test.ts
+++ b/tests/crash-recovery.test.ts
@@ -1,153 +1,72 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import * as fs from "fs";
-import * as path from "path";
 import * as os from "os";
+import * as path from "path";
 
-describe("Crash Recovery", () => {
-  describe("atomic file writes", () => {
-    let tempDir: string;
+import { acquireIndexLock, IndexLockContentionError } from "../src/indexer/index-lock.js";
 
-    beforeEach(() => {
-      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-test-"));
-    });
+describe("legacy crash recovery", () => {
+  let tempDir: string;
+  let indexPath: string;
+  let lockPath: string;
 
-    afterEach(() => {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    });
-
-    it("should leave no .tmp files after successful write via atomicWriteSync pattern", () => {
-      const targetPath = path.join(tempDir, "test-file.json");
-      const tempPath = `${targetPath}.tmp`;
-      const data = JSON.stringify({ test: "data" });
-      
-      fs.writeFileSync(tempPath, data);
-      fs.renameSync(tempPath, targetPath);
-
-      expect(fs.existsSync(targetPath)).toBe(true);
-      expect(fs.existsSync(tempPath)).toBe(false);
-      expect(JSON.parse(fs.readFileSync(targetPath, "utf-8"))).toEqual({ test: "data" });
-    });
-
-    it("should handle rename of non-existent temp file gracefully", () => {
-      const targetPath = path.join(tempDir, "test-file.json");
-      const tempPath = `${targetPath}.tmp`;
-
-      expect(() => fs.renameSync(tempPath, targetPath)).toThrow();
-    });
-
-    it("should create missing parent directories before atomic write", () => {
-      const nestedDir = path.join(tempDir, "deeply", "nested", "dir");
-      const targetPath = path.join(nestedDir, "test-file.json");
-      const tempPath = `${targetPath}.tmp`;
-      const data = JSON.stringify({ test: "data" });
-
-      expect(fs.existsSync(nestedDir)).toBe(false);
-
-      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-      fs.writeFileSync(tempPath, data);
-      fs.renameSync(tempPath, targetPath);
-
-      expect(fs.existsSync(targetPath)).toBe(true);
-      expect(fs.existsSync(tempPath)).toBe(false);
-      expect(JSON.parse(fs.readFileSync(targetPath, "utf-8"))).toEqual({ test: "data" });
-    });
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-recovery-"));
+    indexPath = path.join(tempDir, "index");
+    lockPath = path.join(indexPath, "indexing.lock");
+    fs.mkdirSync(indexPath, { recursive: true });
   });
 
-  describe("indexing lock file", () => {
-    let tempDir: string;
-    let indexPath: string;
-    let lockPath: string;
-
-    beforeEach(() => {
-      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lock-test-"));
-      indexPath = path.join(tempDir, ".opencode", "index");
-      lockPath = path.join(indexPath, "indexing.lock");
-      fs.mkdirSync(indexPath, { recursive: true });
-    });
-
-    afterEach(() => {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    });
-
-    it("should detect when lock file exists", () => {
-      expect(fs.existsSync(lockPath)).toBe(false);
-
-      fs.writeFileSync(lockPath, JSON.stringify({ startedAt: new Date().toISOString(), pid: process.pid }));
-
-      expect(fs.existsSync(lockPath)).toBe(true);
-    });
-
-    it("should parse lock file contents correctly", () => {
-      const lockData = { startedAt: "2025-01-19T12:00:00.000Z", pid: 12345 };
-      fs.writeFileSync(lockPath, JSON.stringify(lockData));
-
-      const parsed = JSON.parse(fs.readFileSync(lockPath, "utf-8"));
-      expect(parsed.startedAt).toBe("2025-01-19T12:00:00.000Z");
-      expect(parsed.pid).toBe(12345);
-    });
-
-    it("should remove lock file on successful completion", () => {
-      fs.writeFileSync(lockPath, JSON.stringify({ startedAt: new Date().toISOString(), pid: process.pid }));
-      expect(fs.existsSync(lockPath)).toBe(true);
-
-      fs.unlinkSync(lockPath);
-
-      expect(fs.existsSync(lockPath)).toBe(false);
-    });
-
-    it("should handle missing lock file in cleanup gracefully", () => {
-      expect(fs.existsSync(lockPath)).toBe(false);
-
-      if (fs.existsSync(lockPath)) {
-        fs.unlinkSync(lockPath);
-      }
-
-      expect(fs.existsSync(lockPath)).toBe(false);
-    });
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  describe("recovery behavior", () => {
-    let tempDir: string;
-    let indexPath: string;
-    let lockPath: string;
-    let fileHashCachePath: string;
-
-    beforeEach(() => {
-      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "recovery-test-"));
-      indexPath = path.join(tempDir, ".opencode", "index");
-      lockPath = path.join(indexPath, "indexing.lock");
-      fileHashCachePath = path.join(indexPath, "file-hashes.json");
-      fs.mkdirSync(indexPath, { recursive: true });
+  it("does not overwrite a live 0.14.0 lock file", () => {
+    const contents = JSON.stringify({
+      pid: process.pid,
+      startedAt: "2025-01-19T12:00:00.000Z",
     });
+    fs.writeFileSync(lockPath, contents, { mode: 0o600 });
 
-    afterEach(() => {
-      fs.rmSync(tempDir, { recursive: true, force: true });
+    expect(() => acquireIndexLock(indexPath, "recovery")).toThrow(
+      expect.objectContaining<Partial<IndexLockContentionError>>({
+        code: "INDEX_BUSY",
+        reason: "legacy-lock",
+        owner: expect.objectContaining({ pid: process.pid }),
+      }),
+    );
+    expect(fs.readFileSync(lockPath, "utf-8")).toBe(contents);
+    expect(fs.lstatSync(lockPath).isFile()).toBe(true);
+  });
+
+  it("requires explicit migration control before removing a dead legacy lock", () => {
+    const deadPid = 2_147_483_647;
+    const contents = JSON.stringify({
+      pid: deadPid,
+      startedAt: "2025-01-19T12:00:00.000Z",
     });
+    fs.writeFileSync(lockPath, contents, { mode: 0o600 });
 
-    it("should clear file hash cache when lock file is present (simulating crash recovery)", () => {
-      fs.writeFileSync(fileHashCachePath, JSON.stringify({ "file1.ts": "hash1", "file2.ts": "hash2" }));
-      fs.writeFileSync(lockPath, JSON.stringify({ startedAt: new Date().toISOString(), pid: process.pid }));
+    expect(() => acquireIndexLock(indexPath, "recovery")).toThrow(
+      expect.objectContaining<Partial<IndexLockContentionError>>({
+        code: "INDEX_BUSY",
+        reason: "legacy-lock",
+        owner: expect.objectContaining({ pid: deadPid }),
+      }),
+    );
+    expect(fs.readFileSync(lockPath, "utf-8")).toBe(contents);
+  });
 
-      expect(fs.existsSync(fileHashCachePath)).toBe(true);
-      expect(fs.existsSync(lockPath)).toBe(true);
+  it("does not overwrite an unreadable legacy lock", () => {
+    fs.writeFileSync(lockPath, "not-json", { mode: 0o600 });
 
-      if (fs.existsSync(lockPath)) {
-        fs.unlinkSync(fileHashCachePath);
-        fs.unlinkSync(lockPath);
-      }
-
-      expect(fs.existsSync(fileHashCachePath)).toBe(false);
-      expect(fs.existsSync(lockPath)).toBe(false);
-    });
-
-    it("should not clear hash cache when no lock file exists", () => {
-      fs.writeFileSync(fileHashCachePath, JSON.stringify({ "file1.ts": "hash1" }));
-
-      expect(fs.existsSync(lockPath)).toBe(false);
-      expect(fs.existsSync(fileHashCachePath)).toBe(true);
-
-      const content = JSON.parse(fs.readFileSync(fileHashCachePath, "utf-8"));
-      expect(content).toEqual({ "file1.ts": "hash1" });
-    });
+    expect(() => acquireIndexLock(indexPath, "recovery")).toThrow(
+      expect.objectContaining<Partial<IndexLockContentionError>>({
+        code: "INDEX_BUSY",
+        reason: "legacy-lock",
+        owner: null,
+      }),
+    );
+    expect(fs.readFileSync(lockPath, "utf-8")).toBe("not-json");
   });
 });

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -55,6 +55,66 @@ describe("Database", () => {
     });
   });
 
+  describe("read-only connections", () => {
+    it("should read a live WAL database without allowing mutations", () => {
+      const dbPath = path.join(tempDir, "test.db");
+      db.setMetadata("reader-visible", "yes");
+      const reader = Database.openReadOnly(dbPath);
+
+      try {
+        expect(reader.getMetadata("reader-visible")).toBe("yes");
+        expect(() => reader.setMetadata("reader-write", "forbidden")).toThrow(/read.?only/i);
+        expect(db.getMetadata("reader-write")).toBeNull();
+      } finally {
+        reader.close();
+      }
+    });
+
+    it("should reject a missing database without creating its parent directory", () => {
+      const dbPath = path.join(tempDir, "missing", "index.db");
+
+      expect(() => Database.openReadOnly(dbPath)).toThrow();
+      expect(fs.existsSync(path.dirname(dbPath))).toBe(false);
+    });
+
+    it("should reject an old schema without migrating the live database", () => {
+      const dbPath = path.join(tempDir, "test.db");
+      db.setMetadata("schema_version", "5");
+
+      expect(() => Database.openReadOnly(dbPath)).toThrow(/found version 5, expected 6/i);
+      expect(db.getMetadata("schema_version")).toBe("5");
+    });
+
+    it("should reject a corrupt database without changing its bytes", () => {
+      const dbPath = path.join(tempDir, "corrupt.db");
+      const content = Buffer.from("not a sqlite database");
+      fs.writeFileSync(dbPath, content);
+
+      expect(() => Database.openReadOnly(dbPath)).toThrow();
+      expect(fs.readFileSync(dbPath)).toEqual(content);
+    });
+
+    it("should provide an empty read-only fallback without creating files", () => {
+      const filesBefore = fs.readdirSync(tempDir).sort();
+      const reader = Database.createEmptyReadOnly();
+
+      try {
+        expect(reader.getStats()).toEqual({
+          embeddingCount: 0,
+          chunkCount: 0,
+          branchChunkCount: 0,
+          branchCount: 0,
+          symbolCount: 0,
+          callEdgeCount: 0,
+        });
+        expect(() => reader.setMetadata("reader-write", "forbidden")).toThrow(/read.?only/i);
+        expect(fs.readdirSync(tempDir).sort()).toEqual(filesBefore);
+      } finally {
+        reader.close();
+      }
+    });
+  });
+
   describe("embeddings", () => {
     it("should check if embedding exists", () => {
       expect(db.embeddingExists("hash123")).toBe(false);

--- a/tests/fixtures/bm25-publication-barrier.mjs
+++ b/tests/fixtures/bm25-publication-barrier.mjs
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+
+const targetPath = process.env.TEST_BM25_TARGET_PATH;
+const readyPath = process.env.TEST_BM25_READY_PATH;
+const releasePath = process.env.TEST_BM25_RELEASE_PATH;
+
+if (targetPath && readyPath && releasePath) {
+  const originalRenameSync = fs.renameSync;
+  const normalizedTargetPath = path.resolve(targetPath);
+  const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+  fs.renameSync = (source, destination) => {
+    const normalizedSource = path.resolve(String(source));
+    const normalizedDestination = path.resolve(String(destination));
+    const isBm25Publication = normalizedDestination === normalizedTargetPath
+      && normalizedSource.startsWith(`${normalizedTargetPath}.tmp.`);
+
+    if (isBm25Publication) {
+      fs.writeFileSync(readyPath, JSON.stringify({ source: normalizedSource, destination: normalizedDestination }));
+      const startedAt = Date.now();
+      while (!fs.existsSync(releasePath)) {
+        if (Date.now() - startedAt > 10000) {
+          throw new Error(`Timed out waiting for BM25 publication release at ${releasePath}`);
+        }
+        Atomics.wait(waitBuffer, 0, 0, 10);
+      }
+    }
+
+    return originalRenameSync(source, destination);
+  };
+
+  // Met à jour les imports ESM nommés de node:fs utilisés par le code produit.
+  syncBuiltinESMExports();
+}

--- a/tests/fixtures/multiprocess-index-worker.ts
+++ b/tests/fixtures/multiprocess-index-worker.ts
@@ -1,0 +1,130 @@
+import { parseConfig } from "../../src/config/schema.js";
+import { Indexer } from "../../src/indexer/index.js";
+import { isIndexLockContentionError } from "../../src/indexer/index-lock.js";
+import { createWatcherWithIndexer, type CombinedWatcher } from "../../src/watcher/index.js";
+
+type WorkerOperation = "index" | "force" | "watch";
+
+interface RunMessage {
+  type: "run";
+  operation: WorkerOperation;
+}
+
+interface StopMessage {
+  type: "stop";
+}
+
+const projectRootValue = process.env.TEST_PROJECT_ROOT;
+const baseUrlValue = process.env.TEST_EMBEDDING_BASE_URL;
+if (!projectRootValue || !baseUrlValue) {
+  throw new Error("TEST_PROJECT_ROOT and TEST_EMBEDDING_BASE_URL are required");
+}
+const projectRoot = projectRootValue;
+const baseUrl = baseUrlValue;
+
+const config = parseConfig({
+  embeddingProvider: "custom",
+  scope: "project",
+  customProvider: {
+    baseUrl,
+    model: "multiprocess-test",
+    dimensions: 8,
+    timeoutMs: 5000,
+    maxBatchSize: 64,
+    concurrency: 1,
+    requestIntervalMs: 0,
+  },
+  include: ["**/*.ts"],
+  exclude: ["**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+  indexing: {
+    autoIndex: false,
+    watchFiles: false,
+    autoGc: false,
+    retries: 0,
+    retryDelayMs: 1,
+    gitBlame: { enabled: false },
+  },
+  debug: { enabled: false },
+});
+
+const indexer = new Indexer(projectRoot, config);
+let watcher: CombinedWatcher | null = null;
+let running = false;
+
+function send(message: Record<string, unknown>): void {
+  if (process.send) process.send(message);
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (isIndexLockContentionError(error)) {
+    return {
+      ok: false,
+      name: "IndexLockContentionError",
+      code: "INDEX_BUSY",
+      owner: error.owner,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return {
+    ok: false,
+    name: error instanceof Error ? error.name : "Error",
+    message: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  };
+}
+
+async function finish(): Promise<void> {
+  await watcher?.stop();
+  watcher = null;
+  await indexer.close();
+  process.disconnect?.();
+}
+
+async function runOnce(operation: Exclude<WorkerOperation, "watch">): Promise<void> {
+  try {
+    const stats = operation === "force" ? await indexer.forceIndex() : await indexer.index();
+    send({ type: "result", operation, ok: true, stats });
+  } catch (error) {
+    send({ type: "result", operation, ...serializeError(error) });
+  } finally {
+    await finish();
+  }
+}
+
+async function startWatcher(): Promise<void> {
+  const originalIndex = indexer.index.bind(indexer);
+  indexer.index = async (...args) => {
+    send({ type: "watch-attempt" });
+    try {
+      const stats = await originalIndex(...args);
+      send({ type: "watch-result", ok: true, stats });
+      return stats;
+    } catch (error) {
+      send({ type: "watch-result", ...serializeError(error) });
+      throw error;
+    }
+  };
+
+  watcher = createWatcherWithIndexer(() => indexer, projectRoot, config);
+  await watcher.whenReady();
+  send({ type: "watcher-ready" });
+}
+
+process.on("message", (message: RunMessage | StopMessage) => {
+  if (message.type === "stop") {
+    void finish();
+    return;
+  }
+  if (message.type !== "run" || running) return;
+  running = true;
+  if (message.operation === "watch") {
+    void startWatcher().catch(async (error) => {
+      send({ type: "result", operation: "watch", ...serializeError(error) });
+      await finish();
+    });
+    return;
+  }
+  void runOnce(message.operation);
+});
+
+send({ type: "ready", pid: process.pid });

--- a/tests/index-lock.test.ts
+++ b/tests/index-lock.test.ts
@@ -1,0 +1,354 @@
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  acquireIndexLock,
+  completeLeaseRecovery,
+  createLeaseTemporaryPath,
+  IndexLockContentionError,
+  recoverLeaseArtifacts,
+  releaseIndexLock,
+  withIndexLock,
+  type IndexLockOwner,
+} from "../src/indexer/index-lock.js";
+
+describe("index mutation lease", () => {
+  let tempDir: string;
+  let indexPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "index-lock-test-"));
+    indexPath = path.join(tempDir, "index");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("acquires atomically and records the complete owner", () => {
+    const lease = acquireIndexLock(indexPath, "index");
+    const ownerPath = path.join(indexPath, "indexing.lock", "owner.json");
+    const stored = JSON.parse(fs.readFileSync(ownerPath, "utf-8")) as IndexLockOwner;
+
+    expect(stored).toEqual(lease.owner);
+    expect(stored.pid).toBe(process.pid);
+    expect(stored.hostname).toBe(os.hostname());
+    expect(stored.operation).toBe("index");
+    expect(stored.token).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(Number.isNaN(Date.parse(stored.startedAt))).toBe(false);
+    expect(fs.readdirSync(indexPath).some((name) => name.startsWith("indexing.lock.candidate."))).toBe(false);
+
+    expect(releaseIndexLock(lease)).toBe(true);
+    expect(fs.existsSync(path.join(indexPath, "indexing.lock"))).toBe(false);
+  });
+
+  it("canonicalizes aliases to the same lock", () => {
+    fs.mkdirSync(indexPath, { recursive: true });
+    const aliasPath = path.join(tempDir, "index-alias");
+    fs.symlinkSync(indexPath, aliasPath, "dir");
+    const lease = acquireIndexLock(indexPath, "index");
+
+    expect(() => acquireIndexLock(aliasPath, "health-check")).toThrow(IndexLockContentionError);
+    releaseIndexLock(lease);
+  });
+
+  it("never steals a live lock because of an old timestamp", () => {
+    const lease = acquireIndexLock(indexPath, "index");
+    const ownerPath = path.join(indexPath, "indexing.lock", "owner.json");
+    fs.writeFileSync(ownerPath, JSON.stringify({
+      ...lease.owner,
+      startedAt: "2000-01-01T00:00:00.000Z",
+    }));
+    const before = fs.readFileSync(ownerPath, "utf-8");
+
+    expect(() => acquireIndexLock(indexPath, "clear")).toThrowError(
+      expect.objectContaining({ code: "INDEX_BUSY" }),
+    );
+    expect(fs.readFileSync(ownerPath, "utf-8")).toBe(before);
+
+    releaseIndexLock({ ...lease, owner: JSON.parse(before) as IndexLockOwner });
+  });
+
+  it.each([
+    ["pid", (owner: IndexLockOwner) => ({ ...owner, pid: owner.pid + 1 })],
+    ["hostname", (owner: IndexLockOwner) => ({ ...owner, hostname: `${owner.hostname}-other` })],
+    ["token", (owner: IndexLockOwner) => ({ ...owner, token: "00000000-0000-4000-8000-000000000000" })],
+  ])("does not allow another %s to release the lock", (_field, changeOwner) => {
+    const lease = acquireIndexLock(indexPath, "index");
+    const wrongLease = {
+      ...lease,
+      owner: changeOwner(lease.owner),
+    };
+
+    expect(releaseIndexLock(wrongLease)).toBe(false);
+    expect(fs.existsSync(lease.lockPath)).toBe(true);
+    expect(releaseIndexLock(lease)).toBe(true);
+  });
+
+  it("releases in finally when the callback fails", async () => {
+    await expect(withIndexLock(indexPath, "index", async () => {
+      throw new Error("expected failure");
+    })).rejects.toThrow("expected failure");
+
+    expect(fs.existsSync(path.join(indexPath, "indexing.lock"))).toBe(false);
+  });
+
+  it("reports both callback and release failures", async () => {
+    const result = withIndexLock(indexPath, "index", async (lease) => {
+      const ownerPath = path.join(lease.lockPath, "owner.json");
+      fs.writeFileSync(ownerPath, JSON.stringify({ ...lease.owner, token: "replacement-token" }));
+      throw new Error("callback failure");
+    });
+
+    await expect(result).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof AggregateError)) return false;
+      return error.errors.some((item) => item instanceof Error && item.message === "callback failure")
+        && error.errors.some((item) => item instanceof Error && item.message.includes("Lost ownership"));
+    });
+  });
+
+  it("recovers a lock whose local owner has exited", () => {
+    const child = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+    expect(child.pid).toBeTypeOf("number");
+
+    const lockPath = path.join(indexPath, "indexing.lock");
+    fs.mkdirSync(lockPath, { recursive: true });
+    fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify({
+      pid: child.pid,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "11111111-1111-4111-8111-111111111111",
+    } satisfies IndexLockOwner));
+
+    const lease = acquireIndexLock(indexPath, "recovery");
+    expect(lease.recoveries.map(({ owner }) => owner.pid)).toEqual([child.pid]);
+    expect(lease.owner.token).not.toBe("11111111-1111-4111-8111-111111111111");
+    completeLeaseRecovery(lease);
+    expect(releaseIndexLock(lease)).toBe(true);
+  });
+
+  it("returns and completes every pending recovery marker", () => {
+    fs.mkdirSync(indexPath, { recursive: true });
+    const deadProcesses = [
+      spawnSync(process.execPath, ["-e", "process.exit(0)"]),
+      spawnSync(process.execPath, ["-e", "process.exit(0)"]),
+    ];
+    const owners = deadProcesses.map((child, index) => ({
+      pid: child.pid!,
+      hostname: os.hostname(),
+      startedAt: new Date(Date.now() + index).toISOString(),
+      operation: "index" as const,
+      token: index === 0
+        ? "77777777-7777-4777-8777-777777777777"
+        : "88888888-8888-4888-8888-888888888888",
+    } satisfies IndexLockOwner));
+
+    for (const owner of owners) {
+      const markerPath = path.join(indexPath, `indexing.lock.recovery.${owner.token}`);
+      fs.mkdirSync(markerPath);
+      fs.writeFileSync(path.join(markerPath, "owner.json"), JSON.stringify(owner));
+    }
+    const incompleteCandidatePath = path.join(
+      indexPath,
+      `indexing.lock.recovery.${owners[0].token}.candidate.${deadProcesses[0].pid}.99999999-9999-4999-8999-999999999999`,
+    );
+    fs.mkdirSync(incompleteCandidatePath);
+
+    const lease = acquireIndexLock(indexPath, "recovery");
+    expect(lease.recoveries.map(({ owner }) => owner.token)).toEqual(owners.map(({ token }) => token));
+    expect(fs.existsSync(incompleteCandidatePath)).toBe(false);
+
+    completeLeaseRecovery(lease);
+    expect(fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."))).toEqual([]);
+    expect(releaseIndexLock(lease)).toBe(true);
+  });
+
+  it("preserves recovery markers when a lease only coordinates another mutation", async () => {
+    fs.mkdirSync(indexPath, { recursive: true });
+    const deadProcess = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+    const owner = {
+      pid: deadProcess.pid!,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index" as const,
+      token: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    } satisfies IndexLockOwner;
+    const markerPath = path.join(indexPath, `indexing.lock.recovery.${owner.token}`);
+    fs.mkdirSync(markerPath);
+    fs.writeFileSync(path.join(markerPath, "owner.json"), JSON.stringify(owner));
+
+    await withIndexLock(indexPath, "force-index", async () => undefined, { completeRecoveries: false });
+
+    expect(fs.existsSync(markerPath)).toBe(true);
+    expect(fs.existsSync(path.join(indexPath, "indexing.lock"))).toBe(false);
+  });
+
+  it("fails closed when a recovery marker name does not match its owner token", () => {
+    fs.mkdirSync(indexPath, { recursive: true });
+    const deadProcess = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+    const owner = {
+      pid: deadProcess.pid!,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index" as const,
+      token: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    } satisfies IndexLockOwner;
+    const markerPath = path.join(indexPath, "indexing.lock.recovery.dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+    fs.mkdirSync(markerPath);
+    fs.writeFileSync(path.join(markerPath, "owner.json"), JSON.stringify(owner));
+
+    expect(() => acquireIndexLock(indexPath, "recovery")).toThrowError(
+      expect.objectContaining({ code: "INDEX_BUSY", reason: "unknown-owner" }),
+    );
+    expect(fs.existsSync(markerPath)).toBe(true);
+    expect(fs.existsSync(path.join(indexPath, "indexing.lock"))).toBe(false);
+  });
+
+  it("recovers when both the owner and a previous reclaimer have exited", () => {
+    const deadOwner = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+    const deadReclaimer = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+    expect(deadOwner.pid).toBeTypeOf("number");
+    expect(deadReclaimer.pid).toBeTypeOf("number");
+
+    const owner = {
+      pid: deadOwner.pid!,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "33333333-3333-4333-8333-333333333333",
+    } satisfies IndexLockOwner;
+    const lockPath = path.join(indexPath, "indexing.lock");
+    fs.mkdirSync(lockPath, { recursive: true });
+    fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify(owner));
+    const reclaimPath = path.join(lockPath, "reclaiming");
+    fs.mkdirSync(reclaimPath);
+    fs.writeFileSync(path.join(reclaimPath, "owner.json"), JSON.stringify({
+      pid: deadReclaimer.pid,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      token: "55555555-5555-4555-8555-555555555555",
+      expectedOwnerToken: owner.token,
+    }));
+
+    const lease = acquireIndexLock(indexPath, "recovery");
+    expect(lease.recoveries.map(({ owner: recoveredOwner }) => recoveredOwner)).toEqual([owner]);
+    completeLeaseRecovery(lease);
+    expect(releaseIndexLock(lease)).toBe(true);
+  });
+
+  it("does not steal a reclaim marker whose process is alive", () => {
+    const deadOwner = spawnSync(process.execPath, ["-e", "process.exit(0)"]);
+    const owner = {
+      pid: deadOwner.pid!,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "44444444-4444-4444-8444-444444444444",
+    } satisfies IndexLockOwner;
+    const lockPath = path.join(indexPath, "indexing.lock");
+    fs.mkdirSync(lockPath, { recursive: true });
+    fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify(owner));
+    const reclaimPath = path.join(lockPath, "reclaiming");
+    fs.mkdirSync(reclaimPath);
+    fs.writeFileSync(path.join(reclaimPath, "owner.json"), JSON.stringify({
+      pid: process.pid,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      token: "66666666-6666-4666-8666-666666666666",
+      expectedOwnerToken: owner.token,
+    }));
+
+    expect(() => acquireIndexLock(indexPath, "recovery")).toThrowError(
+      expect.objectContaining({ code: "INDEX_BUSY", reason: "reclaiming" }),
+    );
+    expect(fs.existsSync(reclaimPath)).toBe(true);
+  });
+
+  it("does not reclaim malformed or foreign lock owners", () => {
+    const lockPath = path.join(indexPath, "indexing.lock");
+    fs.mkdirSync(lockPath, { recursive: true });
+    fs.writeFileSync(path.join(lockPath, "owner.json"), "{");
+
+    expect(() => acquireIndexLock(indexPath, "index")).toThrowError(
+      expect.objectContaining({ code: "INDEX_BUSY" }),
+    );
+
+    fs.rmSync(lockPath, { recursive: true, force: true });
+    fs.mkdirSync(lockPath, { recursive: true });
+    fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify({
+      pid: 999_999,
+      hostname: "another-host",
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "22222222-2222-4222-8222-222222222222",
+    } satisfies IndexLockOwner));
+
+    expect(() => acquireIndexLock(indexPath, "index")).toThrowError(
+      expect.objectContaining({ code: "INDEX_BUSY" }),
+    );
+  });
+
+  it("does not reclaim a dead owner whose token is not a UUID", () => {
+    const lockPath = path.join(indexPath, "indexing.lock");
+    const ownerPath = path.join(lockPath, "owner.json");
+    fs.mkdirSync(lockPath, { recursive: true });
+    const contents = JSON.stringify({
+      pid: 2_147_483_647,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "../invalid-token",
+    });
+    fs.writeFileSync(ownerPath, contents);
+
+    expect(() => acquireIndexLock(indexPath, "recovery")).toThrowError(
+      expect.objectContaining({ code: "INDEX_BUSY", owner: null }),
+    );
+    expect(fs.readFileSync(ownerPath, "utf-8")).toBe(contents);
+  });
+
+  it("restores backups and removes only temporaries from the recovered owner", () => {
+    fs.mkdirSync(indexPath, { recursive: true });
+    const owner: IndexLockOwner = {
+      pid: 1234,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "33333333-3333-4333-8333-333333333333",
+    };
+    const targetPath = path.join(indexPath, "vectors");
+    const backupPath = createLeaseTemporaryPath(targetPath, owner, "bak");
+    const ownedTemporaryPath = createLeaseTemporaryPath(path.join(indexPath, "file-hashes.json"), owner, "tmp");
+    const foreignTemporaryPath = path.join(indexPath, "file-hashes.json.tmp.9999.44444444-4444-4444-8444-444444444444.1");
+    fs.writeFileSync(targetPath, "partial-new-store");
+    fs.writeFileSync(backupPath, "complete-old-store");
+    fs.writeFileSync(ownedTemporaryPath, "owned");
+    fs.writeFileSync(foreignTemporaryPath, "foreign");
+
+    recoverLeaseArtifacts(indexPath, owner, [targetPath]);
+
+    expect(fs.readFileSync(targetPath, "utf-8")).toBe("complete-old-store");
+    expect(fs.existsSync(backupPath)).toBe(false);
+    expect(fs.existsSync(ownedTemporaryPath)).toBe(false);
+    expect(fs.existsSync(foreignTemporaryPath)).toBe(true);
+  });
+
+  it("creates owner-specific temporary paths", () => {
+    const lease = acquireIndexLock(indexPath, "index");
+    const targetPath = path.join(indexPath, "file-hashes.json");
+    const first = createLeaseTemporaryPath(targetPath, lease.owner, "tmp");
+    const second = createLeaseTemporaryPath(targetPath, lease.owner, "tmp");
+
+    expect(first).not.toBe(second);
+    expect(first).toContain(`.tmp.${process.pid}.${lease.owner.token}.`);
+    expect(first).not.toBe(`${targetPath}.tmp`);
+    expect(createLeaseTemporaryPath(targetPath, lease.owner, "bak")).toBe(
+      `${targetPath}.bak.${process.pid}.${lease.owner.token}`,
+    );
+    releaseIndexLock(lease);
+  });
+});

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -329,6 +329,30 @@ describe("indexer clearIndex force rebuild", () => {
     expect(clearedDb.getStats().chunkCount).toBe(0);
   });
 
+  it("keeps mutations on the canonical index after a project symlink is retargeted", async () => {
+    const indexParent = path.join(tempDir, ".opencode");
+    const indexLink = path.join(indexParent, "index");
+    const firstTarget = path.join(tempHome, "canonical-index-a");
+    const secondTarget = path.join(tempHome, "canonical-index-b");
+    fs.mkdirSync(indexParent, { recursive: true });
+    fs.mkdirSync(firstTarget, { recursive: true });
+    fs.mkdirSync(secondTarget, { recursive: true });
+    fs.symlinkSync(firstTarget, indexLink, "dir");
+
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+    expect(fs.existsSync(path.join(firstTarget, "codebase.db"))).toBe(true);
+
+    fs.unlinkSync(indexLink);
+    fs.symlinkSync(secondTarget, indexLink, "dir");
+    fs.writeFileSync(sourceFile, "export function canonicalUpdate() { return 'updated'; }\n", "utf-8");
+
+    await indexer.index();
+
+    expect(fs.existsSync(path.join(firstTarget, "codebase.db"))).toBe(true);
+    expect(fs.existsSync(path.join(secondTarget, "codebase.db"))).toBe(false);
+  });
+
   it("clears only the current project from a shared global index when compatibility is unchanged", async () => {
     vi.stubEnv("HOME", tempHome);
     vi.stubEnv("USERPROFILE", tempHome);
@@ -1518,13 +1542,14 @@ describe("indexer clearIndex force rebuild", () => {
     const fileHashCachePath = path.join(tempHome, ".opencode", "global-index", "file-hashes.json");
     fs.mkdirSync(path.dirname(fileHashCachePath), { recursive: true });
     fs.writeFileSync(fileHashCachePath, "{", "utf-8");
+    const canonicalFileHashCachePath = fs.realpathSync.native(fileHashCachePath);
 
     await indexer.clearIndex();
 
     const logs = indexer.getLogger().getLogs().filter((entry) => entry.level === "warn");
     expect(logs.some((entry) =>
       entry.message === "Failed to load file hash cache, resetting cache state"
-      && entry.data?.fileHashCachePath === fileHashCachePath
+      && entry.data?.fileHashCachePath === canonicalFileHashCachePath
     )).toBe(true);
   });
 

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadMergedConfig } from "../src/config/merger.js";
 import { parseConfig } from "../src/config/schema.js";
 import { Indexer } from "../src/indexer/index.js";
-import { Database, VectorStore } from "../src/native/index.js";
+import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
 import { hashContent } from "../src/native/index.js";
 
 describe("indexer clearIndex force rebuild", () => {
@@ -165,6 +165,44 @@ describe("indexer clearIndex force rebuild", () => {
     await expect(restartedIndexer.index()).rejects.toThrow("Run index_codebase with force=true to rebuild the index");
   });
 
+  it("keeps an in-flight search usable while the same Indexer reloads for a mutation", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+    const immediateFetch = fetchSpy.getMockImplementation()!;
+    let releaseSearch: (() => void) | null = null;
+    let notifySearchStarted: (() => void) | null = null;
+    const searchStarted = new Promise<void>((resolve) => { notifySearchStarted = resolve; });
+    fetchSpy.mockImplementation(async (url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      if (body.input?.includes("slow query")) {
+        notifySearchStarted?.();
+        await new Promise<void>((resolve) => { releaseSearch = resolve; });
+      }
+      return immediateFetch(url, init);
+    });
+
+    const searchPromise = indexer.search("slow query");
+    await searchStarted;
+    await expect(indexer.index()).resolves.toMatchObject({ failedChunks: 0 });
+    releaseSearch?.();
+
+    await expect(searchPromise).resolves.toEqual(expect.any(Array));
+  });
+
+  it("reloads persisted state only once for a force mutation lease", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+    const vectorLoad = vi.spyOn(VectorStore.prototype, "load");
+    const invertedLoad = vi.spyOn(InvertedIndex.prototype, "load");
+
+    await indexer.forceIndex();
+
+    expect(vectorLoad).toHaveBeenCalledOnce();
+    expect(invertedLoad).toHaveBeenCalledOnce();
+    vectorLoad.mockRestore();
+    invertedLoad.mockRestore();
+  });
+
   it("rejects force clearing an inherited project index from a fresh worktree", async () => {
     const mainRepoDir = path.join(tempDir, "main-repo");
     const worktreeDir = path.join(tempDir, "worktree-feature");
@@ -209,6 +247,54 @@ describe("indexer clearIndex force rebuild", () => {
     await expect(inheritedIndexer.clearIndex()).rejects.toThrow(
       "Project-scoped force rebuild is unsafe while using an inherited worktree index"
     );
+  });
+
+  it("preserves an inherited project index when its crashed owner needs recovery", async () => {
+    const mainRepoDir = path.join(tempDir, "main-repo-recovery");
+    const worktreeDir = path.join(tempDir, "worktree-recovery");
+    const worktreeGitDir = path.join(mainRepoDir, ".git", "worktrees", "recovery");
+    const mainSourceFile = path.join(mainRepoDir, "src", "index.ts");
+
+    fs.mkdirSync(path.join(mainRepoDir, ".git", "refs", "heads"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.mkdirSync(path.dirname(mainSourceFile), { recursive: true });
+    fs.mkdirSync(worktreeGitDir, { recursive: true });
+    fs.mkdirSync(worktreeDir, { recursive: true });
+    fs.writeFileSync(path.join(mainRepoDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+    fs.writeFileSync(path.join(mainRepoDir, ".git", "refs", "heads", "main"), "1111111111111111111111111111111111111111\n");
+    fs.writeFileSync(path.join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+    fs.writeFileSync(path.join(worktreeGitDir, "HEAD"), "ref: refs/heads/recovery\n");
+    fs.writeFileSync(path.join(worktreeGitDir, "commondir"), "../..\n");
+    fs.writeFileSync(path.join(mainRepoDir, ".opencode", "codebase-index.json"), JSON.stringify({
+      embeddingProvider: "custom",
+      customProvider: { baseUrl: "http://localhost:11434/v1", model: "mock-8d", dimensions: 8 },
+      scope: "project",
+      indexing: { watchFiles: false, retries: 0, retryDelayMs: 1 },
+    }, null, 2));
+    fs.writeFileSync(mainSourceFile, "export function preserved() { return true; }\n");
+
+    const mainIndexer = createIndexer(mainRepoDir, 8);
+    await mainIndexer.index();
+    await mainIndexer.close();
+    const inheritedIndexPath = path.join(mainRepoDir, ".opencode", "index");
+    const lockPath = path.join(inheritedIndexPath, "indexing.lock");
+    fs.mkdirSync(lockPath);
+    fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify({
+      pid: 2_147_483_647,
+      hostname: os.hostname(),
+      startedAt: new Date().toISOString(),
+      operation: "index",
+      token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    }));
+
+    const inheritedIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir))));
+    await expect(inheritedIndexer.index()).rejects.toThrow(
+      "Interrupted indexing recovery is unsafe while using an inherited worktree index"
+    );
+
+    expect(fs.existsSync(path.join(inheritedIndexPath, "codebase.db"))).toBe(true);
+    expect(fs.existsSync(path.join(inheritedIndexPath, "vectors"))).toBe(true);
+    expect(fs.readdirSync(inheritedIndexPath).some((name) => name.startsWith("indexing.lock.recovery."))).toBe(true);
   });
 
   it("allows codex force clearing a local legacy OpenCode project index", async () => {
@@ -859,13 +945,14 @@ describe("indexer clearIndex force rebuild", () => {
     const stats = await indexer.index();
     expect(stats.indexedChunks).toBeGreaterThan(0);
 
-    const database = (indexer as unknown as { database: Database }).database!;
-    vi.spyOn(database, "gcOrphanEmbeddings").mockReturnValue(0);
-    vi.spyOn(database, "gcOrphanChunks").mockImplementation(() => {
+    const gcEmbeddingsSpy = vi.spyOn(Database.prototype, "gcOrphanEmbeddings").mockReturnValue(0);
+    const gcChunksSpy = vi.spyOn(Database.prototype, "gcOrphanChunks").mockImplementation(() => {
       throw new Error("SQLite error: database disk image is malformed");
     });
 
     const result = await indexer.healthCheck();
+    gcEmbeddingsSpy.mockRestore();
+    gcChunksSpy.mockRestore();
     expect(result.resetCorruptedIndex).toBe(true);
     expect(result.warning).toContain("reset the local index");
 
@@ -914,13 +1001,14 @@ describe("indexer clearIndex force rebuild", () => {
     const indexer = createIndexer(projectA, 8, "global");
     await indexer.index();
 
-    const database = (indexer as unknown as { database: Database }).database;
-    vi.spyOn(database, "gcOrphanEmbeddings").mockReturnValue(0);
-    vi.spyOn(database, "gcOrphanChunks").mockImplementation(() => {
+    const gcEmbeddingsSpy = vi.spyOn(Database.prototype, "gcOrphanEmbeddings").mockReturnValue(0);
+    const gcChunksSpy = vi.spyOn(Database.prototype, "gcOrphanChunks").mockImplementation(() => {
       throw new Error("SQLite error: database disk image is malformed");
     });
 
     await expect(indexer.healthCheck()).rejects.toThrow("Automatic repair is disabled for global scope");
+    gcEmbeddingsSpy.mockRestore();
+    gcChunksSpy.mockRestore();
   });
 
   it("surfaces rebuild guidance when automatic orphan GC resets a corrupted local index", async () => {
@@ -944,8 +1032,7 @@ describe("indexer clearIndex force rebuild", () => {
     const initialStats = await indexer.index();
     expect(initialStats.indexedChunks).toBeGreaterThan(0);
 
-    const database = (indexer as unknown as { database: Database }).database;
-    vi.spyOn(database, "getStats").mockReturnValue({
+    const getStatsSpy = vi.spyOn(Database.prototype, "getStats").mockReturnValue({
       embeddingCount: 2,
       chunkCount: 1,
       branchChunkCount: 1,
@@ -953,9 +1040,11 @@ describe("indexer clearIndex force rebuild", () => {
       symbolCount: 0,
       callEdgeCount: 0,
     });
-    const realGcOrphanEmbeddings = database.gcOrphanEmbeddings.bind(database);
-    vi.spyOn(database, "gcOrphanEmbeddings").mockImplementation(() => realGcOrphanEmbeddings());
-    vi.spyOn(database, "gcOrphanChunks").mockImplementation(() => {
+    const realGcOrphanEmbeddings = Database.prototype.gcOrphanEmbeddings;
+    const gcEmbeddingsSpy = vi.spyOn(Database.prototype, "gcOrphanEmbeddings").mockImplementation(function () {
+      return realGcOrphanEmbeddings.call(this);
+    });
+    const gcChunksSpy = vi.spyOn(Database.prototype, "gcOrphanChunks").mockImplementation(() => {
       throw new Error("SQLite error: database disk image is malformed");
     });
 
@@ -972,6 +1061,9 @@ describe("indexer clearIndex force rebuild", () => {
     ].join("\n"), "utf-8");
 
     const result = await indexer.index();
+    getStatsSpy.mockRestore();
+    gcEmbeddingsSpy.mockRestore();
+    gcChunksSpy.mockRestore();
     expect(maybeRunOrphanGc).toHaveBeenCalled();
     expect(result.resetCorruptedIndex).toBe(true);
     expect(result.warning).toContain("reset the local index");

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -893,6 +893,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     fs.rmSync(path.join(tempHome, ".opencode", "global-index", "vectors.usearch"), { force: true });
     fs.rmSync(path.join(tempHome, ".opencode", "global-index", "vectors"), { recursive: true, force: true });
+    fs.rmSync(path.join(tempHome, ".opencode", "global-index", "vectors.meta.json"), { force: true });
     fs.writeFileSync(
       path.join(tempHome, ".opencode", "global-index", "file-hashes.json"),
       JSON.stringify({}, null, 2),
@@ -937,6 +938,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     fs.rmSync(path.join(tempHome, ".opencode", "global-index", "vectors.usearch"), { force: true });
     fs.rmSync(path.join(tempHome, ".opencode", "global-index", "vectors"), { recursive: true, force: true });
+    fs.rmSync(path.join(tempHome, ".opencode", "global-index", "vectors.meta.json"), { force: true });
     fs.writeFileSync(
       path.join(tempHome, ".opencode", "global-index", "file-hashes.json"),
       JSON.stringify({}, null, 2),

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1207,8 +1207,6 @@ describe("indexer failed batch recovery", () => {
     const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
     fs.mkdirSync(path.dirname(failedBatchesPath), { recursive: true });
     fs.writeFileSync(failedBatchesPath, "{", "utf-8");
-    const canonicalFailedBatchesPath = fs.realpathSync.native(failedBatchesPath);
-
     const indexer = createIndexer();
     await indexer.initialize();
     await indexer.getStatus();
@@ -1216,7 +1214,7 @@ describe("indexer failed batch recovery", () => {
     const logs = indexer.getLogger().getLogs().filter((entry) => entry.level === "warn");
     expect(logs.some((entry) =>
       entry.message === "Failed to load failed batch state, skipping persisted retries"
-      && entry.data?.failedBatchesPath === canonicalFailedBatchesPath
+      && entry.data?.failedBatchesPath === failedBatchesPath
     )).toBe(true);
   });
 

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1207,6 +1207,7 @@ describe("indexer failed batch recovery", () => {
     const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
     fs.mkdirSync(path.dirname(failedBatchesPath), { recursive: true });
     fs.writeFileSync(failedBatchesPath, "{", "utf-8");
+    const canonicalFailedBatchesPath = fs.realpathSync.native(failedBatchesPath);
 
     const indexer = createIndexer();
     await indexer.initialize();
@@ -1215,7 +1216,7 @@ describe("indexer failed batch recovery", () => {
     const logs = indexer.getLogger().getLogs().filter((entry) => entry.level === "warn");
     expect(logs.some((entry) =>
       entry.message === "Failed to load failed batch state, skipping persisted retries"
-      && entry.data?.failedBatchesPath === failedBatchesPath
+      && entry.data?.failedBatchesPath === canonicalFailedBatchesPath
     )).toBe(true);
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -365,7 +365,7 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("INDEX_BUSY");
     expect(content[0].text).toContain("PID 4242");
-    expect(content[0].text).toContain("opération index");
+    expect(content[0].text).toContain("operation index");
     expect(content[0].text).toContain(owner.startedAt);
   });
 
@@ -383,8 +383,32 @@ describe("MCP server tools and prompts", () => {
     expect(result.isError).toBe(true);
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("INDEX_BUSY");
-    expect(content[0].text).toContain("Reprise automatique refusée");
-    expect(content[0].text).toContain("vérification manuelle");
+    expect(content[0].text).toContain("Automatic recovery was refused");
+    expect(content[0].text).toContain("manual verification");
+  });
+
+  it("should explain legacy locks in English", async () => {
+    const owner = {
+      pid: 4243,
+      hostname: "local-test",
+      startedAt: "2026-07-16T12:00:00.000Z",
+      operation: "index" as const,
+      token: "legacy-owner-token",
+    };
+    const indexer = (await import("../src/tools/operations.js")).getIndexerForProject("/tmp/test-project", "opencode");
+    vi.mocked(indexer.index).mockRejectedValueOnce(
+      new IndexLockContentionError("/tmp/indexing.lock", owner, "legacy-lock"),
+    );
+
+    const result = await client.callTool({
+      name: "index_codebase",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("legacy lock format detected");
+    expect(content[0].text).toContain("remove this lock manually only if it is stale");
   });
 
   it("should surface failed batch diagnostics in index_status output", async () => {
@@ -543,7 +567,7 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("INDEX_BUSY");
     expect(content[0].text).toContain("PID 4343");
-    expect(content[0].text).toContain("opération health-check");
+    expect(content[0].text).toContain("operation health-check");
     expect(content[0].text).toContain(owner.startedAt);
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -521,6 +521,32 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("healthy");
   });
 
+  it("should return an explicit INDEX_BUSY result from index_health_check", async () => {
+    const owner = {
+      pid: 4343,
+      hostname: "local-test",
+      startedAt: "2026-07-17T10:00:00.000Z",
+      operation: "health-check" as const,
+      token: "health-owner-token",
+    };
+    const indexer = (await import("../src/tools/operations.js")).getIndexerForProject("/tmp/test-project", "opencode");
+    vi.mocked(indexer.healthCheck).mockRejectedValueOnce(
+      new IndexLockContentionError("/tmp/indexing.lock", owner, "active"),
+    );
+
+    const result = await client.callTool({
+      name: "index_health_check",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("INDEX_BUSY");
+    expect(content[0].text).toContain("PID 4343");
+    expect(content[0].text).toContain("opération health-check");
+    expect(content[0].text).toContain(owner.startedAt);
+  });
+
   it("should surface corruption reset guidance in index_health_check output", async () => {
     mockHealthCheckResult = {
       removed: 0,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,19 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createMcpServer } from "../src/mcp-server.js";
 import { parseConfig } from "../src/config/schema.js";
+import { IndexLockContentionError } from "../src/indexer/index-lock.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import * as fs from "fs";
+
+const { testMainRepo } = vi.hoisted(() => ({
+  testMainRepo: `/tmp/codebase-index-mcp-vitest-main-repo-${process.pid}`,
+}));
 
 vi.mock("fs", async () => {
   const actual = await vi.importActual<typeof import("fs")>("fs");
+  const inheritedIndexPath = `${testMainRepo}/.opencode/index`;
   return {
     ...actual,
-    existsSync: vi.fn((targetPath: string) => targetPath.replace(/\\/g, "/").includes("/main-repo/.opencode/index")),
+    existsSync: vi.fn((targetPath: string) => {
+      const normalizedPath = targetPath.replace(/\\/g, "/");
+      return normalizedPath === inheritedIndexPath || actual.existsSync(targetPath);
+    }),
   };
 });
 
 vi.mock("../src/git/index.js", () => ({
-  resolveWorktreeMainRepoRoot: vi.fn(() => "/tmp/main-repo"),
+  resolveWorktreeMainRepoRoot: vi.fn(() => testMainRepo),
 }));
 
 const mergerMocks = vi.hoisted(() => ({
@@ -27,6 +37,7 @@ const indexerMockState = vi.hoisted(() => ({
     initialize: ReturnType<typeof vi.fn>;
     getStatus: ReturnType<typeof vi.fn>;
     clearIndex: ReturnType<typeof vi.fn>;
+    forceIndex: ReturnType<typeof vi.fn>;
   }>,
 }));
 
@@ -85,6 +96,7 @@ vi.mock("../src/indexer/index.js", () => {
         initialize: this.initialize,
         getStatus: this.getStatus,
         clearIndex: this.clearIndex,
+        forceIndex: this.forceIndex,
       });
     }
 
@@ -112,6 +124,7 @@ vi.mock("../src/indexer/index.js", () => {
       },
     ]);
     index = vi.fn().mockImplementation(async () => mockIndexResult);
+    forceIndex = vi.fn().mockImplementation(async () => mockIndexResult);
     getStatus = vi.fn().mockImplementation(async () => mockStatusResult);
     healthCheck = vi.fn().mockImplementation(async () => mockHealthCheckResult);
     clearIndex = vi.fn().mockResolvedValue(undefined);
@@ -171,6 +184,7 @@ describe("MCP server tools and prompts", () => {
   let server: ReturnType<typeof createMcpServer>;
 
   beforeEach(async () => {
+    fs.mkdirSync(`${testMainRepo}/.opencode/index`, { recursive: true });
     indexerMockState.constructorArgs.length = 0;
     indexerMockState.instances.length = 0;
     mergerMocks.loadProjectConfigLayer.mockReset();
@@ -223,6 +237,7 @@ describe("MCP server tools and prompts", () => {
 
   afterEach(async () => {
     await client.close();
+    fs.rmSync(testMainRepo, { recursive: true, force: true });
   });
 
   it("should register all 12 tools", async () => {
@@ -326,6 +341,50 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("INDEXING WARNING");
     expect(content[0].text).toContain("failed-batches.json");
+  });
+
+  it("should return an explicit INDEX_BUSY MCP result", async () => {
+    const owner = {
+      pid: 4242,
+      hostname: "local-test",
+      startedAt: "2026-07-16T12:00:00.000Z",
+      operation: "index" as const,
+      token: "owner-token",
+    };
+    const indexer = (await import("../src/tools/operations.js")).getIndexerForProject("/tmp/test-project", "opencode");
+    vi.mocked(indexer.index).mockRejectedValueOnce(
+      new IndexLockContentionError("/tmp/indexing.lock", owner, "active"),
+    );
+
+    const result = await client.callTool({
+      name: "index_codebase",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("INDEX_BUSY");
+    expect(content[0].text).toContain("PID 4242");
+    expect(content[0].text).toContain("opération index");
+    expect(content[0].text).toContain(owner.startedAt);
+  });
+
+  it("should explain when an unreadable lock requires manual verification", async () => {
+    const indexer = (await import("../src/tools/operations.js")).getIndexerForProject("/tmp/test-project", "opencode");
+    vi.mocked(indexer.index).mockRejectedValueOnce(
+      new IndexLockContentionError("/tmp/indexing.lock", null, "unknown-owner"),
+    );
+
+    const result = await client.callTool({
+      name: "index_codebase",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("INDEX_BUSY");
+    expect(content[0].text).toContain("Reprise automatique refusée");
+    expect(content[0].text).toContain("vérification manuelle");
   });
 
   it("should surface failed batch diagnostics in index_status output", async () => {

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -1,0 +1,651 @@
+import type { ChildProcess } from "child_process";
+import type { AddressInfo } from "net";
+import { fork } from "child_process";
+import * as fs from "fs";
+import { createServer, type Server, type ServerResponse } from "http";
+import * as os from "os";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
+import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
+
+interface WorkerMessage {
+  type: string;
+  ok?: boolean;
+  code?: string;
+  pid?: number;
+  stats?: { indexedChunks?: number };
+  owner?: { pid?: number; token?: string };
+  message?: string;
+}
+
+class WorkerController {
+  readonly child: ChildProcess;
+  readonly messages: WorkerMessage[] = [];
+  private readonly waiters: Array<{
+    predicate: (message: WorkerMessage) => boolean;
+    resolve: (message: WorkerMessage) => void;
+  }> = [];
+  private readonly output: string[] = [];
+
+  constructor(projectRoot: string, baseUrl: string) {
+    const workerPath = fileURLToPath(new URL("./fixtures/multiprocess-index-worker.ts", import.meta.url));
+    this.child = fork(workerPath, [], {
+      execArgv: ["--import", "tsx"],
+      env: {
+        ...process.env,
+        TEST_PROJECT_ROOT: projectRoot,
+        TEST_EMBEDDING_BASE_URL: baseUrl,
+      },
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+    });
+    this.child.stdout?.on("data", (chunk) => this.output.push(String(chunk)));
+    this.child.stderr?.on("data", (chunk) => this.output.push(String(chunk)));
+    this.child.on("message", (message: WorkerMessage) => {
+      this.messages.push(message);
+      for (const waiter of [...this.waiters]) {
+        if (!waiter.predicate(message)) continue;
+        this.waiters.splice(this.waiters.indexOf(waiter), 1);
+        waiter.resolve(message);
+      }
+    });
+  }
+
+  send(message: Record<string, unknown>): void {
+    if (!this.child.connected) return;
+    this.child.send(message, (error) => {
+      if (error && !["EPIPE", "ERR_IPC_CHANNEL_CLOSED"].includes((error as NodeJS.ErrnoException).code ?? "")) {
+        this.output.push(String(error));
+      }
+    });
+  }
+
+  async waitFor(predicate: (message: WorkerMessage) => boolean, timeoutMs = 5000): Promise<WorkerMessage> {
+    const existing = this.messages.find(predicate);
+    if (existing) return existing;
+
+    return new Promise((resolve, reject) => {
+      const waiter = { predicate, resolve };
+      this.waiters.push(waiter);
+      const timeout = setTimeout(() => {
+        const index = this.waiters.indexOf(waiter);
+        if (index >= 0) this.waiters.splice(index, 1);
+        reject(new Error(`Worker timeout. Messages: ${JSON.stringify(this.messages)}\n${this.output.join("")}`));
+      }, timeoutMs);
+      const originalResolve = waiter.resolve;
+      waiter.resolve = (message) => {
+        clearTimeout(timeout);
+        originalResolve(message);
+      };
+    });
+  }
+
+  async waitForReady(): Promise<void> {
+    await this.waitFor((message) => message.type === "ready");
+  }
+
+  async stop(): Promise<void> {
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+    this.send({ type: "stop" });
+    await this.waitForExit(1500).catch(() => {
+      this.child.kill("SIGKILL");
+    });
+    await this.waitForExit();
+  }
+
+  async kill(): Promise<void> {
+    if (this.child.exitCode === null && this.child.signalCode === null) this.child.kill("SIGKILL");
+    await this.waitForExit();
+  }
+
+  async waitForExit(timeoutMs = 5000): Promise<void> {
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Worker did not exit")), timeoutMs);
+      this.child.once("exit", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
+}
+
+class FakeEmbeddingServer {
+  private server: Server | null = null;
+  private blocked = false;
+  private pendingResponses: Array<() => void> = [];
+  private countWaiters: Array<{ count: number; resolve: () => void }> = [];
+  requestCount = 0;
+  active = 0;
+  maxActive = 0;
+  inputs: string[] = [];
+
+  async start(): Promise<void> {
+    this.server = createServer((request, response) => {
+      if (request.method !== "POST" || request.url !== "/v1/embeddings") {
+        response.writeHead(404).end();
+        return;
+      }
+      let body = "";
+      request.on("data", (chunk) => { body += String(chunk); });
+      request.on("end", () => { void this.respond(body, response); });
+    });
+    await new Promise<void>((resolve, reject) => {
+      const server = this.server!;
+      const onError = (error: Error) => reject(error);
+      server.once("error", onError);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", onError);
+        resolve();
+      });
+    });
+  }
+
+  get baseUrl(): string {
+    const address = this.server?.address() as AddressInfo | null;
+    if (!address) throw new Error("Server is not listening");
+    return `http://127.0.0.1:${address.port}/v1`;
+  }
+
+  block(): void {
+    this.blocked = true;
+  }
+
+  release(): void {
+    this.blocked = false;
+    for (const resolve of this.pendingResponses.splice(0)) resolve();
+  }
+
+  reset(): void {
+    if (this.active !== 0) throw new Error("Cannot reset with active requests");
+    this.requestCount = 0;
+    this.maxActive = 0;
+    this.inputs = [];
+  }
+
+  async waitForRequestCount(count: number, timeoutMs = 5000): Promise<void> {
+    if (this.requestCount >= count) return;
+    await new Promise<void>((resolve, reject) => {
+      const waiter = { count, resolve };
+      this.countWaiters.push(waiter);
+      const timeout = setTimeout(() => {
+        const index = this.countWaiters.indexOf(waiter);
+        if (index >= 0) this.countWaiters.splice(index, 1);
+        reject(new Error(`Expected ${count} requests, received ${this.requestCount}`));
+      }, timeoutMs);
+      waiter.resolve = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+    });
+  }
+
+  async waitForIdle(timeoutMs = 5000): Promise<void> {
+    const startedAt = Date.now();
+    while (this.active > 0) {
+      if (Date.now() - startedAt > timeoutMs) throw new Error(`Server still has ${this.active} active requests`);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  async close(): Promise<void> {
+    this.release();
+    if (!this.server) return;
+    await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+    this.server = null;
+  }
+
+  private async respond(body: string, response: ServerResponse): Promise<void> {
+    const parsed = JSON.parse(body) as { input?: unknown };
+    const requestInputs = Array.isArray(parsed.input) ? parsed.input.map(String) : [String(parsed.input ?? "")];
+    this.inputs.push(...requestInputs);
+    this.requestCount += 1;
+    this.active += 1;
+    this.maxActive = Math.max(this.maxActive, this.active);
+    for (const waiter of [...this.countWaiters]) {
+      if (this.requestCount < waiter.count) continue;
+      this.countWaiters.splice(this.countWaiters.indexOf(waiter), 1);
+      waiter.resolve();
+    }
+
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      this.active -= 1;
+    };
+    response.once("close", finish);
+
+    if (this.blocked) await new Promise<void>((resolve) => this.pendingResponses.push(resolve));
+    if (response.destroyed) {
+      finish();
+      return;
+    }
+
+    const data = requestInputs.map((input, index) => ({
+      object: "embedding",
+      index,
+      embedding: Array.from({ length: 8 }, (_, dimension) => ((input.length + dimension * 17) % 97) / 97),
+    }));
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ data, usage: { total_tokens: requestInputs.length } }), finish);
+  }
+}
+
+describe("multiprocess indexing", () => {
+  let tempDir: string;
+  let projectRoot: string;
+  let sourcePath: string;
+  let embeddingServer: FakeEmbeddingServer;
+  let workers: WorkerController[];
+  let mcpClients: Client[];
+  let localIndexers: Indexer[];
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "multiprocess-index-"));
+    projectRoot = path.join(tempDir, "project");
+    sourcePath = path.join(projectRoot, "src", "index.ts");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, "package.json"), JSON.stringify({ name: "fixture" }));
+    fs.writeFileSync(sourcePath, "export function alpha() { return 'alpha'; }\nexport function beta() { return alpha(); }\n");
+    embeddingServer = new FakeEmbeddingServer();
+    await embeddingServer.start();
+    workers = [];
+    mcpClients = [];
+    localIndexers = [];
+  });
+
+  afterEach(async () => {
+    embeddingServer?.release();
+    await Promise.all((mcpClients ?? []).map((client) => client.close().catch(() => {})));
+    await Promise.all((workers ?? []).map((worker) => worker.stop()));
+    await Promise.all((localIndexers ?? []).map((indexer) => indexer.close().catch(() => {})));
+    await embeddingServer?.close();
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function createWorker(): Promise<WorkerController> {
+    const worker = new WorkerController(projectRoot, embeddingServer.baseUrl);
+    workers.push(worker);
+    await worker.waitForReady();
+    return worker;
+  }
+
+  async function createMcpClient(configPath: string): Promise<{
+    client: Client;
+    transport: StdioClientTransport;
+    stderr: string[];
+  }> {
+    const stderr: string[] = [];
+    const cliPath = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["--import", "tsx", cliPath, "--project", projectRoot, "--config", configPath, "--host", "opencode"],
+      cwd: path.dirname(cliPath),
+      stderr: "pipe",
+    });
+    transport.stderr?.on("data", (chunk) => stderr.push(String(chunk)));
+    const client = new Client({ name: "multiprocess-test-client", version: "1.0.0" });
+    mcpClients.push(client);
+    try {
+      await client.connect(transport);
+    } catch (error) {
+      throw new Error(`MCP client failed to connect: ${stderr.join("")}`, { cause: error });
+    }
+    return { client, transport, stderr };
+  }
+
+  async function seedIndex(): Promise<void> {
+    const worker = await createWorker();
+    worker.send({ type: "run", operation: "index" });
+    const result = await worker.waitFor((message) => message.type === "result");
+    expect(result.ok).toBe(true);
+    await worker.waitForExit();
+    await embeddingServer.waitForIdle();
+  }
+
+  function createLocalIndexer(): Indexer {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      scope: "project",
+      customProvider: {
+        baseUrl: embeddingServer.baseUrl,
+        model: "multiprocess-test",
+        dimensions: 8,
+        timeoutMs: 5000,
+        maxBatchSize: 64,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      include: ["**/*.ts"],
+      exclude: ["**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+      indexing: {
+        autoIndex: false,
+        watchFiles: false,
+        autoGc: false,
+        retries: 0,
+        retryDelayMs: 1,
+        gitBlame: { enabled: false },
+      },
+      debug: { enabled: false },
+    });
+    const indexer = new Indexer(projectRoot, config);
+    localIndexers.push(indexer);
+    return indexer;
+  }
+
+  function readOwner(): string {
+    return fs.readFileSync(path.join(projectRoot, ".opencode", "index", "indexing.lock", "owner.json"), "utf-8");
+  }
+
+  function assertIndexIntegrity(): void {
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const database = new Database(path.join(indexPath, "codebase.db"));
+    const stats = database.getStats();
+    const branchChunkIds = database.getBranchChunkIds("default");
+    expect(stats?.chunkCount).toBeGreaterThan(0);
+    expect(stats?.embeddingCount).toBeGreaterThan(0);
+    expect(stats?.branchChunkCount).toBe(branchChunkIds.length);
+    expect(branchChunkIds.length).toBe(stats?.chunkCount);
+    for (const chunkId of branchChunkIds) {
+      const chunk = database.getChunk(chunkId);
+      expect(chunk).not.toBeNull();
+      expect(database.getEmbedding(chunk!.contentHash)).not.toBeNull();
+    }
+    database.close();
+
+    const vectors = new VectorStore(path.join(indexPath, "vectors"), 8);
+    vectors.load();
+    expect(vectors.count()).toBe(stats?.chunkCount);
+    expect(vectors.getAllMetadata().map(({ key }) => key).sort()).toEqual([...branchChunkIds].sort());
+
+    const inverted = new InvertedIndex(path.join(indexPath, "inverted-index.json"));
+    inverted.load();
+    expect(inverted.getDocumentCount()).toBe(stats?.chunkCount);
+    expect(Array.from(inverted.search("function", 20).keys()).some((chunkId) => branchChunkIds.includes(chunkId))).toBe(true);
+    const hashes = JSON.parse(fs.readFileSync(path.join(indexPath, "file-hashes.json"), "utf-8")) as Record<string, string>;
+    expect(Object.keys(hashes).length).toBeGreaterThan(0);
+    expect(hashes[sourcePath]).toBeTypeOf("string");
+    expect(fs.existsSync(path.join(indexPath, "failed-batches.json"))).toBe(false);
+    expect(fs.existsSync(path.join(indexPath, "indexing.lock"))).toBe(false);
+    expect(fs.readdirSync(indexPath).some((name) => name.includes(".tmp.") || name.includes(".bak.") || name.startsWith("indexing.lock."))).toBe(false);
+  }
+
+  it("allows only one normal indexer to embed", async () => {
+    embeddingServer.block();
+    const first = await createWorker();
+    const second = await createWorker();
+    first.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    const ownerBefore = readOwner();
+    second.send({ type: "run", operation: "index" });
+    const busy = await second.waitFor((message) => message.type === "result");
+
+    expect(busy.code).toBe("INDEX_BUSY");
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(readOwner()).toBe(ownerBefore);
+
+    embeddingServer.release();
+    const success = await first.waitFor((message) => message.type === "result");
+    expect(success.ok).toBe(true);
+    await first.waitForExit();
+    await second.waitForExit();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(new Set(embeddingServer.inputs).size).toBe(embeddingServer.inputs.length);
+    expect(embeddingServer.maxActive).toBe(1);
+    assertIndexIntegrity();
+  });
+
+  it("keeps the active lease when the same Indexer receives an overlapping mutation", async () => {
+    const indexer = createLocalIndexer();
+    embeddingServer.block();
+    const firstIndex = indexer.index();
+    await embeddingServer.waitForRequestCount(1);
+    const ownerBefore = readOwner();
+
+    await expect(indexer.index()).rejects.toMatchObject({ code: "INDEX_BUSY" });
+    expect(readOwner()).toBe(ownerBefore);
+    expect(embeddingServer.requestCount).toBe(1);
+
+    embeddingServer.release();
+    await expect(firstIndex).resolves.toMatchObject({ indexedChunks: expect.any(Number) });
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+    assertIndexIntegrity();
+  });
+
+  it("allows only one of two real MCP stdio servers to index", async () => {
+    const configPath = path.join(tempDir, "mcp-config.json");
+    fs.writeFileSync(configPath, JSON.stringify({
+      embeddingProvider: "custom",
+      scope: "project",
+      customProvider: {
+        baseUrl: embeddingServer.baseUrl,
+        model: "multiprocess-test",
+        dimensions: 8,
+        timeoutMs: 5000,
+        maxBatchSize: 64,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      include: ["**/*.ts"],
+      exclude: ["**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+      indexing: {
+        autoIndex: false,
+        watchFiles: false,
+        autoGc: false,
+        retries: 0,
+        retryDelayMs: 1,
+        gitBlame: { enabled: false },
+      },
+      debug: { enabled: false },
+    }));
+
+    const first = await createMcpClient(configPath);
+    const second = await createMcpClient(configPath);
+    expect(first.transport.pid).not.toBeNull();
+    expect(second.transport.pid).not.toBeNull();
+    expect(first.transport.pid).not.toBe(second.transport.pid);
+
+    embeddingServer.block();
+    const firstResultPromise = first.client.callTool({ name: "index_codebase", arguments: {} });
+    await embeddingServer.waitForRequestCount(1);
+    const ownerBefore = readOwner();
+    const busyResult = await second.client.callTool({ name: "index_codebase", arguments: {} });
+
+    expect(busyResult.isError).toBe(true);
+    expect((busyResult.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n")).toContain("INDEX_BUSY");
+    expect(readOwner()).toBe(ownerBefore);
+    expect(embeddingServer.requestCount).toBe(1);
+
+    embeddingServer.release();
+    const firstResult = await firstResultPromise;
+    expect(firstResult.isError).not.toBe(true);
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+
+    await Promise.all([first.client.close(), second.client.close()]);
+    mcpClients = [];
+    assertIndexIntegrity();
+  });
+
+  it.each([
+    ["force", "index"],
+    ["index", "force"],
+  ] as const)("keeps %s against %s under one lease", async (winningOperation, losingOperation) => {
+    await seedIndex();
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function alpha() { return 'updated'; }\nexport function gamma() { return alpha(); }\n");
+    embeddingServer.block();
+
+    const winner = await createWorker();
+    const loser = await createWorker();
+    winner.send({ type: "run", operation: winningOperation });
+    const firstEvent = await Promise.race([
+      embeddingServer.waitForRequestCount(1).then(() => ({ type: "embedding" as const })),
+      winner.waitFor((message) => message.type === "result").then((message) => ({ type: "result" as const, message })),
+    ]);
+    if (firstEvent.type === "result") {
+      throw new Error(`Winner exited before embedding: ${JSON.stringify(firstEvent.message)}`);
+    }
+    const ownerBefore = readOwner();
+    loser.send({ type: "run", operation: losingOperation });
+    const busy = await loser.waitFor((message) => message.type === "result");
+
+    expect(busy.code).toBe("INDEX_BUSY");
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(readOwner()).toBe(ownerBefore);
+
+    embeddingServer.release();
+    expect((await winner.waitFor((message) => message.type === "result")).ok).toBe(true);
+    await winner.waitForExit();
+    await loser.waitForExit();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+    expect(new Set(embeddingServer.inputs).size).toBe(embeddingServer.inputs.length);
+    assertIndexIntegrity();
+  });
+
+  it("recovers a crashed owner safely with two concurrent reclaimers", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function recovered() { return 'after-crash'; }\n");
+    embeddingServer.block();
+    const crashed = await createWorker();
+    crashed.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    const crashedOwner = JSON.parse(readOwner()) as { pid: number; token: string };
+    await crashed.kill();
+    embeddingServer.release();
+    await embeddingServer.waitForIdle();
+
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    for (const fileName of ["vectors", "vectors.meta.json"]) {
+      const targetPath = path.join(indexPath, fileName);
+      fs.renameSync(targetPath, `${targetPath}.bak.${crashedOwner.pid}.${crashedOwner.token}`);
+    }
+    fs.writeFileSync(
+      path.join(indexPath, `file-hashes.json.tmp.${crashedOwner.pid}.${crashedOwner.token}.1`),
+      "interrupted",
+    );
+
+    embeddingServer.reset();
+    embeddingServer.block();
+
+    const first = await createWorker();
+    const second = await createWorker();
+    first.send({ type: "run", operation: "index" });
+    second.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    const newOwner = JSON.parse(readOwner()) as { token: string };
+    expect(newOwner.token).not.toBe(crashedOwner.token);
+
+    const firstResultPromise = first.waitFor((message) => message.type === "result");
+    const secondResultPromise = second.waitFor((message) => message.type === "result");
+    const busy = await Promise.race([firstResultPromise, secondResultPromise]);
+    expect(busy.code).toBe("INDEX_BUSY");
+    expect(embeddingServer.requestCount).toBe(1);
+
+    embeddingServer.release();
+    const results = await Promise.all([firstResultPromise, secondResultPromise]);
+    expect(results.filter((result) => result.ok).length).toBe(1);
+    expect(results.filter((result) => result.code === "INDEX_BUSY").length).toBe(1);
+    await first.waitForExit();
+    await second.waitForExit();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+    expect(new Set(embeddingServer.inputs).size).toBe(embeddingServer.inputs.length);
+    assertIndexIntegrity();
+  });
+
+  it("recovers every pending owner after the recovery process also crashes", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function recoveredTwice() { return 'after-two-crashes'; }\n");
+    embeddingServer.block();
+
+    const firstCrashed = await createWorker();
+    firstCrashed.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    const firstOwner = JSON.parse(readOwner()) as { token: string };
+    await firstCrashed.kill();
+    embeddingServer.release();
+    await embeddingServer.waitForIdle();
+
+    embeddingServer.reset();
+    embeddingServer.block();
+    const crashedRecovery = await createWorker();
+    crashedRecovery.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    const secondOwner = JSON.parse(readOwner()) as { token: string };
+    expect(secondOwner.token).not.toBe(firstOwner.token);
+    await crashedRecovery.kill();
+    embeddingServer.release();
+    await embeddingServer.waitForIdle();
+
+    embeddingServer.reset();
+    embeddingServer.block();
+    const finalRecovery = await createWorker();
+    finalRecovery.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const pendingMarkers = fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."));
+    expect(pendingMarkers).toHaveLength(2);
+
+    embeddingServer.release();
+    expect((await finalRecovery.waitFor((message) => message.type === "result")).ok).toBe(true);
+    await finalRecovery.waitForExit();
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+    expect(fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."))).toEqual([]);
+    assertIndexIntegrity();
+  });
+
+  it("coalesces two watcher processes without duplicate embeddings", async () => {
+    const first = await createWorker();
+    const second = await createWorker();
+    first.send({ type: "run", operation: "watch" });
+    second.send({ type: "run", operation: "watch" });
+    await Promise.all([
+      first.waitFor((message) => message.type === "watcher-ready"),
+      second.waitFor((message) => message.type === "watcher-ready"),
+    ]);
+
+    embeddingServer.block();
+    fs.writeFileSync(sourcePath, "export function watched() { return 'changed'; }\n");
+    await embeddingServer.waitForRequestCount(1);
+    const ownerBefore = readOwner();
+    const busy = await Promise.race([
+      first.waitFor((message) => message.type === "watch-result" && message.code === "INDEX_BUSY"),
+      second.waitFor((message) => message.type === "watch-result" && message.code === "INDEX_BUSY"),
+    ]);
+    expect(busy.code).toBe("INDEX_BUSY");
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(readOwner()).toBe(ownerBefore);
+
+    embeddingServer.release();
+    await Promise.race([
+      first.waitFor((message) => message.type === "watch-result" && message.ok === true),
+      second.waitFor((message) => message.type === "watch-result" && message.ok === true),
+    ]);
+    await Promise.all([
+      first.waitFor((message) => message.type === "watch-result" && message.ok === true),
+      second.waitFor((message) => message.type === "watch-result" && message.ok === true),
+    ]);
+
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+    expect(new Set(embeddingServer.inputs).size).toBe(embeddingServer.inputs.length);
+    await Promise.all([first.stop(), second.stop()]);
+    assertIndexIntegrity();
+  });
+});

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -695,6 +695,42 @@ describe("multiprocess indexing", () => {
     },
   );
 
+  it.each(["vectors", "vectors.meta.json"])(
+    "rejects an incomplete vector publication during fresh writer initialization when %s is missing",
+    async (missingName) => {
+      await seedIndex();
+      embeddingServer.reset();
+      const indexPath = path.join(projectRoot, ".opencode", "index");
+      const missingPath = path.join(indexPath, missingName);
+      const retainedPath = path.join(
+        indexPath,
+        missingName === "vectors" ? "vectors.meta.json" : "vectors",
+      );
+      const retainedBefore = fs.readFileSync(retainedPath);
+      const databasePath = path.join(indexPath, "codebase.db");
+      const database = new Database(databasePath);
+      const statsBefore = database.getStats();
+      const branchChunkIdsBefore = database.getBranchChunkIds("default");
+      database.close();
+      fs.rmSync(missingPath, { force: true });
+
+      const writer = await createWorker();
+      writer.send({ type: "run", operation: "index" });
+      const result = await writer.waitFor((message) => message.type === "result");
+      await writer.waitForExit();
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/incomplete vector publication/i);
+      expect(embeddingServer.requestCount).toBe(0);
+      expect(fs.existsSync(missingPath)).toBe(false);
+      expect(fs.readFileSync(retainedPath)).toEqual(retainedBefore);
+      const reloadedDatabase = new Database(databasePath);
+      expect(reloadedDatabase.getStats()).toEqual(statsBefore);
+      expect(reloadedDatabase.getBranchChunkIds("default")).toEqual(branchChunkIdsBefore);
+      reloadedDatabase.close();
+    },
+  );
+
   it("reports an unreadable database without resetting published artifacts", async () => {
     await seedIndex();
     embeddingServer.reset();

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -12,6 +12,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 
 import { parseConfig } from "../src/config/schema.js";
 import { Indexer } from "../src/indexer/index.js";
+import { acquireIndexLock, releaseIndexLock } from "../src/indexer/index-lock.js";
 import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
 
 interface WorkerMessage {
@@ -309,7 +310,7 @@ describe("multiprocess indexing", () => {
     await embeddingServer.waitForIdle();
   }
 
-  function createLocalIndexer(): Indexer {
+  function createLocalIndexer(autoGc = false): Indexer {
     const config = parseConfig({
       embeddingProvider: "custom",
       scope: "project",
@@ -327,7 +328,7 @@ describe("multiprocess indexing", () => {
       indexing: {
         autoIndex: false,
         watchFiles: false,
-        autoGc: false,
+        autoGc,
         retries: 0,
         retryDelayMs: 1,
         gitBlame: { enabled: false },
@@ -417,6 +418,100 @@ describe("multiprocess indexing", () => {
     await embeddingServer.waitForIdle();
     expect(embeddingServer.requestCount).toBe(1);
     expect(embeddingServer.maxActive).toBe(1);
+    assertIndexIntegrity();
+  });
+
+  it("keeps a cold status read outside a live writer lease", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const lease = acquireIndexLock(indexPath, "index");
+    const ownerBefore = readOwner();
+
+    try {
+      const status = await createLocalIndexer().getStatus();
+
+      expect(status.indexed).toBe(true);
+      expect(status.vectorCount).toBeGreaterThan(0);
+      expect(readOwner()).toBe(ownerBefore);
+      expect(embeddingServer.requestCount).toBe(0);
+      expect(fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."))).toEqual([]);
+    } finally {
+      releaseIndexLock(lease);
+    }
+  });
+
+  it("coordinates a cold reader and writer on the same Indexer", async () => {
+    const indexer = createLocalIndexer();
+    const [status, stats] = await Promise.all([
+      indexer.getStatus(),
+      indexer.index(),
+    ]);
+
+    expect(status.provider).toBe("custom");
+    expect(stats.indexedChunks).toBeGreaterThan(0);
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+    assertIndexIntegrity();
+  });
+
+  it("waits for writer-first initialization on the same Indexer", async () => {
+    const indexer = createLocalIndexer();
+    const indexing = indexer.index();
+    const status = indexer.getStatus();
+    const [stats, statusResult] = await Promise.all([indexing, status]);
+
+    expect(stats.indexedChunks).toBeGreaterThan(0);
+    expect(statusResult.compatibility).not.toBeNull();
+    expect(embeddingServer.requestCount).toBe(1);
+    assertIndexIntegrity();
+  });
+
+  it("defers auto-GC from a cold reader to the next writer", async () => {
+    const indexer = createLocalIndexer(true);
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+
+    await indexer.getStatus();
+    const databaseBeforeWriter = new Database(path.join(indexPath, "codebase.db"));
+    expect(databaseBeforeWriter.getMetadata("lastGcTimestamp")).toBeNull();
+    databaseBeforeWriter.close();
+    expect(embeddingServer.requestCount).toBe(0);
+
+    await indexer.index();
+    const databaseAfterWriter = new Database(path.join(indexPath, "codebase.db"));
+    expect(databaseAfterWriter.getMetadata("lastGcTimestamp")).not.toBeNull();
+    databaseAfterWriter.close();
+    assertIndexIntegrity();
+  });
+
+  it("leaves crashed-writer recovery to the next writer", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function recovered() { return 'after-crash'; }\n");
+    embeddingServer.block();
+    const crashed = await createWorker();
+    crashed.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    await crashed.kill();
+    embeddingServer.release();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const ownerBeforeRead = readOwner();
+    await createLocalIndexer().getStatus();
+
+    expect(readOwner()).toBe(ownerBeforeRead);
+    expect(embeddingServer.requestCount).toBe(0);
+    expect(fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."))).toEqual([]);
+
+    await createLocalIndexer().index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const recoveredStatus = await createLocalIndexer().getStatus();
+    expect(recoveredStatus.indexed).toBe(true);
+    expect(embeddingServer.requestCount).toBe(0);
     assertIndexIntegrity();
   });
 

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -335,7 +335,14 @@ describe("multiprocess indexing", () => {
     await embeddingServer.waitForIdle();
   }
 
-  function createLocalIndexer(autoGc = false): Indexer {
+  function createLocalIndexer(
+    autoGc = false,
+    search?: {
+      fusionStrategy?: "weighted" | "rrf";
+      hybridWeight?: number;
+      minScore?: number;
+    },
+  ): Indexer {
     const config = parseConfig({
       embeddingProvider: "custom",
       scope: "project",
@@ -358,6 +365,7 @@ describe("multiprocess indexing", () => {
         retryDelayMs: 1,
         gitBlame: { enabled: false },
       },
+      search,
       debug: { enabled: false },
     });
     const indexer = new Indexer(projectRoot, config);
@@ -523,6 +531,26 @@ describe("multiprocess indexing", () => {
     }
   });
 
+  it("falls back to semantic-only ranking when weighted BM25 is unavailable", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const invertedIndexPath = path.join(indexPath, "inverted-index.json");
+    const unreadableBm25 = "{partial";
+    fs.writeFileSync(invertedIndexPath, unreadableBm25);
+    const indexer = createLocalIndexer(false, {
+      fusionStrategy: "weighted",
+      hybridWeight: 1,
+      minScore: 0.1,
+    });
+
+    const results = await indexer.search("conceptual behavior flow");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(fs.readFileSync(invertedIndexPath, "utf-8")).toBe(unreadableBm25);
+    expect(embeddingServer.inputs).toEqual(["conceptual behavior flow"]);
+  });
+
   it("reports an unreadable vector store without replacing it", async () => {
     await seedIndex();
     embeddingServer.reset();
@@ -548,6 +576,95 @@ describe("multiprocess indexing", () => {
     const recoveredStatus = await indexer.getStatus();
     expect(recoveredStatus.indexed).toBe(true);
     expect(recoveredStatus.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it("rejects a valid vector metadata file from a different publication", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const vectorPath = path.join(indexPath, "vectors");
+    const metadataPath = `${vectorPath}.meta.json`;
+    const originalMetadata = fs.readFileSync(metadataPath);
+    const published = new VectorStore(vectorPath, 8);
+    published.loadStrict();
+    const foreignPath = path.join(tempDir, "foreign-vectors");
+    const foreign = new VectorStore(foreignPath, 8);
+    published.getAllMetadata().forEach(({ metadata }, index) => {
+      foreign.add(
+        `foreign-${index}`,
+        Array.from({ length: 8 }, (_, dimension) => index + dimension / 10),
+        { ...metadata, hash: `foreign-hash-${index}` },
+      );
+    });
+    foreign.save();
+    fs.copyFileSync(`${foreignPath}.meta.json`, metadataPath);
+    const reader = createLocalIndexer();
+
+    const mismatchedStatus = await reader.getStatus();
+    expect(mismatchedStatus.indexed).toBe(false);
+    expect(mismatchedStatus.warning).toMatch(/vector.*fingerprint.*index_codebase/i);
+    await expect(reader.search("alpha")).rejects.toThrow(/vector.*fingerprint.*index_codebase/i);
+    expect(embeddingServer.requestCount).toBe(0);
+
+    fs.writeFileSync(metadataPath, originalMetadata);
+    const recoveredStatus = await reader.getStatus();
+    expect(recoveredStatus.indexed).toBe(true);
+    expect(recoveredStatus.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it("requires a writer to fingerprint a structurally valid legacy vector pair", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const metadataPath = path.join(indexPath, "vectors.meta.json");
+    const legacyMetadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as Record<string, unknown>;
+    delete legacyMetadata.vector_fingerprint;
+    fs.writeFileSync(metadataPath, JSON.stringify(legacyMetadata));
+    const reader = createLocalIndexer();
+
+    const legacyStatus = await reader.getStatus();
+
+    expect(legacyStatus.indexed).toBe(false);
+    expect(legacyStatus.warning).toMatch(/vector.*fingerprint.*index_codebase/i);
+    expect(embeddingServer.requestCount).toBe(0);
+    expect((JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as Record<string, unknown>).vector_fingerprint).toBeUndefined();
+
+    const writer = await createWorker();
+    writer.send({ type: "run", operation: "index" });
+    expect((await writer.waitFor((message) => message.type === "result")).ok).toBe(true);
+    await writer.waitForExit();
+    expect(embeddingServer.requestCount).toBe(0);
+    expect((JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as Record<string, unknown>).vector_fingerprint).toBeTypeOf("string");
+
+    const recoveredStatus = await reader.getStatus();
+    expect(recoveredStatus.indexed).toBe(true);
+    expect(recoveredStatus.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it("fingerprints an empty legacy vector pair after a successful writer publication", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    fs.rmSync(sourcePath);
+    await createLocalIndexer().index();
+    expect(embeddingServer.requestCount).toBe(0);
+
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const metadataPath = path.join(indexPath, "vectors.meta.json");
+    const legacyMetadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as Record<string, unknown>;
+    delete legacyMetadata.vector_fingerprint;
+    fs.writeFileSync(metadataPath, JSON.stringify(legacyMetadata));
+    const reader = createLocalIndexer();
+    expect((await reader.getStatus()).warning).toMatch(/vector.*fingerprint.*index_codebase/i);
+
+    const writer = await createWorker();
+    writer.send({ type: "run", operation: "index" });
+    expect((await writer.waitFor((message) => message.type === "result")).ok).toBe(true);
+    await writer.waitForExit();
+
+    expect((JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as Record<string, unknown>).vector_fingerprint).toBeTypeOf("string");
     expect(embeddingServer.requestCount).toBe(0);
   });
 
@@ -824,6 +941,83 @@ describe("multiprocess indexing", () => {
     expect(statusResult.compatibility).not.toBeNull();
     expect(embeddingServer.requestCount).toBe(1);
     assertIndexIntegrity();
+  });
+
+  it("refreshes a stale writer instance after another writer publishes", async () => {
+    const indexer = createLocalIndexer();
+    await indexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    fs.writeFileSync(
+      sourcePath,
+      "export function alpha() { return 'alpha'; }\nexport function publicationmarker() { return 'publicationmarker'; }\n",
+    );
+    const externalWriter = await createWorker();
+    externalWriter.send({ type: "run", operation: "index" });
+    expect((await externalWriter.waitFor((message) => message.type === "result")).ok).toBe(true);
+    await externalWriter.waitForExit();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const results = await indexer.search("publicationmarker");
+    expect(results.some((result) => result.name === "publicationmarker")).toBe(true);
+    const removedResults = await indexer.search("beta");
+    expect(removedResults.every((result) => result.name !== "beta")).toBe(true);
+    expect(embeddingServer.inputs).toEqual(["publicationmarker", "beta"]);
+
+    embeddingServer.reset();
+    fs.appendFileSync(sourcePath, "export function writeragain() { return 'writeragain'; }\n");
+    await expect(indexer.index()).resolves.toMatchObject({ indexedChunks: expect.any(Number) });
+    expect(embeddingServer.inputs.some((input) => input.includes("writeragain"))).toBe(true);
+    assertIndexIntegrity();
+  });
+
+  it("clears a lost local lease before refreshing a later external publication", async () => {
+    const indexer = createLocalIndexer();
+    embeddingServer.block();
+    const indexing = indexer.index();
+    await embeddingServer.waitForRequestCount(1);
+    fs.rmSync(path.join(projectRoot, ".opencode", "index", "indexing.lock"), {
+      recursive: true,
+      force: true,
+    });
+    embeddingServer.release();
+    await expect(indexing).rejects.toThrow(/lost ownership/i);
+    expect(Reflect.get(indexer, "writerArtifactFingerprint")).toBeNull();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    fs.writeFileSync(sourcePath, "export function afterlostlease() { return 'afterlostlease'; }\n");
+    const externalWriter = await createWorker();
+    externalWriter.send({ type: "run", operation: "index" });
+    expect((await externalWriter.waitFor((message) => message.type === "result")).ok).toBe(true);
+    await externalWriter.waitForExit();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const results = await indexer.search("afterlostlease");
+    expect(results.some((result) => result.name === "afterlostlease")).toBe(true);
+    expect(embeddingServer.inputs).toEqual(["afterlostlease"]);
+  });
+
+  it("clears transient reader issues after a successful writer reload", async () => {
+    const indexer = createLocalIndexer();
+    await indexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+    const invertedIndexPath = path.join(projectRoot, ".opencode", "index", "inverted-index.json");
+    const readableBm25 = fs.readFileSync(invertedIndexPath);
+    fs.writeFileSync(invertedIndexPath, "{partial");
+
+    const degradedStatus = await indexer.getStatus();
+    expect(degradedStatus.warning).toMatch(/keyword.*semantic search/i);
+
+    fs.writeFileSync(invertedIndexPath, readableBm25);
+    await indexer.index();
+    const healthyStatus = await indexer.getStatus();
+    expect(healthyStatus.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(0);
   });
 
   it("defers auto-GC from a cold reader to the next writer", async () => {

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -25,6 +25,12 @@ interface WorkerMessage {
   message?: string;
 }
 
+interface Bm25PublicationBarrier {
+  targetPath: string;
+  readyPath: string;
+  releasePath: string;
+}
+
 class WorkerController {
   readonly child: ChildProcess;
   readonly messages: WorkerMessage[] = [];
@@ -34,14 +40,23 @@ class WorkerController {
   }> = [];
   private readonly output: string[] = [];
 
-  constructor(projectRoot: string, baseUrl: string) {
+  constructor(projectRoot: string, baseUrl: string, bm25Barrier?: Bm25PublicationBarrier) {
     const workerPath = fileURLToPath(new URL("./fixtures/multiprocess-index-worker.ts", import.meta.url));
+    const execArgv = ["--import", "tsx"];
+    if (bm25Barrier) {
+      execArgv.push("--import", new URL("./fixtures/bm25-publication-barrier.mjs", import.meta.url).href);
+    }
     this.child = fork(workerPath, [], {
-      execArgv: ["--import", "tsx"],
+      execArgv,
       env: {
         ...process.env,
         TEST_PROJECT_ROOT: projectRoot,
         TEST_EMBEDDING_BASE_URL: baseUrl,
+        ...(bm25Barrier ? {
+          TEST_BM25_TARGET_PATH: bm25Barrier.targetPath,
+          TEST_BM25_READY_PATH: bm25Barrier.readyPath,
+          TEST_BM25_RELEASE_PATH: bm25Barrier.releasePath,
+        } : {}),
       },
       stdio: ["ignore", "pipe", "pipe", "ipc"],
     });
@@ -270,11 +285,21 @@ describe("multiprocess indexing", () => {
     if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  async function createWorker(): Promise<WorkerController> {
-    const worker = new WorkerController(projectRoot, embeddingServer.baseUrl);
+  async function createWorker(bm25Barrier?: Bm25PublicationBarrier): Promise<WorkerController> {
+    const worker = new WorkerController(projectRoot, embeddingServer.baseUrl, bm25Barrier);
     workers.push(worker);
     await worker.waitForReady();
     return worker;
+  }
+
+  async function waitForFile(filePath: string, timeoutMs = 5000): Promise<void> {
+    const startedAt = Date.now();
+    while (!fs.existsSync(filePath)) {
+      if (Date.now() - startedAt > timeoutMs) {
+        throw new Error(`Timed out waiting for ${filePath}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
   }
 
   async function createMcpClient(configPath: string): Promise<{
@@ -421,24 +446,358 @@ describe("multiprocess indexing", () => {
     assertIndexIntegrity();
   });
 
-  it("keeps a cold status read outside a live writer lease", async () => {
+  it("does not create index artifacts for a cold status read", async () => {
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    expect(fs.existsSync(indexPath)).toBe(false);
+
+    const status = await createLocalIndexer().getStatus();
+
+    expect(status.indexed).toBe(false);
+    expect(status.vectorCount).toBe(0);
+    expect(fs.existsSync(indexPath)).toBe(false);
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it("refreshes the same cold reader after the first writer publishes the index", async () => {
+    embeddingServer.block();
+    const worker = await createWorker();
+    worker.send({ type: "run", operation: "index" });
+    await embeddingServer.waitForRequestCount(1);
+    const indexer = createLocalIndexer();
+
+    const statusDuringWrite = await indexer.getStatus();
+    expect(statusDuringWrite.indexed).toBe(false);
+    expect(statusDuringWrite.vectorCount).toBe(0);
+
+    embeddingServer.release();
+    const result = await worker.waitFor((message) => message.type === "result");
+    expect(result.ok).toBe(true);
+    await worker.waitForExit();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const statusAfterWrite = await indexer.getStatus();
+    expect(statusAfterWrite.indexed).toBe(true);
+    expect(statusAfterWrite.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(0);
+
+    const results = await indexer.search("alpha");
+    expect(results.length).toBeGreaterThan(0);
+    expect(embeddingServer.inputs).toEqual(["alpha"]);
+    assertIndexIntegrity();
+  });
+
+  it("keeps an unreadable BM25 artifact untouched under a live writer lease", async () => {
     await seedIndex();
     embeddingServer.reset();
     const indexPath = path.join(projectRoot, ".opencode", "index");
+    const invertedIndexPath = path.join(indexPath, "inverted-index.json");
+    const readableBm25 = fs.readFileSync(invertedIndexPath, "utf-8");
+    const unreadableBm25 = "{partial";
+    fs.writeFileSync(invertedIndexPath, unreadableBm25);
     const lease = acquireIndexLock(indexPath, "index");
     const ownerBefore = readOwner();
 
     try {
-      const status = await createLocalIndexer().getStatus();
+      const indexer = createLocalIndexer();
+      const status = await indexer.getStatus();
+      const results = await indexer.search("alpha");
 
       expect(status.indexed).toBe(true);
       expect(status.vectorCount).toBeGreaterThan(0);
+      expect(status.warning).toMatch(/keyword.*index_codebase with force=true/i);
+      expect(results.length).toBeGreaterThan(0);
+      expect(fs.readFileSync(invertedIndexPath, "utf-8")).toBe(unreadableBm25);
       expect(readOwner()).toBe(ownerBefore);
-      expect(embeddingServer.requestCount).toBe(0);
+      expect(embeddingServer.requestCount).toBe(1);
+      expect(embeddingServer.inputs).toEqual(["alpha"]);
       expect(fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."))).toEqual([]);
+
+      fs.writeFileSync(invertedIndexPath, readableBm25);
+      const recoveredStatus = await indexer.getStatus();
+      expect(recoveredStatus.indexed).toBe(true);
+      expect(recoveredStatus.warning).toBeUndefined();
+      expect(embeddingServer.requestCount).toBe(1);
     } finally {
       releaseIndexLock(lease);
     }
+  });
+
+  it("reports an unreadable vector store without replacing it", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const vectorPath = path.join(indexPath, "vectors");
+    const metadataPath = path.join(indexPath, "vectors.meta.json");
+    const vectorBefore = fs.readFileSync(vectorPath);
+    const metadataBefore = fs.readFileSync(metadataPath, "utf-8");
+    const unreadableMetadata = "{partial";
+    fs.writeFileSync(metadataPath, unreadableMetadata);
+    const indexer = createLocalIndexer();
+
+    const status = await indexer.getStatus();
+
+    expect(status.indexed).toBe(false);
+    expect(status.warning).toMatch(/vector.*remove this checkout's local index directory.*index_codebase/i);
+    expect(fs.readFileSync(vectorPath)).toEqual(vectorBefore);
+    expect(fs.readFileSync(metadataPath, "utf-8")).toBe(unreadableMetadata);
+    await expect(indexer.search("alpha")).rejects.toThrow(/vector.*index_codebase/i);
+    expect(embeddingServer.requestCount).toBe(0);
+
+    fs.writeFileSync(metadataPath, metadataBefore);
+    const recoveredStatus = await indexer.getStatus();
+    expect(recoveredStatus.indexed).toBe(true);
+    expect(recoveredStatus.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it.each(["vectors", "vectors.meta.json"])(
+    "reports an incomplete vector publication when %s is missing",
+    async (missingName) => {
+      await seedIndex();
+      embeddingServer.reset();
+      const indexPath = path.join(projectRoot, ".opencode", "index");
+      const missingPath = path.join(indexPath, missingName);
+      const retainedPath = path.join(
+        indexPath,
+        missingName === "vectors" ? "vectors.meta.json" : "vectors",
+      );
+      const retainedBefore = fs.readFileSync(retainedPath);
+      fs.rmSync(missingPath, { force: true });
+      const indexer = createLocalIndexer();
+
+      const status = await indexer.getStatus();
+
+      expect(status.indexed).toBe(false);
+      expect(status.vectorCount).toBe(0);
+      expect(status.warning).toMatch(/vector.*remove this checkout's local index directory.*index_codebase/i);
+      expect(fs.existsSync(missingPath)).toBe(false);
+      expect(fs.readFileSync(retainedPath)).toEqual(retainedBefore);
+      await expect(indexer.search("alpha")).rejects.toThrow(/vector.*index_codebase/i);
+      expect(embeddingServer.requestCount).toBe(0);
+    },
+  );
+
+  it("reports an unreadable database without resetting published artifacts", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const dbPath = path.join(indexPath, "codebase.db");
+    const vectorPath = path.join(indexPath, "vectors");
+    const metadataPath = path.join(indexPath, "vectors.meta.json");
+    const invertedIndexPath = path.join(indexPath, "inverted-index.json");
+    const hashesPath = path.join(indexPath, "file-hashes.json");
+    fs.rmSync(`${dbPath}-shm`, { force: true });
+    fs.rmSync(`${dbPath}-wal`, { force: true });
+    const unreadableDatabase = Buffer.from("not a sqlite database");
+    fs.writeFileSync(dbPath, unreadableDatabase);
+    const artifactsBefore = new Map([
+      [vectorPath, fs.readFileSync(vectorPath)],
+      [metadataPath, fs.readFileSync(metadataPath)],
+      [invertedIndexPath, fs.readFileSync(invertedIndexPath)],
+      [hashesPath, fs.readFileSync(hashesPath)],
+    ]);
+    const indexer = createLocalIndexer();
+
+    const status = await indexer.getStatus();
+
+    expect(status.indexed).toBe(false);
+    expect(status.vectorCount).toBeGreaterThan(0);
+    expect(status.warning).toMatch(/database.*index_codebase/i);
+    expect(fs.readFileSync(dbPath)).toEqual(unreadableDatabase);
+    for (const [artifactPath, content] of artifactsBefore) {
+      expect(fs.readFileSync(artifactPath)).toEqual(content);
+    }
+    await expect(indexer.search("alpha")).rejects.toThrow(/database.*index_codebase/i);
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it("degrades the same healthy reader when its database becomes unreadable", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const dbPath = path.join(indexPath, "codebase.db");
+    const unreadableDatabase = Buffer.from("not a sqlite database");
+    const indexer = createLocalIndexer();
+
+    const healthyStatus = await indexer.getStatus();
+    expect(healthyStatus.indexed).toBe(true);
+
+    fs.writeFileSync(dbPath, unreadableDatabase);
+    const degradedStatus = await indexer.getStatus();
+
+    expect(degradedStatus.indexed).toBe(false);
+    expect(degradedStatus.warning).toMatch(/database.*index_codebase/i);
+    expect(fs.readFileSync(dbPath)).toEqual(unreadableDatabase);
+    await expect(indexer.search("alpha")).rejects.toThrow(/database.*index_codebase/i);
+    expect(embeddingServer.requestCount).toBe(0);
+  });
+
+  it("keeps a degraded reader snapshot blocked while the same Indexer upgrades to writer", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const dbPath = path.join(indexPath, "codebase.db");
+    fs.rmSync(`${dbPath}-shm`, { force: true });
+    fs.rmSync(`${dbPath}-wal`, { force: true });
+    fs.writeFileSync(dbPath, "not a sqlite database");
+    const indexer = createLocalIndexer();
+
+    const status = await indexer.getStatus();
+    expect(status.warning).toMatch(/database.*index_codebase/i);
+
+    const searching = indexer.search("alpha");
+    const indexing = indexer.index();
+
+    await expect(searching).rejects.toThrow(/database.*index_codebase/i);
+    await expect(indexing).resolves.toMatchObject({ indexedChunks: expect.any(Number) });
+    expect(embeddingServer.inputs).not.toContain("alpha");
+    assertIndexIntegrity();
+  });
+
+  it("defers legacy database creation to the next writer without re-embedding", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const dbPath = path.join(indexPath, "codebase.db");
+    fs.rmSync(dbPath, { force: true });
+    fs.rmSync(`${dbPath}-shm`, { force: true });
+    fs.rmSync(`${dbPath}-wal`, { force: true });
+    const indexer = createLocalIndexer();
+
+    const readerStatus = await indexer.getStatus();
+
+    expect(readerStatus.indexed).toBe(false);
+    expect(readerStatus.vectorCount).toBeGreaterThan(0);
+    expect(readerStatus.warning).toMatch(/database.*index_codebase/i);
+    expect(fs.existsSync(dbPath)).toBe(false);
+    expect(embeddingServer.requestCount).toBe(0);
+
+    const stats = await indexer.index();
+    const writerStatus = await indexer.getStatus();
+    const database = new Database(dbPath);
+    try {
+      expect(stats.indexedChunks).toBe(0);
+      expect(writerStatus.indexed).toBe(true);
+      expect(writerStatus.warning).toBeUndefined();
+      expect(database.getStats().chunkCount).toBeGreaterThan(0);
+      expect(database.getBranchChunkIds("default").length).toBeGreaterThan(0);
+      expect(embeddingServer.requestCount).toBe(0);
+    } finally {
+      database.close();
+    }
+  });
+
+  it("publishes BM25 atomically while a cold reader overlaps the writer save", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const invertedIndexPath = path.join(indexPath, "inverted-index.json");
+    const readyPath = path.join(tempDir, "bm25-publication-ready.json");
+    const releasePath = path.join(tempDir, "bm25-publication-release");
+    const publishedBefore = fs.readFileSync(invertedIndexPath, "utf-8");
+    fs.writeFileSync(
+      sourcePath,
+      "export function alpha() { return 'alpha'; }\nexport function publicationmarker() { return 'publicationmarker'; }\n",
+    );
+    const worker = await createWorker({
+      targetPath: fs.realpathSync(invertedIndexPath),
+      readyPath,
+      releasePath,
+    });
+    worker.send({ type: "run", operation: "index" });
+
+    try {
+      await waitForFile(readyPath);
+    } catch (error) {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}; worker messages: ${JSON.stringify(worker.messages)}`);
+    }
+    const barrier = JSON.parse(fs.readFileSync(readyPath, "utf-8")) as { source: string; destination: string };
+    const ownerBeforeRead = readOwner();
+    const requestsBeforeRead = embeddingServer.requestCount;
+    const inputsBeforeRead = [...embeddingServer.inputs];
+    const reader = createLocalIndexer();
+
+    try {
+      const staged = new InvertedIndex(barrier.source);
+      staged.load();
+      expect(staged.search("publicationmarker").size).toBeGreaterThan(0);
+
+      const published = new InvertedIndex(invertedIndexPath);
+      published.load();
+      expect(published.search("publicationmarker").size).toBe(0);
+      expect(fs.readFileSync(invertedIndexPath, "utf-8")).toBe(publishedBefore);
+
+      const status = await reader.getStatus();
+      expect(status.indexed).toBe(true);
+      expect(fs.readFileSync(invertedIndexPath, "utf-8")).toBe(publishedBefore);
+      expect(fs.existsSync(barrier.source)).toBe(true);
+      expect(readOwner()).toBe(ownerBeforeRead);
+      expect(embeddingServer.requestCount).toBe(requestsBeforeRead);
+      expect(fs.readdirSync(indexPath).filter((name) => name.startsWith("indexing.lock.recovery."))).toEqual([]);
+    } finally {
+      fs.writeFileSync(releasePath, "release");
+    }
+
+    const result = await worker.waitFor((message) => message.type === "result");
+    expect(result.ok).toBe(true);
+    await worker.waitForExit();
+
+    const publishedAfter = new InvertedIndex(invertedIndexPath);
+    publishedAfter.load();
+    expect(fs.readFileSync(invertedIndexPath, "utf-8")).not.toBe(publishedBefore);
+    expect(publishedAfter.search("publicationmarker").size).toBeGreaterThan(0);
+    expect(fs.existsSync(barrier.source)).toBe(false);
+    const finalStatus = await reader.getStatus();
+    expect(finalStatus.indexed).toBe(true);
+    expect(embeddingServer.requestCount).toBe(requestsBeforeRead);
+    const searchResults = await reader.search("publicationmarker");
+    expect(searchResults.some((searchResult) => searchResult.content.includes("publicationmarker"))).toBe(true);
+    expect(embeddingServer.inputs).toEqual([...inputsBeforeRead, "publicationmarker"]);
+    assertIndexIntegrity();
+  });
+
+  it("refreshes a first-publication BM25 reader after the atomic rename", async () => {
+    const indexPath = path.join(projectRoot, ".opencode", "index");
+    const invertedIndexPath = path.join(indexPath, "inverted-index.json");
+    const readyPath = path.join(tempDir, "first-bm25-publication-ready.json");
+    const releasePath = path.join(tempDir, "first-bm25-publication-release");
+    const canonicalTargetPath = path.join(
+      fs.realpathSync(projectRoot),
+      ".opencode",
+      "index",
+      "inverted-index.json",
+    );
+    const worker = await createWorker({
+      targetPath: canonicalTargetPath,
+      readyPath,
+      releasePath,
+    });
+    worker.send({ type: "run", operation: "index" });
+
+    await waitForFile(readyPath);
+    const reader = createLocalIndexer();
+    const requestsBeforeRead = embeddingServer.requestCount;
+    try {
+      const statusBeforePublish = await reader.getStatus();
+
+      expect(statusBeforePublish.indexed).toBe(true);
+      expect(statusBeforePublish.warning).toMatch(/keyword.*semantic search/i);
+      expect(fs.existsSync(invertedIndexPath)).toBe(false);
+      expect(embeddingServer.requestCount).toBe(requestsBeforeRead);
+    } finally {
+      fs.writeFileSync(releasePath, "release");
+    }
+
+    const result = await worker.waitFor((message) => message.type === "result");
+    expect(result.ok).toBe(true);
+    await worker.waitForExit();
+
+    const statusAfterPublish = await reader.getStatus();
+    expect(statusAfterPublish.indexed).toBe(true);
+    expect(statusAfterPublish.warning).toBeUndefined();
+    expect(embeddingServer.requestCount).toBe(requestsBeforeRead);
+    assertIndexIntegrity();
   });
 
   it("coordinates a cold reader and writer on the same Indexer", async () => {

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -501,6 +501,174 @@ end
       expect(newStore.count()).toBe(1);
     });
 
+    it("should fingerprint persisted vectors and require the fingerprint for strict loads", () => {
+      store.add("chunk1", [1, 0, 0], {
+        filePath: "test.ts",
+        startLine: 1,
+        endLine: 5,
+        chunkType: "function",
+        language: "typescript",
+        hash: "abc123",
+      });
+      store.save();
+
+      const metadataPath = path.join(tempDir, "vectors.meta.json");
+      const persisted = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as {
+        vector_fingerprint?: string;
+      };
+      expect(persisted.vector_fingerprint).toBeTypeOf("string");
+      expect(store.hasFingerprint()).toBe(true);
+
+      const strictStore = new VectorStore(path.join(tempDir, "vectors"), 3);
+      strictStore.loadStrict();
+      expect(strictStore.count()).toBe(1);
+    });
+
+    it("should reject valid vector and metadata artifacts from different publications", () => {
+      const firstPath = path.join(tempDir, "vectors-first");
+      const secondPath = path.join(tempDir, "vectors-second");
+      const first = new VectorStore(firstPath, 3);
+      const second = new VectorStore(secondPath, 3);
+      first.add("first", [1, 0, 0], {
+        filePath: "first.ts",
+        startLine: 1,
+        endLine: 2,
+        chunkType: "function",
+        language: "typescript",
+        hash: "first-hash",
+      });
+      second.add("second", [0, 1, 0], {
+        filePath: "second.ts",
+        startLine: 1,
+        endLine: 2,
+        chunkType: "function",
+        language: "typescript",
+        hash: "second-hash",
+      });
+      first.save();
+      second.save();
+      fs.copyFileSync(`${secondPath}.meta.json`, `${firstPath}.meta.json`);
+
+      const mixed = new VectorStore(firstPath, 3);
+      expect(() => mixed.loadStrict()).toThrow(/fingerprint.*mismatch/i);
+      expect(mixed.count()).toBe(0);
+      expect(() => mixed.load()).toThrow(/fingerprint.*mismatch/i);
+      expect(mixed.count()).toBe(0);
+    });
+
+    it("should reject foreign metadata when vector artifacts are identical", () => {
+      const firstPath = path.join(tempDir, "vectors-identical-first");
+      const secondPath = path.join(tempDir, "vectors-identical-second");
+      const first = new VectorStore(firstPath, 3);
+      const second = new VectorStore(secondPath, 3);
+      first.add("first", [1, 0, 0], {
+        filePath: "first.ts",
+        startLine: 1,
+        endLine: 2,
+        chunkType: "function",
+        language: "typescript",
+        hash: "first-hash",
+      });
+      second.add("second", [1, 0, 0], {
+        filePath: "second.ts",
+        startLine: 1,
+        endLine: 2,
+        chunkType: "function",
+        language: "typescript",
+        hash: "second-hash",
+      });
+      first.save();
+      second.save();
+      fs.copyFileSync(`${secondPath}.meta.json`, `${firstPath}.meta.json`);
+
+      const mixed = new VectorStore(firstPath, 3);
+      expect(() => mixed.loadStrict()).toThrow(/fingerprint.*mismatch/i);
+      expect(mixed.count()).toBe(0);
+    });
+
+    it("should allow structurally valid legacy loads only in writer mode", () => {
+      store.add("chunk1", [1, 0, 0], {
+        filePath: "test.ts",
+        startLine: 1,
+        endLine: 5,
+        chunkType: "function",
+        language: "typescript",
+        hash: "abc123",
+      });
+      store.save();
+
+      const metadataPath = path.join(tempDir, "vectors.meta.json");
+      const legacyMetadata = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as Record<string, unknown>;
+      delete legacyMetadata.vector_fingerprint;
+      fs.writeFileSync(metadataPath, JSON.stringify(legacyMetadata));
+
+      const writerStore = new VectorStore(path.join(tempDir, "vectors"), 3);
+      writerStore.load();
+      expect(writerStore.count()).toBe(1);
+      expect(writerStore.hasFingerprint()).toBe(false);
+
+      const readerStore = new VectorStore(path.join(tempDir, "vectors"), 3);
+      expect(() => readerStore.loadStrict()).toThrow(/missing.*fingerprint/i);
+    });
+
+    it("should reject structurally inconsistent vector metadata", () => {
+      store.add("chunk1", [1, 0, 0], {
+        filePath: "test.ts",
+        startLine: 1,
+        endLine: 5,
+        chunkType: "function",
+        language: "typescript",
+        hash: "abc123",
+      });
+      store.save();
+
+      const metadataPath = path.join(tempDir, "vectors.meta.json");
+      const inconsistent = JSON.parse(fs.readFileSync(metadataPath, "utf-8")) as {
+        key_to_id: Record<string, number>;
+        vector_fingerprint?: string;
+      };
+      inconsistent.key_to_id.ghost = 99;
+      delete inconsistent.vector_fingerprint;
+      fs.writeFileSync(metadataPath, JSON.stringify(inconsistent));
+
+      const reloaded = new VectorStore(path.join(tempDir, "vectors"), 3);
+      expect(() => reloaded.load()).toThrow(/structure/i);
+    });
+
+    it("should reject incomplete legacy vector publications in writer mode", () => {
+      const missingMetadataPath = path.join(tempDir, "missing-metadata");
+      const missingMetadata = new VectorStore(missingMetadataPath, 3);
+      missingMetadata.save();
+      fs.rmSync(`${missingMetadataPath}.meta.json`);
+      expect(() => new VectorStore(missingMetadataPath, 3).load()).toThrow(/incomplete vector publication/i);
+
+      const missingVectorsPath = path.join(tempDir, "missing-vectors");
+      const missingVectors = new VectorStore(missingVectorsPath, 3);
+      missingVectors.save();
+      fs.rmSync(missingVectorsPath);
+      expect(() => new VectorStore(missingVectorsPath, 3).load()).toThrow(/incomplete vector publication/i);
+    });
+
+    it("should clear the in-memory fingerprint when metadata publication fails", () => {
+      store.add("chunk1", [1, 0, 0], {
+        filePath: "test.ts",
+        startLine: 1,
+        endLine: 5,
+        chunkType: "function",
+        language: "typescript",
+        hash: "abc123",
+      });
+      store.save();
+      expect(store.hasFingerprint()).toBe(true);
+
+      const metadataPath = path.join(tempDir, "vectors.meta.json");
+      fs.rmSync(metadataPath);
+      fs.mkdirSync(metadataPath);
+
+      expect(() => store.save()).toThrow();
+      expect(store.hasFingerprint()).toBe(false);
+    });
+
     it("should add vectors in batch and keep metadata searchable", () => {
       store.addBatch([
         {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -142,7 +142,7 @@ describe("Pi adapter conformance", () => {
     operationMocks.getIndexHealthCheck.mockRejectedValue(new Error("raw health-check operation must not be used"));
     operationMocks.runIndexHealthCheck.mockResolvedValue({
       kind: "busy",
-      text: "INDEX_BUSY : indexation déjà en cours (PID 4444, opération health-check, depuis 2026-07-17T10:00:00.000Z).",
+      text: "INDEX_BUSY: another index operation is already in progress (PID 4444, operation health-check, since 2026-07-17T10:00:00.000Z).",
     });
     const tools = await registerPiTools();
 

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -5,6 +5,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 const operationMocks = vi.hoisted(() => ({
   getCallGraphData: vi.fn(),
   getCallGraphPath: vi.fn(),
+  getIndexHealthCheck: vi.fn(),
+  runIndexHealthCheck: vi.fn(),
 }));
 
 vi.mock("../src/tools/operations.js", () => ({
@@ -12,7 +14,7 @@ vi.mock("../src/tools/operations.js", () => ({
   findSimilarCode: vi.fn(() => []),
   getCallGraphData: operationMocks.getCallGraphData,
   getCallGraphPath: operationMocks.getCallGraphPath,
-  getIndexHealthCheck: vi.fn(),
+  getIndexHealthCheck: operationMocks.getIndexHealthCheck,
   getIndexLogs: vi.fn(() => ({ text: "" })),
   getIndexMetrics: vi.fn(() => ({ text: "" })),
   getIndexStatus: vi.fn(),
@@ -21,6 +23,7 @@ vi.mock("../src/tools/operations.js", () => ({
   listKnowledgeBases: vi.fn(() => "No knowledge bases configured."),
   removeKnowledgeBase: vi.fn(() => "Removed knowledge base"),
   runIndexCodebase: vi.fn(),
+  runIndexHealthCheck: operationMocks.runIndexHealthCheck,
   searchCodebase: vi.fn(() => []),
 }));
 
@@ -54,6 +57,8 @@ describe("Pi adapter conformance", () => {
   beforeEach(() => {
     operationMocks.getCallGraphData.mockReset();
     operationMocks.getCallGraphPath.mockReset();
+    operationMocks.getIndexHealthCheck.mockReset();
+    operationMocks.runIndexHealthCheck.mockReset();
   });
 
   it("formats caller results like other host adapters", async () => {
@@ -131,5 +136,26 @@ describe("Pi adapter conformance", () => {
     expect(result?.content[0]?.text).toContain("[start] createOrder (src/order.ts:10)");
     expect(result?.content[0]?.text).toContain("--MethodCall--> chargeCard (src/pay.ts:33)");
     expect(result?.details).toHaveLength(2);
+  });
+
+  it("returns INDEX_BUSY details from the Pi health-check tool", async () => {
+    operationMocks.getIndexHealthCheck.mockRejectedValue(new Error("raw health-check operation must not be used"));
+    operationMocks.runIndexHealthCheck.mockResolvedValue({
+      kind: "busy",
+      text: "INDEX_BUSY : indexation déjà en cours (PID 4444, opération health-check, depuis 2026-07-17T10:00:00.000Z).",
+    });
+    const tools = await registerPiTools();
+
+    const result = await tools.get("index_health_check")?.execute(
+      "tool-call",
+      {},
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(result?.content[0]?.text).toContain("INDEX_BUSY");
+    expect(result?.content[0]?.text).toContain("PID 4444");
+    expect(result?.details).toEqual({ code: "INDEX_BUSY" });
   });
 });

--- a/tests/tools-knowledge-bases.test.ts
+++ b/tests/tools-knowledge-bases.test.ts
@@ -54,6 +54,18 @@ const { indexerInstances, MockIndexer } = vi.hoisted(() => {
       skippedFiles: [],
       parseFailures: [],
     });
+    public forceIndex = vi.fn().mockResolvedValue({
+      totalFiles: 0,
+      totalChunks: 0,
+      indexedChunks: 0,
+      failedChunks: 0,
+      tokensUsed: 0,
+      durationMs: 0,
+      existingChunks: 0,
+      removedChunks: 0,
+      skippedFiles: [],
+      parseFailures: [],
+    });
 
     public healthCheck = vi.fn().mockResolvedValue({
       removed: 0,

--- a/tests/tools-knowledge-bases.test.ts
+++ b/tests/tools-knowledge-bases.test.ts
@@ -131,7 +131,7 @@ describe("knowledge base tool config refresh", () => {
 
     expect(result).toContain("INDEX_BUSY");
     expect(result).toContain("PID 4242");
-    expect(result).toContain("opération health-check");
+    expect(result).toContain("operation health-check");
     expect(result).toContain(owner.startedAt);
   });
 

--- a/tests/tools-knowledge-bases.test.ts
+++ b/tests/tools-knowledge-bases.test.ts
@@ -9,6 +9,7 @@ const { indexerInstances, MockIndexer } = vi.hoisted(() => {
     projectRoot: string;
     config: Record<string, unknown>;
     getStatus: ReturnType<typeof vi.fn>;
+    healthCheck: ReturnType<typeof vi.fn>;
   }> = [];
 
   class MockIndexer {
@@ -27,7 +28,7 @@ const { indexerInstances, MockIndexer } = vi.hoisted(() => {
     public constructor(projectRoot: string, config: Record<string, unknown>) {
       this.projectRoot = projectRoot;
       this.config = config;
-      indexerInstances.push({ projectRoot, config, getStatus: this.getStatus });
+      indexerInstances.push({ projectRoot, config, getStatus: this.getStatus, healthCheck: this.healthCheck });
     }
 
     public estimateCost = vi.fn().mockResolvedValue({
@@ -95,7 +96,8 @@ vi.mock("../src/indexer/index.js", () => ({
 
 import { parseConfig } from "../src/config/schema.js";
 import { loadMergedConfig } from "../src/config/merger.js";
-import { add_knowledge_base, index_codebase, initializeTools, remove_knowledge_base } from "../src/tools/index.js";
+import { IndexLockContentionError } from "../src/indexer/index-lock.js";
+import { add_knowledge_base, index_codebase, index_health_check, initializeTools, remove_knowledge_base } from "../src/tools/index.js";
 
 describe("knowledge base tool config refresh", () => {
   let tempDir: string;
@@ -111,6 +113,26 @@ describe("knowledge base tool config refresh", () => {
   afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     fs.rmSync(kbDir, { recursive: true, force: true });
+  });
+
+  it("returns an explicit busy result from the OpenCode health-check tool", async () => {
+    const owner = {
+      pid: 4242,
+      hostname: "local-test",
+      startedAt: "2026-07-17T10:00:00.000Z",
+      operation: "health-check" as const,
+      token: "owner-token",
+    };
+    indexerInstances[0]?.healthCheck.mockRejectedValueOnce(
+      new IndexLockContentionError(path.join(tempDir, ".opencode", "index", "indexing.lock"), owner, "active"),
+    );
+
+    const result = await index_health_check.execute({});
+
+    expect(result).toContain("INDEX_BUSY");
+    expect(result).toContain("PID 4242");
+    expect(result).toContain("opération health-check");
+    expect(result).toContain(owner.startedAt);
   });
 
   it("rebuilds the shared indexer after adding a knowledge base", async () => {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -338,6 +338,26 @@ describe("tools utils", () => {
       expect(result).toContain("INDEXING WARNING");
       expect(result).toContain("failed-batches.json");
     });
+
+    it("should surface a degraded reader warning while semantic data remains usable", () => {
+      const status: StatusResult = {
+        indexed: true,
+        vectorCount: 100,
+        provider: "google",
+        model: "gemini-embedding-001",
+        indexPath: "/tmp/index",
+        currentBranch: "default",
+        baseBranch: "default",
+        compatibility: { compatible: true },
+        failedBatchesCount: 0,
+        warning: "Keyword index could not be read; semantic search remains available. Run index_codebase to repair it under the writer lease.",
+      };
+      const result = formatStatus(status);
+
+      expect(result).toContain("Indexed chunks: 100");
+      expect(result).toContain("INDEX WARNING");
+      expect(result).toContain("semantic search remains available");
+    });
   });
 
   describe("formatProgressTitle", () => {

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -53,7 +53,7 @@ describe("watcher config refresh", () => {
       expect(indexer.index).toHaveBeenCalledTimes(1);
     }, { timeout: 2500 });
 
-    watcher.stop();
+    await watcher.stop();
   });
 
   it("refreshes the codex indexer cache before reindexing when legacy OpenCode config changes", async () => {
@@ -81,7 +81,7 @@ describe("watcher config refresh", () => {
       expect(indexer.index).toHaveBeenCalledTimes(1);
     }, { timeout: 2500 });
 
-    watcher.stop();
+    await watcher.stop();
   });
 
   it("refreshes from explicit config path when configured", async () => {
@@ -114,7 +114,7 @@ describe("watcher config refresh", () => {
       expect(indexer.index).toHaveBeenCalledTimes(1);
     }, { timeout: 2500 });
 
-    watcher.stop();
+    await watcher.stop();
   });
 
   it("does not refresh from project config when explicit config path is configured", async () => {
@@ -145,6 +145,6 @@ describe("watcher config refresh", () => {
     expect(operationMocks.refreshIndexerForDirectory).not.toHaveBeenCalled();
     expect(indexer.index).not.toHaveBeenCalled();
 
-    watcher.stop();
+    await watcher.stop();
   });
 });

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as os from "os";
 import { FileWatcher, GitHeadWatcher, FileChange, createWatcherWithIndexer } from "../src/watcher/index.js";
 import { ParsedCodebaseIndexConfig } from "../src/config/schema.js";
+import { IndexLockContentionError } from "../src/indexer/index-lock.js";
 
 const createTestConfig = (overrides: Partial<ParsedCodebaseIndexConfig> = {}): ParsedCodebaseIndexConfig => ({
   embeddingProvider: "auto",
@@ -59,8 +60,8 @@ describe("FileWatcher", () => {
     fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
   });
 
-  afterEach(() => {
-    watcher?.stop();
+  afterEach(async () => {
+    await watcher?.stop();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -212,7 +213,7 @@ describe("FileWatcher", () => {
       expect(indexer.index).toHaveBeenCalledTimes(1);
       expect(resolveIndex).toBeTypeOf("function");
 
-      combinedWatcher.stop();
+      await combinedWatcher.stop();
       resolveIndex?.();
     });
 
@@ -240,9 +241,65 @@ describe("FileWatcher", () => {
       pendingResolves[0]?.();
       await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2));
 
-      combinedWatcher.stop();
+      await combinedWatcher.stop();
       pendingResolves[1]?.();
     });
+
+    it("keeps one pending request and retries after INDEX_BUSY", async () => {
+      const owner = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        startedAt: new Date().toISOString(),
+        operation: "index" as const,
+        token: "busy-owner",
+      };
+      let rejectFirst: ((error: unknown) => void) | null = null;
+      const firstAttempt = new Promise<void>((_resolve, reject) => { rejectFirst = reject; });
+      const indexer = { index: vi.fn().mockReturnValueOnce(firstAttempt).mockResolvedValue(undefined) };
+      const combinedWatcher = createWatcherWithIndexer(
+        () => indexer,
+        tempDir,
+        createTestConfig(),
+      );
+
+      await combinedWatcher.fileWatcher.waitUntilReady();
+      fs.writeFileSync(path.join(tempDir, "src", "retry.ts"), "export const retry = 1;");
+      await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(1), { timeout: 2500 });
+      rejectFirst?.(new IndexLockContentionError("/tmp/indexing.lock", owner, "active"));
+      await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2), { timeout: 1000 });
+
+      await combinedWatcher.stop();
+    });
+
+    it("logs a non-transient lock state without retrying forever", async () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const owner = {
+        pid: process.pid,
+        hostname: os.hostname(),
+        startedAt: new Date().toISOString(),
+        operation: "index" as const,
+        token: "unknown-owner",
+      };
+      const indexer = {
+        index: vi.fn().mockRejectedValue(
+          new IndexLockContentionError("/tmp/indexing.lock", owner, "unknown-owner"),
+        ),
+      };
+      const combinedWatcher = createWatcherWithIndexer(
+        () => indexer,
+        tempDir,
+        createTestConfig(),
+      );
+
+      await combinedWatcher.fileWatcher.waitUntilReady();
+      fs.writeFileSync(path.join(tempDir, "src", "blocked.ts"), "export const blocked = true;");
+      await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce(), { timeout: 4000 });
+      await vi.waitFor(() => expect(consoleError).toHaveBeenCalledOnce(), { timeout: 1000 });
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      expect(indexer.index).toHaveBeenCalledOnce();
+      await combinedWatcher.stop();
+    }, 7000);
 
     it("uses the latest indexer instance for file-triggered reindexing", async () => {
       const staleIndexer = {
@@ -269,10 +326,10 @@ describe("FileWatcher", () => {
       expect(refreshedIndexer.index).toHaveBeenCalledTimes(1);
       expect(staleIndexer.index).not.toHaveBeenCalled();
 
-      combinedWatcher.stop();
+      await combinedWatcher.stop();
     });
 
-    it("stops the watcher cleanly after start", () => {
+    it("stops the watcher cleanly after start", async () => {
       const indexer = {
         index: vi.fn().mockResolvedValue(undefined),
       };
@@ -286,7 +343,7 @@ describe("FileWatcher", () => {
       expect(combinedWatcher.fileWatcher.isRunning()).toBe(true);
       expect(combinedWatcher.gitWatcher?.isRunning() ?? false).toBe(false);
 
-      combinedWatcher.stop();
+      await combinedWatcher.stop();
 
       expect(combinedWatcher.fileWatcher.isRunning()).toBe(false);
       expect(combinedWatcher.gitWatcher?.isRunning() ?? false).toBe(false);
@@ -302,8 +359,8 @@ describe("GitHeadWatcher", () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-watcher-test-"));
   });
 
-  afterEach(() => {
-    watcher?.stop();
+  afterEach(async () => {
+    await watcher?.stop();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -211,7 +211,7 @@ describe("worktree fallback (issue #60)", () => {
       const status = await indexer.getStatus();
 
       expect(resolveProjectIndexPath(worktreeDir, "project")).toBe(path.join(mainRepoDir, ".opencode", "index"));
-      expect(status.indexPath).toBe(path.join(mainRepoDir, ".opencode", "index"));
+      expect(status.indexPath).toBe(fs.realpathSync.native(path.join(mainRepoDir, ".opencode", "index")));
       expect(status.currentBranch).toBe("feature/x/y");
     } finally {
       await indexer.close();

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -211,7 +211,7 @@ describe("worktree fallback (issue #60)", () => {
       const status = await indexer.getStatus();
 
       expect(resolveProjectIndexPath(worktreeDir, "project")).toBe(path.join(mainRepoDir, ".opencode", "index"));
-      expect(status.indexPath).toBe(fs.realpathSync.native(path.join(mainRepoDir, ".opencode", "index")));
+      expect(status.indexPath).toBe(path.join(mainRepoDir, ".opencode", "index"));
       expect(status.currentBranch).toBe("feature/x/y");
     } finally {
       await indexer.close();


### PR DESCRIPTION
## Summary

The existing queues and coalescing logic only serialized indexing within a single process. Multiple MCP clients or watchers could therefore start embeddings concurrently and mutate the same SQLite, vector, BM25, and state files.

This change adds an inter-process lease based on an atomically created directory. Manual contention now returns an explicit `INDEX_BUSY` result, while watchers retain a single pending request and retry it with bounded backoff.

## Changes

- Add an `indexing.lock` lease with PID, hostname, timestamp, operation, and owner token metadata.
- Detect live owners, safely recover locks held by dead local PIDs, and handle legacy file locks.
- Reload SQLite, VectorStore, BM25, hash caches, and failed batches under the lease before every mutation.
- Cover `initialize`, `index`, `forceIndex`, `clearIndex`, `healthCheck`, `retryFailedBatches`, recovery, and automatic garbage collection.
- Run forced clear and indexing operations within a single critical section.
- Use owner-specific atomic temporary and backup files.
- Return explicit `INDEX_BUSY` results from OpenCode and MCP tools.
- Preserve one coalesced watcher request and retry it with bounded backoff after contention.
- Pin mutations to the canonical index path even if a project symlink is retargeted.
- Add production-backed unit, multiprocess, and MCP tests for contention, crash recovery, and final index consistency.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`: 48 test files, 866 tests)
- [x] Lint passes (`npm run lint`)
- [x] Smoke-tested with two real MCP clients: one winner, one `INDEX_BUSY` result, one embedding request, `maxActive = 1`, and a readable final index

## Release Labels

- [ ] Release category label: `bug` (maintainer action required)
- [ ] Semver label: `semver:patch` (maintainer action required)

## Related Issues

None.
