### PR TITLE
fix: keep search available during embedding outages

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4787,11 +4787,20 @@ export class Indexer {
 
     const embeddingStartTime = performance.now();
     const embeddingQuery = stripFilePathHint(query);
-    const embedding = await this.getQueryEmbedding(embeddingQuery, provider);
+    let embedding: number[] | undefined;
+    try {
+      embedding = await this.getQueryEmbedding(embeddingQuery, provider);
+    } catch (error) {
+      this.logger.warn("Query embedding failed; falling back to keyword-only search", {
+        query,
+        error: getErrorMessage(error),
+        action: "Check the embedding provider configuration and retry search after restoring provider health.",
+      });
+    }
     const embeddingMs = performance.now() - embeddingStartTime;
 
     const vectorStartTime = performance.now();
-    const semanticResults = store.search(embedding, maxResults * 4);
+    const semanticResults = embedding ? store.search(embedding, maxResults * 4) : [];
     const vectorMs = performance.now() - vectorStartTime;
 
     const keywordStartTime = performance.now();
@@ -4842,12 +4851,15 @@ export class Indexer {
     }
 
     const fusionStartTime = performance.now();
+    const rankingHybridWeight = embedding === undefined && fusionStrategy === "weighted"
+      ? 1
+      : effectiveHybridWeight;
     const combined = rankHybridResults(query, semanticCandidates, keywordCandidates, {
       fusionStrategy,
       rrfK,
       rerankTopN,
       limit: maxResults,
-      hybridWeight: effectiveHybridWeight,
+      hybridWeight: rankingHybridWeight,
       prioritizeSourcePaths: sourceIntent,
     });
     const rerankedCombined = await this.rerankCandidatesWithApi(query, combined, {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -363,6 +363,30 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("validateToken");
   });
 
+  it("should execute codebase_search with null optional fields", async () => {
+    const result = await client.callTool({
+      name: "codebase_search",
+      arguments: {
+        query: "test query",
+        limit: null,
+        fileType: null,
+        directory: null,
+        chunkType: null,
+        contextLines: null,
+        blameAuthor: null,
+        blameSha: null,
+        blameSince: null,
+      },
+    });
+
+    expect(result.content).toBeDefined();
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content).toHaveLength(1);
+    expect(content[0].type).toBe("text");
+    expect(content[0].text).toContain("Found 1 results");
+    expect(content[0].text).toContain("validateToken");
+  });
+
   it("should execute codebase_peek tool", async () => {
     const result = await client.callTool({
       name: "codebase_peek",

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -505,4 +505,43 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(results[0]?.filePath).toContain("README.md");
     expect(results[0]?.filePath).not.toContain(path.join("app", "indexer", "index.ts"));
   });
+
+  it("falls back to weighted keyword search when query embedding generation fails", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: { watchFiles: false },
+      search: {
+        maxResults: 10,
+        minScore: 0.01,
+        fusionStrategy: "weighted",
+        hybridWeight: 0,
+        rerankTopN: 20,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+    fetchSpy.mockRejectedValue(new Error("embedding endpoint unavailable"));
+    const warningLog = vi.spyOn(indexer.getLogger(), "warn");
+
+    const results = await indexer.search("rankHybridResults", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]?.filePath).toContain(path.join("app", "indexer", "index.ts"));
+    expect(results[0]?.score).toBeGreaterThan(0);
+    expect(warningLog).toHaveBeenCalledWith(
+      "Query embedding failed; falling back to keyword-only search",
+      expect.objectContaining({
+        error: "embedding endpoint unavailable",
+        action: expect.stringContaining("embedding provider"),
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Keep `codebase_search` and `codebase_peek` useful when the configured query-embedding provider is temporarily unavailable.

## Changes

- Fall back to the existing BM25 keyword lane when query embedding generation fails.
- Preserve vector-store, database, and compatibility errors rather than masking them.
- Force full keyword weighting for weighted fusion during fallback so results retain meaningful scores.
- Log an actionable warning that identifies the provider failure and recovery action.
- Add explicit Jcode-style `null` optional-field coverage for `codebase_search`.
- Add an integration regression for provider outage and weighted keyword fallback.

## Testing

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (48 files, 943 tests)

## Release Labels

- `bug`
- `test`
- `semver:patch`

## Related Issues

Follow-up to #162.