### PR TITLE
feat: add first-class Jcode host support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First-class Jcode integration**: Added the `jcode` MCP host mode, neutral `.codebase-index/` storage, legacy OpenCode state fallback, automated host-path coverage, and global multi-repository setup guidance for Jcode v0.56.0 and newer.
+
 ### Fixed
 
 - **Parser-backed source discovery**: Added `.mts`, `.cts`, `.cxx`, `.hxx`, and `.cs` to the default include patterns.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 
 > **Stop grepping for concepts. Start searching for meaning.**
 
-**opencode-codebase-index** brings semantic understanding to your [OpenCode](https://opencode.ai), [Pi](https://pi.dev), Codex, and MCP-compatible workflows. Instead of guessing function names or grepping for keywords, ask your codebase questions in plain English.
+**opencode-codebase-index** brings semantic understanding to your [OpenCode](https://opencode.ai), [Jcode](https://github.com/1jehuang/jcode), [Pi](https://pi.dev), Codex, and MCP-compatible workflows. Instead of guessing function names or grepping for keywords, ask your codebase questions in plain English.
 
 ## 📌 Quick Navigation
 
 - [⚡ Quick Start](#-quick-start)
+- [🧠 Jcode](#-jcode)
 - [🥧 Pi Package](#-pi-package)
 - [🧩 Codex Plugin](#-codex-plugin)
 - [🧩 Claude Code Plugin](#-claude-code-plugin)
@@ -29,6 +30,7 @@
 ## 👋 Choose Your Path
 
 - **I want to try it now** → go to [Quick Start](#-quick-start)
+- **I use Jcode** → go to [Jcode](#-jcode)
 - **I use Pi** → go to [Pi Package](#-pi-package)
 - **I use Cursor/Claude Code/Windsurf** → go to [MCP Server setup](#-mcp-server-cursor-claude-code-windsurf-etc)
 - **I’m comparing tools and workflows** → go to [When to Use What](#-when-to-use-what)
@@ -42,6 +44,7 @@
 - 🌿 **Branch-Aware**: Seamlessly handles git branch switches — reuses embeddings, filters stale results.
 - 🔒 **Privacy Focused**: Your vector index is stored locally in your project.
 - 🔌 **Model Agnostic**: Works out-of-the-box with GitHub Copilot, OpenAI, Gemini, or local Ollama models.
+- 🧠 **Jcode Host**: One global MCP configuration follows each Jcode session into its active repository.
 - 🥧 **Pi Package**: First-class Pi extension and skill package with native tools.
 - 🌐 **MCP Server**: Use with Cursor, Claude Code, Windsurf, or any MCP-compatible client — index once, search from anywhere.
 
@@ -67,6 +70,37 @@
 4. **Start Searching**
    Ask:
    > "Find the function that handles credit card validation errors"
+
+## 🧠 Jcode
+
+Jcode v0.56.0 and newer starts non-shared MCP servers in each session's working directory. Configure the server once in `~/.jcode/mcp.json` and it will index the repository where each Jcode session is running.
+
+```json
+{
+  "servers": {
+    "codebase-index": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "--package",
+        "opencode-codebase-index@latest",
+        "opencode-codebase-index-mcp",
+        "--host",
+        "jcode"
+      ],
+      "env": {},
+      "shared": false
+    }
+  }
+}
+```
+
+Do not add a fixed `--project` argument. Jcode supplies the active session directory as the MCP process working directory. `shared: false` gives every repository session its own indexer process and prevents cross-repository state from being shared accidentally.
+
+Jcode uses the neutral `.codebase-index/` project storage and falls back to existing OpenCode state when present. Restart Jcode after changing `~/.jcode/mcp.json`, then use `index_codebase`, `index_status`, `codebase_peek`, or `codebase_search`.
+
+The explicit `@latest` keeps `npx` on the published package even when Jcode is opened inside an `opencode-codebase-index` source checkout. For local development of this package instead, run `npm run build:ts && npm run dev:link-mcp` first.
+
 ## 🥧 Pi Package
 
 Install as a Pi package to get first-class `codebase_search`, `index_codebase`, call graph, PR impact, and knowledge-base tools plus the `codebase-search` skill.

--- a/src/config/host.ts
+++ b/src/config/host.ts
@@ -1,6 +1,6 @@
-export type HostMode = "opencode" | "codex" | "claude" | "pi";
+export type HostMode = "opencode" | "codex" | "claude" | "pi" | "jcode";
 
-export const HOST_MODES: ReadonlyArray<HostMode> = ["opencode", "codex", "claude", "pi"];
+export const HOST_MODES: ReadonlyArray<HostMode> = ["opencode", "codex", "claude", "pi", "jcode"];
 
 export function isSupportedHostMode(value: string): value is HostMode {
   return (HOST_MODES as ReadonlyArray<string>).includes(value);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -73,6 +73,10 @@ function hasHostProjectConfig(projectRoot: string, host: HostMode): boolean {
   return existsSync(path.join(projectRoot, getProjectConfigRelativePath(host)));
 }
 
+function hasHostGlobalConfig(host: HostMode): boolean {
+  return existsSync(getGlobalConfigPath(host));
+}
+
 export function getGlobalIndexPath(host: HostMode = "opencode"): string {
   switch (host) {
     case "opencode":
@@ -120,6 +124,10 @@ export function resolveGlobalIndexPath(host: HostMode = "opencode"): string {
   }
 
   if (host !== "opencode") {
+    if (hasHostGlobalConfig(host)) {
+      return hostIndexPath;
+    }
+
     const legacyIndexPath = getGlobalIndexPath("opencode");
     if (existsSync(legacyIndexPath)) {
       return legacyIndexPath;

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -21,6 +21,7 @@ function getProjectConfigRelativePath(host: HostMode): string {
     case "claude":
       return CLAUDE_PROJECT_CONFIG_RELATIVE_PATH;
     default:
+      // Codex, Pi, and Jcode share host-neutral project storage.
       return CODEBASE_PROJECT_CONFIG_RELATIVE_PATH;
   }
 }
@@ -32,6 +33,7 @@ function getProjectIndexRelativePath(host: HostMode): string {
     case "claude":
       return CLAUDE_PROJECT_INDEX_RELATIVE_PATH;
     default:
+      // Codex, Pi, and Jcode share host-neutral project storage.
       return CODEBASE_PROJECT_INDEX_RELATIVE_PATH;
   }
 }
@@ -78,6 +80,7 @@ export function getGlobalIndexPath(host: HostMode = "opencode"): string {
     case "claude":
       return path.join(os.homedir(), ".claude", "global-index");
     default:
+      // Codex, Pi, and Jcode share host-neutral global storage.
       return path.join(os.homedir(), ".codebase-index", "global-index");
   }
 }
@@ -89,6 +92,7 @@ export function getGlobalConfigPath(host: HostMode = "opencode"): string {
     case "claude":
       return path.join(os.homedir(), ".claude", "codebase-index.json");
     default:
+      // Codex, Pi, and Jcode share host-neutral global storage.
       return path.join(os.homedir(), ".config", "codebase-index", "config.json");
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -34,6 +34,28 @@ describe("cli config loading", () => {
     expect(rawConfig.include).toEqual(["custom/**/*.ts"]);
   });
 
+  it("loads jcode host parser options while still honoring explicit config", () => {
+    const configPath = path.join(tempDir, "custom-config.json");
+    mkdirSync(path.dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ embeddingProvider: "ollama", include: ["custom/**/*.ts"] }, null, 2),
+      "utf-8",
+    );
+
+    const args = parseArgs(["node", "dist/cli.js", "--host", "jcode", "--project", tempDir, "--config", configPath]);
+    const rawConfig = loadCliRawConfig(args) as Record<string, unknown>;
+
+    expect(args.host).toBe("jcode");
+    expect(rawConfig.embeddingProvider).toBe("ollama");
+    expect(rawConfig.include).toEqual(["custom/**/*.ts"]);
+  });
+
+  it("throws for unknown --host values", () => {
+    expect(() => parseArgs(["node", "dist/cli.js", "--host", "bad-host"]))
+      .toThrow("Invalid host mode: bad-host. Allowed values: opencode, codex, claude, pi, jcode.");
+  });
+
   it("recognizes npm bin symlinks as the CLI entrypoint", () => {
     const realCliPath = path.join(tempDir, "package", "dist", "cli.js");
     const binPath = path.join(tempDir, ".bin", "opencode-codebase-index-mcp");

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -23,11 +23,12 @@ describe("Codex plugin host mode", () => {
     expect(parseHostMode("codex")).toBe("codex");
     expect(parseHostMode("claude")).toBe("claude");
     expect(parseHostMode("pi")).toBe("pi");
+    expect(parseHostMode("jcode")).toBe("jcode");
   });
 
   it("rejects unknown host mode with a clear error", () => {
     expect(() => parseHostMode("weird"))
-      .toThrow("Invalid host mode: weird. Allowed values: opencode, codex, claude, pi.");
+      .toThrow("Invalid host mode: weird. Allowed values: opencode, codex, claude, pi, jcode.");
   });
 
   it("exposes Codex plugin manifest and MCP command", () => {

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -60,6 +60,9 @@ describe("host-aware path resolution", () => {
     expect(resolveWritableProjectConfigPath(mainRepoDir, "pi")).toBe(
       path.join(mainRepoDir, ".codebase-index", "config.json"),
     );
+    expect(resolveWritableProjectConfigPath(mainRepoDir, "jcode")).toBe(
+      path.join(mainRepoDir, ".codebase-index", "config.json"),
+    );
   });
 
   it("reads legacy OpenCode config for pi host when pi-native config is absent", () => {
@@ -92,6 +95,21 @@ describe("host-aware path resolution", () => {
     expect(loaded.knowledgeBases).toEqual(["legacy-docs"]);
   });
 
+  it("reads legacy OpenCode config for jcode host when jcode-native config is absent", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    const resolved = resolveProjectConfigPath(mainRepoDir, "jcode");
+    const loaded = loadMergedConfig(mainRepoDir, "jcode") as Record<string, unknown>;
+
+    expect(resolved).toBe(path.join(mainRepoDir, ".opencode", "codebase-index.json"));
+    expect(loaded.knowledgeBases).toEqual(["legacy-docs"]);
+  });
+
   it("prefers codex-native config for codex host when present", () => {
     fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
     fs.mkdirSync(path.join(mainRepoDir, ".codebase-index"), { recursive: true });
@@ -114,6 +132,28 @@ describe("host-aware path resolution", () => {
     expect(loaded.knowledgeBases).toEqual(["codex-docs"]);
   });
 
+  it("prefers jcode-native config for jcode host when present", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".codebase-index"), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".codebase-index", "config.json"),
+      JSON.stringify({ knowledgeBases: ["jcode-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    const resolved = resolveProjectConfigPath(mainRepoDir, "jcode");
+    const loaded = loadMergedConfig(mainRepoDir, "jcode") as Record<string, unknown>;
+
+    expect(resolved).toBe(path.join(mainRepoDir, ".codebase-index", "config.json"));
+    expect(loaded.knowledgeBases).toEqual(["jcode-docs"]);
+  });
+
   it("falls back to legacy global config for codex host when codex-native global config is absent", () => {
     fs.mkdirSync(path.join(homeDir, ".config", "opencode"), { recursive: true });
     fs.writeFileSync(
@@ -130,10 +170,34 @@ describe("host-aware path resolution", () => {
     expect(loaded.knowledgeBases).toEqual(["legacy-global-docs"]);
   });
 
+  it("falls back to legacy global config for jcode host when jcode-native global config is absent", () => {
+    fs.mkdirSync(path.join(homeDir, ".config", "opencode"), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, ".config", "opencode", "codebase-index.json"),
+      JSON.stringify({ scope: "global", knowledgeBases: ["legacy-global-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    const resolved = resolveGlobalConfigPath("jcode");
+    const loaded = loadMergedConfig(mainRepoDir, "jcode") as Record<string, unknown>;
+
+    expect(resolved).toBe(path.join(homeDir, ".config", "opencode", "codebase-index.json"));
+    expect(loaded.scope).toBe("global");
+    expect(loaded.knowledgeBases).toEqual(["legacy-global-docs"]);
+  });
+
   it("falls back to legacy worktree index when codex index is absent", () => {
     fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
 
     expect(resolveProjectIndexPath(worktreeDir, "project", "codex")).toBe(
+      path.join(mainRepoDir, ".opencode", "index"),
+    );
+  });
+
+  it("falls back to legacy worktree index when jcode index is absent", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(worktreeDir, "project", "jcode")).toBe(
       path.join(mainRepoDir, ".opencode", "index"),
     );
   });
@@ -147,6 +211,19 @@ describe("host-aware path resolution", () => {
     );
 
     expect(resolveProjectIndexPath(mainRepoDir, "project", "codex")).toBe(
+      path.join(mainRepoDir, ".opencode", "index"),
+    );
+  });
+
+  it("falls back to local legacy project index when jcode host has only OpenCode project state", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ knowledgeBases: ["legacy-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectIndexPath(mainRepoDir, "project", "jcode")).toBe(
       path.join(mainRepoDir, ".opencode", "index"),
     );
   });
@@ -165,6 +242,20 @@ describe("host-aware path resolution", () => {
     );
   });
 
+  it("uses jcode project index when jcode-native config exists next to a legacy index", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".codebase-index"), { recursive: true });
+    fs.writeFileSync(
+      path.join(mainRepoDir, ".codebase-index", "config.json"),
+      JSON.stringify({ knowledgeBases: ["jcode-docs"] }, null, 2),
+      "utf-8",
+    );
+
+    expect(resolveProjectIndexPath(mainRepoDir, "project", "jcode")).toBe(
+      path.join(mainRepoDir, ".codebase-index", "index"),
+    );
+  });
+
   it("prefers codex-index inheritance before legacy when both exist", () => {
     fs.mkdirSync(path.join(mainRepoDir, ".codebase-index", "index"), { recursive: true });
     fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
@@ -174,11 +265,29 @@ describe("host-aware path resolution", () => {
     );
   });
 
+  it("prefers jcode-index inheritance before legacy when both exist", () => {
+    fs.mkdirSync(path.join(mainRepoDir, ".codebase-index", "index"), { recursive: true });
+    fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(worktreeDir, "project", "jcode")).toBe(
+      path.join(mainRepoDir, ".codebase-index", "index"),
+    );
+  });
+
   it("falls back to legacy global index for codex host when codex-native global index is absent", () => {
     fs.mkdirSync(path.join(homeDir, ".opencode", "global-index"), { recursive: true });
 
     expect(resolveGlobalIndexPath("codex")).toBe(path.join(homeDir, ".opencode", "global-index"));
     expect(resolveProjectIndexPath(mainRepoDir, "global", "codex")).toBe(
+      path.join(homeDir, ".opencode", "global-index"),
+    );
+  });
+
+  it("falls back to legacy global index for jcode host when jcode-native global index is absent", () => {
+    fs.mkdirSync(path.join(homeDir, ".opencode", "global-index"), { recursive: true });
+
+    expect(resolveGlobalIndexPath("jcode")).toBe(path.join(homeDir, ".opencode", "global-index"));
+    expect(resolveProjectIndexPath(mainRepoDir, "global", "jcode")).toBe(
       path.join(homeDir, ".opencode", "global-index"),
     );
   });

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -292,6 +292,21 @@ describe("host-aware path resolution", () => {
     );
   });
 
+  it("prefers jcode native global index when jcode global config exists even if index is not present", () => {
+    fs.mkdirSync(path.join(homeDir, ".config", "codebase-index"), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, ".config", "codebase-index", "config.json"),
+      JSON.stringify({ scope: "global" }, null, 2),
+      "utf-8",
+    );
+    fs.mkdirSync(path.join(homeDir, ".opencode", "global-index"), { recursive: true });
+
+    expect(resolveGlobalIndexPath("jcode")).toBe(path.join(homeDir, ".codebase-index", "global-index"));
+    expect(resolveProjectIndexPath(mainRepoDir, "global", "jcode")).toBe(
+      path.join(homeDir, ".codebase-index", "global-index"),
+    );
+  });
+
   it("uses claude-native writable config path", () => {
     expect(resolveWritableProjectConfigPath(mainRepoDir, "claude")).toBe(
       path.join(mainRepoDir, ".claude", "codebase-index.json"),

--- a/tests/host-paths.test.ts
+++ b/tests/host-paths.test.ts
@@ -41,6 +41,7 @@ describe("host path conformance", () => {
       { host: "claude", configPath: path.join(".claude", "codebase-index.json"), indexPath: path.join(".claude", "index") },
       { host: "codex", configPath: path.join(".codebase-index", "config.json"), indexPath: path.join(".codebase-index", "index") },
       { host: "pi", configPath: path.join(".codebase-index", "config.json"), indexPath: path.join(".codebase-index", "index") },
+      { host: "jcode", configPath: path.join(".codebase-index", "config.json"), indexPath: path.join(".codebase-index", "index") },
     ];
 
     for (const entry of cases) {
@@ -61,11 +62,17 @@ describe("host path conformance", () => {
     expect(resolveProjectConfigPath(tempDir, "codex")).toBe(legacyConfig);
     expect(resolveProjectIndexPath(tempDir, "project", "codex")).toBe(legacyIndex);
 
+    expect(resolveProjectConfigPath(tempDir, "jcode")).toBe(legacyConfig);
+    expect(resolveProjectIndexPath(tempDir, "project", "jcode")).toBe(legacyIndex);
+
     const codexConfig = path.join(tempDir, ".codebase-index", "config.json");
     fs.mkdirSync(path.dirname(codexConfig), { recursive: true });
     fs.writeFileSync(codexConfig, "{}", "utf-8");
 
     expect(resolveProjectConfigPath(tempDir, "codex")).toBe(codexConfig);
     expect(resolveProjectIndexPath(tempDir, "project", "codex")).toBe(path.join(tempDir, ".codebase-index", "index"));
+
+    expect(resolveProjectConfigPath(tempDir, "jcode")).toBe(path.join(tempDir, ".codebase-index", "config.json"));
+    expect(resolveProjectIndexPath(tempDir, "project", "jcode")).toBe(path.join(tempDir, ".codebase-index", "index"));
   });
 });

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -56,6 +56,30 @@ describe("watcher config refresh", () => {
     await watcher.stop();
   });
 
+  it("refreshes the jcode indexer cache before reindexing when jcode config changes", async () => {
+    const indexer = {
+      index: vi.fn().mockResolvedValue(undefined),
+    };
+    const watcher = createWatcherWithIndexer(
+      () => indexer,
+      tempDir,
+      parseConfig({ include: ["**/*.ts"] }),
+      "jcode",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    mkdirSync(path.join(tempDir, ".codebase-index"), { recursive: true });
+    writeFileSync(path.join(tempDir, ".codebase-index", "config.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
+
+    await vi.waitFor(() => {
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "jcode", undefined);
+      expect(indexer.index).toHaveBeenCalledTimes(1);
+    }, { timeout: 2500 });
+
+    await watcher.stop();
+  });
+
   it("refreshes the codex indexer cache before reindexing when legacy OpenCode config changes", async () => {
     mkdirSync(path.join(tempDir, ".opencode"), { recursive: true });
     writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), JSON.stringify({ include: ["**/*.ts"] }));
@@ -78,6 +102,34 @@ describe("watcher config refresh", () => {
 
     await vi.waitFor(() => {
       expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "codex", undefined);
+      expect(indexer.index).toHaveBeenCalledTimes(1);
+    }, { timeout: 2500 });
+
+    await watcher.stop();
+  });
+
+  it("refreshes the jcode indexer cache before reindexing when legacy OpenCode config changes", async () => {
+    mkdirSync(path.join(tempDir, ".opencode"), { recursive: true });
+    writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), JSON.stringify({ include: ["**/*.ts"] }));
+
+    const indexer = {
+      index: vi.fn().mockResolvedValue(undefined),
+    };
+    const watcher = createWatcherWithIndexer(
+      () => indexer,
+      tempDir,
+      parseConfig({ include: ["**/*.ts"] }),
+      "jcode",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    mkdirSync(path.join(tempDir, ".opencode", "index"), { recursive: true });
+    writeFileSync(path.join(tempDir, ".opencode", "codebase-index.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
+    writeFileSync(path.join(tempDir, ".opencode", "index", "codebase.db"), "index");
+
+    await vi.waitFor(() => {
+      expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(tempDir, "jcode", undefined);
       expect(indexer.index).toHaveBeenCalledTimes(1);
     }, { timeout: 2500 });
 


### PR DESCRIPTION
## Summary

- add an explicit `jcode` MCP host mode using neutral `.codebase-index/` storage
- preserve legacy OpenCode config/index fallback and worktree behavior
- document one-time global Jcode v0.56.0+ setup with per-session `shared: false` processes
- cover CLI parsing, host paths, config fallback, and watcher refresh behavior

## Why

Jcode now starts non-shared MCP servers in each session's working directory and keeps them out of the global shared pool. This lets one global MCP configuration serve every repository safely, without a fixed `--project` argument or the previous `--host codex` compatibility workaround.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (48 files, 927 tests passed)
- local MCP initialize handshake with `--host jcode`

The first full-suite run exposed one existing timing-sensitive watcher test failure; the isolated retry and two subsequent complete suite runs passed.
