### PR TITLE
feat(call-graph): add C and C++ support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Graphe d'appels C et C++** : ajout de l'extraction Tree-sitter des appels directs, membres et qualifiés, des constructeurs explicites, des includes et des imports de namespaces.
+
 ## [0.14.0] - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **C and C++ call graphs**: Added Tree-sitter extraction for direct, member, and qualified calls, constructors, includes, and namespace imports.
+
 ## [0.17.1] - 2026-07-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Returns recent debug logs with optional filtering.
 
 ### `call_graph`
 
-Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, and Bash.
+Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash, C, and C++.
 
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
 - **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries), `relationshipType` (optional: `Call`, `MethodCall`, `Constructor`, `Import`, `Inherits`, `Implements`).
@@ -1178,7 +1178,7 @@ The Rust native module handles performance-critical operations:
 - **usearch**: High-performance vector similarity search with F16 quantization
 - **SQLite**: Persistent storage for embeddings, chunks, branch catalog, symbols, and call edges
 - **BM25 inverted index**: Fast keyword search for hybrid retrieval
-- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash)
+- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash, C, C++)
 - **xxhash**: Fast content hashing for change detection
 
 Rebuild with: `npm run build:native` (requires Rust toolchain)

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ Returns recent debug logs with optional filtering.
 
 ### `call_graph`
 
-Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, and Bash.
+Query the call graph to find callers or callees of a function/method. Automatically built during indexing for TypeScript, JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash, C, and C++.
 
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
 - **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries), `relationshipType` (optional: `Call`, `MethodCall`, `Constructor`, `Import`, `Inherits`, `Implements`).
@@ -1241,7 +1241,7 @@ The Rust native module handles performance-critical operations:
 - **usearch**: High-performance vector similarity search with F16 quantization
 - **SQLite**: Persistent storage for embeddings, chunks, branch catalog, symbols, and call edges
 - **BM25 inverted index**: Fast keyword search for hybrid retrieval
-- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash)
+- **Call graph extraction**: Tree-sitter query-based extraction of function calls, method calls, constructors, and imports (TypeScript/JavaScript, Python, Go, Rust, PHP, Apex, Zig, GDScript, MATLAB, Bash, C, C++)
 - **xxhash**: Fast content hashing for change detection
 
 Rebuild with: `npm run build:native` (requires Rust toolchain)

--- a/docs/adding-language-support.md
+++ b/docs/adding-language-support.md
@@ -172,6 +172,11 @@ Use the same capture names already expected by `native/src/call_extractor.rs`:
 - `@import.default`
 - `@import.namespace`
 
+Pour les langages proches du C, l'extracteur comprend aussi des captures d'exclusion conservatrices :
+
+- `@excluded.name` pour les macros et les déclarateurs inline de pointeurs de fonction qui ne doivent pas devenir des arêtes d'appel direct
+- `@indirect.type`, `@indirect.variable_type` et `@indirect.variable` pour relier un alias de type fonction indirecte aux variables déclarées avec cet alias
+
 Start small:
 
 - direct calls
@@ -195,6 +200,8 @@ Those chunk-type strings must match the tree-sitter node kinds that actually bec
 ### `tests/call-graph.test.ts`
 
 Add focused tests for the constructs your query file supports.
+
+Lorsque la grammaire est ambiguë, ajoutez aussi des fixtures négatives. Vérifiez notamment que les déclarations, les macros locales, les appels de templates explicites et les appels via pointeur de fonction ne deviennent pas des appels directs ordinaires dans le graphe.
 
 ## Common failure modes
 

--- a/docs/adding-language-support.md
+++ b/docs/adding-language-support.md
@@ -172,6 +172,11 @@ Use the same capture names already expected by `native/src/call_extractor.rs`:
 - `@import.default`
 - `@import.namespace`
 
+For C-family languages, the extractor also supports conservative exclusion captures:
+
+- `@excluded.name` for macros and inline function-pointer declarators that must not become direct-call edges
+- `@indirect.type`, `@indirect.variable_type`, and `@indirect.variable` for connecting an indirect function-type alias to variables declared with that alias
+
 Start small:
 
 - direct calls
@@ -195,6 +200,8 @@ Those chunk-type strings must match the tree-sitter node kinds that actually bec
 ### `tests/call-graph.test.ts`
 
 Add focused tests for the constructs your query file supports.
+
+When the grammar is ambiguous, add negative fixtures as well. In particular, verify that declarations, local macros, explicit template calls, and function-pointer invocations do not become ordinary direct calls in the graph.
 
 ## Common failure modes
 

--- a/native/queries/c-calls.scm
+++ b/native/queries/c-calls.scm
@@ -1,0 +1,69 @@
+; Appels directs : foo(), bar(1, 2)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; Includes locaux et système : #include "header.h", #include <stdio.h>
+(preproc_include
+  path: [
+    (string_literal)
+    (system_lib_string)
+  ] @import.name) @import
+
+; Macros définies dans le fichier, exclues des appels ordinaires.
+(preproc_function_def
+  name: (identifier) @excluded.name)
+
+(preproc_def
+  name: (identifier) @excluded.name)
+
+; Variables, paramètres et alias de pointeurs de fonction.
+(function_declarator
+  declarator: (parenthesized_declarator
+    (pointer_declarator
+      declarator: [
+        (identifier)
+        (field_identifier)
+        (type_identifier)
+      ] @excluded.name)))
+
+; Alias de pointeurs ou de types fonction.
+(type_definition
+  declarator: (function_declarator
+    declarator: (parenthesized_declarator
+      (pointer_declarator
+        declarator: (type_identifier) @indirect.type))))
+
+(type_definition
+  declarator: (function_declarator
+    declarator: (type_identifier) @indirect.type))
+
+; Paramètres déclarés avec un alias de fonction indirecte.
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+; Variables locales ou globales déclarées avec le même type d'alias.
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (pointer_declarator
+      declarator: (identifier) @indirect.variable)))

--- a/native/queries/c-calls.scm
+++ b/native/queries/c-calls.scm
@@ -1,0 +1,69 @@
+; Direct calls: foo(), bar(1, 2)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; Local and system includes: #include "header.h", #include <stdio.h>
+(preproc_include
+  path: [
+    (string_literal)
+    (system_lib_string)
+  ] @import.name) @import
+
+; Macros defined in this file are excluded from ordinary calls.
+(preproc_function_def
+  name: (identifier) @excluded.name)
+
+(preproc_def
+  name: (identifier) @excluded.name)
+
+; Function-pointer variables, parameters, and aliases.
+(function_declarator
+  declarator: (parenthesized_declarator
+    (pointer_declarator
+      declarator: [
+        (identifier)
+        (field_identifier)
+        (type_identifier)
+      ] @excluded.name)))
+
+; Function-pointer or function-type aliases.
+(type_definition
+  declarator: (function_declarator
+    declarator: (parenthesized_declarator
+      (pointer_declarator
+        declarator: (type_identifier) @indirect.type))))
+
+(type_definition
+  declarator: (function_declarator
+    declarator: (type_identifier) @indirect.type))
+
+; Parameters declared with an indirect function alias.
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+; Local or global variables declared with the same alias type.
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (pointer_declarator
+      declarator: (identifier) @indirect.variable)))

--- a/native/queries/cpp-calls.scm
+++ b/native/queries/cpp-calls.scm
@@ -1,0 +1,145 @@
+; Appels directs : foo(), bar(1, 2)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; Appels de membres : object.method(), pointer->method()
+; Les opérateurs de pointeur vers membre sont volontairement exclus.
+(call_expression
+  function: (field_expression
+    operator: ["." "->"]
+    field: (field_identifier) @callee.name)) @method.call
+
+; Appels qualifiés : namespace::function(), Type::method()
+; Sans analyse de types, ils restent classés comme appels directs.
+(call_expression
+  function: (qualified_identifier) @callee.name
+  (#match? @callee.name "(^|::)[A-Za-z_][A-Za-z0-9_]*$")
+  (#not-match? @callee.name "[<>]")) @call
+
+; Constructeurs explicites : new Widget(...)
+(new_expression
+  type: (type_identifier) @callee.name) @constructor
+
+; Constructeurs qualifiés : new namespace::Widget(...)
+(new_expression
+  type: (qualified_identifier) @callee.name
+  (#match? @callee.name "(^|::)[A-Za-z_][A-Za-z0-9_]*$")
+  (#not-match? @callee.name "[<>]")) @constructor
+
+; Temporaires construits avec des accolades : Widget{...}
+(compound_literal_expression
+  type: (type_identifier) @callee.name) @constructor
+
+; Temporaires qualifiés : namespace::Widget{...}
+(compound_literal_expression
+  type: (qualified_identifier) @callee.name
+  (#match? @callee.name "(^|::)[A-Za-z_][A-Za-z0-9_]*$")
+  (#not-match? @callee.name "[<>]")) @constructor
+
+; Includes locaux et système : #include "header.hpp", #include <memory>
+(preproc_include
+  path: [
+    (string_literal)
+    (system_lib_string)
+  ] @import.name) @import
+
+; Imports de namespaces : using namespace std;
+(using_declaration
+  "namespace"
+  (identifier) @import.namespace) @import
+
+; Imports de namespaces qualifiés : using namespace project::detail;
+(using_declaration
+  "namespace"
+  (qualified_identifier) @import.namespace
+  (#not-match? @import.namespace "[<>]")) @import
+
+; Macros définies dans le fichier, exclues des appels ordinaires.
+(preproc_function_def
+  name: (identifier) @excluded.name)
+
+(preproc_def
+  name: (identifier) @excluded.name)
+
+; Variables, paramètres et alias de pointeurs de fonction.
+(function_declarator
+  declarator: (parenthesized_declarator
+    (pointer_declarator
+      declarator: [
+        (identifier)
+        (field_identifier)
+        (type_identifier)
+      ] @excluded.name)))
+
+; Alias de pointeurs ou de types fonction, via typedef ou using.
+(type_definition
+  declarator: (function_declarator
+    declarator: (parenthesized_declarator
+      (pointer_declarator
+        declarator: (type_identifier) @indirect.type))))
+
+(type_definition
+  declarator: (function_declarator
+    declarator: (type_identifier) @indirect.type))
+
+(alias_declaration
+  name: (type_identifier) @indirect.type
+  type: (type_descriptor
+    declarator: (abstract_function_declarator)))
+
+; Paramètres déclarés avec un alias de fonction indirecte.
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (reference_declarator
+    (identifier) @indirect.variable))
+
+; Champs appelables déclarés avec un alias de fonction indirecte.
+(field_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (field_identifier) @indirect.variable)
+
+(field_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (field_identifier) @indirect.variable))
+
+; Variables locales ou globales déclarées avec le même type d'alias.
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (reference_declarator
+    (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (pointer_declarator
+      declarator: (identifier) @indirect.variable)))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (reference_declarator
+      (identifier) @indirect.variable)))

--- a/native/queries/cpp-calls.scm
+++ b/native/queries/cpp-calls.scm
@@ -1,0 +1,171 @@
+; Direct calls: foo(), bar(1, 2)
+(call_expression
+  function: (identifier) @callee.name) @call
+
+; Member calls: object.method(), pointer->method()
+; Pointer-to-member operators are intentionally excluded.
+(call_expression
+  function: (field_expression
+    operator: ["." "->"]
+    field: (field_identifier) @callee.name)) @method.call
+
+; Qualified calls: namespace::function(), Type::method()
+; Without type analysis, these remain classified as direct calls.
+(call_expression
+  function: (qualified_identifier) @callee.name
+  (#match? @callee.name "(^|::)[A-Za-z_][A-Za-z0-9_]*$")
+  (#not-match? @callee.name "[<>]")) @call
+
+; Explicit heap constructors: new Widget(...)
+(new_expression
+  type: (type_identifier) @callee.name) @constructor
+
+; Qualified heap constructors: new namespace::Widget(...)
+(new_expression
+  type: (qualified_identifier) @callee.name
+  (#match? @callee.name "(^|::)[A-Za-z_][A-Za-z0-9_]*$")
+  (#not-match? @callee.name "[<>]")) @constructor
+
+; Braced temporary constructors: Widget{...}
+(compound_literal_expression
+  type: (type_identifier) @callee.name) @constructor
+
+; Qualified braced temporary constructors: namespace::Widget{...}
+(compound_literal_expression
+  type: (qualified_identifier) @callee.name
+  (#match? @callee.name "(^|::)[A-Za-z_][A-Za-z0-9_]*$")
+  (#not-match? @callee.name "[<>]")) @constructor
+
+; Stack constructors: Widget value(...), Widget value{...}
+(declaration
+  type: [
+    (type_identifier)
+    (qualified_identifier)
+  ] @callee.name
+  declarator: (init_declarator
+    value: [
+      (argument_list)
+      (initializer_list)
+    ])) @constructor
+
+; Copy-initialized temporary constructors: Widget value = Widget(...)
+; The extractor verifies that @constructor.type and @callee.name are equal.
+(declaration
+  type: [
+    (type_identifier)
+    (qualified_identifier)
+  ] @constructor.type
+  declarator: (init_declarator
+    value: (call_expression
+      function: [
+        (identifier)
+        (qualified_identifier)
+      ] @callee.name))) @constructor
+
+; Local and system includes: #include "header.hpp", #include <memory>
+(preproc_include
+  path: [
+    (string_literal)
+    (system_lib_string)
+  ] @import.name) @import
+
+; Namespace imports: using namespace std;
+(using_declaration
+  "namespace"
+  (identifier) @import.namespace) @import
+
+; Qualified namespace imports: using namespace project::detail;
+(using_declaration
+  "namespace"
+  (qualified_identifier) @import.namespace
+  (#not-match? @import.namespace "[<>]")) @import
+
+; Macros defined in this file are excluded from ordinary calls.
+(preproc_function_def
+  name: (identifier) @excluded.name)
+
+(preproc_def
+  name: (identifier) @excluded.name)
+
+; Function-pointer variables, parameters, and aliases.
+(function_declarator
+  declarator: (parenthesized_declarator
+    (pointer_declarator
+      declarator: [
+        (identifier)
+        (field_identifier)
+        (type_identifier)
+      ] @excluded.name)))
+
+; Function-pointer or function-type aliases declared with typedef or using.
+(type_definition
+  declarator: (function_declarator
+    declarator: (parenthesized_declarator
+      (pointer_declarator
+        declarator: (type_identifier) @indirect.type))))
+
+(type_definition
+  declarator: (function_declarator
+    declarator: (type_identifier) @indirect.type))
+
+(alias_declaration
+  name: (type_identifier) @indirect.type
+  type: (type_descriptor
+    declarator: (abstract_function_declarator)))
+
+; Parameters declared with an indirect function alias.
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+(parameter_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (reference_declarator
+    (identifier) @indirect.variable))
+
+; Callable fields declared with an indirect function alias.
+(field_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (field_identifier) @indirect.variable)
+
+(field_declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (field_identifier) @indirect.variable))
+
+; Local or global variables declared with the same alias type.
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (identifier) @indirect.variable)
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (pointer_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (reference_declarator
+    (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (identifier) @indirect.variable))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (pointer_declarator
+      declarator: (identifier) @indirect.variable)))
+
+(declaration
+  type: (type_identifier) @indirect.variable_type
+  declarator: (init_declarator
+    declarator: (reference_declarator
+      (identifier) @indirect.variable)))

--- a/native/src/call_extractor.rs
+++ b/native/src/call_extractor.rs
@@ -1,5 +1,6 @@
 use crate::types::Language;
 use anyhow::{anyhow, Result};
+use std::collections::HashSet;
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Parser, Query, QueryCursor};
 
@@ -29,6 +30,67 @@ pub struct CallSite {
     pub confidence: Confidence,
 }
 
+struct CallExclusion {
+    name: String,
+    start_byte: usize,
+    end_byte: usize,
+    include_method_calls: bool,
+}
+
+fn exclusion_scope(
+    node: tree_sitter::Node<'_>,
+    root: tree_sitter::Node<'_>,
+) -> (usize, usize, bool) {
+    let mut current = Some(node);
+    let mut declaration = None;
+    let mut block_end = None;
+    let mut is_parameter = false;
+
+    while let Some(ancestor) = current {
+        match ancestor.kind() {
+            "preproc_def" | "preproc_function_def" => {
+                return (ancestor.end_byte(), root.end_byte(), true);
+            }
+            "parameter_declaration" => is_parameter = true,
+            "declaration" => declaration = Some((ancestor.start_byte(), ancestor.end_byte())),
+            "for_statement" | "for_range_loop" | "if_statement" | "while_statement"
+            | "switch_statement"
+                if block_end.is_none() =>
+            {
+                block_end = Some(ancestor.end_byte());
+            }
+            "compound_statement" if block_end.is_none() => block_end = Some(ancestor.end_byte()),
+            "lambda_expression" => {
+                let start = declaration
+                    .map(|(start, _)| start)
+                    .unwrap_or_else(|| ancestor.start_byte());
+                let end = block_end.unwrap_or_else(|| ancestor.end_byte());
+                return (start, end, node.kind() == "field_identifier");
+            }
+            "function_definition" => {
+                let start = declaration
+                    .map(|(start, _)| start)
+                    .unwrap_or_else(|| ancestor.start_byte());
+                let end = block_end.unwrap_or_else(|| ancestor.end_byte());
+                return (start, end, node.kind() == "field_identifier");
+            }
+            _ => {}
+        }
+        current = ancestor.parent();
+    }
+
+    if is_parameter {
+        if let Some((start, end)) = declaration {
+            return (start, end, node.kind() == "field_identifier");
+        }
+    }
+
+    let start = declaration
+        .map(|(start, _)| start)
+        .unwrap_or(root.start_byte());
+    (start, root.end_byte(), node.kind() == "field_identifier")
+}
+
 pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>> {
     let language = Language::from_string(language_name);
     let ts_language = match language {
@@ -45,6 +107,8 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Matlab => tree_sitter_matlab::LANGUAGE.into(),
         Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
         Language::Bash => tree_sitter_bash::LANGUAGE.into(),
+        Language::C => tree_sitter_c::LANGUAGE.into(),
+        Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
         _ => return Ok(vec![]),
     };
 
@@ -73,6 +137,8 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Matlab => include_str!("../queries/matlab-calls.scm"),
         Language::Apex => include_str!("../queries/apex-calls.scm"),
         Language::Bash => include_str!("../queries/bash-calls.scm"),
+        Language::C => include_str!("../queries/c-calls.scm"),
+        Language::Cpp => include_str!("../queries/cpp-calls.scm"),
         _ => return Ok(vec![]),
     };
 
@@ -89,10 +155,76 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
     let import_namespace_idx = query.capture_index_for_name("import.namespace");
     let inherits_name_idx = query.capture_index_for_name("inherits.name");
     let implements_name_idx = query.capture_index_for_name("implements.name");
+    let excluded_name_idx = query.capture_index_for_name("excluded.name");
+    let indirect_type_idx = query.capture_index_for_name("indirect.type");
+    let indirect_variable_type_idx = query.capture_index_for_name("indirect.variable_type");
+    let indirect_variable_idx = query.capture_index_for_name("indirect.variable");
+    let text_bytes = content.as_bytes();
+
+    let root = tree.root_node();
+    let mut exclusions = Vec::new();
+    let mut indirect_types = HashSet::new();
+    if excluded_name_idx.is_some() || indirect_type_idx.is_some() {
+        let mut exclusion_cursor = QueryCursor::new();
+        let mut exclusion_matches = exclusion_cursor.captures(&query, tree.root_node(), text_bytes);
+        while let Some((match_, _)) = exclusion_matches.next() {
+            for capture in match_.captures {
+                if excluded_name_idx == Some(capture.index) {
+                    let text = capture.node.utf8_text(text_bytes).unwrap_or("");
+                    let (start_byte, end_byte, include_method_calls) =
+                        exclusion_scope(capture.node, root);
+                    exclusions.push(CallExclusion {
+                        name: text.to_string(),
+                        start_byte,
+                        end_byte,
+                        include_method_calls,
+                    });
+                }
+                if indirect_type_idx == Some(capture.index) {
+                    let text = capture.node.utf8_text(text_bytes).unwrap_or("");
+                    indirect_types.insert(text.to_string());
+                }
+            }
+        }
+    }
+
+    if !indirect_types.is_empty()
+        && indirect_variable_type_idx.is_some()
+        && indirect_variable_idx.is_some()
+    {
+        let mut variable_cursor = QueryCursor::new();
+        let mut variables = variable_cursor.captures(&query, tree.root_node(), text_bytes);
+        while let Some((match_, _)) = variables.next() {
+            let mut variable_type = None;
+            let mut variable_name = None;
+
+            for capture in match_.captures {
+                let text = capture.node.utf8_text(text_bytes).unwrap_or("");
+                if indirect_variable_type_idx == Some(capture.index) {
+                    variable_type = Some(text);
+                }
+                if indirect_variable_idx == Some(capture.index) {
+                    variable_name = Some((text, capture.node));
+                }
+            }
+
+            if let (Some(type_name), Some((name, name_node))) = (variable_type, variable_name) {
+                if indirect_types.contains(type_name) {
+                    let (start_byte, end_byte, include_method_calls) =
+                        exclusion_scope(name_node, root);
+                    exclusions.push(CallExclusion {
+                        name: name.to_string(),
+                        start_byte,
+                        end_byte,
+                        include_method_calls,
+                    });
+                }
+            }
+        }
+    }
 
     let mut cursor = QueryCursor::new();
     let mut calls = Vec::new();
-    let text_bytes = content.as_bytes();
 
     let mut captures_iter = cursor.captures(&query, tree.root_node(), text_bytes);
 
@@ -100,6 +232,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         let mut callee_name: Option<String> = None;
         let mut call_type: Option<CallType> = None;
         let mut position: Option<(u32, u32)> = None;
+        let mut callee_byte = None;
 
         for capture in match_.captures {
             let node = capture.node;
@@ -112,6 +245,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
                         let start = node.start_position();
                         position = Some((start.row as u32 + 1, start.column as u32));
                     }
+                    callee_byte = Some(node.start_byte());
                 }
             }
 
@@ -200,12 +334,22 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         // @call is only for direct function calls
         // So we need to check if the call was already classified as a method call
         if let (Some(name), Some(ct), Some(pos)) = (callee_name, call_type, position) {
-            // PHP and Apex are case-insensitive at the language level; normalize
-            // callee names to lowercase so that HELPER() matches symbol `helper`
-            // during resolution and lookup. Constructor names keep their original
-            // casing because they need to match class declarations (which are
-            // resolved by exact name in this codebase). Import, Inherits, and
-            // Implements names similarly preserve their casing.
+            if matches!(language, Language::C | Language::Cpp)
+                && matches!(ct, CallType::Call | CallType::MethodCall)
+                && callee_byte.is_some_and(|byte| {
+                    exclusions.iter().any(|exclusion| {
+                        exclusion.name == name
+                            && byte >= exclusion.start_byte
+                            && byte <= exclusion.end_byte
+                            && (ct == CallType::Call || exclusion.include_method_calls)
+                    })
+                })
+            {
+                continue;
+            }
+
+            // PHP et Apex sont insensibles à la casse : les appels ordinaires
+            // sont normalisés en minuscules pour correspondre aux symboles.
             let normalized_name = if (language == Language::Php || language == Language::Apex)
                 && ct != CallType::Import
                 && ct != CallType::Constructor
@@ -861,5 +1005,169 @@ mod tests {
         let names: Vec<&str> = inherits.iter().map(|c| c.callee_name.as_str()).collect();
         assert!(names.contains(&"Base"));
         assert!(names.contains(&"Client"));
+    }
+
+    #[test]
+    fn test_c_calls_and_conservative_exclusions() {
+        let code = r#"
+#include <stdio.h>
+#define call_helper(value) helper(value)
+#define helper_alias helper
+typedef int (*callback_fn)(int);
+typedef int callback_signature(int);
+int declared_only(int value);
+int helper(int value) { return value + 1; }
+int API_CALL(int value) { return value; }
+int direct_target(void) { return 1; }
+int call_direct(void) { return direct_target(); }
+int use_pointer(int (*direct_target)(void)) { return direct_target(); }
+int run(callback_fn callback, callback_signature *signature) {
+    callback_fn local_callback = callback;
+    int direct = helper(1);
+    int macro_value = call_helper(2);
+    int indirect = callback(3);
+    int local_indirect = local_callback(4);
+    int signature_indirect = signature(5);
+    int alias_value = helper_alias(6);
+    return API_CALL(printf("%d", direct + macro_value + indirect + local_indirect + signature_indirect + alias_value));
+}
+"#;
+        let calls = extract_calls(code, "c").unwrap();
+
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "helper" && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "printf" && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "API_CALL" && call.call_type == CallType::Call));
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.callee_name == "direct_target")
+                .count(),
+            1,
+            "Expected the call outside the pointer parameter's scope only: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|call| call.callee_name.contains("stdio.h")
+                    && call.call_type == CallType::Import)
+        );
+        assert!(!calls.iter().any(|call| matches!(
+            call.callee_name.as_str(),
+            "call_helper"
+                | "helper_alias"
+                | "callback"
+                | "local_callback"
+                | "signature"
+                | "declared_only"
+        )));
+    }
+
+    #[test]
+    fn test_cpp_calls_constructors_namespaces_and_exclusions() {
+        let code = r#"
+#include "widget.hpp"
+#define run_widget(value) helper(value)
+#define helper_alias helper
+using Callback = int (*)(int);
+using CallbackSignature = int(int);
+using LoopCallback = int (*)();
+using namespace project::detail;
+int helper(int value) { return value + 1; }
+template <typename T> T identity(T value) { return value; }
+struct Table { Callback dispatch; };
+int callback(void) { return 1; }
+int loop_scope(LoopCallback initial) {
+    for (LoopCallback callback = initial; false;) { callback(); }
+    return callback();
+}
+int field_call(Table* table) { return table->dispatch(); }
+int lambda_target(void) { return 1; }
+int lambda_scope(void) {
+    auto indirect = [](int (*lambda_target)(void)) { return lambda_target(); };
+    return lambda_target();
+}
+int indirect_run(int (*run)(int)) { return run(1); }
+int method_run(Widget* widget) { return widget->run(); }
+int run(Widget* widget, Callback callback, CallbackSignature* signature) {
+    Callback local_callback = callback;
+    auto* heap = new Widget(1);
+    auto* remote = new project::detail::RemoteWidget(2);
+    int direct = project::detail::normalize(helper(3));
+    int member = widget->run() + Widget{4}.run();
+    int macro_value = run_widget(5);
+    int indirect = callback(6);
+    int local_indirect = local_callback(7);
+    int signature_indirect = signature(8);
+    int alias_value = helper_alias(9);
+    return direct + member + macro_value + indirect + local_indirect + signature_indirect + alias_value + identity<int>(10);
+}
+"#;
+        let calls = extract_calls(code, "cpp").unwrap();
+
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "helper" && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "project::detail::normalize"
+                && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "run" && call.call_type == CallType::MethodCall));
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| {
+                    call.callee_name == "run" && call.call_type == CallType::MethodCall
+                })
+                .count(),
+            3,
+            "Expected member calls to survive an unrelated pointer named run: {:?}",
+            calls
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.callee_name == "callback")
+                .count(),
+            1,
+            "Expected the direct call after the for-loop scope only: {:?}",
+            calls
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.callee_name == "lambda_target")
+                .count(),
+            1,
+            "Expected the direct call outside the lambda parameter's scope only: {:?}",
+            calls
+        );
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "Widget" && call.call_type == CallType::Constructor));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "project::detail::RemoteWidget"
+                && call.call_type == CallType::Constructor));
+        assert!(calls.iter().any(|call| {
+            call.callee_name == "project::detail" && call.call_type == CallType::Import
+        }));
+        assert!(!calls.iter().any(|call| matches!(
+            call.callee_name.as_str(),
+            "run_widget"
+                | "helper_alias"
+                | "local_callback"
+                | "signature"
+                | "dispatch"
+                | "identity"
+        )));
     }
 }

--- a/native/src/call_extractor.rs
+++ b/native/src/call_extractor.rs
@@ -1,5 +1,6 @@
 use crate::types::Language;
 use anyhow::{anyhow, Result};
+use std::collections::{HashMap, HashSet};
 use streaming_iterator::StreamingIterator;
 use tree_sitter::{Parser, Query, QueryCursor};
 
@@ -29,6 +30,66 @@ pub struct CallSite {
     pub confidence: Confidence,
 }
 
+struct CallExclusion {
+    start_byte: usize,
+    end_byte: usize,
+    include_method_calls: bool,
+}
+
+fn exclusion_scope(
+    node: tree_sitter::Node<'_>,
+    root: tree_sitter::Node<'_>,
+) -> (usize, usize, bool) {
+    let mut current = Some(node);
+    let mut declaration = None;
+    let mut block_end = None;
+    let mut is_parameter = false;
+
+    while let Some(ancestor) = current {
+        match ancestor.kind() {
+            "preproc_def" | "preproc_function_def" => {
+                return (ancestor.end_byte(), root.end_byte(), true);
+            }
+            "parameter_declaration" => is_parameter = true,
+            "declaration" => declaration = Some((ancestor.start_byte(), ancestor.end_byte())),
+            "for_statement" | "for_range_loop" | "if_statement" | "while_statement"
+            | "switch_statement"
+                if block_end.is_none() =>
+            {
+                block_end = Some(ancestor.end_byte());
+            }
+            "compound_statement" if block_end.is_none() => block_end = Some(ancestor.end_byte()),
+            "lambda_expression" => {
+                let start = declaration
+                    .map(|(start, _)| start)
+                    .unwrap_or_else(|| ancestor.start_byte());
+                let end = block_end.unwrap_or_else(|| ancestor.end_byte());
+                return (start, end, node.kind() == "field_identifier");
+            }
+            "function_definition" => {
+                let start = declaration
+                    .map(|(start, _)| start)
+                    .unwrap_or_else(|| ancestor.start_byte());
+                let end = block_end.unwrap_or_else(|| ancestor.end_byte());
+                return (start, end, node.kind() == "field_identifier");
+            }
+            _ => {}
+        }
+        current = ancestor.parent();
+    }
+
+    if is_parameter {
+        if let Some((start, end)) = declaration {
+            return (start, end, node.kind() == "field_identifier");
+        }
+    }
+
+    let start = declaration
+        .map(|(start, _)| start)
+        .unwrap_or(root.start_byte());
+    (start, root.end_byte(), node.kind() == "field_identifier")
+}
+
 pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>> {
     let language = Language::from_string(language_name);
     let ts_language = match language {
@@ -45,6 +106,8 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Matlab => tree_sitter_matlab::LANGUAGE.into(),
         Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
         Language::Bash => tree_sitter_bash::LANGUAGE.into(),
+        Language::C => tree_sitter_c::LANGUAGE.into(),
+        Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
         _ => return Ok(vec![]),
     };
 
@@ -73,6 +136,8 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         Language::Matlab => include_str!("../queries/matlab-calls.scm"),
         Language::Apex => include_str!("../queries/apex-calls.scm"),
         Language::Bash => include_str!("../queries/bash-calls.scm"),
+        Language::C => include_str!("../queries/c-calls.scm"),
+        Language::Cpp => include_str!("../queries/cpp-calls.scm"),
         _ => return Ok(vec![]),
     };
 
@@ -89,10 +154,81 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
     let import_namespace_idx = query.capture_index_for_name("import.namespace");
     let inherits_name_idx = query.capture_index_for_name("inherits.name");
     let implements_name_idx = query.capture_index_for_name("implements.name");
+    let constructor_type_idx = query.capture_index_for_name("constructor.type");
+    let excluded_name_idx = query.capture_index_for_name("excluded.name");
+    let indirect_type_idx = query.capture_index_for_name("indirect.type");
+    let indirect_variable_type_idx = query.capture_index_for_name("indirect.variable_type");
+    let indirect_variable_idx = query.capture_index_for_name("indirect.variable");
+    let text_bytes = content.as_bytes();
+
+    let root = tree.root_node();
+    let mut exclusions: HashMap<String, Vec<CallExclusion>> = HashMap::new();
+    let mut indirect_types = HashSet::new();
+    if excluded_name_idx.is_some() || indirect_type_idx.is_some() {
+        let mut exclusion_cursor = QueryCursor::new();
+        let mut exclusion_matches = exclusion_cursor.captures(&query, tree.root_node(), text_bytes);
+        while let Some((match_, _)) = exclusion_matches.next() {
+            for capture in match_.captures {
+                if excluded_name_idx == Some(capture.index) {
+                    let text = capture.node.utf8_text(text_bytes).unwrap_or("");
+                    let (start_byte, end_byte, include_method_calls) =
+                        exclusion_scope(capture.node, root);
+                    exclusions
+                        .entry(text.to_string())
+                        .or_default()
+                        .push(CallExclusion {
+                            start_byte,
+                            end_byte,
+                            include_method_calls,
+                        });
+                }
+                if indirect_type_idx == Some(capture.index) {
+                    let text = capture.node.utf8_text(text_bytes).unwrap_or("");
+                    indirect_types.insert(text.to_string());
+                }
+            }
+        }
+    }
+
+    if !indirect_types.is_empty()
+        && indirect_variable_type_idx.is_some()
+        && indirect_variable_idx.is_some()
+    {
+        let mut variable_cursor = QueryCursor::new();
+        let mut variables = variable_cursor.captures(&query, tree.root_node(), text_bytes);
+        while let Some((match_, _)) = variables.next() {
+            let mut variable_type = None;
+            let mut variable_name = None;
+
+            for capture in match_.captures {
+                let text = capture.node.utf8_text(text_bytes).unwrap_or("");
+                if indirect_variable_type_idx == Some(capture.index) {
+                    variable_type = Some(text);
+                }
+                if indirect_variable_idx == Some(capture.index) {
+                    variable_name = Some((text, capture.node));
+                }
+            }
+
+            if let (Some(type_name), Some((name, name_node))) = (variable_type, variable_name) {
+                if indirect_types.contains(type_name) {
+                    let (start_byte, end_byte, include_method_calls) =
+                        exclusion_scope(name_node, root);
+                    exclusions
+                        .entry(name.to_string())
+                        .or_default()
+                        .push(CallExclusion {
+                            start_byte,
+                            end_byte,
+                            include_method_calls,
+                        });
+                }
+            }
+        }
+    }
 
     let mut cursor = QueryCursor::new();
     let mut calls = Vec::new();
-    let text_bytes = content.as_bytes();
 
     let mut captures_iter = cursor.captures(&query, tree.root_node(), text_bytes);
 
@@ -100,10 +236,16 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         let mut callee_name: Option<String> = None;
         let mut call_type: Option<CallType> = None;
         let mut position: Option<(u32, u32)> = None;
+        let mut callee_byte = None;
+        let mut constructor_type = None;
 
         for capture in match_.captures {
             let node = capture.node;
             let text = node.utf8_text(text_bytes).unwrap_or("");
+
+            if constructor_type_idx == Some(capture.index) {
+                constructor_type = Some(text);
+            }
 
             if let Some(idx) = callee_name_idx {
                 if capture.index == idx {
@@ -112,6 +254,7 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
                         let start = node.start_position();
                         position = Some((start.row as u32 + 1, start.column as u32));
                     }
+                    callee_byte = Some(node.start_byte());
                 }
             }
 
@@ -200,12 +343,29 @@ pub fn extract_calls(content: &str, language_name: &str) -> Result<Vec<CallSite>
         // @call is only for direct function calls
         // So we need to check if the call was already classified as a method call
         if let (Some(name), Some(ct), Some(pos)) = (callee_name, call_type, position) {
-            // PHP and Apex are case-insensitive at the language level; normalize
-            // callee names to lowercase so that HELPER() matches symbol `helper`
-            // during resolution and lookup. Constructor names keep their original
-            // casing because they need to match class declarations (which are
-            // resolved by exact name in this codebase). Import, Inherits, and
-            // Implements names similarly preserve their casing.
+            if ct == CallType::Constructor
+                && constructor_type.is_some_and(|type_name| type_name != name)
+            {
+                continue;
+            }
+
+            if matches!(language, Language::C | Language::Cpp)
+                && matches!(ct, CallType::Call | CallType::MethodCall)
+                && callee_byte.is_some_and(|byte| {
+                    exclusions.get(&name).is_some_and(|matching_exclusions| {
+                        matching_exclusions.iter().any(|exclusion| {
+                            byte >= exclusion.start_byte
+                                && byte <= exclusion.end_byte
+                                && (ct == CallType::Call || exclusion.include_method_calls)
+                        })
+                    })
+                })
+            {
+                continue;
+            }
+
+            // PHP and Apex are case-insensitive, so normalize ordinary calls
+            // to lowercase to match their indexed symbols.
             let normalized_name = if (language == Language::Php || language == Language::Apex)
                 && ct != CallType::Import
                 && ct != CallType::Constructor
@@ -861,5 +1021,194 @@ mod tests {
         let names: Vec<&str> = inherits.iter().map(|c| c.callee_name.as_str()).collect();
         assert!(names.contains(&"Base"));
         assert!(names.contains(&"Client"));
+    }
+
+    #[test]
+    fn test_c_calls_and_conservative_exclusions() {
+        let code = r#"
+#include <stdio.h>
+#define call_helper(value) helper(value)
+#define helper_alias helper
+typedef int (*callback_fn)(int);
+typedef int callback_signature(int);
+int declared_only(int value);
+int helper(int value) { return value + 1; }
+int API_CALL(int value) { return value; }
+int direct_target(void) { return 1; }
+int call_direct(void) { return direct_target(); }
+int use_pointer(int (*direct_target)(void)) { return direct_target(); }
+int run(callback_fn callback, callback_signature *signature) {
+    callback_fn local_callback = callback;
+    int direct = helper(1);
+    int macro_value = call_helper(2);
+    int indirect = callback(3);
+    int local_indirect = local_callback(4);
+    int signature_indirect = signature(5);
+    int alias_value = helper_alias(6);
+    return API_CALL(printf("%d", direct + macro_value + indirect + local_indirect + signature_indirect + alias_value));
+}
+"#;
+        let calls = extract_calls(code, "c").unwrap();
+
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "helper" && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "printf" && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "API_CALL" && call.call_type == CallType::Call));
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.callee_name == "direct_target")
+                .count(),
+            1,
+            "Expected the call outside the pointer parameter's scope only: {:?}",
+            calls
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|call| call.callee_name.contains("stdio.h")
+                    && call.call_type == CallType::Import)
+        );
+        assert!(!calls.iter().any(|call| matches!(
+            call.callee_name.as_str(),
+            "call_helper"
+                | "helper_alias"
+                | "callback"
+                | "local_callback"
+                | "signature"
+                | "declared_only"
+        )));
+    }
+
+    #[test]
+    fn test_cpp_calls_constructors_namespaces_and_exclusions() {
+        let code = r#"
+#include "widget.hpp"
+#define run_widget(value) helper(value)
+#define helper_alias helper
+using Callback = int (*)(int);
+using CallbackSignature = int(int);
+using LoopCallback = int (*)();
+using namespace project::detail;
+int helper(int value) { return value + 1; }
+template <typename T> T identity(T value) { return value; }
+struct Table { Callback dispatch; };
+int callback(void) { return 1; }
+int loop_scope(LoopCallback initial) {
+    for (LoopCallback callback = initial; false;) { callback(); }
+    return callback();
+}
+int field_call(Table* table) { return table->dispatch(); }
+int lambda_target(void) { return 1; }
+int lambda_scope(void) {
+    auto indirect = [](int (*lambda_target)(void)) { return lambda_target(); };
+    return lambda_target();
+}
+int indirect_run(int (*run)(int)) { return run(1); }
+int method_run(Widget* widget) { return widget->run(); }
+Widget make_widget();
+int run(Widget* widget, Callback callback, CallbackSignature* signature) {
+    Callback local_callback = callback;
+    Widget stack(0);
+    Widget braced{0};
+    Widget copied = Widget(0);
+    Widget from_factory = make_widget();
+    Widget vexing();
+    project::detail::RemoteWidget remote_stack(1);
+    auto* heap = new Widget(1);
+    auto* remote = new project::detail::RemoteWidget(2);
+    int direct = project::detail::normalize(helper(3));
+    int member = widget->run() + Widget{4}.run();
+    int macro_value = run_widget(5);
+    int indirect = callback(6);
+    int local_indirect = local_callback(7);
+    int signature_indirect = signature(8);
+    int alias_value = helper_alias(9);
+    return direct + member + macro_value + indirect + local_indirect + signature_indirect + alias_value + identity<int>(10);
+}
+"#;
+        let calls = extract_calls(code, "cpp").unwrap();
+
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "helper" && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "project::detail::normalize"
+                && call.call_type == CallType::Call));
+        assert!(calls
+            .iter()
+            .any(|call| call.callee_name == "run" && call.call_type == CallType::MethodCall));
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| {
+                    call.callee_name == "run" && call.call_type == CallType::MethodCall
+                })
+                .count(),
+            3,
+            "Expected member calls to survive an unrelated pointer named run: {:?}",
+            calls
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.callee_name == "callback")
+                .count(),
+            1,
+            "Expected the direct call after the for-loop scope only: {:?}",
+            calls
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.callee_name == "lambda_target")
+                .count(),
+            1,
+            "Expected the direct call outside the lambda parameter's scope only: {:?}",
+            calls
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| {
+                    call.callee_name == "Widget" && call.call_type == CallType::Constructor
+                })
+                .count(),
+            5,
+            "Expected stack, braced, copy-initialized, heap, and temporary constructors: {:?}",
+            calls
+        );
+        assert!(calls
+            .iter()
+            .any(|call| { call.callee_name == "make_widget" && call.call_type == CallType::Call }));
+        assert!(!calls.iter().any(|call| call.callee_name == "vexing"));
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| {
+                    call.callee_name == "project::detail::RemoteWidget"
+                        && call.call_type == CallType::Constructor
+                })
+                .count(),
+            2
+        );
+        assert!(calls.iter().any(|call| {
+            call.callee_name == "project::detail" && call.call_type == CallType::Import
+        }));
+        assert!(!calls.iter().any(|call| matches!(
+            call.callee_name.as_str(),
+            "run_widget"
+                | "helper_alias"
+                | "local_callback"
+                | "signature"
+                | "dispatch"
+                | "identity"
+        )));
     }
 }

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -147,7 +147,8 @@ fn extract_semantic_nodes(
             let content = &source[start_byte..end_byte];
 
             if content.len() >= MIN_CHUNK_SIZE
-                || (*language == Language::Bash && node_type == "function_definition")
+                || (matches!(*language, Language::Bash | Language::C | Language::Cpp)
+                    && node_type == "function_definition")
             {
                 let name = extract_name(cursor, source);
 
@@ -607,6 +608,7 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
             || kind == "property_identifier"
             || kind == "property_name"
             || kind == "type_identifier"
+            || kind == "namespace_identifier"
             || kind == "name"
             || kind == "word"
         {
@@ -623,6 +625,19 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
                 PERF_STATS.lock().unwrap().extract_name_time += elapsed;
             }
             return Some(name);
+        }
+    }
+
+    if node.kind() == "function_definition" {
+        if let Some(declarator) = node.child_by_field_name("declarator") {
+            if let Some(name) = extract_declarator_name(declarator, source) {
+                #[cfg(debug_assertions)]
+                {
+                    let elapsed = start.elapsed().as_micros();
+                    PERF_STATS.lock().unwrap().extract_name_time += elapsed;
+                }
+                return Some(name);
+            }
         }
     }
 
@@ -707,6 +722,24 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
     None
 }
 
+fn extract_declarator_name(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    if matches!(
+        node.kind(),
+        "identifier" | "field_identifier" | "type_identifier"
+    ) {
+        return Some(source[node.start_byte()..node.end_byte()].to_string());
+    }
+
+    if node.kind() == "qualified_identifier" {
+        return node
+            .child_by_field_name("name")
+            .and_then(|name| extract_declarator_name(name, source));
+    }
+
+    node.child_by_field_name("declarator")
+        .and_then(|declarator| extract_declarator_name(declarator, source))
+}
+
 fn split_large_chunk(chunk: CodeChunk, chunks: &mut Vec<CodeChunk>) {
     let lines: Vec<&str> = chunk.content.lines().collect();
     let total_lines = lines.len();
@@ -760,9 +793,11 @@ fn merge_small_chunks(chunks: &mut Vec<CodeChunk>) {
             continue;
         };
 
-        let can_merge_without_losing_symbol = !(cur.language == "bash"
-            && cur.chunk_type == "function_definition"
-            || chunk.language == "bash" && chunk.chunk_type == "function_definition");
+        let can_merge_without_losing_symbol =
+            !((matches!(cur.language.as_str(), "bash" | "c" | "cpp")
+                && cur.chunk_type == "function_definition")
+                || (matches!(chunk.language.as_str(), "bash" | "c" | "cpp")
+                    && chunk.chunk_type == "function_definition"));
 
         if can_merge_without_losing_symbol
             && cur.content.len() < MIN_CHUNK_SIZE * 2
@@ -1066,6 +1101,15 @@ greet "World"
 
         let has_function = chunks.iter().any(|c| c.chunk_type == "function_definition");
         assert!(has_function, "Should find function_definition");
+        let names: Vec<&str> = chunks
+            .iter()
+            .filter_map(|chunk| chunk.name.as_deref())
+            .collect();
+        assert!(names.contains(&"add"), "Should extract the C function name");
+        assert!(
+            names.contains(&"greet"),
+            "Should preserve adjacent C functions"
+        );
     }
 
     #[test]
@@ -1133,6 +1177,10 @@ template<typename T>
 T max(T a, T b) {
     return (a > b) ? a : b;
 }
+
+int main() {
+    return Math::add(1, 2);
+}
 "#;
 
         let chunks = parse_file_internal("main.cpp", content).unwrap();
@@ -1145,6 +1193,12 @@ T max(T a, T b) {
         assert!(
             has_class || has_namespace,
             "Should find class_specifier or namespace_definition"
+        );
+        assert!(
+            chunks
+                .iter()
+                .any(|chunk| chunk.name.as_deref() == Some("main")),
+            "Should extract and preserve the C++ function name"
         );
     }
 

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -146,9 +146,17 @@ fn extract_semantic_nodes(
 
             let content = &source[start_byte..end_byte];
 
-            if content.len() >= MIN_CHUNK_SIZE
-                || (*language == Language::Bash && node_type == "function_definition")
-            {
+            let preserve_small_call_graph_symbol = match language {
+                Language::Bash => node_type == "function_definition",
+                Language::C => node_type == "function_definition",
+                Language::Cpp => matches!(
+                    node_type,
+                    "function_definition" | "class_specifier" | "struct_specifier"
+                ),
+                _ => false,
+            };
+
+            if content.len() >= MIN_CHUNK_SIZE || preserve_small_call_graph_symbol {
                 let name = extract_name(cursor, source);
 
                 let start_line = if leading_comment.is_some() {
@@ -607,6 +615,7 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
             || kind == "property_identifier"
             || kind == "property_name"
             || kind == "type_identifier"
+            || kind == "namespace_identifier"
             || kind == "name"
             || kind == "word"
         {
@@ -623,6 +632,19 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
                 PERF_STATS.lock().unwrap().extract_name_time += elapsed;
             }
             return Some(name);
+        }
+    }
+
+    if node.kind() == "function_definition" {
+        if let Some(declarator) = node.child_by_field_name("declarator") {
+            if let Some(name) = extract_declarator_name(declarator, source) {
+                #[cfg(debug_assertions)]
+                {
+                    let elapsed = start.elapsed().as_micros();
+                    PERF_STATS.lock().unwrap().extract_name_time += elapsed;
+                }
+                return Some(name);
+            }
         }
     }
 
@@ -707,6 +729,24 @@ fn extract_name(cursor: &tree_sitter::TreeCursor, source: &str) -> Option<String
     None
 }
 
+fn extract_declarator_name(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    if matches!(
+        node.kind(),
+        "identifier" | "field_identifier" | "type_identifier"
+    ) {
+        return Some(source[node.start_byte()..node.end_byte()].to_string());
+    }
+
+    if node.kind() == "qualified_identifier" {
+        return node
+            .child_by_field_name("name")
+            .and_then(|name| extract_declarator_name(name, source));
+    }
+
+    node.child_by_field_name("declarator")
+        .and_then(|declarator| extract_declarator_name(declarator, source))
+}
+
 fn split_large_chunk(chunk: CodeChunk, chunks: &mut Vec<CodeChunk>) {
     let lines: Vec<&str> = chunk.content.lines().collect();
     let total_lines = lines.len();
@@ -760,9 +800,17 @@ fn merge_small_chunks(chunks: &mut Vec<CodeChunk>) {
             continue;
         };
 
-        let can_merge_without_losing_symbol = !(cur.language == "bash"
-            && cur.chunk_type == "function_definition"
-            || chunk.language == "bash" && chunk.chunk_type == "function_definition");
+        let is_preserved_call_graph_symbol =
+            |candidate: &CodeChunk| match candidate.language.as_str() {
+                "bash" | "c" => candidate.chunk_type == "function_definition",
+                "cpp" => matches!(
+                    candidate.chunk_type.as_str(),
+                    "function_definition" | "class_specifier" | "struct_specifier"
+                ),
+                _ => false,
+            };
+        let can_merge_without_losing_symbol =
+            !is_preserved_call_graph_symbol(&cur) && !is_preserved_call_graph_symbol(&chunk);
 
         if can_merge_without_losing_symbol
             && cur.content.len() < MIN_CHUNK_SIZE * 2
@@ -1066,6 +1114,15 @@ greet "World"
 
         let has_function = chunks.iter().any(|c| c.chunk_type == "function_definition");
         assert!(has_function, "Should find function_definition");
+        let names: Vec<&str> = chunks
+            .iter()
+            .filter_map(|chunk| chunk.name.as_deref())
+            .collect();
+        assert!(names.contains(&"add"), "Should extract the C function name");
+        assert!(
+            names.contains(&"greet"),
+            "Should preserve adjacent C functions"
+        );
     }
 
     #[test]
@@ -1133,6 +1190,10 @@ template<typename T>
 T max(T a, T b) {
     return (a > b) ? a : b;
 }
+
+int main() {
+    return Math::add(1, 2);
+}
 "#;
 
         let chunks = parse_file_internal("main.cpp", content).unwrap();
@@ -1146,6 +1207,24 @@ T max(T a, T b) {
             has_class || has_namespace,
             "Should find class_specifier or namespace_definition"
         );
+        assert!(
+            chunks
+                .iter()
+                .any(|chunk| chunk.name.as_deref() == Some("main")),
+            "Should extract and preserve the C++ function name"
+        );
+    }
+
+    #[test]
+    fn test_parse_cpp_preserves_small_type_symbols() {
+        let chunks = parse_file_internal("small.cpp", "class Tag {};\nstruct Point {};\n").unwrap();
+
+        assert!(chunks.iter().any(|chunk| {
+            chunk.chunk_type == "class_specifier" && chunk.name.as_deref() == Some("Tag")
+        }));
+        assert!(chunks.iter().any(|chunk| {
+            chunk.chunk_type == "struct_specifier" && chunk.name.as_deref() == Some("Point")
+        }));
     }
 
     #[test]

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -42,7 +42,7 @@ import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
 import { getChunkGitBlame, type GitBlameMetadata } from "./git-blame.js";
 
-export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash"]);
+export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp"]);
 // Languages whose identifiers are case-insensitive at the language level.
 // The Rust call_extractor lowercases callee names for these languages (except
 // constructors and imports), so same-file resolution in this file must use
@@ -61,6 +61,9 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "enum_declaration",
   "function_definition",
   "class_definition",
+  "class_specifier",
+  "struct_specifier",
+  "namespace_definition",
   "decorated_definition",
   "method_declaration",
   "type_declaration",
@@ -85,6 +88,19 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "const_statement",
   "class_name_statement",
 ]);
+
+const C_FAMILY_TYPE_SYMBOL_CHUNK_TYPES = new Set(["class_specifier", "struct_specifier"]);
+
+function isCompatibleCFamilyCallTarget(
+  language: string,
+  callType: string,
+  symbolKind: string,
+): boolean {
+  if (language !== "c" && language !== "cpp") return true;
+  if (symbolKind === "namespace_definition") return callType === "Import";
+  if (!C_FAMILY_TYPE_SYMBOL_CHUNK_TYPES.has(symbolKind)) return true;
+  return callType === "Constructor" || callType === "Inherits" || callType === "Implements";
+}
 
 function float32ArrayToBuffer(arr: number[]): Buffer {
   const float32 = new Float32Array(arr);
@@ -3603,7 +3619,11 @@ export class Indexer {
         // Resolve same-file calls (with the same case-insensitivity rules
         // used to build symbolsByName above).
         for (const edge of edges) {
-          const candidates = symbolsByName.get(normalizeSymbolKey(edge.targetName));
+          const candidates = symbolsByName
+            .get(normalizeSymbolKey(edge.targetName))
+            ?.filter((symbol) =>
+              isCompatibleCFamilyCallTarget(fileLanguage, edge.callType, symbol.kind)
+            );
           if (candidates && candidates.length === 1) {
             database.resolveCallEdge(edge.id, candidates[0].id);
           }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -53,7 +53,7 @@ import {
   type IndexMutationOperation,
 } from "./index-lock.js";
 
-export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash"]);
+export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp"]);
 // Languages whose identifiers are case-insensitive at the language level.
 // The Rust call_extractor lowercases callee names for these languages (except
 // constructors and imports), so same-file resolution in this file must use
@@ -61,7 +61,7 @@ export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", 
 // sync with the matching branch in native/src/call_extractor.rs.
 export const CASE_INSENSITIVE_LANGUAGES = new Set(["apex", "php"]);
 // Existing indexes without this metadata are the implicit version 1.
-const CALL_GRAPH_RESOLUTION_VERSION = "2";
+const CALL_GRAPH_RESOLUTION_VERSION = "3";
 const PHP_FUNCTION_SYMBOL_CHUNK_TYPES = new Set([
   "function_declaration",
   "function",
@@ -83,6 +83,9 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "enum_declaration",
   "function_definition",
   "class_definition",
+  "class_specifier",
+  "struct_specifier",
+  "namespace_definition",
   "decorated_definition",
   "method_declaration",
   "type_declaration",
@@ -107,6 +110,22 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "const_statement",
   "class_name_statement",
 ]);
+
+const C_FAMILY_TYPE_SYMBOL_CHUNK_TYPES = new Set(["class_specifier", "struct_specifier"]);
+
+function isCompatibleCFamilyCallTarget(
+  language: string,
+  callType: string,
+  symbolKind: string,
+): boolean {
+  if (language !== "c" && language !== "cpp") return true;
+  if (symbolKind === "namespace_definition") return callType === "Import";
+  const isTypeSymbol = C_FAMILY_TYPE_SYMBOL_CHUNK_TYPES.has(symbolKind);
+  if (callType === "Constructor" || callType === "Inherits" || callType === "Implements") {
+    return isTypeSymbol;
+  }
+  return !isTypeSymbol;
+}
 
 function float32ArrayToBuffer(arr: number[]): Buffer {
   const float32 = new Float32Array(arr);
@@ -3947,11 +3966,13 @@ export class Indexer {
       currentFileHashes.set(f.path, currentHash);
 
       const cachedHashMatches = this.fileHashCache.get(f.path) === currentHash;
-      const needsPhpCallGraphRefresh = cachedHashMatches &&
+      const needsCallGraphRefresh = cachedHashMatches &&
         needsCallGraphResolutionMigration &&
-        database.getChunksByFile(f.path).some((chunk) => chunk.language === "php");
+        database.getChunksByFile(f.path).some((chunk) =>
+          chunk.language === "php" || chunk.language === "c" || chunk.language === "cpp"
+        );
 
-      if (cachedHashMatches && !needsPhpCallGraphRefresh) {
+      if (cachedHashMatches && !needsCallGraphRefresh) {
         unchangedFilePaths.add(f.path);
         this.logger.recordCacheHit();
       } else {
@@ -4275,6 +4296,9 @@ export class Indexer {
               );
             }
           }
+          candidates = candidates?.filter((symbol) =>
+            isCompatibleCFamilyCallTarget(fileLanguage, edge.callType, symbol.kind)
+          );
           if (candidates && candidates.length === 1) {
             database.resolveCallEdge(edge.id, candidates[0].id);
           }

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
 import { extractCalls, Database, hashContent, parseFiles } from "../src/native/index.js";
 import type { SymbolData, CallEdgeData } from "../src/native/index.js";
 import {
@@ -20,6 +22,28 @@ describe("call-graph", () => {
     const d = new Database(path.join(tempDir, "test.db"));
     _dbs.push(d);
     return d;
+  }
+
+  function buildFileSymbols(filePath: string, content: string): SymbolData[] {
+    const parsed = parseFiles([{ path: filePath, content }])[0];
+    const symbols: SymbolData[] = [];
+
+    for (const chunk of parsed.chunks) {
+      if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
+      symbols.push({
+        id: `sym_${hashContent(filePath + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`,
+        filePath,
+        name: chunk.name,
+        kind: chunk.chunkType,
+        startLine: chunk.startLine,
+        startCol: 0,
+        endLine: chunk.endLine,
+        endCol: 0,
+        language: chunk.language,
+      });
+    }
+
+    return symbols;
   }
 
   beforeEach(() => {
@@ -688,6 +712,304 @@ const math = @import("math.zig");
       expect(importCalls.length).toBeGreaterThanOrEqual(2);
       expect(importCalls.some((c) => c.calleeName.includes("std"))).toBe(true);
       expect(importCalls.some((c) => c.calleeName.includes("math.zig"))).toBe(true);
+    });
+  });
+
+  describe("C call graph", () => {
+    const filePath = path.join(fixturesDir, "c-calls.c");
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    it("should extract conservative C calls and includes", () => {
+      const calls = extractCalls(content, "c");
+      const callNames = calls.map((call) => call.calleeName);
+      const imports = calls.filter((call) => call.callType === "Import");
+
+      expect(CALL_GRAPH_LANGUAGES.has("c")).toBe(true);
+      expect(calls.find((call) => call.calleeName === "helper")?.callType).toBe("Call");
+      expect(callNames).toContain("compute");
+      expect(callNames).toContain("printf");
+      expect(callNames).toContain("external_api");
+      expect(imports.some((call) => call.calleeName.includes("stdio.h"))).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("helpers.h"))).toBe(true);
+
+      expect(callNames).not.toContain("declared_only");
+      expect(callNames).not.toContain("call_helper");
+      expect(callNames).not.toContain("helper_alias");
+      expect(callNames).not.toContain("callback");
+      expect(callNames).not.toContain("local_callback");
+    });
+
+    it("should preserve C function symbols and resolve a same-file call", () => {
+      const db = openDb();
+      const symbols = buildFileSymbols(filePath, content);
+      const names = symbols.map((symbol) => symbol.name);
+
+      expect(names).toContain("helper");
+      expect(names).toContain("compute");
+      expect(names).toContain("invoke");
+      expect(names).toContain("inspect");
+      expect(names).toContain("external_api");
+      expect(names).toContain("main");
+
+      const helper = symbols.find((symbol) => symbol.name === "helper");
+      const compute = symbols.find((symbol) => symbol.name === "compute");
+      expect(helper).toBeDefined();
+      expect(compute).toBeDefined();
+
+      const helperCall = extractCalls(content, "c").find(
+        (call) =>
+          call.calleeName === "helper" &&
+          call.line >= compute!.startLine &&
+          call.line <= compute!.endLine,
+      );
+      expect(helperCall).toBeDefined();
+
+      db.upsertSymbolsBatch(symbols);
+      const edge: CallEdgeData = {
+        id: "edge_c_helper",
+        fromSymbolId: compute!.id,
+        targetName: helperCall!.calleeName,
+        callType: helperCall!.callType,
+        confidence: helperCall!.confidence,
+        line: helperCall!.line,
+        col: helperCall!.column,
+        isResolved: false,
+      };
+      db.upsertCallEdgesBatch([edge]);
+      const candidates = symbols.filter((symbol) => symbol.name === edge.targetName);
+      expect(candidates).toHaveLength(1);
+      db.resolveCallEdge(edge.id, candidates[0].id);
+      db.addSymbolsToBranchBatch("test", symbols.map((symbol) => symbol.id));
+
+      const callees = db.getCallees(compute!.id, "test");
+      expect(callees).toHaveLength(1);
+      expect(callees[0].targetName).toBe("helper");
+      expect(callees[0].toSymbolId).toBe(helper!.id);
+      expect(callees[0].isResolved).toBe(true);
+    });
+  });
+
+  describe("C++ call graph", () => {
+    const filePath = path.join(fixturesDir, "cpp-calls.cpp");
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    it("should extract conservative C++ calls, constructors, namespaces, and includes", () => {
+      const calls = extractCalls(content, "cpp");
+      const callNames = calls.map((call) => call.calleeName);
+      const imports = calls.filter((call) => call.callType === "Import");
+      const constructors = calls.filter((call) => call.callType === "Constructor");
+      const runCalls = calls.filter(
+        (call) => call.calleeName === "run" && call.callType === "MethodCall",
+      );
+
+      expect(CALL_GRAPH_LANGUAGES.has("cpp")).toBe(true);
+      expect(calls.find((call) => call.calleeName === "helper")?.callType).toBe("Call");
+      expect(
+        calls.find((call) => call.calleeName === "project::detail::normalize")?.callType,
+      ).toBe("Call");
+      expect(runCalls).toHaveLength(4);
+      expect(constructors.filter((call) => call.calleeName === "Widget")).toHaveLength(2);
+      expect(
+        constructors.some((call) => call.calleeName === "project::detail::RemoteWidget"),
+      ).toBe(true);
+      expect(constructors.some((call) => call.calleeName === "Point")).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("memory"))).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("widget.hpp"))).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("project::detail"))).toBe(true);
+
+      expect(callNames).not.toContain("declared_only");
+      expect(callNames).not.toContain("run_widget");
+      expect(callNames).not.toContain("helper_alias");
+      expect(callNames).not.toContain("callback");
+      expect(callNames).not.toContain("local_callback");
+      expect(callNames).not.toContain("signature");
+      expect(callNames).not.toContain("identity");
+    });
+
+    it("should preserve C++ symbols and resolve same-file calls and constructors", () => {
+      const db = openDb();
+      const symbols = buildFileSymbols(filePath, content);
+      const names = symbols.map((symbol) => symbol.name);
+
+      expect(names).toContain("Widget");
+      expect(names).toContain("Point");
+      expect(names).toContain("project");
+      expect(names).toContain("helper");
+      expect(names).toContain("process");
+
+      const widget = symbols.find((symbol) => symbol.name === "Widget");
+      const point = symbols.find((symbol) => symbol.name === "Point");
+      const helper = symbols.find((symbol) => symbol.name === "helper");
+      const process = symbols.find((symbol) => symbol.name === "process");
+      expect(widget).toBeDefined();
+      expect(point).toBeDefined();
+      expect(helper).toBeDefined();
+      expect(process).toBeDefined();
+
+      const processCalls = extractCalls(content, "cpp").filter(
+        (call) => call.line >= process!.startLine && call.line <= process!.endLine,
+      );
+      const helperCall = processCalls.find((call) => call.calleeName === "helper");
+      const widgetConstructor = processCalls.find(
+        (call) => call.calleeName === "Widget" && call.callType === "Constructor",
+      );
+      const pointConstructor = processCalls.find(
+        (call) => call.calleeName === "Point" && call.callType === "Constructor",
+      );
+      expect(helperCall).toBeDefined();
+      expect(widgetConstructor).toBeDefined();
+      expect(pointConstructor).toBeDefined();
+
+      db.upsertSymbolsBatch(symbols);
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_cpp_helper",
+          fromSymbolId: process!.id,
+          targetName: helperCall!.calleeName,
+          callType: helperCall!.callType,
+          confidence: helperCall!.confidence,
+          line: helperCall!.line,
+          col: helperCall!.column,
+          isResolved: false,
+        },
+        {
+          id: "edge_cpp_widget",
+          fromSymbolId: process!.id,
+          targetName: widgetConstructor!.calleeName,
+          callType: widgetConstructor!.callType,
+          confidence: widgetConstructor!.confidence,
+          line: widgetConstructor!.line,
+          col: widgetConstructor!.column,
+          isResolved: false,
+        },
+        {
+          id: "edge_cpp_point",
+          fromSymbolId: process!.id,
+          targetName: pointConstructor!.calleeName,
+          callType: pointConstructor!.callType,
+          confidence: pointConstructor!.confidence,
+          line: pointConstructor!.line,
+          col: pointConstructor!.column,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+      for (const edge of edges) {
+        const candidates = symbols.filter((symbol) => symbol.name === edge.targetName);
+        expect(candidates).toHaveLength(1);
+        db.resolveCallEdge(edge.id, candidates[0].id);
+      }
+      db.addSymbolsToBranchBatch("test", symbols.map((symbol) => symbol.id));
+
+      const callees = db.getCallees(process!.id, "test");
+      expect(callees.find((edge) => edge.targetName === "helper")?.toSymbolId).toBe(helper!.id);
+      expect(callees.find((edge) => edge.targetName === "Widget")?.toSymbolId).toBe(widget!.id);
+      expect(callees.find((edge) => edge.targetName === "Point")?.toSymbolId).toBe(point!.id);
+      expect(callees.filter((edge) => edge.isResolved)).toHaveLength(3);
+    });
+  });
+
+  describe("C and C++ indexing integration", () => {
+    it("should build and resolve same-file edges through the Indexer", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init?) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string | string[] };
+        const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        return new Response(
+          JSON.stringify({
+            data: inputs.map(() => ({ embedding: Array.from({ length: 8 }, () => 0.125) })),
+            usage: { total_tokens: Math.max(1, inputs.length) },
+          }),
+          { status: 200 },
+        );
+      });
+
+      fs.mkdirSync(path.join(tempDir, ".git", "refs", "heads"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+      fs.writeFileSync(
+        path.join(tempDir, ".git", "refs", "heads", "main"),
+        "1111111111111111111111111111111111111111\n",
+      );
+      fs.copyFileSync(path.join(fixturesDir, "c-calls.c"), path.join(tempDir, "main.c"));
+      fs.copyFileSync(path.join(fixturesDir, "cpp-calls.cpp"), path.join(tempDir, "main.cpp"));
+
+      const config = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-model",
+          dimensions: 8,
+        },
+        indexing: { watchFiles: false },
+      });
+      const indexer = new Indexer(tempDir, config);
+
+      try {
+        await indexer.index();
+        const symbols = await indexer.getSymbolsForBranch();
+        const compute = symbols.find(
+          (symbol) => symbol.name === "compute" && symbol.language === "c",
+        );
+        const invoke = symbols.find(
+          (symbol) => symbol.name === "invoke" && symbol.language === "c",
+        );
+        const inspect = symbols.find(
+          (symbol) => symbol.name === "inspect" && symbol.language === "c",
+        );
+        const cMain = symbols.find(
+          (symbol) => symbol.name === "main" && symbol.language === "c",
+        );
+        const process = symbols.find(
+          (symbol) => symbol.name === "process" && symbol.language === "cpp",
+        );
+        expect(compute).toBeDefined();
+        expect(invoke).toBeDefined();
+        expect(inspect).toBeDefined();
+        expect(cMain).toBeDefined();
+        expect(process).toBeDefined();
+
+        const cCallees = await indexer.getCallees(compute!.id);
+        const cHelper = cCallees.find((edge) => edge.targetName === "helper");
+        expect(cHelper?.isResolved).toBe(true);
+        expect(cHelper?.toSymbolId).toBeDefined();
+
+        const invokeCallees = await indexer.getCallees(invoke!.id);
+        expect(invokeCallees.some((edge) => edge.targetName === "callback")).toBe(false);
+        expect(invokeCallees.some((edge) => edge.targetName === "local_callback")).toBe(false);
+
+        const mainCallees = await indexer.getCallees(cMain!.id);
+        expect(mainCallees.some((edge) => edge.targetName === "call_helper")).toBe(false);
+        expect(mainCallees.some((edge) => edge.targetName === "helper_alias")).toBe(false);
+
+        const inspectCallees = await indexer.getCallees(inspect!.id);
+        const externalApiCall = inspectCallees.find((edge) => edge.targetName === "external_api");
+        expect(externalApiCall).toBeDefined();
+        expect(externalApiCall?.isResolved).toBe(false);
+
+        const cppCallees = await indexer.getCallees(process!.id);
+        const cppHelper = cppCallees.find((edge) => edge.targetName === "helper");
+        const widgetConstructor = cppCallees.find(
+          (edge) => edge.targetName === "Widget" && edge.callType === "Constructor",
+        );
+        const pointConstructor = cppCallees.find(
+          (edge) => edge.targetName === "Point" && edge.callType === "Constructor",
+        );
+        expect(cppHelper?.isResolved).toBe(true);
+        expect(widgetConstructor?.isResolved).toBe(true);
+        expect(pointConstructor?.isResolved).toBe(true);
+        const qualifiedNormalize = cppCallees.find(
+          (edge) => edge.targetName === "project::detail::normalize",
+        );
+        expect(qualifiedNormalize).toBeDefined();
+        expect(qualifiedNormalize?.isResolved).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "run_widget")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "helper_alias")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "callback")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "local_callback")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "signature")).toBe(false);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -24,6 +24,28 @@ describe("call-graph", () => {
     return d;
   }
 
+  function buildFileSymbols(filePath: string, content: string): SymbolData[] {
+    const parsed = parseFiles([{ path: filePath, content }])[0];
+    const symbols: SymbolData[] = [];
+
+    for (const chunk of parsed.chunks) {
+      if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
+      symbols.push({
+        id: `sym_${hashContent(filePath + ":" + chunk.name + ":" + chunk.chunkType + ":" + chunk.startLine).slice(0, 16)}`,
+        filePath,
+        name: chunk.name,
+        kind: chunk.chunkType,
+        startLine: chunk.startLine,
+        startCol: 0,
+        endLine: chunk.endLine,
+        endCol: 0,
+        language: chunk.language,
+      });
+    }
+
+    return symbols;
+  }
+
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "call-graph-test-"));
     _dbs = [];
@@ -860,6 +882,383 @@ const math = @import("math.zig");
       expect(importCalls.length).toBeGreaterThanOrEqual(2);
       expect(importCalls.some((c) => c.calleeName.includes("std"))).toBe(true);
       expect(importCalls.some((c) => c.calleeName.includes("math.zig"))).toBe(true);
+    });
+  });
+
+  describe("C call graph", () => {
+    const filePath = path.join(fixturesDir, "c-calls.c");
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    it("should extract conservative C calls and includes", () => {
+      const calls = extractCalls(content, "c");
+      const callNames = calls.map((call) => call.calleeName);
+      const imports = calls.filter((call) => call.callType === "Import");
+
+      expect(CALL_GRAPH_LANGUAGES.has("c")).toBe(true);
+      expect(calls.find((call) => call.calleeName === "helper")?.callType).toBe("Call");
+      expect(callNames).toContain("compute");
+      expect(callNames).toContain("printf");
+      expect(callNames).toContain("external_api");
+      expect(imports.some((call) => call.calleeName.includes("stdio.h"))).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("helpers.h"))).toBe(true);
+
+      expect(callNames).not.toContain("declared_only");
+      expect(callNames).not.toContain("call_helper");
+      expect(callNames).not.toContain("helper_alias");
+      expect(callNames).not.toContain("callback");
+      expect(callNames).not.toContain("local_callback");
+    });
+
+    it("should preserve C function symbols and resolve a same-file call", () => {
+      const db = openDb();
+      const symbols = buildFileSymbols(filePath, content);
+      const names = symbols.map((symbol) => symbol.name);
+
+      expect(names).toContain("helper");
+      expect(names).toContain("compute");
+      expect(names).toContain("invoke");
+      expect(names).toContain("inspect");
+      expect(names).toContain("external_api");
+      expect(names).toContain("main");
+
+      const helper = symbols.find((symbol) => symbol.name === "helper");
+      const compute = symbols.find((symbol) => symbol.name === "compute");
+      expect(helper).toBeDefined();
+      expect(compute).toBeDefined();
+
+      const helperCall = extractCalls(content, "c").find(
+        (call) =>
+          call.calleeName === "helper" &&
+          call.line >= compute!.startLine &&
+          call.line <= compute!.endLine,
+      );
+      expect(helperCall).toBeDefined();
+
+      db.upsertSymbolsBatch(symbols);
+      const edge: CallEdgeData = {
+        id: "edge_c_helper",
+        fromSymbolId: compute!.id,
+        targetName: helperCall!.calleeName,
+        callType: helperCall!.callType,
+        confidence: helperCall!.confidence,
+        line: helperCall!.line,
+        col: helperCall!.column,
+        isResolved: false,
+      };
+      db.upsertCallEdgesBatch([edge]);
+      const candidates = symbols.filter((symbol) => symbol.name === edge.targetName);
+      expect(candidates).toHaveLength(1);
+      db.resolveCallEdge(edge.id, candidates[0].id);
+      db.addSymbolsToBranchBatch("test", symbols.map((symbol) => symbol.id));
+
+      const callees = db.getCallees(compute!.id, "test");
+      expect(callees).toHaveLength(1);
+      expect(callees[0].targetName).toBe("helper");
+      expect(callees[0].toSymbolId).toBe(helper!.id);
+      expect(callees[0].isResolved).toBe(true);
+    });
+  });
+
+  describe("C++ call graph", () => {
+    const filePath = path.join(fixturesDir, "cpp-calls.cpp");
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    it("should extract conservative C++ calls, constructors, namespaces, and includes", () => {
+      const calls = extractCalls(content, "cpp");
+      const callNames = calls.map((call) => call.calleeName);
+      const imports = calls.filter((call) => call.callType === "Import");
+      const constructors = calls.filter((call) => call.callType === "Constructor");
+      const runCalls = calls.filter(
+        (call) => call.calleeName === "run" && call.callType === "MethodCall",
+      );
+
+      expect(CALL_GRAPH_LANGUAGES.has("cpp")).toBe(true);
+      expect(calls.find((call) => call.calleeName === "helper")?.callType).toBe("Call");
+      expect(
+        calls.find((call) => call.calleeName === "project::detail::normalize")?.callType,
+      ).toBe("Call");
+      expect(runCalls).toHaveLength(4);
+      expect(constructors.filter((call) => call.calleeName === "Widget")).toHaveLength(5);
+      expect(
+        constructors.filter((call) => call.calleeName === "project::detail::RemoteWidget"),
+      ).toHaveLength(2);
+      expect(constructors.some((call) => call.calleeName === "Point")).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("memory"))).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("widget.hpp"))).toBe(true);
+      expect(imports.some((call) => call.calleeName.includes("project::detail"))).toBe(true);
+
+      expect(callNames).not.toContain("declared_only");
+      expect(callNames).not.toContain("run_widget");
+      expect(callNames).not.toContain("helper_alias");
+      expect(callNames).not.toContain("callback");
+      expect(callNames).not.toContain("local_callback");
+      expect(callNames).not.toContain("signature");
+      expect(callNames).not.toContain("identity");
+      expect(callNames).not.toContain("vexing");
+      expect(calls.find((call) => call.calleeName === "make_widget")?.callType).toBe("Call");
+    });
+
+    it("should preserve short C++ class and struct symbols", () => {
+      const shortTypes = parseFiles([{
+        path: "short.cpp",
+        content: "class Tag {};\nstruct Tiny {};\n",
+      }])[0].chunks;
+
+      expect(shortTypes).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "Tag", chunkType: "class_specifier" }),
+        expect.objectContaining({ name: "Tiny", chunkType: "struct_specifier" }),
+      ]));
+    });
+
+    it("should preserve C++ symbols and resolve same-file calls and constructors", () => {
+      const db = openDb();
+      const symbols = buildFileSymbols(filePath, content);
+      const names = symbols.map((symbol) => symbol.name);
+
+      expect(names).toContain("Widget");
+      expect(names).toContain("Point");
+      expect(names).toContain("project");
+      expect(names).toContain("helper");
+      expect(names).toContain("process");
+
+      const widget = symbols.find((symbol) => symbol.name === "Widget");
+      const point = symbols.find((symbol) => symbol.name === "Point");
+      const helper = symbols.find((symbol) => symbol.name === "helper");
+      const process = symbols.find((symbol) => symbol.name === "process");
+      expect(widget).toBeDefined();
+      expect(point).toBeDefined();
+      expect(helper).toBeDefined();
+      expect(process).toBeDefined();
+
+      const processCalls = extractCalls(content, "cpp").filter(
+        (call) => call.line >= process!.startLine && call.line <= process!.endLine,
+      );
+      const helperCall = processCalls.find((call) => call.calleeName === "helper");
+      const widgetConstructor = processCalls.find(
+        (call) => call.calleeName === "Widget" && call.callType === "Constructor",
+      );
+      const pointConstructor = processCalls.find(
+        (call) => call.calleeName === "Point" && call.callType === "Constructor",
+      );
+      expect(helperCall).toBeDefined();
+      expect(widgetConstructor).toBeDefined();
+      expect(pointConstructor).toBeDefined();
+
+      db.upsertSymbolsBatch(symbols);
+      const edges: CallEdgeData[] = [
+        {
+          id: "edge_cpp_helper",
+          fromSymbolId: process!.id,
+          targetName: helperCall!.calleeName,
+          callType: helperCall!.callType,
+          confidence: helperCall!.confidence,
+          line: helperCall!.line,
+          col: helperCall!.column,
+          isResolved: false,
+        },
+        {
+          id: "edge_cpp_widget",
+          fromSymbolId: process!.id,
+          targetName: widgetConstructor!.calleeName,
+          callType: widgetConstructor!.callType,
+          confidence: widgetConstructor!.confidence,
+          line: widgetConstructor!.line,
+          col: widgetConstructor!.column,
+          isResolved: false,
+        },
+        {
+          id: "edge_cpp_point",
+          fromSymbolId: process!.id,
+          targetName: pointConstructor!.calleeName,
+          callType: pointConstructor!.callType,
+          confidence: pointConstructor!.confidence,
+          line: pointConstructor!.line,
+          col: pointConstructor!.column,
+          isResolved: false,
+        },
+      ];
+      db.upsertCallEdgesBatch(edges);
+      for (const edge of edges) {
+        const candidates = symbols.filter((symbol) => symbol.name === edge.targetName);
+        expect(candidates).toHaveLength(1);
+        db.resolveCallEdge(edge.id, candidates[0].id);
+      }
+      db.addSymbolsToBranchBatch("test", symbols.map((symbol) => symbol.id));
+
+      const callees = db.getCallees(process!.id, "test");
+      expect(callees.find((edge) => edge.targetName === "helper")?.toSymbolId).toBe(helper!.id);
+      expect(callees.find((edge) => edge.targetName === "Widget")?.toSymbolId).toBe(widget!.id);
+      expect(callees.find((edge) => edge.targetName === "Point")?.toSymbolId).toBe(point!.id);
+      expect(callees.filter((edge) => edge.isResolved)).toHaveLength(3);
+    });
+  });
+
+  describe("C and C++ indexing integration", () => {
+    it("should build and resolve same-file edges through the Indexer", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init?) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string | string[] };
+        const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        return new Response(
+          JSON.stringify({
+            data: inputs.map(() => ({ embedding: Array.from({ length: 8 }, () => 0.125) })),
+            usage: { total_tokens: Math.max(1, inputs.length) },
+          }),
+          { status: 200 },
+        );
+      });
+
+      fs.mkdirSync(path.join(tempDir, ".git", "refs", "heads"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+      fs.writeFileSync(
+        path.join(tempDir, ".git", "refs", "heads", "main"),
+        "1111111111111111111111111111111111111111\n",
+      );
+      fs.copyFileSync(path.join(fixturesDir, "c-calls.c"), path.join(tempDir, "main.c"));
+      fs.copyFileSync(path.join(fixturesDir, "cpp-calls.cpp"), path.join(tempDir, "main.cpp"));
+
+      const config = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-model",
+          dimensions: 8,
+        },
+        indexing: { watchFiles: false },
+      });
+      const indexer = new Indexer(tempDir, config);
+
+      try {
+        await indexer.index();
+        const symbols = await indexer.getSymbolsForBranch();
+        const compute = symbols.find(
+          (symbol) => symbol.name === "compute" && symbol.language === "c",
+        );
+        const invoke = symbols.find(
+          (symbol) => symbol.name === "invoke" && symbol.language === "c",
+        );
+        const inspect = symbols.find(
+          (symbol) => symbol.name === "inspect" && symbol.language === "c",
+        );
+        const cMain = symbols.find(
+          (symbol) => symbol.name === "main" && symbol.language === "c",
+        );
+        const process = symbols.find(
+          (symbol) => symbol.name === "process" && symbol.language === "cpp",
+        );
+        expect(compute).toBeDefined();
+        expect(invoke).toBeDefined();
+        expect(inspect).toBeDefined();
+        expect(cMain).toBeDefined();
+        expect(process).toBeDefined();
+
+        const cCallees = await indexer.getCallees(compute!.id);
+        const cHelper = cCallees.find((edge) => edge.targetName === "helper");
+        expect(cHelper?.isResolved).toBe(true);
+        expect(cHelper?.toSymbolId).toBeDefined();
+
+        const invokeCallees = await indexer.getCallees(invoke!.id);
+        expect(invokeCallees.some((edge) => edge.targetName === "callback")).toBe(false);
+        expect(invokeCallees.some((edge) => edge.targetName === "local_callback")).toBe(false);
+
+        const mainCallees = await indexer.getCallees(cMain!.id);
+        expect(mainCallees.some((edge) => edge.targetName === "call_helper")).toBe(false);
+        expect(mainCallees.some((edge) => edge.targetName === "helper_alias")).toBe(false);
+
+        const inspectCallees = await indexer.getCallees(inspect!.id);
+        const externalApiCall = inspectCallees.find((edge) => edge.targetName === "external_api");
+        expect(externalApiCall).toBeDefined();
+        expect(externalApiCall?.isResolved).toBe(false);
+
+        const cppCallees = await indexer.getCallees(process!.id);
+        const cppHelper = cppCallees.find((edge) => edge.targetName === "helper");
+        const widgetConstructor = cppCallees.find(
+          (edge) => edge.targetName === "Widget" && edge.callType === "Constructor",
+        );
+        const pointConstructor = cppCallees.find(
+          (edge) => edge.targetName === "Point" && edge.callType === "Constructor",
+        );
+        expect(cppHelper?.isResolved).toBe(true);
+        expect(widgetConstructor?.isResolved).toBe(true);
+        expect(pointConstructor?.isResolved).toBe(true);
+        const qualifiedNormalize = cppCallees.find(
+          (edge) => edge.targetName === "project::detail::normalize",
+        );
+        expect(qualifiedNormalize).toBeDefined();
+        expect(qualifiedNormalize?.isResolved).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "run_widget")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "helper_alias")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "callback")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "local_callback")).toBe(false);
+        expect(cppCallees.some((edge) => edge.targetName === "signature")).toBe(false);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("should reprocess unchanged C files after a call-graph version upgrade", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init?) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string | string[] };
+        const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        return new Response(
+          JSON.stringify({
+            data: inputs.map(() => ({ embedding: Array.from({ length: 8 }, () => 0.125) })),
+            usage: { total_tokens: Math.max(1, inputs.length) },
+          }),
+          { status: 200 },
+        );
+      });
+      fs.writeFileSync(
+        path.join(tempDir, "main.c"),
+        "int helper(int value) { return value + 1; }\nint caller(void) { return helper(1); }\n",
+      );
+      const config = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-model",
+          dimensions: 8,
+        },
+        indexing: { watchFiles: false },
+      });
+
+      CALL_GRAPH_LANGUAGES.delete("c");
+      let indexer = new Indexer(tempDir, config);
+      try {
+        await indexer.index();
+        const caller = (await indexer.getSymbolsForBranch()).find(
+          (symbol) => symbol.name === "caller",
+        );
+        expect(caller).toBeDefined();
+        expect(await indexer.getCallees(caller!.id)).toHaveLength(0);
+      } finally {
+        await indexer.close();
+        CALL_GRAPH_LANGUAGES.add("c");
+      }
+
+      const database = new Database(path.join(tempDir, ".opencode", "index", "codebase.db"));
+      database.setMetadata("index.callGraphResolutionVersion", "2");
+      database.close();
+      const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
+
+      indexer = new Indexer(tempDir, config);
+      try {
+        await indexer.index();
+        const symbols = await indexer.getSymbolsForBranch();
+        const caller = symbols.find((symbol) => symbol.name === "caller");
+        const helper = symbols.find((symbol) => symbol.name === "helper");
+        const edge = (await indexer.getCallees(caller!.id)).find(
+          (candidate) => candidate.targetName === "helper",
+        );
+        expect(edge).toMatchObject({
+          isResolved: true,
+          toSymbolId: helper!.id,
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(embeddingCallsBeforeUpgrade);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/fixtures/call-graph/c-calls.c
+++ b/tests/fixtures/call-graph/c-calls.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include "helpers.h"
+
+#define call_helper(value) helper(value)
+#define helper_alias helper
+
+typedef int (*callback_fn)(int);
+
+struct external_api {
+    long first;
+    long second;
+    long third;
+    long fourth;
+    long fifth;
+    long sixth;
+};
+
+int external_api(int value);
+
+int helper(int value) {
+    return value + 1;
+}
+
+int compute(int value) {
+    return helper(value) * 2;
+}
+
+int invoke(callback_fn callback, int value) {
+    callback_fn local_callback = callback;
+    return callback(value) + local_callback(value);
+}
+
+int inspect(void) {
+    return external_api(1);
+}
+
+int declared_only(int value);
+
+int main(void) {
+    int result = compute(3);
+    int macro_result = call_helper(4);
+    int alias_result = helper_alias(5);
+    printf("%d\n", result + macro_result + alias_result);
+    return result;
+}

--- a/tests/fixtures/call-graph/cpp-calls.cpp
+++ b/tests/fixtures/call-graph/cpp-calls.cpp
@@ -1,0 +1,84 @@
+#include <memory>
+#include "widget.hpp"
+
+#define run_widget(value) helper(value)
+#define helper_alias helper
+
+using Callback = int (*)(int);
+using CallbackSignature = int(int);
+
+using namespace project::detail;
+
+namespace project {
+namespace detail {
+class RemoteWidget {
+public:
+    explicit RemoteWidget(int value) : value_(value) {}
+
+private:
+    int value_;
+};
+
+int normalize(int value) {
+    return value < 0 ? -value : value;
+}
+}
+}
+
+class Widget {
+public:
+    explicit Widget(int value) : value_(value) {}
+
+    int run() const {
+        return value_;
+    }
+
+private:
+    int value_;
+};
+
+struct Point {
+    int x;
+    int y;
+
+    int sum() const {
+        return x + y;
+    }
+};
+
+template <typename T>
+T identity(T value) {
+    return value;
+}
+
+int helper(int value) {
+    return value + 1;
+}
+
+int normalize(int value) {
+    return value + 100;
+}
+
+int declared_only(int value);
+
+int process(Widget* pointer, Callback callback, CallbackSignature* signature) {
+    Callback local_callback = callback;
+    Widget stack(1);
+    auto* heap = new Widget(2);
+    auto* remote = new project::detail::RemoteWidget(3);
+    auto* point = new Point{8, 9};
+    int qualified = project::detail::normalize(helper(4));
+    int members = heap->run() + pointer->run() + Widget{5}.run();
+    int point_value = point->sum();
+    int indirect = callback(qualified);
+    int local_indirect = local_callback(qualified);
+    int signature_indirect = signature(qualified);
+    int macro_result = run_widget(6);
+    int alias_result = helper_alias(7);
+    int template_result = identity<int>(8);
+    delete heap;
+    delete remote;
+    delete point;
+    return stack.run() + members + point_value + indirect + local_indirect + signature_indirect +
+        macro_result + alias_result + template_result;
+}

--- a/tests/fixtures/call-graph/cpp-calls.cpp
+++ b/tests/fixtures/call-graph/cpp-calls.cpp
@@ -1,0 +1,90 @@
+#include <memory>
+#include "widget.hpp"
+
+#define run_widget(value) helper(value)
+#define helper_alias helper
+
+using Callback = int (*)(int);
+using CallbackSignature = int(int);
+
+using namespace project::detail;
+
+namespace project {
+namespace detail {
+class RemoteWidget {
+public:
+    explicit RemoteWidget(int value) : value_(value) {}
+
+private:
+    int value_;
+};
+
+int normalize(int value) {
+    return value < 0 ? -value : value;
+}
+}
+}
+
+class Widget {
+public:
+    explicit Widget(int value) : value_(value) {}
+
+    int run() const {
+        return value_;
+    }
+
+private:
+    int value_;
+};
+
+struct Point {
+    int x;
+    int y;
+
+    int sum() const {
+        return x + y;
+    }
+};
+
+template <typename T>
+T identity(T value) {
+    return value;
+}
+
+int helper(int value) {
+    return value + 1;
+}
+
+int normalize(int value) {
+    return value + 100;
+}
+
+int declared_only(int value);
+Widget make_widget();
+
+int process(Widget* pointer, Callback callback, CallbackSignature* signature) {
+    Callback local_callback = callback;
+    Widget stack(1);
+    Widget braced{1};
+    Widget copied = Widget(1);
+    Widget from_factory = make_widget();
+    Widget vexing();
+    project::detail::RemoteWidget remote_stack(1);
+    auto* heap = new Widget(2);
+    auto* remote = new project::detail::RemoteWidget(3);
+    auto* point = new Point{8, 9};
+    int qualified = project::detail::normalize(helper(4));
+    int members = heap->run() + pointer->run() + Widget{5}.run();
+    int point_value = point->sum();
+    int indirect = callback(qualified);
+    int local_indirect = local_callback(qualified);
+    int signature_indirect = signature(qualified);
+    int macro_result = run_widget(6);
+    int alias_result = helper_alias(7);
+    int template_result = identity<int>(8);
+    delete heap;
+    delete remote;
+    delete point;
+    return stack.run() + members + point_value + indirect + local_indirect + signature_indirect +
+        macro_result + alias_result + template_result;
+}


### PR DESCRIPTION
## Summary

- add Tree-sitter call queries for C and C++
- extract direct, member, and qualified calls, stack/brace/heap/temporary constructors, includes, and namespace imports
- conservatively exclude declarations, vexing parses, local macros, explicit template calls, and function-pointer invocations
- support raw function pointers plus `typedef` and `using` aliases with AST-scoped exclusions
- preserve small C/C++ function, class, and struct symbols required for same-file resolution
- prevent ordinary calls and constructors from resolving to incompatible homonymous symbols
- refresh unchanged persisted C/C++ files once after upgrading, without re-embedding them
- register C and C++ in the call-graph language allowlist
- add native, fixture, same-file, migration, and end-to-end Indexer coverage

## Motivation

The repository already includes the Tree-sitter C and C++ grammars and semantic parsers, but both languages were excluded from call-graph extraction. This adds the missing query, routing, symbol, resolution, migration, test, and documentation integration without introducing another parser or dependency.

## Review fixes

- handle common C++ stack and brace constructors, including qualified names
- distinguish copy-initialized constructors from factory function calls
- exclude vexing function declarations from constructor edges
- retain small class and struct chunks through chunk merging
- translate all changed comments and documentation to English
- integrate the feature with current `main` and the call-graph resolution migration

## Validation

- `cargo fmt --check`
- `cargo test` (96 tests)
- `cargo clippy -- -D warnings`
- native release and N-API builds
- `npx vitest run tests/call-graph.test.ts` (77 tests)
- `npx vitest run` (52 files, 996 tests)
- `npm run build:ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- English-only diff scan and manual review of added prose/comments

## Risks and limitations

The implementation intentionally favors conservative extraction:

- explicit template calls and indirect calls without a recognizable function-pointer declaration are omitted
- qualified C++ targets remain unresolved when only terminal symbols are available
- macros imported from headers require preprocessing and remain outside the current model
- nested namespace or class declarations may not produce independently resolvable symbols

## Dependencies

No new dependency is added. The existing `tree-sitter-c` and `tree-sitter-cpp` crates are reused.
