### PR TITLE
feat: improve agent context retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent-facing retrieval evaluation**: Added a versioned `codebase_context` golden dataset, `npm run eval:agent`, and per-query route metadata for measuring definition routing and conceptual discovery.
+
+### Changed
+
+- **Automatic definition routing**: MCP and Pi `codebase_context` now conservatively infer unambiguous symbol names from definition-style questions before falling back to conceptual search.
+- **Large-file retrieval coverage**: Files exceeding `maxChunksPerFile` now retain representative chunks from across the file instead of silently indexing only the beginning.
+
 ## [0.16.0] - 2026-07-24
 
 ### Added

--- a/benchmarks/golden/agent-context.json
+++ b/benchmarks/golden/agent-context.json
@@ -1,0 +1,126 @@
+{
+  "version": "1.0.0",
+  "name": "agent-context",
+  "description": "Agent-facing retrieval set covering automatic definition routing and conceptual codebase discovery through codebase_context semantics.",
+  "queries": [
+    {
+      "id": "context-def-fuse-rrf",
+      "query": "where is fuseResultsRrf implemented?",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/indexer/index.ts",
+        "symbol": "fuseResultsRrf"
+      }
+    },
+    {
+      "id": "context-def-get-status",
+      "query": "find the getStatus method definition",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/indexer/index.ts",
+        "symbol": "getStatus"
+      }
+    },
+    {
+      "id": "context-def-rerank-results",
+      "query": "show me the rerankResults function",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/indexer/index.ts",
+        "symbol": "rerankResults"
+      }
+    },
+    {
+      "id": "context-def-create-mcp-server",
+      "query": "where is `createMcpServer` defined?",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/mcp-server.ts",
+        "symbol": "createMcpServer"
+      }
+    },
+    {
+      "id": "context-concept-embedding-fallback",
+      "query": "continue with lexical keyword retrieval when creating a semantic query embedding fails",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/indexer/index.ts"
+      }
+    },
+    {
+      "id": "context-concept-mcp-registration",
+      "query": "register and route the MCP tools exposed to coding agents",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/mcp-server/register-tools.ts"
+      }
+    },
+    {
+      "id": "context-concept-pi-integration",
+      "query": "integrate repository search tools into the Pi coding agent",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/pi-extension.ts"
+      }
+    },
+    {
+      "id": "context-concept-eval-metrics",
+      "query": "calculate retrieval recall reciprocal rank and discounted cumulative gain",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/eval/metrics.ts"
+      }
+    },
+    {
+      "id": "context-concept-index-lock",
+      "query": "prevent two processes from mutating the same code index concurrently",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "src/indexer/index-lock.ts"
+      }
+    },
+    {
+      "id": "context-concept-config-loading",
+      "query": "load project and user configuration then validate defaults",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "acceptableFiles": [
+          "src/config/index.ts",
+          "src/config/merger.ts",
+          "src/config/schema.ts"
+        ]
+      }
+    },
+    {
+      "id": "context-concept-call-extraction",
+      "query": "extract function calls from syntax trees for the repository graph",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "filePath": "native/src/call_extractor.rs"
+      }
+    },
+    {
+      "id": "context-concept-file-watching",
+      "query": "watch source files and refresh the index after code changes",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "expected": {
+        "acceptableFiles": [
+          "src/watcher/index.ts",
+          "src/watcher/file-watcher.ts"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -10,6 +10,13 @@ This project ships a first-class retrieval evaluation harness with CLI subcomman
 npm run eval -- --dataset benchmarks/golden/small.json
 ```
 
+To measure the same automatic definition-versus-concept routing used by the
+agent-facing `codebase_context` gateway, run:
+
+```bash
+npm run eval:agent
+```
+
 Optional flags:
 
 - `--project <path>`: project root (default: current directory)
@@ -166,6 +173,7 @@ Golden sets are versioned JSON files:
 - `benchmarks/golden/small.json`
 - `benchmarks/golden/medium.json`
 - `benchmarks/golden/large.json`
+- `benchmarks/golden/agent-context.json`
 
 Schema:
 
@@ -179,6 +187,7 @@ Schema:
       "id": "def-rank-hybrid-results",
       "query": "where is rankHybridResults implementation",
       "queryType": "definition",
+      "retrievalMode": "context",
       "expected": {
         "filePath": "src/indexer/index.ts",
         "acceptableFiles": ["src/indexer/index.ts"],
@@ -198,6 +207,17 @@ Allowed values:
 - `implementation-intent`
 - `similarity`
 - `keyword-heavy`
+- `conceptual`
+
+### `retrievalMode`
+
+- `search` (default) evaluates the raw hybrid search path.
+- `context` evaluates agent-facing gateway behavior. Confident symbol queries
+  use authoritative definition lookup; other questions use conceptual search.
+
+The per-query artifact records both `resolvedRoute` and `routedQuery`, making
+automatic routing decisions visible rather than hiding them inside aggregate
+quality scores.
 
 ### `expected`
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "visualize": "node dist/cli.js visualize",
     "dev": "tsup --watch",
     "eval": "npx tsx src/cli.ts eval run",
+    "eval:agent": "npx tsx src/cli.ts eval run --dataset benchmarks/golden/agent-context.json",
     "eval:smoke": "npx tsx src/cli.ts eval run --config .github/eval-config.json --reindex --dataset benchmarks/golden/small.json",
     "eval:ci": "npx tsx src/cli.ts eval run --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:ci:ollama": "npx tsx src/cli.ts eval run --config .github/eval-ollama-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -2,6 +2,7 @@ import { estimateTokens } from "../utils/cost.js";
 import { normalizePathSeparators } from "../utils/paths.js";
 
 import type {
+  EvalResolvedRoute,
   EvalMetrics,
   FailureBucket,
   GoldenQuery,
@@ -138,7 +139,11 @@ export function buildPerQueryResult(
   query: GoldenQuery,
   results: PerQueryEvalResult["results"],
   latencyMs: number,
-  k: number
+  k: number,
+  route: { resolvedRoute: EvalResolvedRoute; routedQuery: string } = {
+    resolvedRoute: "search",
+    routedQuery: query.query,
+  },
 ): PerQueryEvalResult {
   const relevantPaths = getRelevantPaths(query);
   const deduped = uniqueResultsByPath(results);
@@ -149,6 +154,9 @@ export function buildPerQueryResult(
     id: query.id,
     query: query.query,
     queryType: query.queryType,
+    retrievalMode: query.retrievalMode ?? "search",
+    resolvedRoute: route.resolvedRoute,
+    routedQuery: route.routedQuery,
     latencyMs,
     hitAt1: hitAt(1),
     hitAt3: hitAt(3),

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { performance } from "perf_hooks";
 
 import { Indexer } from "../indexer/index.js";
+import { inferExactSymbolFromQuery } from "../tools/symbol-inference.js";
 
 import { evaluateBudgetGate } from "./budget.js";
 import { compareSummaries } from "./compare.js";
@@ -64,104 +65,114 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
   const indexer = new Indexer(options.projectRoot, effectiveConfig);
 
   try {
-  await indexer.index();
+    await indexer.index();
 
-  const perQuery: PerQueryEvalResult[] = [];
+    const perQuery: PerQueryEvalResult[] = [];
 
-  for (const query of dataset.queries) {
-    if (query.expected.branch && query.expected.branch !== indexer.getCurrentBranch()) {
-      throw new Error(
-        `Query '${query.id}' expects branch '${query.expected.branch}', but current branch is '${indexer.getCurrentBranch()}'. Switch branch before running this dataset.`
-      );
-    }
-
-    const start = performance.now();
-    const result = await indexer.search(query.query, 10, {
-      metadataOnly: true,
-      filterByBranch: !!query.expected.branch,
-    });
-    const elapsed = performance.now() - start;
-
-    const materialized = result.map((item) => ({
-      filePath: item.filePath,
-      startLine: item.startLine,
-      endLine: item.endLine,
-      score: item.score,
-      chunkType: item.chunkType,
-      name: item.name,
-    }));
-
-    perQuery.push(buildPerQueryResult(query, materialized, elapsed, 10));
-  }
-
-  const logger = indexer.getLogger();
-  const metricSnapshot = logger.getMetrics();
-
-  const costPer1MTokensUsd = getEmbeddingCostPer1MTokens(effectiveConfig.embeddingProvider);
-
-  const summary: EvalSummary = {
-    generatedAt: new Date().toISOString(),
-    projectRoot: options.projectRoot,
-    datasetPath,
-    datasetName: dataset.name,
-    datasetVersion: dataset.version,
-    queryCount: dataset.queries.length,
-    topK: 10,
-    searchConfig: {
-      fusionStrategy: effectiveConfig.search.fusionStrategy,
-      hybridWeight: effectiveConfig.search.hybridWeight,
-      rrfK: effectiveConfig.search.rrfK,
-      rerankTopN: effectiveConfig.search.rerankTopN,
-    },
-    metrics: computeEvalMetrics(
-      dataset.queries,
-      perQuery,
-      metricSnapshot.embeddingApiCalls,
-      metricSnapshot.embeddingTokensUsed,
-      costPer1MTokensUsd
-    ),
-  };
-
-  const outputDir = createRunDirectory(toAbsolute(options.projectRoot, options.outputRoot));
-  const perQueryArtifact = buildPerQueryArtifact(perQuery);
-
-  writeJson(path.join(outputDir, "summary.json"), summary);
-  writeJson(path.join(outputDir, "per-query.json"), perQueryArtifact);
-
-  let comparison: EvalComparison | undefined;
-  if (againstPath) {
-    const baseline = loadSummary(againstPath);
-    comparison = compareSummaries(summary, baseline, againstPath);
-    writeJson(path.join(outputDir, "compare.json"), comparison);
-  }
-
-  let gate: EvalGateResult | undefined;
-  if (options.ciMode) {
-    if (!budgetPath) {
-      throw new Error("CI mode requires --budget path");
-    }
-    const budget = loadBudget(budgetPath);
-
-    if (!comparison && budget.baselinePath) {
-      const resolvedBaseline = toAbsolute(options.projectRoot, budget.baselinePath);
-      if (existsSync(resolvedBaseline)) {
-        const baselineSummary = loadSummary(resolvedBaseline);
-        comparison = compareSummaries(summary, baselineSummary, resolvedBaseline);
-        writeJson(path.join(outputDir, "compare.json"), comparison);
-      } else if (budget.failOnMissingBaseline) {
+    for (const query of dataset.queries) {
+      if (query.expected.branch && query.expected.branch !== indexer.getCurrentBranch()) {
         throw new Error(
-          `Budget baseline is missing: ${resolvedBaseline}. Set failOnMissingBaseline=false to allow CI run without baseline.`
+          `Query '${query.id}' expects branch '${query.expected.branch}', but current branch is '${indexer.getCurrentBranch()}'. Switch branch before running this dataset.`
         );
       }
+
+      const inferredSymbol = query.retrievalMode === "context"
+        ? inferExactSymbolFromQuery(query.query)
+        : undefined;
+      const routedQuery = inferredSymbol ?? query.query;
+      const resolvedRoute = inferredSymbol ? "definition" : "search";
+
+      const start = performance.now();
+      const result = await indexer.search(routedQuery, 10, {
+        metadataOnly: true,
+        filterByBranch: !!query.expected.branch,
+        definitionIntent: inferredSymbol !== undefined,
+      });
+      const elapsed = performance.now() - start;
+
+      const materialized = result.map((item) => ({
+        filePath: item.filePath,
+        startLine: item.startLine,
+        endLine: item.endLine,
+        score: item.score,
+        chunkType: item.chunkType,
+        name: item.name,
+      }));
+
+      perQuery.push(buildPerQueryResult(query, materialized, elapsed, 10, {
+        resolvedRoute,
+        routedQuery,
+      }));
     }
 
-    gate = evaluateBudgetGate(budget, summary, comparison);
-  }
+    const logger = indexer.getLogger();
+    const metricSnapshot = logger.getMetrics();
 
-  const markdown = createSummaryMarkdown(summary, comparison, gate);
-  writeText(path.join(outputDir, "summary.md"), markdown);
+    const costPer1MTokensUsd = getEmbeddingCostPer1MTokens(effectiveConfig.embeddingProvider);
 
-  return { outputDir, summary, perQuery, comparison, gate };
+    const summary: EvalSummary = {
+      generatedAt: new Date().toISOString(),
+      projectRoot: options.projectRoot,
+      datasetPath,
+      datasetName: dataset.name,
+      datasetVersion: dataset.version,
+      queryCount: dataset.queries.length,
+      topK: 10,
+      searchConfig: {
+        fusionStrategy: effectiveConfig.search.fusionStrategy,
+        hybridWeight: effectiveConfig.search.hybridWeight,
+        rrfK: effectiveConfig.search.rrfK,
+        rerankTopN: effectiveConfig.search.rerankTopN,
+      },
+      metrics: computeEvalMetrics(
+        dataset.queries,
+        perQuery,
+        metricSnapshot.embeddingApiCalls,
+        metricSnapshot.embeddingTokensUsed,
+        costPer1MTokensUsd
+      ),
+    };
+
+    const outputDir = createRunDirectory(toAbsolute(options.projectRoot, options.outputRoot));
+    const perQueryArtifact = buildPerQueryArtifact(perQuery);
+
+    writeJson(path.join(outputDir, "summary.json"), summary);
+    writeJson(path.join(outputDir, "per-query.json"), perQueryArtifact);
+
+    let comparison: EvalComparison | undefined;
+    if (againstPath) {
+      const baseline = loadSummary(againstPath);
+      comparison = compareSummaries(summary, baseline, againstPath);
+      writeJson(path.join(outputDir, "compare.json"), comparison);
+    }
+
+    let gate: EvalGateResult | undefined;
+    if (options.ciMode) {
+      if (!budgetPath) {
+        throw new Error("CI mode requires --budget path");
+      }
+      const budget = loadBudget(budgetPath);
+
+      if (!comparison && budget.baselinePath) {
+        const resolvedBaseline = toAbsolute(options.projectRoot, budget.baselinePath);
+        if (existsSync(resolvedBaseline)) {
+          const baselineSummary = loadSummary(resolvedBaseline);
+          comparison = compareSummaries(summary, baselineSummary, resolvedBaseline);
+          writeJson(path.join(outputDir, "compare.json"), comparison);
+        } else if (budget.failOnMissingBaseline) {
+          throw new Error(
+            `Budget baseline is missing: ${resolvedBaseline}. Set failOnMissingBaseline=false to allow CI run without baseline.`
+          );
+        }
+      }
+
+      gate = evaluateBudgetGate(budget, summary, comparison);
+    }
+
+    const markdown = createSummaryMarkdown(summary, comparison, gate);
+    writeText(path.join(outputDir, "summary.md"), markdown);
+
+    return { outputDir, summary, perQuery, comparison, gate };
   } finally {
     await indexer.close();
   }

--- a/src/eval/schema.ts
+++ b/src/eval/schema.ts
@@ -5,6 +5,7 @@ import type {
   GoldenDataset,
   GoldenExpected,
   GoldenQuery,
+  GoldenRetrievalMode,
   GoldenQueryType,
 } from "./types.js";
 
@@ -39,13 +40,20 @@ function parseQueryType(value: unknown, path: string): GoldenQueryType {
     value === "definition" ||
     value === "implementation-intent" ||
     value === "similarity" ||
-    value === "keyword-heavy"
+    value === "keyword-heavy" ||
+    value === "conceptual"
   ) {
     return value;
   }
   throw new Error(
-    `${path} must be one of: definition, implementation-intent, similarity, keyword-heavy`
+    `${path} must be one of: definition, implementation-intent, similarity, keyword-heavy, conceptual`
   );
+}
+
+function parseRetrievalMode(value: unknown, path: string): GoldenRetrievalMode {
+  if (value === undefined || value === "search") return "search";
+  if (value === "context") return value;
+  throw new Error(`${path} must be one of: search, context`);
 }
 
 function parseExpected(input: unknown, path: string): GoldenExpected {
@@ -77,9 +85,6 @@ function parseExpected(input: unknown, path: string): GoldenExpected {
     throw new Error(`${path}.branch must be a string when provided`);
   }
 
-
-
-
   return {
     filePath,
     acceptableFiles,
@@ -97,6 +102,7 @@ function parseQuery(input: unknown, index: number): GoldenQuery {
   const id = input.id;
   const query = input.query;
   const queryType = input.queryType;
+  const retrievalMode = input.retrievalMode;
   const expected = input.expected;
 
   if (typeof id !== "string" || id.trim().length === 0) {
@@ -111,6 +117,7 @@ function parseQuery(input: unknown, index: number): GoldenQuery {
     id,
     query,
     queryType: parseQueryType(queryType, `${path}.queryType`),
+    retrievalMode: parseRetrievalMode(retrievalMode, `${path}.retrievalMode`),
     expected: parseExpected(expected, `${path}.expected`),
   };
 }

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -4,7 +4,11 @@ export type GoldenQueryType =
   | "definition"
   | "implementation-intent"
   | "similarity"
-  | "keyword-heavy";
+  | "keyword-heavy"
+  | "conceptual";
+
+export type GoldenRetrievalMode = "search" | "context";
+export type EvalResolvedRoute = "search" | "definition";
 
 export interface GoldenExpected {
   filePath?: string;
@@ -17,6 +21,7 @@ export interface GoldenQuery {
   id: string;
   query: string;
   queryType: GoldenQueryType;
+  retrievalMode?: GoldenRetrievalMode;
   expected: GoldenExpected;
 }
 
@@ -62,6 +67,9 @@ export interface PerQueryEvalResult {
   id: string;
   query: string;
   queryType: GoldenQueryType;
+  retrievalMode: GoldenRetrievalMode;
+  resolvedRoute: EvalResolvedRoute;
+  routedQuery: string;
   latencyMs: number;
   hitAt1: boolean;
   hitAt3: boolean;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1828,6 +1828,27 @@ export function mergeTieredResults(
   return out;
 }
 
+export function selectChunksWithFileCoverage<T>(chunks: T[], limit: number): T[] {
+  if (limit <= 0 || chunks.length === 0) {
+    return [];
+  }
+
+  if (chunks.length <= limit) {
+    return chunks;
+  }
+
+  if (limit === 1) {
+    return [chunks[Math.floor((chunks.length - 1) / 2)]!];
+  }
+
+  const selected: T[] = [];
+  for (let index = 0; index < limit; index++) {
+    const sourceIndex = Math.round(index * (chunks.length - 1) / (limit - 1));
+    selected.push(chunks[sourceIndex]!);
+  }
+  return selected;
+}
+
 function matchesSearchFilters(
   candidate: RankedCandidate,
   options: SearchFilterOptions | undefined,
@@ -4015,7 +4036,6 @@ export class Indexer {
         stats.parseFailures.push(relativePath);
       }
 
-      let fileChunkCount = 0;
       let chunksToProcess = parsed.chunks;
 
       if (this.config.indexing.fallbackToTextOnMaxChunks && chunksToProcess.length > this.config.indexing.maxChunksPerFile) {
@@ -4026,10 +4046,12 @@ export class Indexer {
         }
       }
 
+      chunksToProcess = selectChunksWithFileCoverage(
+        chunksToProcess,
+        this.config.indexing.maxChunksPerFile,
+      );
+
       for (const chunk of chunksToProcess) {
-        if (fileChunkCount >= this.config.indexing.maxChunksPerFile) {
-          break;
-        }
 
         if (this.config.indexing.semanticOnly && chunk.chunkType === "other") {
           continue;
@@ -4062,7 +4084,6 @@ export class Indexer {
         });
 
         if (existingContentHash === contentHash) {
-          fileChunkCount++;
           continue;
         }
 
@@ -4089,7 +4110,6 @@ export class Indexer {
           contentHash,
           metadata,
         });
-        fileChunkCount++;
       }
     }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1849,6 +1849,17 @@ export function selectChunksWithFileCoverage<T>(chunks: T[], limit: number): T[]
   return selected;
 }
 
+export function selectIndexableChunks<T extends { chunkType: string }>(
+  chunks: T[],
+  limit: number,
+  semanticOnly: boolean,
+): T[] {
+  const indexableChunks = semanticOnly
+    ? chunks.filter((chunk) => chunk.chunkType !== "other")
+    : chunks;
+  return selectChunksWithFileCoverage(indexableChunks, limit);
+}
+
 function matchesSearchFilters(
   candidate: RankedCandidate,
   options: SearchFilterOptions | undefined,
@@ -4046,17 +4057,13 @@ export class Indexer {
         }
       }
 
-      chunksToProcess = selectChunksWithFileCoverage(
+      chunksToProcess = selectIndexableChunks(
         chunksToProcess,
         this.config.indexing.maxChunksPerFile,
+        this.config.indexing.semanticOnly,
       );
 
       for (const chunk of chunksToProcess) {
-
-        if (this.config.indexing.semanticOnly && chunk.chunkType === "other") {
-          continue;
-        }
-
         const id = generateChunkId(parsed.path, chunk);
         const contentHash = generateChunkHash(chunk);
         const existingContentHash = existingChunks.get(id);

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -27,6 +27,7 @@ import {
   runIndexHealthCheck,
   searchCodebase,
 } from "../tools/operations.js";
+import { inferExactSymbolFromQuery } from "../tools/symbol-inference.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime } from "./shared.js";
 
 function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
@@ -85,6 +86,19 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         });
 
         return { content: [{ type: "text", text: formatDefinitionLookup(results, args.symbol) }] };
+      }
+
+      const inferredSymbol = inferExactSymbolFromQuery(args.query);
+      if (inferredSymbol) {
+        const inferredResults = await implementationLookup(runtime.projectRoot, runtime.host, inferredSymbol, {
+          limit: args.limit ?? 10,
+          fileType: args.fileType,
+          directory: args.directory,
+        });
+
+        if (inferredResults.length > 0) {
+          return { content: [{ type: "text", text: formatDefinitionLookup(inferredResults, inferredSymbol) }] };
+        }
       }
 
       const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -28,6 +28,7 @@ import {
   formatSearchResults,
   formatStatus,
 } from "./tools/utils.js";
+import { inferExactSymbolFromQuery } from "./tools/symbol-inference.js";
 import { registerPiCallGraphTools } from "./pi-call-graph.js";
 
 const HOST = "pi" as const;
@@ -100,6 +101,19 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
           directory: params.directory,
         });
         return text(formatDefinitionLookup(results, params.symbol), results);
+      }
+
+      const inferredSymbol = inferExactSymbolFromQuery(params.query);
+      if (inferredSymbol) {
+        const inferredResults = await implementationLookup(root, HOST, inferredSymbol, {
+          limit: params.limit ?? 10,
+          fileType: params.fileType,
+          directory: params.directory,
+        });
+
+        if (inferredResults.length > 0) {
+          return text(formatDefinitionLookup(inferredResults, inferredSymbol), inferredResults);
+        }
       }
 
       const results = await searchCodebase(root, HOST, params.query, {

--- a/src/tools/symbol-inference.ts
+++ b/src/tools/symbol-inference.ts
@@ -1,0 +1,135 @@
+const IDENTIFIER_RE = /[A-Za-z_$][A-Za-z0-9_$]*/g;
+const QUOTED_BACKTICK_RE = /`([^`]+)`/g;
+const QUOTED_SINGLE_RE = /'([^'\\]+)'/g;
+const QUOTED_DOUBLE_RE = /"([^"]+)"/g;
+
+const SYMBOL_LIKE_RE = /^(?:[A-Za-z_$][A-Za-z0-9_$]*)$/;
+const CAMEL_CASE_RE = /^[a-z_][A-Za-z0-9_$]*[A-Z][A-Za-z0-9_$]*$/;
+const PASCAL_CASE_RE = /^[A-Z][A-Za-z0-9_$]*$/;
+const SNAKE_CASE_RE = /^[a-z][a-z0-9_]*_[a-z0-9_]+$/;
+
+const DEFINITION_INTENT_RE = /\b(where|defined|definition|define|declaration|symbol|function|method|class|interface|type)\b/i;
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "at",
+  "for",
+  "find",
+  "how",
+  "i",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "that",
+  "the",
+  "definition",
+  "show",
+  "to",
+  "where",
+  "which",
+  "what",
+  "you",
+  "your",
+  "with",
+]);
+
+function stripCallSuffix(token: string): string {
+  return token.replace(/\(\s*\)$/, "");
+}
+
+function isLikelySymbolName(token: string): boolean {
+  if (!SYMBOL_LIKE_RE.test(token)) {
+    return false;
+  }
+
+  if (STOP_WORDS.has(token.toLowerCase())) {
+    return false;
+  }
+
+  return CAMEL_CASE_RE.test(token) || PASCAL_CASE_RE.test(token) || SNAKE_CASE_RE.test(token);
+}
+
+function extractQuotedIdentifiers(query: string): string[] {
+  const identifiers = new Set<string>();
+
+  for (const match of query.matchAll(QUOTED_BACKTICK_RE)) {
+    const candidate = stripCallSuffix(match[1]!.trim());
+    if (candidate && isLikelySymbolName(candidate)) {
+      identifiers.add(candidate);
+    }
+  }
+
+  for (const match of query.matchAll(QUOTED_SINGLE_RE)) {
+    const candidate = stripCallSuffix(match[1]!.trim());
+    if (candidate && isLikelySymbolName(candidate)) {
+      identifiers.add(candidate);
+    }
+  }
+
+  for (const match of query.matchAll(QUOTED_DOUBLE_RE)) {
+    const candidate = stripCallSuffix(match[1]!.trim());
+    if (candidate && isLikelySymbolName(candidate)) {
+      identifiers.add(candidate);
+    }
+  }
+
+  return [...identifiers];
+}
+
+function extractBareIdentifiers(query: string): string[] {
+  const unquoted = query
+    .replace(QUOTED_BACKTICK_RE, " ")
+    .replace(QUOTED_SINGLE_RE, " ")
+    .replace(QUOTED_DOUBLE_RE, " ");
+
+  const identifiers = new Set<string>();
+  for (const match of unquoted.matchAll(IDENTIFIER_RE)) {
+    const candidate = stripCallSuffix(match[0]);
+    if (isLikelySymbolName(candidate)) {
+      identifiers.add(candidate);
+    }
+  }
+
+  return [...identifiers];
+}
+
+function isSingleMeaningfulToken(query: string, symbol: string): boolean {
+  const tokens = query
+    .replace(/[`'"()]/g, " ")
+    .split(/[^A-Za-z0-9_$]+/)
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length > 0)
+    .filter((token) => !STOP_WORDS.has(token));
+
+  return tokens.length === 1 && tokens[0] === symbol.toLowerCase();
+}
+
+export function inferExactSymbolFromQuery(query: string): string | undefined {
+  const quoted = extractQuotedIdentifiers(query);
+  if (quoted.length === 1) {
+    return quoted[0];
+  }
+  if (quoted.length > 1) {
+    return undefined;
+  }
+
+  const candidates = extractBareIdentifiers(query);
+  if (candidates.length !== 1) {
+    return undefined;
+  }
+
+  const candidate = candidates[0];
+  if (DEFINITION_INTENT_RE.test(query)) {
+    return candidate;
+  }
+
+  if (isSingleMeaningfulToken(query, candidate)) {
+    return candidate;
+  }
+
+  return undefined;
+}

--- a/tests/eval-runner.test.ts
+++ b/tests/eval-runner.test.ts
@@ -92,6 +92,7 @@ describe("eval runner", () => {
               id: "q1",
               query: "where is rankHybridResults implementation",
               queryType: "definition",
+              retrievalMode: "context",
               expected: {
                 filePath: "src/indexer/index.ts",
                 symbol: "rankHybridResults",
@@ -121,6 +122,8 @@ describe("eval runner", () => {
     });
 
     expect(result.summary.queryCount).toBe(1);
+    expect(result.perQuery[0]?.resolvedRoute).toBe("definition");
+    expect(result.perQuery[0]?.routedQuery).toBe("rankHybridResults");
     expect(typeof result.summary.metrics.distinctTop3Ratio).toBe("number");
     expect(typeof result.summary.metrics.rawDistinctTop3Ratio).toBe("number");
     expect(readFileSync(path.join(result.outputDir, "summary.json"), "utf-8")).toContain("\"metrics\"");

--- a/tests/eval-schema.test.ts
+++ b/tests/eval-schema.test.ts
@@ -38,6 +38,48 @@ describe("eval schema", () => {
 
     expect(dataset.name).toBe("small");
     expect(dataset.queries).toHaveLength(1);
+    expect(dataset.queries[0]?.retrievalMode).toBe("search");
+  });
+
+  it("parses agent-facing context retrieval queries", () => {
+    const dataset = parseGoldenDataset(
+      {
+        version: "1.0.0",
+        name: "agent-context",
+        queries: [
+          {
+            id: "q1",
+            query: "where is createMcpServer defined",
+            queryType: "conceptual",
+            retrievalMode: "context",
+            expected: { filePath: "src/mcp-server.ts" },
+          },
+        ],
+      },
+      "dataset.json",
+    );
+
+    expect(dataset.queries[0]?.queryType).toBe("conceptual");
+    expect(dataset.queries[0]?.retrievalMode).toBe("context");
+  });
+
+  it("rejects unknown retrieval modes", () => {
+    expect(() => parseGoldenDataset(
+      {
+        version: "1.0.0",
+        name: "invalid",
+        queries: [
+          {
+            id: "q1",
+            query: "where",
+            queryType: "conceptual",
+            retrievalMode: "magic",
+            expected: { filePath: "src/index.ts" },
+          },
+        ],
+      },
+      "dataset.json",
+    )).toThrow(/retrievalMode.*search, context/);
   });
 
   it("rejects dataset with missing expected path", () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -35,6 +35,7 @@ const indexerMockState = vi.hoisted(() => ({
   constructorArgs: [] as Array<[string, unknown]>,
   instances: [] as Array<{
     initialize: ReturnType<typeof vi.fn>;
+    search: ReturnType<typeof vi.fn>;
     getStatus: ReturnType<typeof vi.fn>;
     getCallers: ReturnType<typeof vi.fn>;
     getCallees: ReturnType<typeof vi.fn>;
@@ -97,6 +98,7 @@ vi.mock("../src/indexer/index.js", () => {
       indexerMockState.constructorArgs.push([projectRoot, config]);
       indexerMockState.instances.push({
         initialize: this.initialize,
+        search: this.search,
         getStatus: this.getStatus,
         getCallers: this.getCallers,
         getCallees: this.getCallees,
@@ -450,6 +452,68 @@ describe("MCP server tools and prompts", () => {
 
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain('function "validateToken"');
+    const indexer = indexerMockState.instances.at(-1);
+    expect(indexer?.search).toHaveBeenCalledWith(
+      "validateToken",
+      10,
+      expect.objectContaining({ definitionIntent: true }),
+    );
+  });
+
+  it("should infer an exact symbol and route through implementation lookup", async () => {
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "Find definition for `getStatus`" },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain('function "validateToken"');
+    const indexer = indexerMockState.instances.at(-1);
+    expect(indexer?.search).toHaveBeenCalledWith(
+      "getStatus",
+      10,
+      expect.objectContaining({ definitionIntent: true }),
+    );
+  });
+
+  it("should fall back to conceptual search when inferred symbol lookup returns no matches", async () => {
+    const warmResult = [{
+      filePath: "src/auth.ts",
+      startLine: 10,
+      endLine: 25,
+      name: "validateToken",
+      chunkType: "function",
+      content: "function validateToken(token: string) {\n  return token.length > 0;\n}",
+      score: 0.95,
+    }];
+
+    const warmup = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "known symbol", symbol: "validateToken" },
+    });
+    expect(warmup.content).toBeDefined();
+
+    const indexer = indexerMockState.instances.at(-1);
+    indexer?.search.mockImplementation(async (query: string) => {
+      if (query === "missingDefinition") {
+        return [];
+      }
+
+      return warmResult;
+    });
+
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "Find definition for `missingDefinition`" },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain("Found 1 locations for \"Find definition for `missingDefinition`\":");
+    expect(indexer?.search).toHaveBeenCalledWith(
+      "Find definition for `missingDefinition`",
+      10,
+      expect.objectContaining({ metadataOnly: true }),
+    );
   });
 
   it("should route codebase_context endpoint pairs to call graph paths", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -223,6 +223,80 @@ describe("Pi adapter conformance", () => {
     });
   });
 
+  it("routes inferred symbol-style codebase_context queries through implementation lookup", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([
+      {
+        chunkType: "function",
+        name: "getStatus",
+        filePath: "src/auth.ts",
+        startLine: 12,
+        endLine: 30,
+        score: 0.95,
+        content: "function getStatus() {}",
+      },
+    ]);
+
+    const { tools } = await registerPiTools();
+
+    const result = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "where is `getStatus` defined" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "pi", "getStatus", {
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+    });
+    expect(result?.content[0]?.text).toContain("\"getStatus\"");
+  });
+
+  it("falls back to conceptual search when inferred symbol lookup returns no matches", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([]);
+    operationMocks.searchCodebase.mockResolvedValue([
+      {
+        chunkType: "function",
+        name: "missingDefinition",
+        filePath: "src/auth.ts",
+        startLine: 12,
+        endLine: 30,
+        score: 0.95,
+        content: "function missingDefinition() {}",
+      },
+    ]);
+
+    const { tools } = await registerPiTools();
+
+    const result = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "show definition for `missingDefinition`" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "pi", "missingDefinition", {
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+    });
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith(
+      "/repo",
+      "pi",
+      "show definition for `missingDefinition`",
+      {
+        limit: 10,
+        fileType: undefined,
+        directory: undefined,
+        metadataOnly: true,
+      },
+    );
+    expect(result?.content[0]?.text).toContain("Found 1 locations for \"show definition for `missingDefinition`\":");
+  });
+
   it("routes codebase_context query-only lookups with metadata-only search", async () => {
     operationMocks.searchCodebase.mockResolvedValue([
       {

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -13,6 +13,7 @@ import {
   rankSemanticOnlyResults,
   mergeTieredResults,
   rankHybridResults,
+  selectChunksWithFileCoverage,
   stripFilePathHint,
   rerankResults,
 } from "../src/indexer/index.js";
@@ -287,6 +288,20 @@ describe("retrieval ranking", () => {
     const merged = mergeTieredResults(symbolLane, hybridLane, 5);
     expect(merged.map((r) => r.id).slice(0, 2)).toEqual(["def1", "def2"]);
     expect(merged.map((r) => r.id)).toContain("noise");
+  });
+
+  it("preserves coverage across large files when enforcing a chunk limit", () => {
+    const chunks = Array.from({ length: 201 }, (_, index) => index);
+
+    const selected = selectChunksWithFileCoverage(chunks, 5);
+
+    expect(selected).toEqual([0, 50, 100, 150, 200]);
+  });
+
+  it("handles whole-file chunk coverage edge cases", () => {
+    expect(selectChunksWithFileCoverage([0, 1, 2], 5)).toEqual([0, 1, 2]);
+    expect(selectChunksWithFileCoverage([0, 1, 2], 1)).toEqual([1]);
+    expect(selectChunksWithFileCoverage([0, 1, 2], 0)).toEqual([]);
   });
 
   it("builds fallback lane from implementation code-term hints when exact symbol names are unavailable", () => {

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -14,6 +14,7 @@ import {
   mergeTieredResults,
   rankHybridResults,
   selectChunksWithFileCoverage,
+  selectIndexableChunks,
   stripFilePathHint,
   rerankResults,
 } from "../src/indexer/index.js";
@@ -302,6 +303,23 @@ describe("retrieval ranking", () => {
     expect(selectChunksWithFileCoverage([0, 1, 2], 5)).toEqual([0, 1, 2]);
     expect(selectChunksWithFileCoverage([0, 1, 2], 1)).toEqual([1]);
     expect(selectChunksWithFileCoverage([0, 1, 2], 0)).toEqual([]);
+  });
+
+  it("filters generic chunks before sampling a semantic-only file", () => {
+    const chunks = [
+      ...Array.from({ length: 100 }, (_, id) => ({ id: `other-${id}`, chunkType: "other" })),
+      ...Array.from({ length: 10 }, (_, id) => ({ id: `function-${id}`, chunkType: "function" })),
+    ];
+
+    const selected = selectIndexableChunks(chunks, 5, true);
+
+    expect(selected.map((chunk) => chunk.id)).toEqual([
+      "function-0",
+      "function-2",
+      "function-5",
+      "function-7",
+      "function-9",
+    ]);
   });
 
   it("builds fallback lane from implementation code-term hints when exact symbol names are unavailable", () => {

--- a/tests/symbol-inference.test.ts
+++ b/tests/symbol-inference.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+import { inferExactSymbolFromQuery } from "../src/tools/symbol-inference.js";
+
+describe("inferExactSymbolFromQuery", () => {
+  it("infers a backticked identifier", () => {
+    expect(inferExactSymbolFromQuery("Where is `getStatus` defined?"))
+      .toBe("getStatus");
+  });
+
+  it("infers a quoted identifier", () => {
+    expect(inferExactSymbolFromQuery("Where is 'rerankResults' defined?"))
+      .toBe("rerankResults");
+  });
+
+  it("infers camelCase identifier from definition-style language", () => {
+    expect(inferExactSymbolFromQuery("where is function getStatus defined"))
+      .toBe("getStatus");
+  });
+
+  it("infers PascalCase and snake_case candidates", () => {
+    expect(inferExactSymbolFromQuery("Where is the Indexer class defined?"))
+      .toBe("Indexer");
+    expect(inferExactSymbolFromQuery("Definition for RerankResults"))
+      .toBe("RerankResults");
+    expect(inferExactSymbolFromQuery("Find definition for rerank_results"))
+      .toBe("rerank_results");
+  });
+
+  it("does not infer ambiguous or non-symbol queries", () => {
+    expect(inferExactSymbolFromQuery("find where auth logic is handled"))
+      .toBeUndefined();
+    expect(inferExactSymbolFromQuery("get status then define"))
+      .toBeUndefined();
+    expect(inferExactSymbolFromQuery("compare getStatus and forceIndex definitions"))
+      .toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Improve agent-facing codebase understanding with conservative automatic definition routing, a reproducible `codebase_context` evaluation dataset, and representative indexing coverage for files that exceed the per-file chunk cap.

On a fresh local Ollama index, the fairly labeled agent-context benchmark improved:

- Hit@5: **41.67% → 50.00%**
- MRR@10: **0.3593 → 0.4519**
- Final p95 query latency: **41.47 ms**

## Changes

- Add shared exact-symbol inference for unambiguous definition-style questions and use it consistently in MCP and Pi `codebase_context`, while preserving explicit symbol/path routes and conceptual-search fallback.
- Add `benchmarks/golden/agent-context.json`, `npm run eval:agent`, schema support for `retrievalMode: context` and conceptual queries, plus visible `resolvedRoute` and `routedQuery` artifacts.
- Distribute capped chunks across large files instead of indexing only the beginning, with deterministic regression coverage. Semantic-only filtering now happens before sampling so generic chunks cannot consume the useful per-file budget.
- Document the evaluation workflow and record the changes under `Unreleased`.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional validation:

- Full suite: **49 files, 957 tests passed**
- Fresh real-provider evaluation: `npm run eval:agent -- --reindex`
- Final artifact: Hit@5 **50.00%**, MRR@10 **0.4519**, p95 **41.47 ms**
- `git diff --check` passed

## Release Labels

- [x] Added at least one release category label (`feature`, `documentation`, and `test`)
- [x] Added at most one semver label (`semver:minor`)

## Related Issues

N/A

