### PR TITLE
chore: prepare v0.16.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.13.2"
+      "version": "0.16.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.13.2",
+  "version": "0.16.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-24
+
+### Added
+
+- **Unified agent context gateway**: Added the `codebase_context` MCP and Pi tool as the preferred first step for repository questions, routing conceptual discovery, authoritative symbol definitions, and call-graph paths through one low-friction interface.
+- **Cross-client tool adoption**: Added native Codex session guidance, skill/default-prompt updates, and Pi pre-agent routing guidance so Jcode, OpenCode, Codex, and Pi agents select codebase tools before broad shell search or file reads.
+
+### Changed
+
+- **Self-routing MCP guidance**: Reworked server instructions and tool descriptions around a staged, client-neutral workflow: check readiness, retrieve lightweight context, locate definitions or graph paths, then use full-content search or exact grep only when needed.
+- **Client plugin metadata**: Aligned Codex and Claude Code marketplace manifests with the package release version so clients can discover and refresh the updated integration guidance.
+
+### Fixed
+
+- **Jcode MCP argument compatibility**: Treat explicit JSON `null` values for optional MCP arguments as omitted values across search, definition, graph, PR-impact, and index tools.
+- **Embedding-provider outages**: Keep `codebase_search` and `codebase_peek` operational through BM25 keyword fallback when query embedding generation is temporarily unavailable, with full keyword weighting and actionable diagnostics.
+
 ## [0.15.0] - 2026-07-24
 
 ### Added
@@ -413,7 +430,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.1...v0.13.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.13.2");
+    expect(pluginManifest.version).toBe("0.16.0");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -42,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.13.2",
+      version: "0.16.0",
     }));
   });
 });


### PR DESCRIPTION
## Summary

Prepares the v0.16.0 minor release by reconciling the complete delta since v0.15.0, synchronizing package and client-plugin versions, and validating the publishable package.

## Changes

- Add the complete v0.16.0 changelog covering the unified `codebase_context` gateway, cross-client adoption guidance, Jcode null-argument compatibility, and BM25 fallback during embedding outages.
- Bump `package.json` and `package-lock.json` to 0.16.0.
- Align Codex and Claude Code plugin/marketplace manifests to 0.16.0 and update their automated assertions.
- Update changelog comparison links for v0.16.0.

## Testing

- [x] Unit tests added/updated (Claude manifest release assertions)
- [x] Manual testing performed (`npm pack --dry-run` contents and version inspected)
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`), 48 files and 943 tests
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added release category label: `skip-changelog`
- [x] Added semver label: `semver:minor`

## Related Issues

Release includes #162 and #163.

## Release Checklist

- [x] Draft notes reconciled against `git log --oneline v0.15.0..HEAD`
- [x] `CHANGELOG.md` updated
- [x] `package.json` and `package-lock.json` bumped to 0.16.0
- [x] Codex and Claude Code marketplace metadata synchronized
- [x] Full validation and npm package inspection passed