### PR TITLE
fix: discover parser-backed source extensions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser-backed source discovery**: Added `.mts`, `.cts`, `.cxx`, `.hxx`, and `.cs` to the default include patterns.
+
 ## [0.14.0] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ graph TD
 
 **Default File Patterns**:
 ```
-**/*.{ts,tsx,js,jsx,mjs,cjs}    **/*.{py,pyi}
-**/*.{go,rs,java,kt,scala}      **/*.{c,cpp,cc,h,hpp}
+**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}    **/*.{py,pyi}
+**/*.{go,rs,java,cs,kt,scala}            **/*.{c,cpp,cc,cxx,h,hpp,hxx}
 **/*.{rb,php,inc,swift}         **/*.{vue,svelte,astro}
 **/*.{sql,graphql,proto}        **/*.{yaml,yml,toml}
 **/*.{md,mdx}                   **/*.{sh,bash,zsh}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,8 +1,8 @@
 export const DEFAULT_INCLUDE = [
-  "**/*.{ts,tsx,js,jsx,mjs,cjs}",
+  "**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
   "**/*.{py,pyi}",
-  "**/*.{go,rs,java,kt,scala}",
-  "**/*.{c,cpp,cc,h,hpp}",
+  "**/*.{go,rs,java,cs,kt,scala}",
+  "**/*.{c,cpp,cc,cxx,h,hpp,hxx}",
   "**/*.{rb,php,inc,swift}",
   "**/*.{cls,trigger}",
   "**/*.{vue,svelte,astro}",

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -148,6 +148,25 @@ describe("files utilities", () => {
       expect(result.files.some((f) => f.path.endsWith("util.ts"))).toBe(true);
     });
 
+    it("should collect parser-backed source extensions by default", async () => {
+      const fileNames = ["module.mts", "module.cts", "widget.cxx", "widget.hxx", "Service.cs"];
+      fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+      for (const fileName of fileNames) {
+        fs.writeFileSync(path.join(tempDir, "src", fileName), "source");
+      }
+
+      const result = await collectFiles(
+        tempDir,
+        DEFAULT_INCLUDE,
+        DEFAULT_EXCLUDE,
+        1048576
+      );
+
+      expect(result.files.map((file) => path.basename(file.path)).sort()).toEqual(
+        [...fileNames].sort()
+      );
+    });
+
     it("should skip files exceeding max size", async () => {
       fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
       fs.writeFileSync(path.join(tempDir, "src/small.ts"), "x");

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -54,6 +54,54 @@ export class UserService {
       expect(chunks.some((c) => c.content.includes("class UserService"))).toBe(true);
     });
 
+    it.each(["module.mts", "module.cts"])(
+      "should classify and semantically parse %s as TypeScript",
+      (filePath) => {
+        const content = `
+function normalizeName(value: string): string {
+  return value.trim().toLowerCase();
+}
+`;
+        const chunks = parseFile(filePath, content);
+
+        expect(chunks.some((c) => c.chunkType === "function_declaration")).toBe(true);
+        expect(chunks.every((c) => c.language === "typescript")).toBe(true);
+      }
+    );
+
+    it.each(["widget.cxx", "widget.hxx"])(
+      "should classify and semantically parse %s as C++",
+      (filePath) => {
+        const content = `
+#include <string>
+
+std::string normalize_name(const std::string& value) {
+  return value;
+}
+`;
+        const chunks = parseFile(filePath, content);
+
+        expect(chunks.some((c) => c.chunkType === "function_definition")).toBe(true);
+        expect(chunks.every((c) => c.language === "cpp")).toBe(true);
+      }
+    );
+
+    it("should classify and semantically parse .cs files as C#", () => {
+      const content = `
+public class UserService
+{
+    public string NormalizeName(string value)
+    {
+        return value.Trim().ToLowerInvariant();
+    }
+}
+`;
+      const chunks = parseFile("UserService.cs", content);
+
+      expect(chunks.some((c) => c.chunkType === "class_declaration")).toBe(true);
+      expect(chunks.every((c) => c.language === "csharp")).toBe(true);
+    });
+
     it("should parse JavaScript files", () => {
       const content = `
 function greet(name) {


### PR DESCRIPTION
## Summary

- discover `.mts` and `.cts` files through the existing TypeScript parser
- discover `.cxx` and `.hxx` files through the existing C++ parser
- discover `.cs` files through the existing C# parser
- add coverage for default collection, language classification, and semantic parsing
- synchronize the README default patterns and changelog

## Motivation

`Language::from_extension` already classified these extensions and routed them
to working tree-sitter parsers, but `DEFAULT_INCLUDE` did not collect them.
As a result, zero-config indexing silently skipped supported source files.

## Compatibility and scope

This is an additive change to the default include patterns. It does not change
parser behavior or custom `include` configurations. Default users will discover
the additional source files on their next indexing pass.

MATLAB `.m` files remain opt-in because the extension conflicts with
Objective-C. JSON was audited but remains outside this source-focused change:
it currently has no configured semantic node types and falls back to line-based
chunking.

No Objective-C, Metal, content-based detection, or unclassified extensions are
introduced.

## Validation

- `npx vitest run tests/files.test.ts tests/native.test.ts` (73 tests passed)
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (843 tests passed)
- `git diff --check`

## Personal note

Sorry for the rapid succession of contributions. I really enjoy this project
and have been exploring it quite deeply, so I may send a few more focused PRs
over the next several hours.

I'll keep each contribution small and self-contained to make the review process
as easy as possible. Thank you for building and maintaining such a great
project.
