### PR TITLE
chore: prepare v0.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-24
+
 ### Added
 
 - **First-class Jcode integration**: Added the `jcode` MCP host mode, neutral `.codebase-index/` storage, legacy OpenCode state fallback, automated host-path coverage, and global multi-repository setup guidance for Jcode v0.56.0 and newer.
 
+### Changed
+
+- **Node.js runtime requirement**: Raised the supported Node.js version from 18 to 20 to use patched runtime dependencies.
+
 ### Fixed
 
+- **Multiprocess index safety**: Serialized index mutations across processes with canonical-path leases, kept cold readers non-mutating, hardened atomic vector and BM25 publication, and added recovery for incomplete or crashed publications.
 - **Parser-backed source discovery**: Added `.mts`, `.cts`, `.cxx`, `.hxx`, and `.cs` to the default include patterns.
+
+### Security
+
+- **Dependency vulnerabilities**: Updated vulnerable runtime and development dependency chains, including Hono, `@hono/node-server`, `body-parser`, `fast-uri`, `brace-expansion`, `js-yaml`, and Pi's shrinkwrapped dependencies. `npm audit` now reports zero vulnerabilities.
 
 ## [0.14.0] - 2026-07-08
 
@@ -402,7 +413,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.0...v0.13.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://img.shields.io/npm/dm/opencode-codebase-index.svg)](https://www.npmjs.com/package/opencode-codebase-index)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Helweg/opencode-codebase-index/ci.yml?branch=main)](https://github.com/Helweg/opencode-codebase-index/actions)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 
 > **Stop grepping for concepts. Start searching for meaning.**
 
@@ -49,6 +49,8 @@
 - 🌐 **MCP Server**: Use with Cursor, Claude Code, Windsurf, or any MCP-compatible client — index once, search from anywhere.
 
 ## ⚡ Quick Start
+
+Requires Node.js 20 or newer.
 
 1. **Install the plugin**
    ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -36,7 +36,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",
@@ -33,7 +33,7 @@
     "pi"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:native",


### PR DESCRIPTION
## Summary

Prepares the v0.15.0 minor release by reconciling the complete delta since v0.14.0, updating release documentation, and synchronizing package metadata.

## Changes

- Add the complete v0.15.0 changelog covering Jcode host support, multiprocess index safety, parser-backed source discovery, and dependency security fixes.
- Raise the documented and declared Node.js runtime requirement to Node 20 because the patched Hono runtime requires it.
- Bump `package.json` and `package-lock.json` to 0.15.0 and update changelog comparison links.

## Testing

- [ ] Unit tests added/updated (release metadata only; existing full suite exercised)
- [x] Manual testing performed (`npm pack --dry-run` contents and version inspected)
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:coverage`), 48 files and 928 tests
- [x] Lint passes (`npm run lint`)

Additional checks completed: `npm ci`, `npm audit` (0 vulnerabilities), `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and the eval smoke test using an isolated local mock port.

## Release Labels

- [x] Added release category label: `skip-changelog`
- [x] Added semver label: `semver:minor`

## Related Issues

Release includes #149, #150, #159, and #160.

## Release Checklist

- [x] Draft notes reconciled against `git log --oneline v0.14.0..HEAD`
- [x] `CHANGELOG.md` updated
- [x] `package.json` and `package-lock.json` bumped to 0.15.0
- [x] README and Node.js compatibility documentation reviewed
- [x] Full validation and npm package inspection passed
