### PR TITLE
feat: improve codebase tool adoption across agent clients

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.13.2",
+  "version": "0.15.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",
@@ -37,7 +37,7 @@
     "termsOfServiceURL": "https://github.com/Helweg/opencode-codebase-index/blob/main/LICENSE",
     "brandColor": "#3B82F6",
     "defaultPrompt": [
-      "Use codebase-search skills and MCP tools to find local implementation context before edits."
+      "For repository questions, use index_status when readiness is unknown, then call codebase_context before shell search or broad file reads."
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -225,16 +225,17 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    npx -y --package opencode-codebase-index opencode-codebase-index-mcp
    ```
 
-The MCP server exposes all 12 tools (`codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`).
+The MCP server exposes all 13 tools (`codebase_context`, `codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`).
 
 The tools carry self-routing descriptions so clients can choose the lightweight path without relying on separate documentation:
 
-1. `index_status` when index readiness is unknown
-2. `codebase_peek` for low-token conceptual discovery
-3. `implementation_lookup` for known symbols and definitions
-4. `codebase_search` only when full semantic content is needed
-5. `grep` for exact identifiers or exhaustive matches
-6. `call_graph` / `call_graph_path` after symbols are known
+1. `codebase_context` as the preferred single entry point for repository questions
+2. `index_status` when index readiness is unknown
+3. `codebase_peek` for direct low-token conceptual discovery
+4. `implementation_lookup` for direct known-symbol definition lookup
+5. `codebase_search` only when full semantic content is needed
+6. `grep` for exact identifiers or exhaustive matches
+7. `call_graph` / `call_graph_path` for direct graph queries
 
 The server also publishes this workflow through the standard MCP initialization `instructions` field. Client behavior remains client-controlled: an MCP server can describe and recommend its tools, but cannot force an agent host to read server instructions or invoke a tool before filesystem search. Clients that ignore MCP instructions still receive the routing guidance in each tool description.
 
@@ -265,9 +266,9 @@ src/api/checkout.ts:89      (Route handler for /pay)
 
 | Scenario | Tool | Why |
 |----------|------|-----|
-| Don't know the function name | `codebase_search` | Semantic search finds by meaning |
-| Exploring unfamiliar codebase | `codebase_search` | Discovers related code across files |
-| Just need to find locations | `codebase_peek` | Returns metadata only, saves ~90% tokens |
+| Don't know the function name | `codebase_context` (MCP) | Routes conceptual questions to low-token discovery first |
+| Exploring unfamiliar codebase | `codebase_context` (MCP) | Discovers related code and then guides to definitions or graph queries |
+| Just need to find locations | `codebase_peek` (or `codebase_context`) | Returns metadata only, saves ~90% tokens |
 | Need the authoritative definition site | `implementation_lookup` | Prioritizes real implementation definitions over docs/tests |
 | Understand code flow | `call_graph` | Find callers/callees of any function |
 | Trace dependency paths | `call_graph_path` | Find the shortest known call path between two symbols |
@@ -275,7 +276,7 @@ src/api/checkout.ts:89      (Route handler for /pay)
 | Need ALL matches | `grep` | Semantic returns top N only |
 | Mixed discovery + precision | `/find` (hybrid) | Best of both worlds |
 
-**Rule of thumb**: `codebase_peek` to find locations → `Read` to examine → `grep` for precision. For symbol-definition questions, use `implementation_lookup` first.
+**Rule of thumb**: `codebase_context` to route discovery first. Then `Read` to examine exact content and `grep` for precision. For symbol-definition questions, use `implementation_lookup` first.
 
 ## 🧭 OMO CodeGraph Compatibility
 
@@ -292,7 +293,7 @@ Recent OMO releases include a built-in CodeGraph MCP and make it part of the def
 
 Recommended OMO workflow:
 
-1. Start broad with `codebase_peek` when the prompt is conceptual, such as "where is auth enforced?" or "payment validation flow".
+1. Start broad with `codebase_context` when the prompt is conceptual, such as "where is auth enforced?" or "payment validation flow".
 2. Use `implementation_lookup` once you have a symbol or concept that should resolve to a definition.
 3. Use OMO CodeGraph, `call_graph`, or `call_graph_path` after locating the relevant symbol to check blast radius and dependency flow.
 4. Keep `grep` for exact identifiers and exhaustive text matches.
@@ -435,9 +436,18 @@ The following files/folders are excluded from indexing by default:
 
 The plugin exposes these tools to the OpenCode agent:
 
+`codebase_context` is MCP-server-only.
+
+### `codebase_context`
+*MCP-only entrypoint for combined routing*
+**Preferred first tool for repository questions.** Routes to the lowest-token indexed operation that matches the query: conceptual discovery, definition lookup, callers/callees, or symbol-to-symbol paths.
+- **Use for**: New questions about behavior, locating symbols, or tracing direct call relationships.
+- **Example**: `"Where is the payment validation logic?"`
+- **Workflow**: If the query is conceptual, it may return locations first. For exact behavior text, follow with `codebase_search`.
+
 ### `codebase_search`
-**The primary tool.** Searches code by describing behavior.
-- **Use for**: Discovery, understanding flows, finding logic when you don't know the names.
+**Behavioral semantic retrieval with full content.** Searches code by describing behavior.
+- **Use for**: Discovery when you already want full matching snippets and are ready to inspect implementation text.
 - **Example**: `"find the middleware that sanitizes input"`
 - **Ranking path**: hybrid retrieval → fusion (`search.fusionStrategy`) → deterministic rerank (`search.rerankTopN`) → filters
 - **Blame filters**: when `indexing.gitBlame.enabled` is `true`, filter with `blameAuthor`, `blameSha`, or `blameSince`.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,17 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
 
 The MCP server exposes all 12 tools (`codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`).
 
+The tools carry self-routing descriptions so clients can choose the lightweight path without relying on separate documentation:
+
+1. `index_status` when index readiness is unknown
+2. `codebase_peek` for low-token conceptual discovery
+3. `implementation_lookup` for known symbols and definitions
+4. `codebase_search` only when full semantic content is needed
+5. `grep` for exact identifiers or exhaustive matches
+6. `call_graph` / `call_graph_path` after symbols are known
+
+The server also publishes this workflow through the standard MCP initialization `instructions` field. Client behavior remains client-controlled: an MCP server can describe and recommend its tools, but cannot force an agent host to read server instructions or invoke a tool before filesystem search. Clients that ignore MCP instructions still receive the routing guidance in each tool description.
+
 The MCP dependencies (`@modelcontextprotocol/sdk`, `zod`) ship with the package so published `npx --package opencode-codebase-index` launches work in clean MCP clients.
 
 If you are testing the MCP command from inside this repository checkout and see `opencode-codebase-index-mcp: command not found`, run `npm run build:ts && npm run dev:link-mcp`. That adds the local bin shim expected by `npx` without changing the published MCP config.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ pi install ./path/to/opencode-codebase-index
 
 Pi uses the neutral `.codebase-index/` project storage and falls back to existing OpenCode state when present.
 
+The Pi extension injects lightweight routing guidance and exposes `codebase_context` as its preferred first repository tool. It routes conceptual discovery, known-symbol definitions, and dependency paths before broad shell search or file reads.
+
 ## 🧩 Codex Plugin
 Install once for Codex threads and get skill guidance plus MCP tools in one manifest.
 
@@ -143,6 +145,8 @@ npm run dev:link-mcp
 ```
 
 After that, the normal `.mcp.json` command also works when Codex starts the plugin from this repository.
+
+The native Codex plugin is important: its session hook and `codebase-search` skill tell Codex to use `index_status` and `codebase_context` before shell exploration. A bare MCP configuration does not provide the same selection reliability. Current Codex `exec` releases may cancel MCP calls in non-interactive mode while waiting for an app-tool approval; use an interactive Codex thread to approve the tool call. This is a Codex client limitation, not an MCP server failure.
 
 ## 🧩 Claude Code Plugin
 Install once for Claude Code sessions and get skill guidance plus MCP tools in one manifest.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "printf '\nUse codebase_peek for quick location discovery, then codebase_search for implementation details. Use index_status before searching on first run.\\n'",
-            "commandWindows": "Write-Output 'Use codebase_peek for quick location discovery, then codebase_search for implementation details. Use index_status before searching on first run.'",
+            "command": "printf '\nFor repository questions, use index_status when readiness is unknown, then call codebase_context before shell search, grep, or broad file reads. Pass symbol for definitions or from+to for dependency paths; use specialized lookup and graph tools afterward.\\n'",
+            "commandWindows": "Write-Output 'For repository questions, use index_status when readiness is unknown, then call codebase_context before shell search, grep, or broad file reads. Pass symbol for definitions or from+to for dependency paths; use specialized lookup and graph tools afterward.'",
             "statusMessage": "Codebase Index ready"
           }
         ]

--- a/skills/codebase-search/SKILL.md
+++ b/skills/codebase-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-search
-description: Semantic code and documentation search by meaning for Pi and Codex workflows. Use codebase_peek to find WHERE code is first, then codebase_search for implementation details.
+description: Preferred local codebase-understanding workflow for Pi and Codex. Start with codebase_context before shell search or broad reads, then use specialized semantic and graph tools.
 ---
 
 # Codebase Search Skill
@@ -9,17 +9,19 @@ Use this skill when you need local repository knowledge before web lookup.
 
 ## Core workflow
 
-1. `codebase_peek(query, ...)` to find likely locations quickly with metadata-only results.
-2. `codebase_search(query, ...)` when you need full code context.
-3. `call_graph(name, direction)` when you need callers/callees after locating a symbol.
-4. `find_similar(code)` for duplicate patterns and refactor planning.
-5. `implementation_lookup(query)` when you need the authoritative definition location.
+1. Run `index_status` when index readiness or freshness is unknown.
+2. Use `codebase_context(query, ...)` before shell search, grep, or broad file reads. Pass `symbol` for an authoritative definition or `from` + `to` for a dependency path.
+3. Use `codebase_peek(query, ...)` for specialized metadata-only conceptual lookup.
+4. Use `codebase_search(query, ...)` when you need full code context.
+5. Use `implementation_lookup(query)` for known-symbol definitions and `call_graph` / `call_graph_path` for execution flow.
+6. Use `find_similar(code)` for duplicate patterns and refactor planning.
 
 If results are weak, run `index_status` (check readiness) and `index_codebase`.
 
 ## Tool Priority
 
-- `codebase_peek` for discovery (fastest, cheap tokens).
+- `codebase_context` as the preferred first repository tool and unified router.
+- `codebase_peek` for specialized discovery (fastest, cheap tokens).
 - `codebase_search` for exact implementation review.
 - `find_similar` for pattern matching and duplication.
 - `call_graph` and `call_graph_path` for execution flow.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7,6 +7,11 @@ import { registerMcpPrompts } from "./mcp-server/register-prompts.js";
 import { registerMcpTools } from "./mcp-server/register-tools.js";
 import { initializeTools } from "./tools/operations.js";
 
+function getServerInstructions(host: string): string {
+  const hostText = `host ${host}`;
+  return `This MCP server helps navigate indexed code for ${hostText}. For best results, verify freshness with index_status first if you suspect stale results. Start discovery with codebase_peek for conceptual matches, then call implementation_lookup for concrete definitions. Use codebase_search for semantic content matches and grep for exact/exhaustive string matches. After you have symbol names, use call_graph and call_graph_path to trace dependencies.`;
+}
+
 function getPackageVersion(): string {
   const raw = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as unknown;
   if (raw && typeof raw === "object" && "version" in raw && typeof raw.version === "string") {
@@ -24,6 +29,8 @@ export function createMcpServer(
   const server = new McpServer({
     name: "opencode-codebase-index",
     version: getPackageVersion(),
+  }, {
+    instructions: getServerInstructions(host),
   });
 
   initializeTools(projectRoot, config, host);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,7 +9,7 @@ import { initializeTools } from "./tools/operations.js";
 
 function getServerInstructions(host: string): string {
   const hostText = `host ${host}`;
-  return `This MCP server is the preferred codebase-understanding path for ${hostText}. Start a repository task with index_status when index readiness or freshness is unknown. Use codebase_peek as the default first retrieval step because it returns low-token locations. Use implementation_lookup first for a known symbol or definition question. Escalate to codebase_search only when full semantic code content is needed, and use grep for exact identifiers or exhaustive matches. After identifying symbols, use call_graph or call_graph_path to trace dependencies. If the index is unavailable, run index_codebase, then retry the retrieval tool.`;
+  return `This MCP server is the preferred codebase-understanding path for ${hostText}. Start a repository task with index_status when index readiness or freshness is unknown. Use codebase_context as the preferred first entry point because it returns low-token locations first and routes to definitions or call-graph helpers when symbol intent is present. Use codebase_peek for direct conceptual location lookup, implementation_lookup for known-symbol definition questions, and codebase_search only when full semantic code content is needed. For exact identifiers or exhaustive matches, use grep. After identifying symbols, use call_graph or call_graph_path to trace dependencies. If the index is unavailable, run index_codebase, then retry the retrieval tool.`;
 }
 
 function getPackageVersion(): string {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,7 +9,7 @@ import { initializeTools } from "./tools/operations.js";
 
 function getServerInstructions(host: string): string {
   const hostText = `host ${host}`;
-  return `This MCP server helps navigate indexed code for ${hostText}. For best results, verify freshness with index_status first if you suspect stale results. Start discovery with codebase_peek for conceptual matches, then call implementation_lookup for concrete definitions. Use codebase_search for semantic content matches and grep for exact/exhaustive string matches. After you have symbol names, use call_graph and call_graph_path to trace dependencies.`;
+  return `This MCP server is the preferred codebase-understanding path for ${hostText}. Start a repository task with index_status when index readiness or freshness is unknown. Use codebase_peek as the default first retrieval step because it returns low-token locations. Use implementation_lookup first for a known symbol or definition question. Escalate to codebase_search only when full semantic code content is needed, and use grep for exact identifiers or exhaustive matches. After identifying symbols, use call_graph or call_graph_path to trace dependencies. If the index is unavailable, run index_codebase, then retry the retrieval tool.`;
 }
 
 function getPackageVersion(): string {

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -36,7 +36,7 @@ function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
     "codebase_search",
-    "Search codebase by MEANING, not keywords. Returns full code content. For just finding WHERE code is (saves ~90% tokens), use codebase_peek instead.",
+    "FULL-CONTENT semantic retrieval. Use after codebase_peek when you need implementation text, not as the default first step. For exact identifiers or exhaustive matches use grep instead.",
     {
       query: z.string().describe("Natural language description of what code you're looking for. Describe behavior, not syntax."),
       limit: allowNullAsUndefined(z.number().optional().default(5)).describe("Maximum number of results to return"),
@@ -70,7 +70,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "codebase_peek",
-    "Quick lookup of code locations by meaning. Returns only metadata (file, line, name, type) WITHOUT code content. Saves ~90% tokens vs codebase_search.",
+    "DEFAULT FIRST TOOL for unfamiliar-code discovery. Finds locations by meaning and returns only file, line, symbol, and type metadata, saving about 90% of tokens versus codebase_search. Read selected files or escalate to codebase_search afterward.",
     {
       query: z.string().describe("Natural language description of what code you're looking for."),
       limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of results to return"),
@@ -103,7 +103,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "index_codebase",
-    "Index the codebase for semantic search. Creates vector embeddings of code chunks. Incremental - only re-indexes changed files. Run before first codebase_search.",
+    "Create or refresh the semantic index. Call index_status first when readiness is unknown, then use this tool only if the index is missing, stale, or incompatible. Incremental by default; force=true rebuilds everything.",
     {
       force: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Force reindex even if already indexed"),
       estimateOnly: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Only show cost estimate without indexing"),
@@ -123,7 +123,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "index_status",
-    "Check the status of the codebase index. Shows whether the codebase is indexed, how many chunks are stored, and the embedding provider being used.",
+    "START HERE once per repository task when index readiness or freshness is unknown. Reports whether semantic retrieval is ready, chunk counts, compatibility, and the embedding provider. If ready, continue with codebase_peek or implementation_lookup; otherwise run index_codebase.",
     {},
     async () => {
       const status = await getIndexStatus(runtime.projectRoot, runtime.host);
@@ -174,7 +174,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "find_similar",
-    "Find code similar to a given snippet. Use for duplicate detection, pattern discovery, or refactoring prep.",
+    "Use when you already have a code snippet and need analogous implementations, duplicates, patterns, or refactoring candidates. For a natural-language concept without example code, start with codebase_peek instead.",
     {
       code: z.string().describe("The code snippet to find similar code for"),
       limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of results to return"),
@@ -202,7 +202,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "implementation_lookup",
-    "Jump to symbol definition. Find WHERE something is defined. Returns the authoritative source location(s). Prefers real implementation files over tests, docs, examples, and fixtures.",
+    "FIRST TOOL for known-symbol and definition questions. Returns authoritative source locations and prefers implementations over tests, docs, examples, and fixtures. Use codebase_peek instead when you know the behavior but not the symbol name.",
     {
       query: z.string().describe("Symbol name or natural language description (e.g., 'validateToken', 'where is the payment handler defined')"),
       limit: allowNullAsUndefined(z.number().optional().default(5)).describe("Maximum number of results"),
@@ -222,7 +222,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "call_graph",
-    "Query the call graph to find callers or callees of a function/method. Use to understand code flow and dependencies."
+    "Use after identifying a symbol to find its direct callers or callees and understand code flow. Use implementation_lookup first if the symbol or definition is still ambiguous."
       + " Supports relationship types: Call, MethodCall, Constructor, Import, Inherits, Implements.",
     {
       name: z.string().describe("Function or method name to query"),
@@ -250,7 +250,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "call_graph_path",
-    "Find the shortest connection path between two symbols in the call graph. Returns the chain of calls connecting them.",
+    "Use after identifying both endpoint symbols to find the shortest known call path between them. Use codebase_peek or implementation_lookup first when either endpoint is unknown.",
     {
       from: z.string().describe("Source function/method name (starting point)"),
       to: z.string().describe("Target function/method name (destination)"),
@@ -263,7 +263,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
   );
   server.tool(
     "pr_impact",
-    "Analyze the impact of a pull request or branch by examining changed files, affected symbols, transitive callers, communities touched, hub nodes, and risk level. Use to understand blast radius before merging.",
+    "FIRST TOOL for pull-request or branch blast-radius questions. Analyzes changed files, affected symbols, transitive dependencies, communities, hub nodes, conflicts, and risk before merging.",
     {
       pr: allowNullAsUndefined(z.number().optional()).describe("Pull request number to analyze"),
       branch: allowNullAsUndefined(z.string().optional()).describe("Branch name to analyze (defaults to current branch)"),

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -29,20 +29,24 @@ import {
 } from "../tools/operations.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime } from "./shared.js";
 
+function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
+  return z.preprocess((value) => (value === null ? undefined : value), schema) as unknown as T;
+}
+
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
     "codebase_search",
     "Search codebase by MEANING, not keywords. Returns full code content. For just finding WHERE code is (saves ~90% tokens), use codebase_peek instead.",
     {
       query: z.string().describe("Natural language description of what code you're looking for. Describe behavior, not syntax."),
-      limit: z.number().optional().default(5).describe("Maximum number of results to return"),
-      fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
-      directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
-      chunkType: z.enum(CHUNK_TYPE_ENUM).optional().describe("Filter by code chunk type"),
-      contextLines: z.number().optional().describe("Number of extra lines to include before/after each match (default: 0)"),
-      blameAuthor: z.string().optional().describe("Filter by git blame author name or email"),
-      blameSha: z.string().optional().describe("Filter by git blame commit SHA or prefix"),
-      blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date"),
+      limit: allowNullAsUndefined(z.number().optional().default(5)).describe("Maximum number of results to return"),
+      fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
+      directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
+      chunkType: allowNullAsUndefined(z.enum(CHUNK_TYPE_ENUM).optional()).describe("Filter by code chunk type"),
+      contextLines: allowNullAsUndefined(z.number().optional()).describe("Number of extra lines to include before/after each match (default: 0)"),
+      blameAuthor: allowNullAsUndefined(z.string().optional()).describe("Filter by git blame author name or email"),
+      blameSha: allowNullAsUndefined(z.string().optional()).describe("Filter by git blame commit SHA or prefix"),
+      blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
     },
     async (args) => {
       const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
@@ -69,13 +73,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Quick lookup of code locations by meaning. Returns only metadata (file, line, name, type) WITHOUT code content. Saves ~90% tokens vs codebase_search.",
     {
       query: z.string().describe("Natural language description of what code you're looking for."),
-      limit: z.number().optional().default(10).describe("Maximum number of results to return"),
-      fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
-      directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
-      chunkType: z.enum(CHUNK_TYPE_ENUM).optional().describe("Filter by code chunk type"),
-      blameAuthor: z.string().optional().describe("Filter by git blame author name or email"),
-      blameSha: z.string().optional().describe("Filter by git blame commit SHA or prefix"),
-      blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date"),
+      limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of results to return"),
+      fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
+      directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
+      chunkType: allowNullAsUndefined(z.enum(CHUNK_TYPE_ENUM).optional()).describe("Filter by code chunk type"),
+      blameAuthor: allowNullAsUndefined(z.string().optional()).describe("Filter by git blame author name or email"),
+      blameSha: allowNullAsUndefined(z.string().optional()).describe("Filter by git blame commit SHA or prefix"),
+      blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
     },
     async (args) => {
       const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
@@ -101,9 +105,9 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "index_codebase",
     "Index the codebase for semantic search. Creates vector embeddings of code chunks. Incremental - only re-indexes changed files. Run before first codebase_search.",
     {
-      force: z.boolean().optional().default(false).describe("Force reindex even if already indexed"),
-      estimateOnly: z.boolean().optional().default(false).describe("Only show cost estimate without indexing"),
-      verbose: z.boolean().optional().default(false).describe("Show detailed info about skipped files and parsing failures"),
+      force: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Force reindex even if already indexed"),
+      estimateOnly: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Only show cost estimate without indexing"),
+      verbose: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Show detailed info about skipped files and parsing failures"),
     },
     async (args) => {
       const result = await runIndexCodebase(runtime.projectRoot, runtime.host, args);
@@ -154,9 +158,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "index_logs",
     "Get recent debug logs from the codebase indexer. Requires debug.enabled=true in config.",
     {
-      limit: z.number().optional().default(20).describe("Maximum number of log entries to return"),
-      category: z.enum(["search", "embedding", "cache", "gc", "branch", "general"]).optional().describe("Filter by log category"),
-      level: z.enum(["error", "warn", "info", "debug"]).optional().describe("Filter by minimum log level"),
+      limit: allowNullAsUndefined(z.number().optional().default(20)).describe("Maximum number of log entries to return"),
+      category: allowNullAsUndefined(
+        z.enum(["search", "embedding", "cache", "gc", "branch", "general"]).optional(),
+      ).describe("Filter by log category"),
+      level: allowNullAsUndefined(
+        z.enum(["error", "warn", "info", "debug"]).optional(),
+      ).describe("Filter by minimum log level"),
     },
     async (args) => {
       const result = await getIndexLogs(runtime.projectRoot, runtime.host, args);
@@ -169,11 +177,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Find code similar to a given snippet. Use for duplicate detection, pattern discovery, or refactoring prep.",
     {
       code: z.string().describe("The code snippet to find similar code for"),
-      limit: z.number().optional().default(10).describe("Maximum number of results to return"),
-      fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
-      directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
-      chunkType: z.enum(CHUNK_TYPE_ENUM).optional().describe("Filter by code chunk type"),
-      excludeFile: z.string().optional().describe("Exclude results from this file path"),
+      limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of results to return"),
+      fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
+      directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
+      chunkType: allowNullAsUndefined(z.enum(CHUNK_TYPE_ENUM).optional()).describe("Filter by code chunk type"),
+      excludeFile: allowNullAsUndefined(z.string().optional()).describe("Exclude results from this file path"),
     },
     async (args) => {
       const results = await findSimilarCode(runtime.projectRoot, runtime.host, args.code, {
@@ -197,9 +205,9 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "Jump to symbol definition. Find WHERE something is defined. Returns the authoritative source location(s). Prefers real implementation files over tests, docs, examples, and fixtures.",
     {
       query: z.string().describe("Symbol name or natural language description (e.g., 'validateToken', 'where is the payment handler defined')"),
-      limit: z.number().optional().default(5).describe("Maximum number of results"),
-      fileType: z.string().optional().describe("Filter by file extension (e.g., 'ts', 'py')"),
-      directory: z.string().optional().describe("Filter by directory path (e.g., 'src/utils')"),
+      limit: allowNullAsUndefined(z.number().optional().default(5)).describe("Maximum number of results"),
+      fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py')"),
+      directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils')"),
     },
     async (args) => {
       const results = await implementationLookup(runtime.projectRoot, runtime.host, args.query, {
@@ -218,9 +226,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       + " Supports relationship types: Call, MethodCall, Constructor, Import, Inherits, Implements.",
     {
       name: z.string().describe("Function or method name to query"),
-      direction: z.enum(["callers", "callees"]).default("callers").describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
-      symbolId: z.string().optional().describe("Symbol ID (required for 'callees' direction)"),
-      relationshipType: z.enum(["Call", "MethodCall", "Constructor", "Import", "Inherits", "Implements"]).optional().describe("Filter by relationship type. Omit to show all."),
+      direction: allowNullAsUndefined(
+        z.enum(["callers", "callees"]).default("callers"),
+      ).describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
+      symbolId: allowNullAsUndefined(z.string().optional()).describe("Symbol ID (required for 'callees' direction)"),
+      relationshipType: allowNullAsUndefined(
+        z.enum(["Call", "MethodCall", "Constructor", "Import", "Inherits", "Implements"]).optional(),
+      ).describe("Filter by relationship type. Omit to show all."),
     },
     async (args) => {
       if (args.direction === "callees") {
@@ -242,7 +254,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     {
       from: z.string().describe("Source function/method name (starting point)"),
       to: z.string().describe("Target function/method name (destination)"),
-      maxDepth: z.number().optional().default(10).describe("Maximum traversal depth (default: 10)"),
+      maxDepth: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum traversal depth (default: 10)"),
     },
     async (args) => {
       const path = await getCallGraphPath(runtime.projectRoot, runtime.host, args.from, args.to, args.maxDepth);
@@ -253,12 +265,14 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     "pr_impact",
     "Analyze the impact of a pull request or branch by examining changed files, affected symbols, transitive callers, communities touched, hub nodes, and risk level. Use to understand blast radius before merging.",
     {
-      pr: z.number().optional().describe("Pull request number to analyze"),
-      branch: z.string().optional().describe("Branch name to analyze (defaults to current branch)"),
-      maxDepth: z.number().optional().default(5).describe("Maximum traversal depth for transitive callers (default: 5)"),
-      hubThreshold: z.number().optional().default(10).describe("Minimum caller count to flag a symbol as a hub node (default: 10)"),
-      checkConflicts: z.boolean().optional().default(false).describe("Check for conflicting open PRs touching the same communities (default: false)"),
-      direction: z.enum(["callers", "callees", "both"]).optional().default("both").describe("Call-graph traversal direction: 'callers' for upstream, 'callees' for downstream, 'both' for union (default: both)"),
+      pr: allowNullAsUndefined(z.number().optional()).describe("Pull request number to analyze"),
+      branch: allowNullAsUndefined(z.string().optional()).describe("Branch name to analyze (defaults to current branch)"),
+      maxDepth: allowNullAsUndefined(z.number().optional().default(5)).describe("Maximum traversal depth for transitive callers (default: 5)"),
+      hubThreshold: allowNullAsUndefined(z.number().optional().default(10)).describe("Minimum caller count to flag a symbol as a hub node (default: 10)"),
+      checkConflicts: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Check for conflicting open PRs touching the same communities (default: false)"),
+      direction: allowNullAsUndefined(
+        z.enum(["callers", "callees", "both"]).optional().default("both"),
+      ).describe("Call-graph traversal direction: 'callers' for upstream, 'callees' for downstream, 'both' for union (default: both)"),
     },
     async (args) => {
       try {

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -36,7 +36,7 @@ function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
     "codebase_context",
-    "PREFERRED FIRST TOOL for any question about this repository. Use before agentgrep, grep, or broad file reads. Provide from+to for a dependency path, symbol for a definition, or only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
+    "PREFERRED FIRST TOOL for any question about this repository. Use before built-in code search, grep, shell search, or broad file reads. Provide from+to for a dependency path, symbol for a definition, or only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
     {
       query: z.string().describe("The codebase question or behavior to locate. Always provide the user's repository question here."),
       from: allowNullAsUndefined(z.string().optional()).describe("Source symbol. For dependency-path questions, extract the first endpoint and provide it here."),

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -35,6 +35,81 @@ function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
 
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
+    "codebase_context",
+    "PREFERRED FIRST TOOL for any question about this repository. Use before agentgrep, grep, or broad file reads. Provide from+to for a dependency path, symbol for a definition, or only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
+    {
+      query: z.string().describe("The codebase question or behavior to locate. Always provide the user's repository question here."),
+      from: allowNullAsUndefined(z.string().optional()).describe("Source symbol. For dependency-path questions, extract the first endpoint and provide it here."),
+      to: allowNullAsUndefined(z.string().optional()).describe("Target symbol. For dependency-path questions, extract the second endpoint and provide it here."),
+      symbol: allowNullAsUndefined(z.string().optional()).describe("Exact symbol for an authoritative definition lookup. Omit when from and to are supplied."),
+      limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of search or definition results"),
+      maxDepth: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum call-graph traversal depth for from/to path lookup"),
+      fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
+      directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
+    },
+    async (args) => {
+      if (args.from && args.to) {
+        const path = await getCallGraphPath(runtime.projectRoot, runtime.host, args.from, args.to, args.maxDepth);
+        if (path.length > 0) {
+          return { content: [{ type: "text", text: formatCallGraphPath(args.from, args.to, path) }] };
+        }
+
+        // Path traversal follows resolved symbol IDs, but extraction can still
+        // retain a useful direct edge before the target has been resolved.
+        const { callers } = await getCallGraphData(runtime.projectRoot, runtime.host, {
+          name: args.to,
+          direction: "callers",
+        });
+        const directEdge = callers.find(edge => edge.fromSymbolName === args.from);
+        if (directEdge) {
+          const location = directEdge.fromSymbolFilePath
+            ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
+            : "";
+          return {
+            content: [{
+              type: "text",
+              text: `Direct path: ${args.from} --${directEdge.callType}--> ${args.to}${location} ` +
+                `(edge is ${directEdge.isResolved ? "resolved" : "unresolved"}).`,
+            }],
+          };
+        }
+
+        return { content: [{ type: "text", text: formatCallGraphPath(args.from, args.to, path) }] };
+      }
+
+      if (args.symbol) {
+        const results = await implementationLookup(runtime.projectRoot, runtime.host, args.symbol, {
+          limit: args.limit ?? 10,
+          fileType: args.fileType,
+          directory: args.directory,
+        });
+
+        return { content: [{ type: "text", text: formatDefinitionLookup(results, args.symbol) }] };
+      }
+
+      const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
+        limit: args.limit ?? 10,
+        fileType: args.fileType,
+        directory: args.directory,
+        metadataOnly: true,
+      });
+
+      if (results.length === 0) {
+        return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}\n\n` +
+            "Use implementation_lookup for an authoritative definition, or call call_graph/call_graph_path once you have a symbol.",
+        }],
+      };
+    },
+  );
+
+
+  server.tool(
     "codebase_search",
     "FULL-CONTENT semantic retrieval. Use after codebase_peek when you need implementation text, not as the default first step. For exact identifiers or exhaustive matches use grep instead.",
     {
@@ -70,7 +145,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "codebase_peek",
-    "DEFAULT FIRST TOOL for unfamiliar-code discovery. Finds locations by meaning and returns only file, line, symbol, and type metadata, saving about 90% of tokens versus codebase_search. Read selected files or escalate to codebase_search afterward.",
+    "DIRECT LOW-TOKEN semantic location lookup for unfamiliar-code discovery. Prefer codebase_context when the request may involve definitions or graph navigation; use this specialized tool when you only need conceptual locations.",
     {
       query: z.string().describe("Natural language description of what code you're looking for."),
       limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of results to return"),
@@ -202,7 +277,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "implementation_lookup",
-    "FIRST TOOL for known-symbol and definition questions. Returns authoritative source locations and prefers implementations over tests, docs, examples, and fixtures. Use codebase_peek instead when you know the behavior but not the symbol name.",
+    "FIRST TOOL only for known-symbol definition questions. Returns authoritative source locations and prefers implementations over tests, docs, examples, and fixtures. Do not use for callers, callees, dependency paths, or code flow; use codebase_context with direction or from/to for those questions.",
     {
       query: z.string().describe("Symbol name or natural language description (e.g., 'validateToken', 'where is the payment handler defined')"),
       limit: allowNullAsUndefined(z.number().optional().default(5)).describe("Maximum number of results"),

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -6,6 +6,8 @@ import { formatPrImpact } from "./tools/format-pr-impact.js";
 import {
   addKnowledgeBase,
   findSimilarCode,
+  getCallGraphData,
+  getCallGraphPath,
   getIndexLogs,
   getIndexMetrics,
   getIndexStatus,
@@ -18,6 +20,8 @@ import {
   searchCodebase,
 } from "./tools/operations.js";
 import {
+  formatCallGraphPath,
+  formatCodebasePeek,
   formatDefinitionLookup,
   formatHealthCheck,
   formatIndexStats,
@@ -48,9 +52,75 @@ function projectRoot(ctx: { cwd?: string } | undefined): string | undefined {
 
 export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
+    name: "codebase_context",
+    label: "Codebase Context",
+    description: "PREFERRED FIRST TOOL for any repository question. Check index_status when freshness is unknown, then use this tool for low-token location discovery and dependency flow.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Natural language description of what code you're trying to locate" }),
+      from: Type.Optional(Type.String({ description: "Source symbol when asking for a dependency path." })),
+      to: Type.Optional(Type.String({ description: "Target symbol when asking for a dependency path." })),
+      symbol: Type.Optional(Type.String({ description: "Exact symbol name for an authoritative definition lookup." })),
+      limit: Type.Optional(Type.Number({ description: "Maximum results (default: 10)" })),
+      maxDepth: Type.Optional(Type.Number({ description: "Maximum call-graph traversal depth for from/to paths" })),
+      fileType: Type.Optional(Type.String({ description: "Filter by file extension, e.g., ts, py, rs" })),
+      directory: Type.Optional(Type.String({ description: "Filter by directory path" })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const root = projectRoot(ctx);
+
+      if (params.from && params.to) {
+        const path = await getCallGraphPath(root, HOST, params.from, params.to, params.maxDepth);
+        if (path.length > 0) {
+          return text(formatCallGraphPath(params.from, params.to, path), path);
+        }
+
+        const { callers } = await getCallGraphData(root, HOST, {
+          name: params.to,
+          direction: "callers",
+        });
+        const directEdge = callers.find((edge) => edge.fromSymbolName === params.from);
+        if (directEdge) {
+          const location = directEdge.fromSymbolFilePath
+            ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
+            : "";
+          return text(
+            `Direct path: ${params.from} --${directEdge.callType}--> ${params.to}${location} ` +
+              `(edge is ${directEdge.isResolved ? "resolved" : "unresolved"}).`,
+            path,
+          );
+        }
+
+        return text(formatCallGraphPath(params.from, params.to, path), path);
+      }
+
+      if (params.symbol) {
+        const results = await implementationLookup(root, HOST, params.symbol, {
+          limit: params.limit ?? 10,
+          fileType: params.fileType,
+          directory: params.directory,
+        });
+        return text(formatDefinitionLookup(results, params.symbol), results);
+      }
+
+      const results = await searchCodebase(root, HOST, params.query, {
+        limit: params.limit ?? 10,
+        fileType: params.fileType,
+        directory: params.directory,
+        metadataOnly: true,
+      });
+
+      if (results.length === 0) {
+        return text("No matching code found. Try a different query or run index_status/index_codebase first.");
+      }
+
+      return text(`Found ${results.length} locations for "${params.query}":\n\n${formatCodebasePeek(results)}`, results);
+    },
+  });
+
+  pi.registerTool({
     name: "codebase_search",
     label: "Codebase Search",
-    description: "Semantic search over the indexed codebase. Describe behavior, not syntax.",
+    description: "Use this after codebase_context when you need semantic content, not just locations. Describe behavior, not syntax.",
     parameters: Type.Object({
       query: Type.String({ description: "Natural language description of what code you're looking for" }),
       limit: Type.Optional(Type.Number({ description: "Maximum results (default: 10)" })),
@@ -71,7 +141,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "codebase_peek",
     label: "Codebase Peek",
-    description: "Semantic search returning only metadata (file, lines, symbol) to save tokens.",
+    description: "LOW-TOKEN location-first retrieval. Prefer codebase_context first, then use this for cheap conceptual lookup.",
     parameters: Type.Object({
       query: Type.String(),
       limit: Type.Optional(Type.Number()),
@@ -91,7 +161,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "find_similar",
     label: "Find Similar Code",
-    description: "Find code similar to a snippet for duplicate detection and pattern discovery.",
+    description: "Find code similar to a snippet for duplicate detection, pattern discovery, and refactor planning.",
     parameters: Type.Object({
       code: Type.String({ description: "Code snippet to compare" }),
       limit: Type.Optional(Type.Number()),
@@ -109,7 +179,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "implementation_lookup",
     label: "Implementation Lookup",
-    description: "Find likely symbol definitions or implementations by name or natural language.",
+    description: "Find likely symbol definitions or implementations after codebase_context identifies a symbol.",
     parameters: Type.Object({
       query: Type.String(),
       limit: Type.Optional(Type.Number()),
@@ -125,7 +195,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "index_codebase",
     label: "Index Codebase",
-    description: "Build or refresh the semantic codebase index.",
+    description: "Build or refresh the semantic codebase index. Run index_status when freshness is unknown.",
     parameters: Type.Object({
       force: Type.Optional(Type.Boolean({ default: false })),
       estimateOnly: Type.Optional(Type.Boolean({ default: false })),
@@ -153,7 +223,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "index_health_check",
     label: "Index Health Check",
-    description: "Garbage collect orphaned embeddings/chunks and report health.",
+    description: "Garbage collect orphaned embeddings/chunks and report index health status.",
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const result = await runIndexHealthCheck(projectRoot(ctx), HOST);
@@ -196,6 +266,14 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   });
 
   registerPiCallGraphTools(pi);
+
+  pi.on("before_agent_start", (event) => ({
+    systemPrompt:
+      `${event.systemPrompt}\n\n` +
+      "Check index_status first when index readiness is unknown. For repository questions, call codebase_context before search/grep/bash/read-style broad reads. " +
+      "Use implementation_lookup for known symbols and call_graph/call_graph_path after endpoints are identified for dependency flow. " +
+      "Avoid broad tool calls until semantic locations are known.",
+  }));
 
   pi.registerTool({
     name: "pr_impact",

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -35,6 +35,7 @@ describe("Codex plugin host mode", () => {
     const pluginManifest = JSON.parse(fs.readFileSync(".codex-plugin/plugin.json", "utf-8")) as {
       mcpServers?: string;
       hooks?: string;
+      interface?: { defaultPrompt?: string[] };
       version: string;
       name: string;
     };
@@ -43,7 +44,8 @@ describe("Codex plugin host mode", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.13.2");
+    const packageManifest = JSON.parse(fs.readFileSync("package.json", "utf-8")) as { version: string };
+    expect(pluginManifest.version).toBe(packageManifest.version);
     expect(pluginManifest.mcpServers).toBe("./.mcp.json");
     expect(pluginManifest.hooks).toBe("./hooks/hooks.json");
     expect(fs.existsSync("hooks/hooks.json")).toBe(true);
@@ -58,5 +60,11 @@ describe("Codex plugin host mode", () => {
       "--host",
       "codex",
     ]);
+
+    const hookManifest = fs.readFileSync("hooks/hooks.json", "utf-8");
+    const skill = fs.readFileSync("skills/codebase-search/SKILL.md", "utf-8");
+    expect(pluginManifest.interface?.defaultPrompt?.join(" ")).toContain("codebase_context");
+    expect(hookManifest).toContain("codebase_context before shell search");
+    expect(skill).toContain("codebase_context(query, ...)");
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -36,6 +36,8 @@ const indexerMockState = vi.hoisted(() => ({
   instances: [] as Array<{
     initialize: ReturnType<typeof vi.fn>;
     getStatus: ReturnType<typeof vi.fn>;
+    getCallers: ReturnType<typeof vi.fn>;
+    getCallees: ReturnType<typeof vi.fn>;
     clearIndex: ReturnType<typeof vi.fn>;
     forceIndex: ReturnType<typeof vi.fn>;
   }>,
@@ -95,6 +97,8 @@ vi.mock("../src/indexer/index.js", () => {
       indexerMockState.instances.push({
         initialize: this.initialize,
         getStatus: this.getStatus,
+        getCallers: this.getCallers,
+        getCallees: this.getCallees,
         clearIndex: this.clearIndex,
         forceIndex: this.forceIndex,
       });
@@ -128,6 +132,33 @@ vi.mock("../src/indexer/index.js", () => {
     getStatus = vi.fn().mockImplementation(async () => mockStatusResult);
     healthCheck = vi.fn().mockImplementation(async () => mockHealthCheckResult);
     clearIndex = vi.fn().mockResolvedValue(undefined);
+    getCallers = vi.fn().mockResolvedValue([
+      {
+        id: "edge_1",
+        fromSymbolId: "sym_caller",
+        targetName: "validateToken",
+        callType: "Call",
+        confidence: "Direct",
+        line: 12,
+        col: 4,
+        isResolved: true,
+        fromSymbolName: "callerFn",
+        fromSymbolFilePath: "src/caller.ts",
+      },
+    ]);
+    getCallees = vi.fn().mockResolvedValue([
+      {
+        id: "edge_2",
+        fromSymbolId: "sym_validate",
+        targetName: "calledFn",
+        callType: "Call",
+        confidence: "Direct",
+        line: 4,
+        col: 2,
+        isResolved: true,
+        toSymbolId: "sym_called",
+      },
+    ]);
     estimateCost = vi.fn().mockResolvedValue({
       filesCount: 10,
       totalSizeBytes: 50000,
@@ -301,6 +332,41 @@ describe("MCP server tools and prompts", () => {
     expect(content).toHaveLength(1);
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("Found 1 locations");
+  });
+
+  it("should execute codebase_peek with null optional fields", async () => {
+    const result = await client.callTool({
+      name: "codebase_peek",
+      arguments: {
+        query: "test query",
+        limit: null,
+        fileType: null,
+        directory: null,
+        chunkType: null,
+        blameAuthor: null,
+        blameSha: null,
+        blameSince: null,
+      },
+    });
+
+    expect(result.content).toBeDefined();
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+    expect(content[0].text).toContain("Found 1 locations");
+  });
+
+  it("should expose concise server instructions for tool workflow", async () => {
+    const instructions = await client.getInstructions();
+
+    expect(instructions).toBeDefined();
+    expect(instructions).toContain("index_status");
+    expect(instructions).toContain("codebase_peek");
+    expect(instructions).toContain("implementation_lookup");
+    expect(instructions).toContain("codebase_search");
+    expect(instructions).toContain("grep");
+    expect(instructions).toContain("call_graph");
+    expect(instructions).toContain("opencode");
   });
 
   it("should execute index_status tool", async () => {
@@ -617,6 +683,26 @@ describe("MCP server tools and prompts", () => {
     expect(content).toHaveLength(1);
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("validateToken");
+  });
+
+  it("should execute call_graph callers with null optional fields", async () => {
+    const result = await client.callTool({
+      name: "call_graph",
+      arguments: {
+        name: "validateToken",
+        direction: null,
+        symbolId: null,
+        relationshipType: null,
+      },
+    });
+
+    expect(result.content).toBeDefined();
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+    expect(content[0].text).toContain("called by 1 function");
+    const indexer = indexerMockState.instances[0];
+    expect(indexer.getCallers).toHaveBeenCalledWith("validateToken", undefined);
   });
 
   it("should get search prompt", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -38,6 +38,7 @@ const indexerMockState = vi.hoisted(() => ({
     getStatus: ReturnType<typeof vi.fn>;
     getCallers: ReturnType<typeof vi.fn>;
     getCallees: ReturnType<typeof vi.fn>;
+    findCallPath: ReturnType<typeof vi.fn>;
     clearIndex: ReturnType<typeof vi.fn>;
     forceIndex: ReturnType<typeof vi.fn>;
   }>,
@@ -99,6 +100,7 @@ vi.mock("../src/indexer/index.js", () => {
         getStatus: this.getStatus,
         getCallers: this.getCallers,
         getCallees: this.getCallees,
+        findCallPath: this.findCallPath,
         clearIndex: this.clearIndex,
         forceIndex: this.forceIndex,
       });
@@ -157,6 +159,24 @@ vi.mock("../src/indexer/index.js", () => {
         col: 2,
         isResolved: true,
         toSymbolId: "sym_called",
+      },
+    ]);
+    findCallPath = vi.fn().mockResolvedValue([
+      {
+        symbolName: "fromNode",
+        filePath: "src/start.ts",
+        line: 1,
+        symbolId: "from-node-id",
+        toSymbolId: "to-node-id",
+        callType: "Call",
+      },
+      {
+        symbolName: "toNode",
+        filePath: "src/end.ts",
+        line: 2,
+        symbolId: "to-node-id",
+        toSymbolId: "to-symbol-id",
+        callType: "Call",
       },
     ]);
     estimateCost = vi.fn().mockResolvedValue({
@@ -271,15 +291,16 @@ describe("MCP server tools and prompts", () => {
     fs.rmSync(testMainRepo, { recursive: true, force: true });
   });
 
-  it("should register all 12 tools", async () => {
+  it("should register all 13 tools", async () => {
     const tools = await client.listTools();
 
-    expect(tools.tools).toHaveLength(12);
+    expect(tools.tools).toHaveLength(13);
 
     const toolNames = tools.tools.map(t => t.name).sort();
     const expectedNames = [
       "call_graph",
       "call_graph_path",
+      "codebase_context",
       "codebase_peek",
       "codebase_search",
       "find_similar",
@@ -300,12 +321,16 @@ describe("MCP server tools and prompts", () => {
     const tools = await client.listTools();
     const descriptions = new Map(tools.tools.map(tool => [tool.name, tool.description ?? ""]));
 
+    expect(tools.tools[0]?.name).toBe("codebase_context");
+    expect(descriptions.get("codebase_context")).toContain("PREFERRED FIRST TOOL");
+    expect(descriptions.get("codebase_context")).toContain("before agentgrep");
     expect(descriptions.get("index_status")).toContain("START HERE");
     expect(descriptions.get("index_status")).toContain("codebase_peek");
-    expect(descriptions.get("codebase_peek")).toContain("DEFAULT FIRST TOOL");
-    expect(descriptions.get("codebase_peek")).toContain("codebase_search");
+    expect(descriptions.get("codebase_peek")).toContain("LOW-TOKEN");
+    expect(descriptions.get("codebase_peek")).toContain("codebase_context");
     expect(descriptions.get("implementation_lookup")).toContain("FIRST TOOL");
     expect(descriptions.get("implementation_lookup")).toContain("known-symbol");
+    expect(descriptions.get("implementation_lookup")).toContain("Do not use for callers");
     expect(descriptions.get("codebase_search")).toContain("after codebase_peek");
     expect(descriptions.get("codebase_search")).toContain("grep");
     expect(descriptions.get("call_graph")).toContain("after identifying a symbol");
@@ -373,11 +398,79 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("Found 1 locations");
   });
 
+  it("should route codebase_context conceptual discovery with null optional fields", async () => {
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: {
+        query: "where is authentication handled",
+        symbol: null,
+        from: null,
+        to: null,
+        limit: null,
+        maxDepth: null,
+        fileType: null,
+        directory: null,
+      },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("Found 1 locations");
+    expect(content[0].text).toContain("implementation_lookup");
+  });
+
+  it("should route codebase_context known symbols to definition lookup", async () => {
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "where is validateToken defined", symbol: "validateToken" },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain('function "validateToken"');
+  });
+
+  it("should route codebase_context endpoint pairs to call graph paths", async () => {
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "trace fromNode to toNode", from: "fromNode", to: "toNode", maxDepth: 7 },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("Path (2 hops)");
+    const indexer = indexerMockState.instances.at(-1);
+    expect(indexer?.findCallPath).toHaveBeenCalledWith("fromNode", "toNode", 7);
+  });
+
+  it("should recover direct unresolved edges when path traversal returns no hops", async () => {
+    const indexer = indexerMockState.instances.at(-1);
+    indexer?.findCallPath.mockResolvedValueOnce([]);
+    indexer?.getCallers.mockResolvedValueOnce([{
+      fromSymbolId: "from-node-id",
+      fromSymbolName: "fromNode",
+      fromSymbolFilePath: "src/start.ts",
+      toSymbolId: null,
+      targetName: "toNode",
+      callType: "Call",
+      line: 12,
+      confidence: "Direct",
+      isResolved: false,
+    }]);
+
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "trace fromNode to toNode", from: "fromNode", to: "toNode" },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("Direct path: fromNode --Call--> toNode");
+    expect(content[0].text).toContain("edge is unresolved");
+  });
+
   it("should expose concise server instructions for tool workflow", async () => {
     const instructions = await client.getInstructions();
 
     expect(instructions).toBeDefined();
     expect(instructions).toContain("index_status");
+    expect(instructions).toContain("codebase_context");
     expect(instructions).toContain("codebase_peek");
     expect(instructions).toContain("implementation_lookup");
     expect(instructions).toContain("codebase_search");

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -296,6 +296,23 @@ describe("MCP server tools and prompts", () => {
     expect(toolNames).toEqual(expectedNames);
   });
 
+  it("should expose self-routing descriptions even when the client ignores server instructions", async () => {
+    const tools = await client.listTools();
+    const descriptions = new Map(tools.tools.map(tool => [tool.name, tool.description ?? ""]));
+
+    expect(descriptions.get("index_status")).toContain("START HERE");
+    expect(descriptions.get("index_status")).toContain("codebase_peek");
+    expect(descriptions.get("codebase_peek")).toContain("DEFAULT FIRST TOOL");
+    expect(descriptions.get("codebase_peek")).toContain("codebase_search");
+    expect(descriptions.get("implementation_lookup")).toContain("FIRST TOOL");
+    expect(descriptions.get("implementation_lookup")).toContain("known-symbol");
+    expect(descriptions.get("codebase_search")).toContain("after codebase_peek");
+    expect(descriptions.get("codebase_search")).toContain("grep");
+    expect(descriptions.get("call_graph")).toContain("after identifying a symbol");
+    expect(descriptions.get("call_graph_path")).toContain("both endpoint symbols");
+    expect(descriptions.get("pr_impact")).toContain("FIRST TOOL");
+  });
+
   it("should register all 5 prompts", async () => {
     const prompts = await client.listPrompts();
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -323,7 +323,7 @@ describe("MCP server tools and prompts", () => {
 
     expect(tools.tools[0]?.name).toBe("codebase_context");
     expect(descriptions.get("codebase_context")).toContain("PREFERRED FIRST TOOL");
-    expect(descriptions.get("codebase_context")).toContain("before agentgrep");
+    expect(descriptions.get("codebase_context")).toContain("before built-in code search");
     expect(descriptions.get("index_status")).toContain("START HERE");
     expect(descriptions.get("index_status")).toContain("codebase_peek");
     expect(descriptions.get("codebase_peek")).toContain("LOW-TOKEN");

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -7,6 +7,8 @@ const operationMocks = vi.hoisted(() => ({
   getCallGraphPath: vi.fn(),
   getIndexHealthCheck: vi.fn(),
   runIndexHealthCheck: vi.fn(),
+  searchCodebase: vi.fn(),
+  implementationLookup: vi.fn(),
 }));
 
 vi.mock("../src/tools/operations.js", () => ({
@@ -15,16 +17,16 @@ vi.mock("../src/tools/operations.js", () => ({
   getCallGraphData: operationMocks.getCallGraphData,
   getCallGraphPath: operationMocks.getCallGraphPath,
   getIndexHealthCheck: operationMocks.getIndexHealthCheck,
-  getIndexLogs: vi.fn(() => ({ text: "" })),
   getIndexMetrics: vi.fn(() => ({ text: "" })),
   getIndexStatus: vi.fn(),
   getPrImpact: vi.fn(),
-  implementationLookup: vi.fn(() => []),
+  implementationLookup: operationMocks.implementationLookup,
   listKnowledgeBases: vi.fn(() => "No knowledge bases configured."),
   removeKnowledgeBase: vi.fn(() => "Removed knowledge base"),
   runIndexCodebase: vi.fn(),
   runIndexHealthCheck: operationMocks.runIndexHealthCheck,
-  searchCodebase: vi.fn(() => []),
+  searchCodebase: operationMocks.searchCodebase,
+  getIndexLogs: vi.fn(() => ({ text: "" })),
 }));
 
 interface RegisteredTool {
@@ -38,19 +40,29 @@ interface RegisteredTool {
   ) => Promise<{ readonly content: ReadonlyArray<{ readonly type: "text"; readonly text: string }>; readonly details?: unknown }>;
 }
 
-async function registerPiTools(): Promise<Map<string, RegisteredTool>> {
-  const tools = new Map<string, RegisteredTool>();
-  const { default: codebaseIndexPiExtension } = await import("../src/pi-extension.js");
+interface RegisteredPiRuntime {
+  tools: Map<string, RegisteredTool>;
+  beforeAgentStartHandlers: Array<(event: { systemPrompt: string }) => Promise<unknown> | unknown>;
+}
 
+async function registerPiTools(): Promise<RegisteredPiRuntime> {
+  const tools = new Map<string, RegisteredTool>();
+  const beforeAgentStartHandlers: Array<(event: { systemPrompt: string }) => Promise<unknown> | unknown> = [];
   const pi = {
     registerTool(tool) {
       tools.set(tool.name, tool);
     },
-  } satisfies Pick<ExtensionAPI, "registerTool">;
+    on(eventName, handler) {
+      if (eventName === "before_agent_start") {
+        beforeAgentStartHandlers.push(handler as (event: { systemPrompt: string }) => Promise<unknown> | unknown);
+      }
+    },
+  } satisfies Pick<ExtensionAPI, "registerTool" | "on">;
 
+  const { default: codebaseIndexPiExtension } = await import("../src/pi-extension.js");
   codebaseIndexPiExtension(pi);
 
-  return tools;
+  return { tools, beforeAgentStartHandlers };
 }
 
 describe("Pi adapter conformance", () => {
@@ -59,6 +71,17 @@ describe("Pi adapter conformance", () => {
     operationMocks.getCallGraphPath.mockReset();
     operationMocks.getIndexHealthCheck.mockReset();
     operationMocks.runIndexHealthCheck.mockReset();
+    operationMocks.searchCodebase.mockReset();
+    operationMocks.implementationLookup.mockReset();
+  });
+
+  it("registers codebase_context first as the preferred gateway route", async () => {
+    const { tools } = await registerPiTools();
+    const names = [...tools.keys()];
+
+    expect(names[0]).toBe("codebase_context");
+    expect(names).toContain("codebase_search");
+    expect(names).toContain("implementation_lookup");
   });
 
   it("formats caller results like other host adapters", async () => {
@@ -75,7 +98,7 @@ describe("Pi adapter conformance", () => {
       }],
       callees: [],
     });
-    const tools = await registerPiTools();
+    const { tools } = await registerPiTools();
 
     const result = await tools.get("call_graph")?.execute(
       "tool-call",
@@ -103,7 +126,7 @@ describe("Pi adapter conformance", () => {
         isResolved: true,
       }],
     });
-    const tools = await registerPiTools();
+    const { tools } = await registerPiTools();
 
     const result = await tools.get("call_graph")?.execute(
       "tool-call",
@@ -122,7 +145,7 @@ describe("Pi adapter conformance", () => {
       { symbolName: "createOrder", filePath: "src/order.ts", line: 10, callType: "Call" },
       { symbolName: "chargeCard", filePath: "src/pay.ts", line: 33, callType: "MethodCall" },
     ]);
-    const tools = await registerPiTools();
+    const { tools } = await registerPiTools();
 
     const result = await tools.get("call_graph_path")?.execute(
       "tool-call",
@@ -138,13 +161,120 @@ describe("Pi adapter conformance", () => {
     expect(result?.details).toHaveLength(2);
   });
 
+  it("routes codebase_context from/to through call-graph lookup with fallback", async () => {
+    operationMocks.getCallGraphPath.mockResolvedValue([]);
+    operationMocks.getCallGraphData.mockResolvedValue({
+      direction: "callers",
+      callers: [{
+        fromSymbolName: "callerFn",
+        fromSymbolFilePath: "src/app.ts",
+        fromSymbolId: "sym_caller",
+        callType: "Call",
+        confidence: "Direct",
+        line: 19,
+        isResolved: false,
+      }],
+      callees: [],
+    });
+
+    const { tools } = await registerPiTools();
+    const result = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "dependency", from: "callerFn", to: "targetFn" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "pi", "callerFn", "targetFn", undefined);
+    expect(operationMocks.getCallGraphData).toHaveBeenCalledWith("/repo", "pi", { name: "targetFn", direction: "callers" });
+    expect(result?.content[0]?.text).toContain("Direct path: callerFn --Call--> targetFn");
+    expect(result?.content[0]?.text).toContain("src/app.ts:19");
+    expect(result?.content[0]?.text).toContain("edge is unresolved");
+  });
+
+  it("routes codebase_context symbol lookups through implementation lookup", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([
+      {
+        chunkType: "function",
+        name: "validateToken",
+        filePath: "src/auth.ts",
+        startLine: 12,
+        endLine: 30,
+        score: 0.95,
+        content: "function validateToken() {}",
+      },
+    ]);
+
+    const { tools } = await registerPiTools();
+
+    await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8 },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "pi", "validateToken", {
+      limit: 8,
+      fileType: undefined,
+      directory: undefined,
+    });
+  });
+
+  it("routes codebase_context query-only lookups with metadata-only search", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([
+      {
+        chunkType: "function",
+        name: "validateToken",
+        filePath: "src/auth.ts",
+        startLine: 12,
+        endLine: 30,
+        score: 0.95,
+        content: "function validateToken() {}",
+      },
+    ]);
+
+    const { tools } = await registerPiTools();
+
+    const result = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "validation helper", limit: 4, fileType: "ts", directory: "src" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "validation helper", {
+      limit: 4,
+      fileType: "ts",
+      directory: "src",
+      metadataOnly: true,
+    });
+    expect(result?.content[0]?.text).toContain("Found 1 locations for \"validation helper\":");
+  });
+
+  it("injects client-neutral repository guidance on before_agent_start", async () => {
+    const { beforeAgentStartHandlers } = await registerPiTools();
+
+    const result = await beforeAgentStartHandlers[0]?.({ systemPrompt: "Base system prompt." });
+
+    expect(result).toMatchObject({
+      systemPrompt: expect.stringContaining("Check index_status first"),
+    });
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain("codebase_context");
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain("implementation_lookup");
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain("call_graph");
+  });
+
   it("returns INDEX_BUSY details from the Pi health-check tool", async () => {
     operationMocks.getIndexHealthCheck.mockRejectedValue(new Error("raw health-check operation must not be used"));
     operationMocks.runIndexHealthCheck.mockResolvedValue({
       kind: "busy",
       text: "INDEX_BUSY: another index operation is already in progress (PID 4444, operation health-check, since 2026-07-17T10:00:00.000Z).",
     });
-    const tools = await registerPiTools();
+    const { tools } = await registerPiTools();
 
     const result = await tools.get("index_health_check")?.execute(
       "tool-call",

--- a/tests/pi-package.test.ts
+++ b/tests/pi-package.test.ts
@@ -36,9 +36,11 @@ describe("Pi package integration", () => {
       registerTool(tool) {
         tools.push({ name: tool.name, parameters: tool.parameters });
       },
+      on() {},
     } as Parameters<typeof codebaseIndexPiExtension>[0]);
 
     expect(tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+      "codebase_context",
       "codebase_search",
       "codebase_peek",
       "find_similar",


### PR DESCRIPTION
## Summary

Improve reliable, low-token codebase understanding across Jcode, OpenCode, Codex, Pi, and MCP-compatible clients. This adds a unified `codebase_context` gateway, self-routing MCP guidance, client-compatible argument handling, and native Codex/Pi adoption guidance validated through blind client tests.

## Changes

- Add `codebase_context` as the preferred MCP entry point for conceptual discovery, authoritative symbol definitions, and dependency-path routing, including unresolved direct-edge fallback.
- Normalize explicit JSON `null` optional MCP arguments and expose host-aware server instructions plus clearer specialized tool descriptions.
- Improve the native Codex plugin hook, skill, default prompt, and manifest version so fresh Codex sessions select index tools before shell exploration.
- Add the same unified gateway and `before_agent_start` routing guidance to the Pi extension.
- Document client workflows and the current upstream Codex noninteractive MCP approval limitation.
- Add focused MCP, Codex plugin, and Pi conformance/package coverage.

## Testing

Blind discovery, definition, and call-flow prompts were run without naming the plugin:

- Jcode: improved from 1/3 to 3/3 plugin-first.
- OpenCode: 3/3 plugin-first.
- Codex bare MCP: 0/3; native Codex plugin improved from 2/3 to 3/3 plugin-first after the updated hook and skill.
- Pi extension: improved from 0/3 to 3/3 plugin-first.
- Codex `exec` selected the correct MCP tools, but current noninteractive Codex releases auto-cancel app-tool approval under a read-only sandbox. Interactive Codex sessions can approve the call.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`) - 48 files, 941 tests
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`)
- [x] Added at most one semver label (`semver:minor`)

## Related Issues

N/A
