### PR TITLE
feat: add token-budgeted codebase context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Agent-facing retrieval evaluation**: Added a versioned `codebase_context` golden dataset, `npm run eval:agent`, and per-query route metadata for measuring definition routing and conceptual discovery.
+- **Token-budgeted context packs**: Added deterministic, overlapping-result deduplication and cross-file evidence selection with configurable 128-4000 token response budgets across native OpenCode, MCP, and Pi clients.
+- **Context efficiency gates**: Added returned-token, duplicate-candidate, file-diversity, and quality-per-1,000-token evaluation metrics with configurable CI thresholds.
 
 ### Changed
 
 - **Automatic definition routing**: MCP and Pi `codebase_context` now conservatively infer unambiguous symbol names from definition-style questions before falling back to conceptual search.
 - **Large-file retrieval coverage**: Files exceeding `maxChunksPerFile` now retain representative chunks from across the file instead of silently indexing only the beginning.
+- **Location-first context details**: `codebase_context` definition and conceptual routes now return compact locations rather than full source bodies; Pi details expose metadata only.
 
 ## [0.16.0] - 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Use the same semantic search from any MCP-compatible client. Index once, search 
    npx -y --package opencode-codebase-index opencode-codebase-index-mcp
    ```
 
-The MCP server exposes all 13 tools (`codebase_context`, `codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`).
+The MCP server exposes all 13 tools (`codebase_context`, `codebase_search`, `codebase_peek`, `find_similar`, `implementation_lookup`, `call_graph`, `call_graph_path`, `pr_impact`, `index_codebase`, `index_status`, `index_health_check`, `index_metrics`, `index_logs`) and 5 prompts (`search`, `find`, `definition`, `index`, `status`). Native OpenCode and Pi integrations expose the same `codebase_context` entry point.
 
 The tools carry self-routing descriptions so clients can choose the lightweight path without relying on separate documentation:
 
@@ -240,6 +240,8 @@ The tools carry self-routing descriptions so clients can choose the lightweight 
 5. `codebase_search` only when full semantic content is needed
 6. `grep` for exact identifiers or exhaustive matches
 7. `call_graph` / `call_graph_path` for direct graph queries
+
+`codebase_context` accepts a `tokenBudget` from 128 to 4000 tokens, defaulting to 1200. It returns deterministic location evidence rather than source bodies, removes overlapping same-file results, diversifies the selected evidence across files, and reports omitted candidates. Increase the budget only when broader location coverage is useful. Use `implementation_lookup`, `codebase_search`, or a targeted file read for the exact source after selecting a location.
 
 The server also publishes this workflow through the standard MCP initialization `instructions` field. Client behavior remains client-controlled: an MCP server can describe and recommend its tools, but cannot force an agent host to read server instructions or invoke a tool before filesystem search. Clients that ignore MCP instructions still receive the routing guidance in each tool description.
 
@@ -270,8 +272,8 @@ src/api/checkout.ts:89      (Route handler for /pay)
 
 | Scenario | Tool | Why |
 |----------|------|-----|
-| Don't know the function name | `codebase_context` (MCP) | Routes conceptual questions to low-token discovery first |
-| Exploring unfamiliar codebase | `codebase_context` (MCP) | Discovers related code and then guides to definitions or graph queries |
+| Don't know the function name | `codebase_context` | Routes conceptual questions to a bounded, low-token evidence pack |
+| Exploring unfamiliar codebase | `codebase_context` | Available natively in OpenCode and Pi, and through MCP for other clients |
 | Just need to find locations | `codebase_peek` (or `codebase_context`) | Returns metadata only, saves ~90% tokens |
 | Need the authoritative definition site | `implementation_lookup` | Prioritizes real implementation definitions over docs/tests |
 | Understand code flow | `call_graph` | Find callers/callees of any function |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ The tools carry self-routing descriptions so clients can choose the lightweight 
 6. `grep` for exact identifiers or exhaustive matches
 7. `call_graph` / `call_graph_path` for direct graph queries
 
-`codebase_context` accepts a `tokenBudget` from 128 to 4000 tokens, defaulting to 1200. It returns deterministic location evidence rather than source bodies, removes overlapping same-file results, diversifies the selected evidence across files, and reports omitted candidates. Increase the budget only when broader location coverage is useful. Use `implementation_lookup`, `codebase_search`, or a targeted file read for the exact source after selecting a location.
+`codebase_context` accepts a `tokenBudget` from 128 to 4000 tokens, defaulting to 1200. The hard cap is counted with the `cl100k_base` tokenizer, including multilingual and emoji text. It returns deterministic location evidence rather than source bodies, removes overlapping same-file results, diversifies evidence across files, and distinguishes duplicates, result-limit exclusions, and token-budget omissions. Increase the budget only when broader location coverage is useful. Use `implementation_lookup`, `codebase_search`, or a targeted file read for the exact source after selecting a location.
 
 The server also publishes this workflow through the standard MCP initialization `instructions` field. Client behavior remains client-controlled: an MCP server can describe and recommend its tools, but cannot force an agent host to read server instructions or invoke a tool before filesystem search. Clients that ignore MCP instructions still receive the routing guidance in each tool description.
 

--- a/benchmarks/budgets/agent-context.json
+++ b/benchmarks/budgets/agent-context.json
@@ -1,11 +1,10 @@
 {
-  "name": "github-models-eval-budget",
+  "name": "agent-context-eval-budget",
   "failOnMissingBaseline": false,
   "thresholds": {
-    "minHitAt5": 0.5,
-    "minMrrAt10": 0.45,
-    "minRawDistinctTop3Ratio": 0.5,
-    "p95LatencyMaxAbsoluteMs": 500,
+    "p95LatencyMaxAbsoluteMs": 4000,
+    "minHitAt5": 0.25,
+    "minMrrAt10": 0.18,
     "maxContextResponseTokensAverage": 1000,
     "maxContextResponseTokensP95": 1200,
     "maxContextResponseTokensMax": 1200,

--- a/benchmarks/budgets/default.json
+++ b/benchmarks/budgets/default.json
@@ -10,6 +10,13 @@
     "p95LatencyMaxAbsoluteMs": 4000,
     "minHitAt5": 0.4,
     "minMrrAt10": 0.25,
-    "minRawDistinctTop3Ratio": 0.5
+    "minRawDistinctTop3Ratio": 0.5,
+    "maxContextResponseTokensAverage": 1000,
+    "maxContextResponseTokensP95": 1200,
+    "maxContextResponseTokensMax": 1200,
+    "maxContextDuplicateCandidateRatio": 0.5,
+    "minContextSelectedFileRatio": 0.5,
+    "minContextHitAt5Per1kResponseTokens": 0.5,
+    "minContextMrrAt10Per1kResponseTokens": 0.25
   }
 }

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -17,6 +17,21 @@ agent-facing `codebase_context` gateway, run:
 npm run eval:agent
 ```
 
+Run the agent-facing dataset with its matching quality and context-efficiency gates:
+
+```bash
+npm run eval:agent:ci
+```
+
+Evaluation comparisons require the same dataset name, version, and query count. Use the
+agent-context budget rather than the default search baseline when evaluating `agent-context.json`.
+
+Context-mode evaluation applies the production evidence packer with its default
+1200-token response budget. The pack contains location evidence only, removes
+overlapping same-file candidates, and round-robins across files before selecting
+additional locations from the same file. Agents should drill into chosen
+locations with `implementation_lookup`, `codebase_search`, or targeted file reads.
+
 Optional flags:
 
 - `--project <path>`: project root (default: current directory)
@@ -242,6 +257,9 @@ The harness computes:
 - nDCG@10
 - Latency p50/p95/p99
 - Token estimate + embedding call counts + estimated embedding cost
+- Context response-token total/average/p95/max
+- Context duplicate-candidate and selected-file ratios
+- Context Hit@5 and MRR@10 per 1,000 returned response tokens
 - Failure buckets:
   - `wrong-file`
   - `wrong-symbol`
@@ -300,7 +318,14 @@ Example:
     "p95LatencyMaxMultiplier": 1.35,
     "p95LatencyMaxAbsoluteMs": 4000,
     "minHitAt5": 0.4,
-    "minMrrAt10": 0.25
+    "minMrrAt10": 0.25,
+    "maxContextResponseTokensAverage": 1000,
+    "maxContextResponseTokensP95": 1200,
+    "maxContextResponseTokensMax": 1200,
+    "maxContextDuplicateCandidateRatio": 0.5,
+    "minContextSelectedFileRatio": 0.5,
+    "minContextHitAt5Per1kResponseTokens": 0.5,
+    "minContextMrrAt10Per1kResponseTokens": 0.25
   }
 }
 ```
@@ -310,3 +335,6 @@ Guidance:
 - Tighten `hitAt5MaxDrop` / `mrrAt10MaxDrop` gradually.
 - Keep `p95LatencyMaxMultiplier` tolerant enough for CI variance.
 - Use absolute floor metrics (`minHitAt5`, `minMrrAt10`) to prevent silent quality drift.
+- Keep context response caps at or below the production default unless a dataset intentionally exercises a larger `tokenBudget`.
+- Track quality-per-token floors together with absolute quality so smaller responses do not pass by becoming less useful.
+- Duplicate-candidate gates measure retrieval waste before packing; the selected-file floor prevents evidence from concentrating in too few files.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -252,6 +252,8 @@ Validation errors are surfaced with clear path-specific messages (e.g. `queries[
 
 The harness computes:
 
+Context response budgets and response-token metrics use the `cl100k_base` tokenizer rather than a character heuristic.
+
 - Hit@1, Hit@3, Hit@5, Hit@10
 - MRR@10
 - nDCG@10

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dev": "tsup --watch",
     "eval": "npx tsx src/cli.ts eval run",
     "eval:agent": "npx tsx src/cli.ts eval run --dataset benchmarks/golden/agent-context.json",
+    "eval:agent:ci": "npx tsx src/cli.ts eval run --dataset benchmarks/golden/agent-context.json --reindex --ci --budget benchmarks/budgets/agent-context.json",
     "eval:smoke": "npx tsx src/cli.ts eval run --config .github/eval-config.json --reindex --dataset benchmarks/golden/small.json",
     "eval:ci": "npx tsx src/cli.ts eval run --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:ci:ollama": "npx tsx src/cli.ts eval run --config .github/eval-ollama-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",

--- a/src/eval/budget.ts
+++ b/src/eval/budget.ts
@@ -89,6 +89,79 @@ export function evaluateBudgetGate(
     });
   }
 
+  const context = summary.metrics.contextEfficiency;
+  if (context.queryCount > 0) {
+    if (
+      thresholds.maxContextResponseTokensAverage !== undefined &&
+      context.responseTokens.average > thresholds.maxContextResponseTokensAverage
+    ) {
+      violations.push({
+        metric: "maxContextResponseTokensAverage",
+        message: `Context response average ${context.responseTokens.average.toFixed(1)} tokens exceeds maximum ${thresholds.maxContextResponseTokensAverage.toFixed(1)}`,
+      });
+    }
+
+    if (
+      thresholds.maxContextResponseTokensP95 !== undefined &&
+      context.responseTokens.p95 > thresholds.maxContextResponseTokensP95
+    ) {
+      violations.push({
+        metric: "maxContextResponseTokensP95",
+        message: `Context response p95 ${context.responseTokens.p95.toFixed(1)} tokens exceeds maximum ${thresholds.maxContextResponseTokensP95.toFixed(1)}`,
+      });
+    }
+
+    if (
+      thresholds.maxContextResponseTokensMax !== undefined &&
+      context.responseTokens.max > thresholds.maxContextResponseTokensMax
+    ) {
+      violations.push({
+        metric: "maxContextResponseTokensMax",
+        message: `Context response maximum ${context.responseTokens.max.toFixed(1)} tokens exceeds maximum ${thresholds.maxContextResponseTokensMax.toFixed(1)}`,
+      });
+    }
+
+    if (
+      thresholds.maxContextDuplicateCandidateRatio !== undefined &&
+      context.duplicateCandidateRatio > thresholds.maxContextDuplicateCandidateRatio
+    ) {
+      violations.push({
+        metric: "maxContextDuplicateCandidateRatio",
+        message: `Context duplicate candidate ratio ${context.duplicateCandidateRatio.toFixed(4)} exceeds maximum ${thresholds.maxContextDuplicateCandidateRatio.toFixed(4)}`,
+      });
+    }
+
+    if (
+      thresholds.minContextSelectedFileRatio !== undefined &&
+      context.selectedFileRatio < thresholds.minContextSelectedFileRatio
+    ) {
+      violations.push({
+        metric: "minContextSelectedFileRatio",
+        message: `Context selected-file ratio ${context.selectedFileRatio.toFixed(4)} is below minimum ${thresholds.minContextSelectedFileRatio.toFixed(4)}`,
+      });
+    }
+
+    if (
+      thresholds.minContextHitAt5Per1kResponseTokens !== undefined &&
+      context.hitAt5Per1kResponseTokens < thresholds.minContextHitAt5Per1kResponseTokens
+    ) {
+      violations.push({
+        metric: "minContextHitAt5Per1kResponseTokens",
+        message: `Context Hit@5 per 1k response tokens ${context.hitAt5Per1kResponseTokens.toFixed(4)} is below minimum ${thresholds.minContextHitAt5Per1kResponseTokens.toFixed(4)}`,
+      });
+    }
+
+    if (
+      thresholds.minContextMrrAt10Per1kResponseTokens !== undefined &&
+      context.mrrAt10Per1kResponseTokens < thresholds.minContextMrrAt10Per1kResponseTokens
+    ) {
+      violations.push({
+        metric: "minContextMrrAt10Per1kResponseTokens",
+        message: `Context MRR@10 per 1k response tokens ${context.mrrAt10Per1kResponseTokens.toFixed(4)} is below minimum ${thresholds.minContextMrrAt10Per1kResponseTokens.toFixed(4)}`,
+      });
+    }
+  }
+
   return {
     passed: violations.length === 0,
     budgetName: budget.name,

--- a/src/eval/compare.ts
+++ b/src/eval/compare.ts
@@ -12,6 +12,17 @@ function metricDelta(current: number, baseline: number): MetricDelta {
 }
 
 export function compareSummaries(current: EvalSummary, baseline: EvalSummary, againstPath: string): EvalComparison {
+  if (
+    current.datasetName !== baseline.datasetName ||
+    current.datasetVersion !== baseline.datasetVersion ||
+    current.queryCount !== baseline.queryCount
+  ) {
+    throw new Error(
+      `Cannot compare incompatible evaluation datasets: current=${current.datasetName}@${current.datasetVersion} (${current.queryCount} queries), ` +
+      `baseline=${baseline.datasetName}@${baseline.datasetVersion} (${baseline.queryCount} queries) at ${againstPath}`,
+    );
+  }
+
   return {
     againstPath,
     deltas: {
@@ -33,6 +44,34 @@ export function compareSummaries(current: EvalSummary, baseline: EvalSummary, ag
       estimatedCostUsd: metricDelta(
         current.metrics.embedding.estimatedCostUsd,
         baseline.metrics.embedding.estimatedCostUsd
+      ),
+      contextResponseTokensAverage: metricDelta(
+        current.metrics.contextEfficiency.responseTokens.average,
+        baseline.metrics.contextEfficiency.responseTokens.average,
+      ),
+      contextResponseTokensP95: metricDelta(
+        current.metrics.contextEfficiency.responseTokens.p95,
+        baseline.metrics.contextEfficiency.responseTokens.p95,
+      ),
+      contextResponseTokensMax: metricDelta(
+        current.metrics.contextEfficiency.responseTokens.max,
+        baseline.metrics.contextEfficiency.responseTokens.max,
+      ),
+      contextDuplicateCandidateRatio: metricDelta(
+        current.metrics.contextEfficiency.duplicateCandidateRatio,
+        baseline.metrics.contextEfficiency.duplicateCandidateRatio,
+      ),
+      contextSelectedFileRatio: metricDelta(
+        current.metrics.contextEfficiency.selectedFileRatio,
+        baseline.metrics.contextEfficiency.selectedFileRatio,
+      ),
+      contextHitAt5Per1kResponseTokens: metricDelta(
+        current.metrics.contextEfficiency.hitAt5Per1kResponseTokens,
+        baseline.metrics.contextEfficiency.hitAt5Per1kResponseTokens,
+      ),
+      contextMrrAt10Per1kResponseTokens: metricDelta(
+        current.metrics.contextEfficiency.mrrAt10Per1kResponseTokens,
+        baseline.metrics.contextEfficiency.mrrAt10Per1kResponseTokens,
       ),
     },
   };

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -144,6 +144,13 @@ export function buildPerQueryResult(
     resolvedRoute: "search",
     routedQuery: query.query,
   },
+  context?: {
+    tokenBudget: number;
+    responseTokens: number;
+    candidateCount: number;
+    deduplicatedCount: number;
+    omittedCount: number;
+  },
 ): PerQueryEvalResult {
   const relevantPaths = getRelevantPaths(query);
   const deduped = uniqueResultsByPath(results);
@@ -166,6 +173,18 @@ export function buildPerQueryResult(
     ndcgAt10: ndcgAtK(deduped, relevantPaths, 10),
     failureBucket: classifyFailureBucket(query, results, k),
     rawTop3DistinctRatio: distinctTopKRatio(results, 3),
+    tokenBudget: context?.tokenBudget,
+    responseTokens: context?.responseTokens ?? 0,
+    candidateCount: context?.candidateCount ?? results.length,
+    deduplicatedCount: context?.deduplicatedCount ?? results.length,
+    selectedCount: results.length,
+    omittedCount: context?.omittedCount ?? 0,
+    duplicateCandidateRatio: context && context.candidateCount > 0
+      ? (context.candidateCount - context.deduplicatedCount) / context.candidateCount
+      : 0,
+    selectedFileRatio: results.length === 0
+      ? 0
+      : new Set(results.map((result) => normalizePath(result.filePath))).size / results.length,
     results: deduped,
   };
 
@@ -201,6 +220,10 @@ export function computeEvalMetrics(
   };
 
   const latencies = perQuery.map((item) => item.latencyMs);
+  const contextQueries = perQuery.filter((item) => item.retrievalMode === "context");
+  const contextResponseTokens = contextQueries.map((item) => item.responseTokens);
+  const totalContextResponseTokens = contextResponseTokens.reduce((sum, value) => sum + value, 0);
+  const contextTokenUnits = totalContextResponseTokens / 1000;
 
   for (const query of perQuery) {
     if (query.hitAt1) sum.hitAt1 += 1;
@@ -240,6 +263,27 @@ export function computeEvalMetrics(
       callCount: embeddingCallCount,
       estimatedCostUsd: (embeddingTokensUsed / 1_000_000) * costPer1MTokensUsd,
       costPer1MTokensUsd,
+    },
+    contextEfficiency: {
+      queryCount: contextQueries.length,
+      responseTokens: {
+        total: totalContextResponseTokens,
+        average: contextQueries.length === 0 ? 0 : totalContextResponseTokens / contextQueries.length,
+        p95: percentile(contextResponseTokens, 0.95),
+        max: contextResponseTokens.length === 0 ? 0 : Math.max(...contextResponseTokens),
+      },
+      duplicateCandidateRatio: contextQueries.length === 0
+        ? 0
+        : contextQueries.reduce((sum, item) => sum + item.duplicateCandidateRatio, 0) / contextQueries.length,
+      selectedFileRatio: contextQueries.length === 0
+        ? 0
+        : contextQueries.reduce((sum, item) => sum + item.selectedFileRatio, 0) / contextQueries.length,
+      hitAt5Per1kResponseTokens: contextTokenUnits === 0
+        ? 0
+        : contextQueries.filter((item) => item.hitAt5).length / contextTokenUnits,
+      mrrAt10Per1kResponseTokens: contextTokenUnits === 0
+        ? 0
+        : contextQueries.reduce((sum, item) => sum + item.reciprocalRankAt10, 0) / contextTokenUnits,
     },
     failureBuckets,
   };

--- a/src/eval/report-formatters.ts
+++ b/src/eval/report-formatters.ts
@@ -43,6 +43,26 @@ export function validateSummary(
   assertFiniteNumber(summary.metrics.embedding.callCount, `${summaryPath}.metrics.embedding.callCount`);
   assertFiniteNumber(summary.metrics.embedding.estimatedCostUsd, `${summaryPath}.metrics.embedding.estimatedCostUsd`);
 
+  if (!summary.metrics.contextEfficiency) {
+    summary.metrics.contextEfficiency = {
+      queryCount: 0,
+      responseTokens: { total: 0, average: 0, p95: 0, max: 0 },
+      duplicateCandidateRatio: 0,
+      selectedFileRatio: 0,
+      hitAt5Per1kResponseTokens: 0,
+      mrrAt10Per1kResponseTokens: 0,
+    };
+  }
+  assertFiniteNumber(summary.metrics.contextEfficiency.queryCount, `${summaryPath}.metrics.contextEfficiency.queryCount`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.responseTokens.total, `${summaryPath}.metrics.contextEfficiency.responseTokens.total`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.responseTokens.average, `${summaryPath}.metrics.contextEfficiency.responseTokens.average`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.responseTokens.p95, `${summaryPath}.metrics.contextEfficiency.responseTokens.p95`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.responseTokens.max, `${summaryPath}.metrics.contextEfficiency.responseTokens.max`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.duplicateCandidateRatio, `${summaryPath}.metrics.contextEfficiency.duplicateCandidateRatio`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.selectedFileRatio, `${summaryPath}.metrics.contextEfficiency.selectedFileRatio`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.hitAt5Per1kResponseTokens, `${summaryPath}.metrics.contextEfficiency.hitAt5Per1kResponseTokens`);
+  assertFiniteNumber(summary.metrics.contextEfficiency.mrrAt10Per1kResponseTokens, `${summaryPath}.metrics.contextEfficiency.mrrAt10Per1kResponseTokens`);
+
   return summary;
 }
 

--- a/src/eval/reports.ts
+++ b/src/eval/reports.ts
@@ -87,6 +87,15 @@ export function createSummaryMarkdown(
   lines.push(`| Embedding calls | ${summary.metrics.embedding.callCount} |`);
   lines.push(`| Embedding tokens | ${summary.metrics.tokenEstimate.embeddingTokensUsed} |`);
   lines.push(`| Estimated embedding cost | ${formatUsd(summary.metrics.embedding.estimatedCostUsd)} |`);
+  lines.push(`| Context queries | ${summary.metrics.contextEfficiency.queryCount} |`);
+  lines.push(`| Context response tokens total | ${summary.metrics.contextEfficiency.responseTokens.total} |`);
+  lines.push(`| Context response tokens avg | ${summary.metrics.contextEfficiency.responseTokens.average.toFixed(1)} |`);
+  lines.push(`| Context response tokens p95 | ${summary.metrics.contextEfficiency.responseTokens.p95.toFixed(1)} |`);
+  lines.push(`| Context response tokens max | ${summary.metrics.contextEfficiency.responseTokens.max.toFixed(1)} |`);
+  lines.push(`| Context duplicate candidate ratio | ${formatPct(summary.metrics.contextEfficiency.duplicateCandidateRatio)} |`);
+  lines.push(`| Context selected-file ratio | ${formatPct(summary.metrics.contextEfficiency.selectedFileRatio)} |`);
+  lines.push(`| Context Hit@5 / 1k response tokens | ${summary.metrics.contextEfficiency.hitAt5Per1kResponseTokens.toFixed(4)} |`);
+  lines.push(`| Context MRR@10 / 1k response tokens | ${summary.metrics.contextEfficiency.mrrAt10Per1kResponseTokens.toFixed(4)} |`);
   lines.push("");
 
   lines.push("## Failure Buckets");
@@ -131,6 +140,27 @@ export function createSummaryMarkdown(
     );
     lines.push(
       `| p95 latency (ms) | ${comparison.deltas.latencyP95Ms.baseline.toFixed(3)} | ${comparison.deltas.latencyP95Ms.current.toFixed(3)} | ${signed(comparison.deltas.latencyP95Ms.absolute, 3)} |`
+    );
+    lines.push(
+      `| Context response tokens avg | ${comparison.deltas.contextResponseTokensAverage.baseline.toFixed(1)} | ${comparison.deltas.contextResponseTokensAverage.current.toFixed(1)} | ${signed(comparison.deltas.contextResponseTokensAverage.absolute, 1)} |`
+    );
+    lines.push(
+      `| Context response tokens p95 | ${comparison.deltas.contextResponseTokensP95.baseline.toFixed(1)} | ${comparison.deltas.contextResponseTokensP95.current.toFixed(1)} | ${signed(comparison.deltas.contextResponseTokensP95.absolute, 1)} |`
+    );
+    lines.push(
+      `| Context response tokens max | ${comparison.deltas.contextResponseTokensMax.baseline.toFixed(1)} | ${comparison.deltas.contextResponseTokensMax.current.toFixed(1)} | ${signed(comparison.deltas.contextResponseTokensMax.absolute, 1)} |`
+    );
+    lines.push(
+      `| Context duplicate candidate ratio | ${formatPct(comparison.deltas.contextDuplicateCandidateRatio.baseline)} | ${formatPct(comparison.deltas.contextDuplicateCandidateRatio.current)} | ${signed(comparison.deltas.contextDuplicateCandidateRatio.absolute)} |`
+    );
+    lines.push(
+      `| Context selected-file ratio | ${formatPct(comparison.deltas.contextSelectedFileRatio.baseline)} | ${formatPct(comparison.deltas.contextSelectedFileRatio.current)} | ${signed(comparison.deltas.contextSelectedFileRatio.absolute)} |`
+    );
+    lines.push(
+      `| Context Hit@5 / 1k response tokens | ${comparison.deltas.contextHitAt5Per1kResponseTokens.baseline.toFixed(4)} | ${comparison.deltas.contextHitAt5Per1kResponseTokens.current.toFixed(4)} | ${signed(comparison.deltas.contextHitAt5Per1kResponseTokens.absolute)} |`
+    );
+    lines.push(
+      `| Context MRR@10 / 1k response tokens | ${comparison.deltas.contextMrrAt10Per1kResponseTokens.baseline.toFixed(4)} | ${comparison.deltas.contextMrrAt10Per1kResponseTokens.current.toFixed(4)} | ${signed(comparison.deltas.contextMrrAt10Per1kResponseTokens.absolute)} |`
     );
     lines.push("");
   }

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -3,11 +3,8 @@ import * as path from "path";
 import { performance } from "perf_hooks";
 
 import { Indexer } from "../indexer/index.js";
-import { inferExactSymbolFromQuery } from "../tools/symbol-inference.js";
-import {
-  buildContextPack,
-  DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
-} from "../tools/utils.js";
+import { resolveSearchContext } from "../tools/context.js";
+import { DEFAULT_CONTEXT_PACK_TOKEN_BUDGET } from "../tools/utils.js";
 
 import { evaluateBudgetGate } from "./budget.js";
 import { compareSummaries } from "./compare.js";
@@ -80,30 +77,34 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
         );
       }
 
-      const inferredSymbol = query.retrievalMode === "context"
-        ? inferExactSymbolFromQuery(query.query)
-        : undefined;
-      const routedQuery = inferredSymbol ?? query.query;
-      const resolvedRoute = inferredSymbol ? "definition" : "search";
-
       const start = performance.now();
-      const result = await indexer.search(routedQuery, 10, {
-        metadataOnly: true,
-        filterByBranch: !!query.expected.branch,
-        definitionIntent: inferredSymbol !== undefined,
-      });
-      const elapsed = performance.now() - start;
-      const contextPack = query.retrievalMode === "context"
-        ? buildContextPack(result, {
+      const contextResult = query.retrievalMode === "context"
+        ? await resolveSearchContext({
+          query: query.query,
+          limit: 10,
           tokenBudget: DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
-          heading: inferredSymbol
-            ? `Definition evidence for ${JSON.stringify(inferredSymbol)}`
-            : `Codebase evidence for ${JSON.stringify(query.query)}`,
+        }, {
+          lookup: (symbol, limit) => indexer.search(symbol, limit, {
+            metadataOnly: true,
+            filterByBranch: !!query.expected.branch,
+            definitionIntent: true,
+          }),
+          search: (searchQuery, limit) => indexer.search(searchQuery, limit, {
+            metadataOnly: true,
+            filterByBranch: !!query.expected.branch,
+            definitionIntent: false,
+          }),
         })
         : undefined;
-      const evaluatedResults = contextPack?.results ?? result;
+      const result = contextResult?.details?.results ?? await indexer.search(query.query, 10, {
+        metadataOnly: true,
+        filterByBranch: !!query.expected.branch,
+      });
+      const elapsed = performance.now() - start;
+      const resolvedRoute = contextResult?.details?.route === "definition" ? "definition" : "search";
+      const routedQuery = contextResult?.details?.routedQuery ?? query.query;
 
-      const materialized = evaluatedResults.map((item) => ({
+      const materialized = result.map((item) => ({
         filePath: item.filePath,
         startLine: item.startLine,
         endLine: item.endLine,
@@ -115,12 +116,12 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
       perQuery.push(buildPerQueryResult(query, materialized, elapsed, 10, {
         resolvedRoute,
         routedQuery,
-      }, contextPack ? {
-        tokenBudget: contextPack.tokenBudget,
-        responseTokens: contextPack.tokenEstimate,
-        candidateCount: contextPack.candidateCount,
-        deduplicatedCount: contextPack.deduplicatedCount,
-        omittedCount: contextPack.omittedCount,
+      }, contextResult?.details ? {
+        tokenBudget: contextResult.details.tokenBudget,
+        responseTokens: contextResult.details.tokenEstimate,
+        candidateCount: contextResult.details.candidateCount ?? 0,
+        deduplicatedCount: contextResult.details.deduplicatedCount ?? 0,
+        omittedCount: contextResult.details.omittedCount ?? 0,
       } : undefined));
     }
 

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -4,6 +4,10 @@ import { performance } from "perf_hooks";
 
 import { Indexer } from "../indexer/index.js";
 import { inferExactSymbolFromQuery } from "../tools/symbol-inference.js";
+import {
+  buildContextPack,
+  DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
+} from "../tools/utils.js";
 
 import { evaluateBudgetGate } from "./budget.js";
 import { compareSummaries } from "./compare.js";
@@ -89,8 +93,17 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
         definitionIntent: inferredSymbol !== undefined,
       });
       const elapsed = performance.now() - start;
+      const contextPack = query.retrievalMode === "context"
+        ? buildContextPack(result, {
+          tokenBudget: DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
+          heading: inferredSymbol
+            ? `Definition evidence for ${JSON.stringify(inferredSymbol)}`
+            : `Codebase evidence for ${JSON.stringify(query.query)}`,
+        })
+        : undefined;
+      const evaluatedResults = contextPack?.results ?? result;
 
-      const materialized = result.map((item) => ({
+      const materialized = evaluatedResults.map((item) => ({
         filePath: item.filePath,
         startLine: item.startLine,
         endLine: item.endLine,
@@ -102,7 +115,13 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
       perQuery.push(buildPerQueryResult(query, materialized, elapsed, 10, {
         resolvedRoute,
         routedQuery,
-      }));
+      }, contextPack ? {
+        tokenBudget: contextPack.tokenBudget,
+        responseTokens: contextPack.tokenEstimate,
+        candidateCount: contextPack.candidateCount,
+        deduplicatedCount: contextPack.deduplicatedCount,
+        omittedCount: contextPack.omittedCount,
+      } : undefined));
     }
 
     const logger = indexer.getLogger();

--- a/src/eval/schema.ts
+++ b/src/eval/schema.ts
@@ -253,6 +253,41 @@ export function parseBudget(raw: unknown, sourceLabel: string): EvalBudget {
         "minRawDistinctTop3Ratio",
         sourceLabel
       ),
+      maxContextResponseTokensAverage: parseThresholdValue(
+        thresholds.maxContextResponseTokensAverage,
+        "maxContextResponseTokensAverage",
+        sourceLabel
+      ),
+      maxContextResponseTokensP95: parseThresholdValue(
+        thresholds.maxContextResponseTokensP95,
+        "maxContextResponseTokensP95",
+        sourceLabel
+      ),
+      maxContextResponseTokensMax: parseThresholdValue(
+        thresholds.maxContextResponseTokensMax,
+        "maxContextResponseTokensMax",
+        sourceLabel
+      ),
+      maxContextDuplicateCandidateRatio: parseThresholdValue(
+        thresholds.maxContextDuplicateCandidateRatio,
+        "maxContextDuplicateCandidateRatio",
+        sourceLabel
+      ),
+      minContextSelectedFileRatio: parseThresholdValue(
+        thresholds.minContextSelectedFileRatio,
+        "minContextSelectedFileRatio",
+        sourceLabel
+      ),
+      minContextHitAt5Per1kResponseTokens: parseThresholdValue(
+        thresholds.minContextHitAt5Per1kResponseTokens,
+        "minContextHitAt5Per1kResponseTokens",
+        sourceLabel
+      ),
+      minContextMrrAt10Per1kResponseTokens: parseThresholdValue(
+        thresholds.minContextMrrAt10Per1kResponseTokens,
+        "minContextMrrAt10Per1kResponseTokens",
+        sourceLabel
+      ),
     },
   };
 }

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -45,6 +45,13 @@ export interface EvalBudget {
     minHitAt5?: number;
     minMrrAt10?: number;
     minRawDistinctTop3Ratio?: number;
+    maxContextResponseTokensAverage?: number;
+    maxContextResponseTokensP95?: number;
+    maxContextResponseTokensMax?: number;
+    maxContextDuplicateCandidateRatio?: number;
+    minContextSelectedFileRatio?: number;
+    minContextHitAt5Per1kResponseTokens?: number;
+    minContextMrrAt10Per1kResponseTokens?: number;
   };
 }
 
@@ -79,7 +86,29 @@ export interface PerQueryEvalResult {
   ndcgAt10: number;
   failureBucket?: FailureBucket;
   rawTop3DistinctRatio: number;
+  tokenBudget?: number;
+  responseTokens: number;
+  candidateCount: number;
+  deduplicatedCount: number;
+  selectedCount: number;
+  omittedCount: number;
+  duplicateCandidateRatio: number;
+  selectedFileRatio: number;
   results: EvalSearchResult[];
+}
+
+export interface ContextEfficiencyMetrics {
+  queryCount: number;
+  responseTokens: {
+    total: number;
+    average: number;
+    p95: number;
+    max: number;
+  };
+  duplicateCandidateRatio: number;
+  selectedFileRatio: number;
+  hitAt5Per1kResponseTokens: number;
+  mrrAt10Per1kResponseTokens: number;
 }
 
 export interface EvalMetrics {
@@ -105,6 +134,7 @@ export interface EvalMetrics {
     estimatedCostUsd: number;
     costPer1MTokensUsd: number;
   };
+  contextEfficiency: ContextEfficiencyMetrics;
   failureBuckets: Record<FailureBucket, number>;
 }
 
@@ -143,6 +173,13 @@ export interface EvalComparison {
     latencyP99Ms: MetricDelta;
     embeddingCallCount: MetricDelta;
     estimatedCostUsd: MetricDelta;
+    contextResponseTokensAverage: MetricDelta;
+    contextResponseTokensP95: MetricDelta;
+    contextResponseTokensMax: MetricDelta;
+    contextDuplicateCandidateRatio: MetricDelta;
+    contextSelectedFileRatio: MetricDelta;
+    contextHitAt5Per1kResponseTokens: MetricDelta;
+    contextMrrAt10Per1kResponseTokens: MetricDelta;
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { loadMergedConfig } from "./config/merger.js";
 import { createWatcherWithIndexer } from "./watcher/index.js";
 import {
   codebase_search,
+  codebase_context,
   codebase_peek,
   index_codebase,
   index_status,
@@ -122,6 +123,7 @@ const plugin: Plugin = async ({ directory, worktree }) => {
 
     return {
       tool: {
+        codebase_context,
         codebase_search,
         codebase_peek,
         index_codebase,

--- a/src/indexer/index-lock.ts
+++ b/src/indexer/index-lock.ts
@@ -185,7 +185,12 @@ function sameReclaimOwner(left: ReclaimOwner, right: ReclaimOwner): boolean {
 
 function publishJsonDirectory(finalPath: string, value: IndexLockOwner | ReclaimOwner): boolean {
   const candidatePath = `${finalPath}.candidate.${process.pid}.${randomUUID()}`;
-  mkdirSync(candidatePath, { mode: 0o700 });
+  try {
+    mkdirSync(candidatePath, { mode: 0o700 });
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
   try {
     writeFileSync(path.join(candidatePath, OWNER_FILE_NAME), JSON.stringify(value), {
       encoding: "utf-8",
@@ -198,8 +203,12 @@ function publishJsonDirectory(finalPath: string, value: IndexLockOwner | Reclaim
       return true;
     } catch (error) {
       if (existsSync(finalPath)) return false;
+      if (getErrorCode(error) === "ENOENT") return false;
       throw error;
     }
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
   } finally {
     if (existsSync(candidatePath)) rmSync(candidatePath, { recursive: true, force: true });
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9,7 +9,7 @@ import { initializeTools } from "./tools/operations.js";
 
 function getServerInstructions(host: string): string {
   const hostText = `host ${host}`;
-  return `This MCP server is the preferred codebase-understanding path for ${hostText}. Start a repository task with index_status when index readiness or freshness is unknown. Use codebase_context as the preferred first entry point because it returns low-token locations first and routes to definitions or call-graph helpers when symbol intent is present. Use codebase_peek for direct conceptual location lookup, implementation_lookup for known-symbol definition questions, and codebase_search only when full semantic code content is needed. For exact identifiers or exhaustive matches, use grep. After identifying symbols, use call_graph or call_graph_path to trace dependencies. If the index is unavailable, run index_codebase, then retry the retrieval tool.`;
+  return `This MCP server is the preferred codebase-understanding path for ${hostText}. Start a repository task with index_status when index readiness or freshness is unknown. Use codebase_context as the preferred first entry point because it returns a token-budgeted location pack and routes to definitions or call-graph helpers when symbol intent is present. Keep the default tokenBudget for normal discovery, then use implementation_lookup, codebase_search, or a targeted file read only for selected locations that need source content. Use codebase_peek for direct conceptual location lookup. For exact identifiers or exhaustive matches, use grep. After identifying symbols, use call_graph or call_graph_path to trace dependencies. If the index is unavailable, run index_codebase, then retry the retrieval tool.`;
 }
 
 function getPackageVersion(): string {

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -16,7 +16,13 @@ import {
   MAX_CONTEXT_PACK_TOKEN_BUDGET,
   MIN_CONTEXT_PACK_TOKEN_BUDGET,
 } from "../tools/utils.js";
-import { resolveCodebaseContext } from "../tools/context.js";
+import {
+  MAX_CONTEXT_PATH_DEPTH,
+  MAX_CONTEXT_RESULT_LIMIT,
+  MIN_CONTEXT_PATH_DEPTH,
+  MIN_CONTEXT_RESULT_LIMIT,
+  resolveCodebaseContext,
+} from "../tools/context.js";
 import { formatPrImpact } from "../tools/format-pr-impact.js";
 import {
   findSimilarCode,
@@ -46,8 +52,12 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       from: allowNullAsUndefined(z.string().optional()).describe("Source symbol. For dependency-path questions, extract the first endpoint and provide it here."),
       to: allowNullAsUndefined(z.string().optional()).describe("Target symbol. For dependency-path questions, extract the second endpoint and provide it here."),
       symbol: allowNullAsUndefined(z.string().optional()).describe("Exact symbol for an authoritative definition lookup. Omit when from and to are supplied."),
-      limit: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum number of search or definition results"),
-      maxDepth: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum call-graph traversal depth for from/to path lookup"),
+      limit: allowNullAsUndefined(
+        z.number().int().min(MIN_CONTEXT_RESULT_LIMIT).max(MAX_CONTEXT_RESULT_LIMIT).optional().default(10),
+      ).describe(`Maximum number of search or definition results (${MIN_CONTEXT_RESULT_LIMIT}-${MAX_CONTEXT_RESULT_LIMIT})`),
+      maxDepth: allowNullAsUndefined(
+        z.number().int().min(MIN_CONTEXT_PATH_DEPTH).max(MAX_CONTEXT_PATH_DEPTH).optional().default(10),
+      ).describe(`Maximum call-graph traversal depth for from/to path lookup (${MIN_CONTEXT_PATH_DEPTH}-${MAX_CONTEXT_PATH_DEPTH})`),
       fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
       directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
       tokenBudget: allowNullAsUndefined(

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { formatCostEstimate } from "../utils/cost.js";
 import {
+  DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
   formatCallGraphCallees,
   formatCallGraphCallers,
   formatCallGraphPath,
@@ -12,7 +13,10 @@ import {
   formatIndexStats,
   formatSearchResults,
   formatStatus,
+  MAX_CONTEXT_PACK_TOKEN_BUDGET,
+  MIN_CONTEXT_PACK_TOKEN_BUDGET,
 } from "../tools/utils.js";
+import { resolveCodebaseContext } from "../tools/context.js";
 import { formatPrImpact } from "../tools/format-pr-impact.js";
 import {
   findSimilarCode,
@@ -27,7 +31,6 @@ import {
   runIndexHealthCheck,
   searchCodebase,
 } from "../tools/operations.js";
-import { inferExactSymbolFromQuery } from "../tools/symbol-inference.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime } from "./shared.js";
 
 function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
@@ -37,7 +40,7 @@ function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
     "codebase_context",
-    "PREFERRED FIRST TOOL for any question about this repository. Use before built-in code search, grep, shell search, or broad file reads. Provide from+to for a dependency path, symbol for a definition, or only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
+    "PREFERRED FIRST TOOL for any question about this repository. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Use before built-in code search, grep, shell search, or broad file reads. Provide from+to for a dependency path, symbol for a definition, or only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
     {
       query: z.string().describe("The codebase question or behavior to locate. Always provide the user's repository question here."),
       from: allowNullAsUndefined(z.string().optional()).describe("Source symbol. For dependency-path questions, extract the first endpoint and provide it here."),
@@ -47,78 +50,14 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       maxDepth: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum call-graph traversal depth for from/to path lookup"),
       fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py', 'rs')"),
       directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils', 'lib')"),
+      tokenBudget: allowNullAsUndefined(
+        z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET).optional()
+          .default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET),
+      ).describe(`Maximum response tokens for this context pack (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
     },
     async (args) => {
-      if (args.from && args.to) {
-        const path = await getCallGraphPath(runtime.projectRoot, runtime.host, args.from, args.to, args.maxDepth);
-        if (path.length > 0) {
-          return { content: [{ type: "text", text: formatCallGraphPath(args.from, args.to, path) }] };
-        }
-
-        // Path traversal follows resolved symbol IDs, but extraction can still
-        // retain a useful direct edge before the target has been resolved.
-        const { callers } = await getCallGraphData(runtime.projectRoot, runtime.host, {
-          name: args.to,
-          direction: "callers",
-        });
-        const directEdge = callers.find(edge => edge.fromSymbolName === args.from);
-        if (directEdge) {
-          const location = directEdge.fromSymbolFilePath
-            ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
-            : "";
-          return {
-            content: [{
-              type: "text",
-              text: `Direct path: ${args.from} --${directEdge.callType}--> ${args.to}${location} ` +
-                `(edge is ${directEdge.isResolved ? "resolved" : "unresolved"}).`,
-            }],
-          };
-        }
-
-        return { content: [{ type: "text", text: formatCallGraphPath(args.from, args.to, path) }] };
-      }
-
-      if (args.symbol) {
-        const results = await implementationLookup(runtime.projectRoot, runtime.host, args.symbol, {
-          limit: args.limit ?? 10,
-          fileType: args.fileType,
-          directory: args.directory,
-        });
-
-        return { content: [{ type: "text", text: formatDefinitionLookup(results, args.symbol) }] };
-      }
-
-      const inferredSymbol = inferExactSymbolFromQuery(args.query);
-      if (inferredSymbol) {
-        const inferredResults = await implementationLookup(runtime.projectRoot, runtime.host, inferredSymbol, {
-          limit: args.limit ?? 10,
-          fileType: args.fileType,
-          directory: args.directory,
-        });
-
-        if (inferredResults.length > 0) {
-          return { content: [{ type: "text", text: formatDefinitionLookup(inferredResults, inferredSymbol) }] };
-        }
-      }
-
-      const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
-        limit: args.limit ?? 10,
-        fileType: args.fileType,
-        directory: args.directory,
-        metadataOnly: true,
-      });
-
-      if (results.length === 0) {
-        return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
-      }
-
-      return {
-        content: [{
-          type: "text",
-          text: `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}\n\n` +
-            "Use implementation_lookup for an authoritative definition, or call call_graph/call_graph_path once you have a symbol.",
-        }],
-      };
+      const result = await resolveCodebaseContext(runtime.projectRoot, runtime.host, args);
+      return { content: [{ type: "text", text: result.text }] };
     },
   );
 

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -6,8 +6,6 @@ import { formatPrImpact } from "./tools/format-pr-impact.js";
 import {
   addKnowledgeBase,
   findSimilarCode,
-  getCallGraphData,
-  getCallGraphPath,
   getIndexLogs,
   getIndexMetrics,
   getIndexStatus,
@@ -20,15 +18,16 @@ import {
   searchCodebase,
 } from "./tools/operations.js";
 import {
-  formatCallGraphPath,
-  formatCodebasePeek,
+  DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
   formatDefinitionLookup,
   formatHealthCheck,
   formatIndexStats,
   formatSearchResults,
   formatStatus,
+  MAX_CONTEXT_PACK_TOKEN_BUDGET,
+  MIN_CONTEXT_PACK_TOKEN_BUDGET,
 } from "./tools/utils.js";
-import { inferExactSymbolFromQuery } from "./tools/symbol-inference.js";
+import { resolveCodebaseContext } from "./tools/context.js";
 import { registerPiCallGraphTools } from "./pi-call-graph.js";
 
 const HOST = "pi" as const;
@@ -55,7 +54,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "codebase_context",
     label: "Codebase Context",
-    description: "PREFERRED FIRST TOOL for any repository question. Check index_status when freshness is unknown, then use this tool for low-token location discovery and dependency flow.",
+    description: "PREFERRED FIRST TOOL for any repository question. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Check index_status when freshness is unknown, then use this tool for low-token location discovery and dependency flow.",
     parameters: Type.Object({
       query: Type.String({ description: "Natural language description of what code you're trying to locate" }),
       from: Type.Optional(Type.String({ description: "Source symbol when asking for a dependency path." })),
@@ -65,69 +64,16 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       maxDepth: Type.Optional(Type.Number({ description: "Maximum call-graph traversal depth for from/to paths" })),
       fileType: Type.Optional(Type.String({ description: "Filter by file extension, e.g., ts, py, rs" })),
       directory: Type.Optional(Type.String({ description: "Filter by directory path" })),
+      tokenBudget: Type.Optional(Type.Integer({
+        default: DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
+        minimum: MIN_CONTEXT_PACK_TOKEN_BUDGET,
+        maximum: MAX_CONTEXT_PACK_TOKEN_BUDGET,
+        description: `Maximum response tokens (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`,
+      })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const root = projectRoot(ctx);
-
-      if (params.from && params.to) {
-        const path = await getCallGraphPath(root, HOST, params.from, params.to, params.maxDepth);
-        if (path.length > 0) {
-          return text(formatCallGraphPath(params.from, params.to, path), path);
-        }
-
-        const { callers } = await getCallGraphData(root, HOST, {
-          name: params.to,
-          direction: "callers",
-        });
-        const directEdge = callers.find((edge) => edge.fromSymbolName === params.from);
-        if (directEdge) {
-          const location = directEdge.fromSymbolFilePath
-            ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
-            : "";
-          return text(
-            `Direct path: ${params.from} --${directEdge.callType}--> ${params.to}${location} ` +
-              `(edge is ${directEdge.isResolved ? "resolved" : "unresolved"}).`,
-            path,
-          );
-        }
-
-        return text(formatCallGraphPath(params.from, params.to, path), path);
-      }
-
-      if (params.symbol) {
-        const results = await implementationLookup(root, HOST, params.symbol, {
-          limit: params.limit ?? 10,
-          fileType: params.fileType,
-          directory: params.directory,
-        });
-        return text(formatDefinitionLookup(results, params.symbol), results);
-      }
-
-      const inferredSymbol = inferExactSymbolFromQuery(params.query);
-      if (inferredSymbol) {
-        const inferredResults = await implementationLookup(root, HOST, inferredSymbol, {
-          limit: params.limit ?? 10,
-          fileType: params.fileType,
-          directory: params.directory,
-        });
-
-        if (inferredResults.length > 0) {
-          return text(formatDefinitionLookup(inferredResults, inferredSymbol), inferredResults);
-        }
-      }
-
-      const results = await searchCodebase(root, HOST, params.query, {
-        limit: params.limit ?? 10,
-        fileType: params.fileType,
-        directory: params.directory,
-        metadataOnly: true,
-      });
-
-      if (results.length === 0) {
-        return text("No matching code found. Try a different query or run index_status/index_codebase first.");
-      }
-
-      return text(`Found ${results.length} locations for "${params.query}":\n\n${formatCodebasePeek(results)}`, results);
+      const result = await resolveCodebaseContext(projectRoot(ctx), HOST, params);
+      return text(result.text, result.details);
     },
   });
 

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -27,7 +27,13 @@ import {
   MAX_CONTEXT_PACK_TOKEN_BUDGET,
   MIN_CONTEXT_PACK_TOKEN_BUDGET,
 } from "./tools/utils.js";
-import { resolveCodebaseContext } from "./tools/context.js";
+import {
+  MAX_CONTEXT_PATH_DEPTH,
+  MAX_CONTEXT_RESULT_LIMIT,
+  MIN_CONTEXT_PATH_DEPTH,
+  MIN_CONTEXT_RESULT_LIMIT,
+  resolveCodebaseContext,
+} from "./tools/context.js";
 import { registerPiCallGraphTools } from "./pi-call-graph.js";
 
 const HOST = "pi" as const;
@@ -57,17 +63,24 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
     description: "PREFERRED FIRST TOOL for any repository question. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Check index_status when freshness is unknown, then use this tool for low-token location discovery and dependency flow.",
     parameters: Type.Object({
       query: Type.String({ description: "Natural language description of what code you're trying to locate" }),
-      from: Type.Optional(Type.String({ description: "Source symbol when asking for a dependency path." })),
-      to: Type.Optional(Type.String({ description: "Target symbol when asking for a dependency path." })),
-      symbol: Type.Optional(Type.String({ description: "Exact symbol name for an authoritative definition lookup." })),
-      limit: Type.Optional(Type.Number({ description: "Maximum results (default: 10)" })),
-      maxDepth: Type.Optional(Type.Number({ description: "Maximum call-graph traversal depth for from/to paths" })),
-      fileType: Type.Optional(Type.String({ description: "Filter by file extension, e.g., ts, py, rs" })),
-      directory: Type.Optional(Type.String({ description: "Filter by directory path" })),
-      tokenBudget: Type.Optional(Type.Integer({
+      from: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Source symbol when asking for a dependency path." })),
+      to: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Target symbol when asking for a dependency path." })),
+      symbol: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Exact symbol name for an authoritative definition lookup." })),
+      limit: Type.Optional(Type.Union([
+        Type.Integer({ minimum: MIN_CONTEXT_RESULT_LIMIT, maximum: MAX_CONTEXT_RESULT_LIMIT }),
+        Type.Null(),
+      ], { default: 10, description: `Maximum results (${MIN_CONTEXT_RESULT_LIMIT}-${MAX_CONTEXT_RESULT_LIMIT})` })),
+      maxDepth: Type.Optional(Type.Union([
+        Type.Integer({ minimum: MIN_CONTEXT_PATH_DEPTH, maximum: MAX_CONTEXT_PATH_DEPTH }),
+        Type.Null(),
+      ], { default: 10, description: `Maximum call-graph traversal depth (${MIN_CONTEXT_PATH_DEPTH}-${MAX_CONTEXT_PATH_DEPTH})` })),
+      fileType: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Filter by file extension, e.g., ts, py, rs" })),
+      directory: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Filter by directory path" })),
+      tokenBudget: Type.Optional(Type.Union([
+        Type.Integer({ minimum: MIN_CONTEXT_PACK_TOKEN_BUDGET, maximum: MAX_CONTEXT_PACK_TOKEN_BUDGET }),
+        Type.Null(),
+      ], {
         default: DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
-        minimum: MIN_CONTEXT_PACK_TOKEN_BUDGET,
-        maximum: MAX_CONTEXT_PACK_TOKEN_BUDGET,
         description: `Maximum response tokens (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`,
       })),
     }),

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -44,6 +44,7 @@ export interface CodebaseContextResult {
   text: string;
   details?: {
     route: "path" | "direct-edge" | "definition" | "conceptual";
+    routedQuery?: string;
     tokenBudget: number;
     tokenEstimate: number;
     truncated?: boolean;
@@ -71,12 +72,14 @@ function locations(results: SearchResult[]): ContextLocation[] {
 
 function packedResult(
   route: "definition" | "conceptual",
+  routedQuery: string,
   pack: ReturnType<typeof buildContextPack>,
 ): CodebaseContextResult {
   return {
     text: pack.text,
     details: {
       route,
+      routedQuery,
       tokenBudget: pack.tokenBudget,
       tokenEstimate: pack.tokenEstimate,
       candidateCount: pack.candidateCount,
@@ -89,6 +92,54 @@ function packedResult(
       results: locations(pack.results),
     },
   };
+}
+
+interface SearchContextOperations {
+  lookup(symbol: string, limit: number): Promise<SearchResult[]>;
+  search(query: string, limit: number): Promise<SearchResult[]>;
+}
+
+export async function resolveSearchContext(
+  input: Pick<CodebaseContextInput, "query" | "symbol" | "limit" | "tokenBudget">,
+  operations: SearchContextOperations,
+): Promise<CodebaseContextResult> {
+  const explicitSymbol = input.symbol ?? undefined;
+  const limit = input.limit ?? 10;
+  const tokenBudget = input.tokenBudget ?? undefined;
+  const lookupSymbol = explicitSymbol ?? inferExactSymbolFromQuery(input.query);
+
+  if (lookupSymbol) {
+    const definitions = await operations.lookup(lookupSymbol, MAX_CONTEXT_RESULT_LIMIT);
+    if (definitions.length > 0) {
+      return packedResult("definition", lookupSymbol, buildContextPack(definitions, {
+        tokenBudget,
+        maxResults: limit,
+        heading: `Definition evidence for ${JSON.stringify(lookupSymbol)}`,
+      }));
+    }
+    if (explicitSymbol) {
+      const fitted = fitTextToContextBudget(
+        formatDefinitionLookup(definitions, lookupSymbol),
+        tokenBudget,
+      );
+      return { text: fitted.text };
+    }
+  }
+
+  const results = await operations.search(input.query, MAX_CONTEXT_RESULT_LIMIT);
+  if (results.length === 0) {
+    const fitted = fitTextToContextBudget(
+      "No matching code found. Try a different query or run index_codebase first.",
+      tokenBudget,
+    );
+    return { text: fitted.text };
+  }
+
+  return packedResult("conceptual", input.query, buildContextPack(results, {
+    tokenBudget,
+    maxResults: limit,
+    heading: `Codebase evidence for ${JSON.stringify(input.query)}`,
+  }));
 }
 
 function fittedDetails(
@@ -159,46 +210,17 @@ export async function resolveCodebaseContext(
     };
   }
 
-  const lookupSymbol = symbol ?? inferExactSymbolFromQuery(input.query);
-  if (lookupSymbol) {
-    const definitions = await implementationLookup(projectRoot, host, lookupSymbol, {
-      limit,
+  return resolveSearchContext({ query: input.query, symbol, limit, tokenBudget }, {
+    lookup: (lookupSymbol, retrievalLimit) => implementationLookup(projectRoot, host, lookupSymbol, {
+      limit: retrievalLimit,
       fileType,
       directory,
-    });
-    if (definitions.length > 0) {
-      return packedResult("definition", buildContextPack(definitions, {
-        tokenBudget,
-        maxResults: limit,
-        heading: `Definition evidence for ${JSON.stringify(lookupSymbol)}`,
-      }));
-    }
-    if (symbol) {
-      const fitted = fitTextToContextBudget(
-        formatDefinitionLookup(definitions, lookupSymbol),
-        tokenBudget,
-      );
-      return { text: fitted.text };
-    }
-  }
-
-  const results = await searchCodebase(projectRoot, host, input.query, {
-    limit,
-    fileType,
-    directory,
-    metadataOnly: true,
+    }),
+    search: (query, retrievalLimit) => searchCodebase(projectRoot, host, query, {
+      limit: retrievalLimit,
+      fileType,
+      directory,
+      metadataOnly: true,
+    }),
   });
-  if (results.length === 0) {
-    const fitted = fitTextToContextBudget(
-      "No matching code found. Try a different query or run index_codebase first.",
-      tokenBudget,
-    );
-    return { text: fitted.text };
-  }
-
-  return packedResult("conceptual", buildContextPack(results, {
-    tokenBudget,
-    maxResults: limit,
-    heading: `Codebase evidence for ${JSON.stringify(input.query)}`,
-  }));
 }

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -1,0 +1,189 @@
+import type { HostMode } from "../config/host.js";
+import type { SearchResult } from "../indexer/index.js";
+import {
+  getCallGraphData,
+  getCallGraphPath,
+  implementationLookup,
+  searchCodebase,
+} from "./operations.js";
+import { inferExactSymbolFromQuery } from "./symbol-inference.js";
+import {
+  buildContextPack,
+  fitTextToContextBudget,
+  formatCallGraphPath,
+  formatDefinitionLookup,
+} from "./utils.js";
+
+export interface CodebaseContextInput {
+  query: string;
+  from?: string;
+  to?: string;
+  symbol?: string;
+  limit?: number;
+  maxDepth?: number;
+  fileType?: string;
+  directory?: string;
+  tokenBudget?: number;
+}
+
+interface ContextLocation {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  chunkType: string;
+  name?: string;
+}
+
+export interface CodebaseContextResult {
+  text: string;
+  details?: {
+    route: "path" | "direct-edge" | "definition" | "conceptual";
+    tokenBudget: number;
+    tokenEstimate: number;
+    truncated?: boolean;
+    candidateCount?: number;
+    deduplicatedCount?: number;
+    selectedCount?: number;
+    omittedCount?: number;
+    duplicateCount?: number;
+    budgetOmittedCount?: number;
+    results?: ContextLocation[];
+  };
+}
+
+function locations(results: SearchResult[]): ContextLocation[] {
+  return results.map((result) => ({
+    filePath: result.filePath,
+    startLine: result.startLine,
+    endLine: result.endLine,
+    score: result.score,
+    chunkType: result.chunkType,
+    name: result.name,
+  }));
+}
+
+function packedResult(
+  route: "definition" | "conceptual",
+  pack: ReturnType<typeof buildContextPack>,
+): CodebaseContextResult {
+  return {
+    text: pack.text,
+    details: {
+      route,
+      tokenBudget: pack.tokenBudget,
+      tokenEstimate: pack.tokenEstimate,
+      candidateCount: pack.candidateCount,
+      deduplicatedCount: pack.deduplicatedCount,
+      selectedCount: pack.selectedCount,
+      omittedCount: pack.omittedCount,
+      duplicateCount: pack.duplicateCount,
+      budgetOmittedCount: pack.budgetOmittedCount,
+      results: locations(pack.results),
+    },
+  };
+}
+
+function fittedDetails(
+  route: "path" | "direct-edge",
+  fitted: ReturnType<typeof fitTextToContextBudget>,
+): NonNullable<CodebaseContextResult["details"]> {
+  return {
+    route,
+    tokenBudget: fitted.tokenBudget,
+    tokenEstimate: fitted.tokenEstimate,
+    truncated: fitted.truncated,
+  };
+}
+
+export async function resolveCodebaseContext(
+  projectRoot: string | undefined,
+  host: HostMode,
+  input: CodebaseContextInput,
+): Promise<CodebaseContextResult> {
+  if (input.from && input.to) {
+    const path = await getCallGraphPath(projectRoot, host, input.from, input.to, input.maxDepth);
+    if (path.length > 0) {
+      const fitted = fitTextToContextBudget(
+        formatCallGraphPath(input.from, input.to, path),
+        input.tokenBudget,
+      );
+      return {
+        text: fitted.text,
+        details: fittedDetails("path", fitted),
+      };
+    }
+
+    const { callers } = await getCallGraphData(projectRoot, host, {
+      name: input.to,
+      direction: "callers",
+    });
+    const directEdge = callers.find((edge) => edge.fromSymbolName === input.from);
+    if (directEdge) {
+      const location = directEdge.fromSymbolFilePath
+        ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
+        : "";
+      const fitted = fitTextToContextBudget(
+        `Direct path: ${input.from} --${directEdge.callType}--> ${input.to}${location} ` +
+          `(edge is ${directEdge.isResolved ? "resolved" : "unresolved"}).`,
+        input.tokenBudget,
+      );
+      return {
+        text: fitted.text,
+        details: fittedDetails("direct-edge", fitted),
+      };
+    }
+
+    const fitted = fitTextToContextBudget(
+      formatCallGraphPath(input.from, input.to, path),
+      input.tokenBudget,
+    );
+    return {
+      text: fitted.text,
+      details: fittedDetails("path", fitted),
+    };
+  }
+
+  const lookupSymbol = input.symbol ?? inferExactSymbolFromQuery(input.query);
+  if (lookupSymbol) {
+    const definitions = await implementationLookup(projectRoot, host, lookupSymbol, {
+      limit: input.limit ?? 10,
+      fileType: input.fileType,
+      directory: input.directory,
+    });
+    if (definitions.length > 0) {
+      return packedResult("definition", buildContextPack(definitions, {
+        tokenBudget: input.tokenBudget,
+        maxResults: input.limit ?? 10,
+        heading: `Definition evidence for ${JSON.stringify(lookupSymbol)}`,
+      }));
+    }
+    if (input.symbol) {
+      const fitted = fitTextToContextBudget(
+        formatDefinitionLookup(definitions, lookupSymbol),
+        input.tokenBudget,
+      );
+      return { text: fitted.text };
+    }
+  }
+
+  const results = await searchCodebase(projectRoot, host, input.query, {
+    limit: input.limit ?? 10,
+    fileType: input.fileType,
+    directory: input.directory,
+    metadataOnly: true,
+  });
+  if (results.length === 0) {
+    const fitted = fitTextToContextBudget(
+      "No matching code found. Try a different query or run index_codebase first.",
+      input.tokenBudget,
+    );
+    return { text: fitted.text };
+  }
+
+  return packedResult("conceptual", buildContextPack(results, {
+    tokenBudget: input.tokenBudget,
+    maxResults: input.limit ?? 10,
+    heading: `Codebase evidence for ${JSON.stringify(input.query)}`,
+  }));
+}

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -16,15 +16,20 @@ import {
 
 export interface CodebaseContextInput {
   query: string;
-  from?: string;
-  to?: string;
-  symbol?: string;
-  limit?: number;
-  maxDepth?: number;
-  fileType?: string;
-  directory?: string;
-  tokenBudget?: number;
+  from?: string | null;
+  to?: string | null;
+  symbol?: string | null;
+  limit?: number | null;
+  maxDepth?: number | null;
+  fileType?: string | null;
+  directory?: string | null;
+  tokenBudget?: number | null;
 }
+
+export const MIN_CONTEXT_RESULT_LIMIT = 1;
+export const MAX_CONTEXT_RESULT_LIMIT = 100;
+export const MIN_CONTEXT_PATH_DEPTH = 1;
+export const MAX_CONTEXT_PATH_DEPTH = 100;
 
 interface ContextLocation {
   filePath: string;
@@ -47,6 +52,7 @@ export interface CodebaseContextResult {
     selectedCount?: number;
     omittedCount?: number;
     duplicateCount?: number;
+    limitOmittedCount?: number;
     budgetOmittedCount?: number;
     results?: ContextLocation[];
   };
@@ -78,6 +84,7 @@ function packedResult(
       selectedCount: pack.selectedCount,
       omittedCount: pack.omittedCount,
       duplicateCount: pack.duplicateCount,
+      limitOmittedCount: pack.limitOmittedCount,
       budgetOmittedCount: pack.budgetOmittedCount,
       results: locations(pack.results),
     },
@@ -101,12 +108,20 @@ export async function resolveCodebaseContext(
   host: HostMode,
   input: CodebaseContextInput,
 ): Promise<CodebaseContextResult> {
-  if (input.from && input.to) {
-    const path = await getCallGraphPath(projectRoot, host, input.from, input.to, input.maxDepth);
+  const from = input.from ?? undefined;
+  const to = input.to ?? undefined;
+  const symbol = input.symbol ?? undefined;
+  const limit = input.limit ?? 10;
+  const maxDepth = input.maxDepth ?? 10;
+  const fileType = input.fileType ?? undefined;
+  const directory = input.directory ?? undefined;
+  const tokenBudget = input.tokenBudget ?? undefined;
+  if (from && to) {
+    const path = await getCallGraphPath(projectRoot, host, from, to, maxDepth);
     if (path.length > 0) {
       const fitted = fitTextToContextBudget(
-        formatCallGraphPath(input.from, input.to, path),
-        input.tokenBudget,
+        formatCallGraphPath(from, to, path),
+        tokenBudget,
       );
       return {
         text: fitted.text,
@@ -115,18 +130,18 @@ export async function resolveCodebaseContext(
     }
 
     const { callers } = await getCallGraphData(projectRoot, host, {
-      name: input.to,
+      name: to,
       direction: "callers",
     });
-    const directEdge = callers.find((edge) => edge.fromSymbolName === input.from);
+    const directEdge = callers.find((edge) => edge.fromSymbolName === from);
     if (directEdge) {
       const location = directEdge.fromSymbolFilePath
         ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
         : "";
       const fitted = fitTextToContextBudget(
-        `Direct path: ${input.from} --${directEdge.callType}--> ${input.to}${location} ` +
+        `Direct path: ${from} --${directEdge.callType}--> ${to}${location} ` +
           `(edge is ${directEdge.isResolved ? "resolved" : "unresolved"}).`,
-        input.tokenBudget,
+        tokenBudget,
       );
       return {
         text: fitted.text,
@@ -135,8 +150,8 @@ export async function resolveCodebaseContext(
     }
 
     const fitted = fitTextToContextBudget(
-      formatCallGraphPath(input.from, input.to, path),
-      input.tokenBudget,
+      formatCallGraphPath(from, to, path),
+      tokenBudget,
     );
     return {
       text: fitted.text,
@@ -144,46 +159,46 @@ export async function resolveCodebaseContext(
     };
   }
 
-  const lookupSymbol = input.symbol ?? inferExactSymbolFromQuery(input.query);
+  const lookupSymbol = symbol ?? inferExactSymbolFromQuery(input.query);
   if (lookupSymbol) {
     const definitions = await implementationLookup(projectRoot, host, lookupSymbol, {
-      limit: input.limit ?? 10,
-      fileType: input.fileType,
-      directory: input.directory,
+      limit,
+      fileType,
+      directory,
     });
     if (definitions.length > 0) {
       return packedResult("definition", buildContextPack(definitions, {
-        tokenBudget: input.tokenBudget,
-        maxResults: input.limit ?? 10,
+        tokenBudget,
+        maxResults: limit,
         heading: `Definition evidence for ${JSON.stringify(lookupSymbol)}`,
       }));
     }
-    if (input.symbol) {
+    if (symbol) {
       const fitted = fitTextToContextBudget(
         formatDefinitionLookup(definitions, lookupSymbol),
-        input.tokenBudget,
+        tokenBudget,
       );
       return { text: fitted.text };
     }
   }
 
   const results = await searchCodebase(projectRoot, host, input.query, {
-    limit: input.limit ?? 10,
-    fileType: input.fileType,
-    directory: input.directory,
+    limit,
+    fileType,
+    directory,
     metadataOnly: true,
   });
   if (results.length === 0) {
     const fitted = fitTextToContextBudget(
       "No matching code found. Try a different query or run index_codebase first.",
-      input.tokenBudget,
+      tokenBudget,
     );
     return { text: fitted.text };
   }
 
   return packedResult("conceptual", buildContextPack(results, {
-    tokenBudget: input.tokenBudget,
-    maxResults: input.limit ?? 10,
+    tokenBudget,
+    maxResults: limit,
     heading: `Codebase evidence for ${JSON.stringify(input.query)}`,
   }));
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,6 +5,7 @@ import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
 import type { Indexer } from "../indexer/index.js";
 import { formatCostEstimate } from "../utils/cost.js";
 import {
+  DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
   formatCodebasePeek,
   formatCallGraphCallees,
   formatCallGraphCallers,
@@ -14,6 +15,8 @@ import {
   formatIndexStats,
   formatSearchResults,
   formatStatus,
+  MAX_CONTEXT_PACK_TOKEN_BUDGET,
+  MIN_CONTEXT_PACK_TOKEN_BUDGET,
 } from "./utils.js";
 import {
   addKnowledgeBase,
@@ -34,6 +37,7 @@ import {
   searchCodebase,
 } from "./operations.js";
 import { pr_impact } from "./pr-impact.js";
+import { resolveCodebaseContext } from "./context.js";
 import { writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -68,6 +72,27 @@ export function getSharedIndexer(): Indexer {
 export function getIndexerForProject(directory: string): Indexer {
   return getOperationIndexerForProject(directory, DEFAULT_HOST);
 }
+
+export const codebase_context: ToolDefinition = tool({
+  description:
+    "PREFERRED FIRST TOOL for repository questions. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Provide from and to for dependency paths, symbol for definitions, or only query for conceptual discovery.",
+  args: {
+    query: z.string().describe("The repository question or behavior to locate"),
+    from: z.string().optional().describe("Source symbol for a dependency path"),
+    to: z.string().optional().describe("Target symbol for a dependency path"),
+    symbol: z.string().optional().describe("Exact symbol for authoritative definition lookup"),
+    limit: z.number().optional().default(10).describe("Maximum number of results"),
+    maxDepth: z.number().optional().default(10).describe("Maximum call-path traversal depth"),
+    fileType: z.string().optional().describe("Filter by file extension"),
+    directory: z.string().optional().describe("Filter by directory path"),
+    tokenBudget: z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET)
+      .optional().default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET)
+      .describe(`Maximum response tokens (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
+  },
+  async execute(args, context) {
+    return (await resolveCodebaseContext(context?.worktree, DEFAULT_HOST, args)).text;
+  },
+});
 
 export const codebase_peek: ToolDefinition = tool({
   description:

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -37,7 +37,13 @@ import {
   searchCodebase,
 } from "./operations.js";
 import { pr_impact } from "./pr-impact.js";
-import { resolveCodebaseContext } from "./context.js";
+import {
+  MAX_CONTEXT_PATH_DEPTH,
+  MAX_CONTEXT_RESULT_LIMIT,
+  MIN_CONTEXT_PATH_DEPTH,
+  MIN_CONTEXT_RESULT_LIMIT,
+  resolveCodebaseContext,
+} from "./context.js";
 import { writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -78,15 +84,17 @@ export const codebase_context: ToolDefinition = tool({
     "PREFERRED FIRST TOOL for repository questions. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Provide from and to for dependency paths, symbol for definitions, or only query for conceptual discovery.",
   args: {
     query: z.string().describe("The repository question or behavior to locate"),
-    from: z.string().optional().describe("Source symbol for a dependency path"),
-    to: z.string().optional().describe("Target symbol for a dependency path"),
-    symbol: z.string().optional().describe("Exact symbol for authoritative definition lookup"),
-    limit: z.number().optional().default(10).describe("Maximum number of results"),
-    maxDepth: z.number().optional().default(10).describe("Maximum call-path traversal depth"),
-    fileType: z.string().optional().describe("Filter by file extension"),
-    directory: z.string().optional().describe("Filter by directory path"),
+    from: z.string().nullable().optional().describe("Source symbol for a dependency path"),
+    to: z.string().nullable().optional().describe("Target symbol for a dependency path"),
+    symbol: z.string().nullable().optional().describe("Exact symbol for authoritative definition lookup"),
+    limit: z.number().int().min(MIN_CONTEXT_RESULT_LIMIT).max(MAX_CONTEXT_RESULT_LIMIT).nullable().optional().default(10)
+      .describe(`Maximum number of results (${MIN_CONTEXT_RESULT_LIMIT}-${MAX_CONTEXT_RESULT_LIMIT})`),
+    maxDepth: z.number().int().min(MIN_CONTEXT_PATH_DEPTH).max(MAX_CONTEXT_PATH_DEPTH).nullable().optional().default(10)
+      .describe(`Maximum call-path traversal depth (${MIN_CONTEXT_PATH_DEPTH}-${MAX_CONTEXT_PATH_DEPTH})`),
+    fileType: z.string().nullable().optional().describe("Filter by file extension"),
+    directory: z.string().nullable().optional().describe("Filter by directory path"),
     tokenBudget: z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET)
-      .optional().default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET)
+      .nullable().optional().default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET)
       .describe(`Maximum response tokens (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
   },
   async execute(args, context) {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,6 +1,209 @@
 import { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../indexer/index.js";
 import type { CallEdgeData, PathHopData } from "../native/index.js";
 import type { LogEntry } from "../utils/logger.js";
+import { estimateTokens } from "../utils/cost.js";
+
+export const MIN_CONTEXT_PACK_TOKEN_BUDGET = 128;
+export const MAX_CONTEXT_PACK_TOKEN_BUDGET = 4000;
+export const DEFAULT_CONTEXT_PACK_TOKEN_BUDGET = 1200;
+
+interface RankedSearchResult {
+  result: SearchResult;
+  originalIndex: number;
+}
+
+export interface ContextPackOptions {
+  tokenBudget?: number;
+  heading?: string;
+  maxResults?: number;
+}
+
+export interface ContextPackResult {
+  requestedTokenBudget: number;
+  tokenBudget: number;
+  text: string;
+  tokenEstimate: number;
+  results: SearchResult[];
+  candidateCount: number;
+  deduplicatedCount: number;
+  selectedCount: number;
+  omittedCount: number;
+  duplicateCount: number;
+  budgetOmittedCount: number;
+}
+
+export interface BudgetedTextResult {
+  text: string;
+  tokenBudget: number;
+  tokenEstimate: number;
+  truncated: boolean;
+}
+
+export function clampContextPackTokenBudget(tokenBudget?: number): number {
+  if (tokenBudget === undefined || !Number.isFinite(tokenBudget)) {
+    return DEFAULT_CONTEXT_PACK_TOKEN_BUDGET;
+  }
+  return Math.min(
+    MAX_CONTEXT_PACK_TOKEN_BUDGET,
+    Math.max(MIN_CONTEXT_PACK_TOKEN_BUDGET, Math.floor(tokenBudget)),
+  );
+}
+
+export function fitTextToContextBudget(text: string, tokenBudget?: number): BudgetedTextResult {
+  const normalizedBudget = clampContextPackTokenBudget(tokenBudget);
+  if (estimateTokens(text) <= normalizedBudget) {
+    return {
+      text,
+      tokenBudget: normalizedBudget,
+      tokenEstimate: estimateTokens(text),
+      truncated: false,
+    };
+  }
+
+  const suffix = "\n...[truncated to context token budget]";
+  const maxChars = Math.max(0, normalizedBudget * 4 - suffix.length);
+  const fitted = `${text.slice(0, maxChars).trimEnd()}${suffix}`;
+  return {
+    text: fitted,
+    tokenBudget: normalizedBudget,
+    tokenEstimate: estimateTokens(fitted),
+    truncated: true,
+  };
+}
+
+function normalizedLineRange(result: SearchResult): { start: number; end: number } {
+  return result.startLine <= result.endLine
+    ? { start: result.startLine, end: result.endLine }
+    : { start: result.endLine, end: result.startLine };
+}
+
+function rankContextCandidates(results: SearchResult[]): RankedSearchResult[] {
+  return results
+    .map((result, originalIndex) => ({ result, originalIndex }))
+    .sort((left, right) => right.result.score - left.result.score || left.originalIndex - right.originalIndex);
+}
+
+function deduplicateContextCandidates(candidates: RankedSearchResult[]): SearchResult[] {
+  const acceptedByFile = new Map<string, Array<{ start: number; end: number }>>();
+  const deduplicated: SearchResult[] = [];
+
+  for (const { result } of candidates) {
+    const range = normalizedLineRange(result);
+    const accepted = acceptedByFile.get(result.filePath) ?? [];
+    if (accepted.some((item) => item.start <= range.end && range.start <= item.end)) {
+      continue;
+    }
+    accepted.push(range);
+    acceptedByFile.set(result.filePath, accepted);
+    deduplicated.push(result);
+  }
+
+  return deduplicated;
+}
+
+function diversifyContextCandidates(results: SearchResult[]): SearchResult[] {
+  const byFile = new Map<string, SearchResult[]>();
+  for (const result of results) {
+    const bucket = byFile.get(result.filePath) ?? [];
+    bucket.push(result);
+    byFile.set(result.filePath, bucket);
+  }
+
+  const files = [...byFile.keys()];
+  const diversified: SearchResult[] = [];
+  for (let depth = 0; diversified.length < results.length; depth += 1) {
+    for (const file of files) {
+      const result = byFile.get(file)?.[depth];
+      if (result) diversified.push(result);
+    }
+  }
+  return diversified;
+}
+
+function compactEvidenceValue(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `…${value.slice(-(maxChars - 1))}`;
+}
+
+function formatContextEvidence(result: SearchResult, index: number): string {
+  const symbol = result.name ? ` ${JSON.stringify(compactEvidenceValue(result.name, 80))}` : "";
+  const path = compactEvidenceValue(result.filePath, 120);
+  return `[${index}] ${result.chunkType}${symbol} in ${path}:${result.startLine}-${result.endLine} (score ${result.score.toFixed(2)})`;
+}
+
+function formatContextPack(
+  heading: string,
+  selected: SearchResult[],
+  candidateCount: number,
+  duplicateCount: number,
+  budgetOmittedCount: number,
+): string {
+  const lines = selected.map((result, index) => formatContextEvidence(result, index + 1));
+  const notes: string[] = [];
+  if (duplicateCount > 0) notes.push(`${duplicateCount} overlapping duplicate${duplicateCount === 1 ? "" : "s"} removed`);
+  if (budgetOmittedCount > 0) notes.push(`${budgetOmittedCount} additional result${budgetOmittedCount === 1 ? "" : "s"} omitted by token budget`);
+  const footer = notes.length > 0
+    ? `Selected ${selected.length} of ${candidateCount} candidates; ${notes.join("; ")}.`
+    : `Selected ${selected.length} of ${candidateCount} candidates.`;
+  return `${heading}\n\n${lines.join("\n")}\n\n${footer}`;
+}
+
+export function buildContextPack(results: SearchResult[], options: ContextPackOptions = {}): ContextPackResult {
+  const requestedTokenBudget = options.tokenBudget ?? DEFAULT_CONTEXT_PACK_TOKEN_BUDGET;
+  const tokenBudget = clampContextPackTokenBudget(options.tokenBudget);
+  const heading = compactEvidenceValue(options.heading?.trim() || "Codebase evidence", 160);
+  const maxResults = Math.max(0, Math.floor(options.maxResults ?? results.length));
+  const candidateCount = results.length;
+  const deduplicated = deduplicateContextCandidates(rankContextCandidates(results));
+  const diversified = diversifyContextCandidates(deduplicated);
+  const duplicateCount = candidateCount - deduplicated.length;
+  const selectable = diversified.slice(0, maxResults);
+  let selected: SearchResult[] = [];
+  let text = formatContextPack(heading, selected, candidateCount, duplicateCount, deduplicated.length);
+
+  for (let count = 1; count <= selectable.length; count += 1) {
+    const candidateSelection = selectable.slice(0, count);
+    const budgetOmittedCount = deduplicated.length - candidateSelection.length;
+    const candidateText = formatContextPack(
+      heading,
+      candidateSelection,
+      candidateCount,
+      duplicateCount,
+      budgetOmittedCount,
+    );
+    if (estimateTokens(candidateText) > tokenBudget) break;
+    selected = candidateSelection;
+    text = candidateText;
+  }
+
+  if (selected.length === 0 && selectable.length > 0) {
+    selected = [selectable[0]];
+    text = formatContextPack(
+      compactEvidenceValue(heading, 60),
+      selected,
+      candidateCount,
+      duplicateCount,
+      deduplicated.length - 1,
+    );
+  }
+
+  const fitted = fitTextToContextBudget(text, tokenBudget);
+  const budgetOmittedCount = deduplicated.length - selected.length;
+  const omittedCount = candidateCount - selected.length;
+  return {
+    requestedTokenBudget,
+    tokenBudget,
+    text: fitted.text,
+    tokenEstimate: fitted.tokenEstimate,
+    results: selected,
+    candidateCount,
+    deduplicatedCount: deduplicated.length,
+    selectedCount: selected.length,
+    omittedCount,
+    duplicateCount,
+    budgetOmittedCount,
+  };
+}
 
 const MAX_CONTENT_LINES = 30;
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,11 +1,12 @@
-import { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../indexer/index.js";
+import type { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../indexer/index.js";
 import type { CallEdgeData, PathHopData } from "../native/index.js";
 import type { LogEntry } from "../utils/logger.js";
-import { estimateTokens } from "../utils/cost.js";
+import { get_encoding } from "tiktoken";
 
 export const MIN_CONTEXT_PACK_TOKEN_BUDGET = 128;
 export const MAX_CONTEXT_PACK_TOKEN_BUDGET = 4000;
 export const DEFAULT_CONTEXT_PACK_TOKEN_BUDGET = 1200;
+const CONTEXT_TOKENIZER = get_encoding("cl100k_base");
 
 interface RankedSearchResult {
   result: SearchResult;
@@ -29,6 +30,7 @@ export interface ContextPackResult {
   selectedCount: number;
   omittedCount: number;
   duplicateCount: number;
+  limitOmittedCount: number;
   budgetOmittedCount: number;
 }
 
@@ -49,24 +51,37 @@ export function clampContextPackTokenBudget(tokenBudget?: number): number {
   );
 }
 
+export function countContextTokens(text: string): number {
+  return CONTEXT_TOKENIZER.encode(text).length;
+}
+
 export function fitTextToContextBudget(text: string, tokenBudget?: number): BudgetedTextResult {
   const normalizedBudget = clampContextPackTokenBudget(tokenBudget);
-  if (estimateTokens(text) <= normalizedBudget) {
+  const tokenEstimate = countContextTokens(text);
+  if (tokenEstimate <= normalizedBudget) {
     return {
       text,
       tokenBudget: normalizedBudget,
-      tokenEstimate: estimateTokens(text),
+      tokenEstimate,
       truncated: false,
     };
   }
 
   const suffix = "\n...[truncated to context token budget]";
-  const maxChars = Math.max(0, normalizedBudget * 4 - suffix.length);
-  const fitted = `${text.slice(0, maxChars).trimEnd()}${suffix}`;
+  const codePoints = Array.from(text);
+  let low = 0;
+  let high = codePoints.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = `${codePoints.slice(0, middle).join("").trimEnd()}${suffix}`;
+    if (countContextTokens(candidate) <= normalizedBudget) low = middle;
+    else high = middle - 1;
+  }
+  const fitted = `${codePoints.slice(0, low).join("").trimEnd()}${suffix}`;
   return {
     text: fitted,
     tokenBudget: normalizedBudget,
-    tokenEstimate: estimateTokens(fitted),
+    tokenEstimate: countContextTokens(fitted),
     truncated: true,
   };
 }
@@ -136,11 +151,13 @@ function formatContextPack(
   selected: SearchResult[],
   candidateCount: number,
   duplicateCount: number,
+  limitOmittedCount: number,
   budgetOmittedCount: number,
 ): string {
   const lines = selected.map((result, index) => formatContextEvidence(result, index + 1));
   const notes: string[] = [];
   if (duplicateCount > 0) notes.push(`${duplicateCount} overlapping duplicate${duplicateCount === 1 ? "" : "s"} removed`);
+  if (limitOmittedCount > 0) notes.push(`${limitOmittedCount} additional result${limitOmittedCount === 1 ? "" : "s"} excluded by result limit`);
   if (budgetOmittedCount > 0) notes.push(`${budgetOmittedCount} additional result${budgetOmittedCount === 1 ? "" : "s"} omitted by token budget`);
   const footer = notes.length > 0
     ? `Selected ${selected.length} of ${candidateCount} candidates; ${notes.join("; ")}.`
@@ -158,20 +175,22 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const diversified = diversifyContextCandidates(deduplicated);
   const duplicateCount = candidateCount - deduplicated.length;
   const selectable = diversified.slice(0, maxResults);
+  const limitOmittedCount = deduplicated.length - selectable.length;
   let selected: SearchResult[] = [];
-  let text = formatContextPack(heading, selected, candidateCount, duplicateCount, deduplicated.length);
+  let text = formatContextPack(heading, selected, candidateCount, duplicateCount, limitOmittedCount, selectable.length);
 
   for (let count = 1; count <= selectable.length; count += 1) {
     const candidateSelection = selectable.slice(0, count);
-    const budgetOmittedCount = deduplicated.length - candidateSelection.length;
+    const budgetOmittedCount = selectable.length - candidateSelection.length;
     const candidateText = formatContextPack(
       heading,
       candidateSelection,
       candidateCount,
       duplicateCount,
+      limitOmittedCount,
       budgetOmittedCount,
     );
-    if (estimateTokens(candidateText) > tokenBudget) break;
+    if (countContextTokens(candidateText) > tokenBudget) break;
     selected = candidateSelection;
     text = candidateText;
   }
@@ -183,12 +202,13 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
       selected,
       candidateCount,
       duplicateCount,
-      deduplicated.length - 1,
+      limitOmittedCount,
+      selectable.length - 1,
     );
   }
 
   const fitted = fitTextToContextBudget(text, tokenBudget);
-  const budgetOmittedCount = deduplicated.length - selected.length;
+  const budgetOmittedCount = selectable.length - selected.length;
   const omittedCount = candidateCount - selected.length;
   return {
     requestedTokenBudget,
@@ -201,6 +221,7 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
     selectedCount: selected.length,
     omittedCount,
     duplicateCount,
+    limitOmittedCount,
     budgetOmittedCount,
   };
 }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -136,8 +136,9 @@ function diversifyContextCandidates(results: SearchResult[]): SearchResult[] {
 }
 
 function compactEvidenceValue(value: string, maxChars: number): string {
-  if (value.length <= maxChars) return value;
-  return `…${value.slice(-(maxChars - 1))}`;
+  const characters = [...value];
+  if (characters.length <= maxChars) return value;
+  return `…${characters.slice(-(maxChars - 1)).join("")}`;
 }
 
 function formatContextEvidence(result: SearchResult, index: number): string {
@@ -193,18 +194,6 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
     if (countContextTokens(candidateText) > tokenBudget) break;
     selected = candidateSelection;
     text = candidateText;
-  }
-
-  if (selected.length === 0 && selectable.length > 0) {
-    selected = [selectable[0]];
-    text = formatContextPack(
-      compactEvidenceValue(heading, 60),
-      selected,
-      candidateCount,
-      duplicateCount,
-      limitOmittedCount,
-      selectable.length - 1,
-    );
   }
 
   const fitted = fitTextToContextBudget(text, tokenBudget);

--- a/tests/eval-budget.test.ts
+++ b/tests/eval-budget.test.ts
@@ -41,6 +41,14 @@ function summary(p95: number): EvalSummary {
         estimatedCostUsd: 0,
         costPer1MTokensUsd: 0,
       },
+      contextEfficiency: {
+        queryCount: 1,
+        responseTokens: { total: 100, average: 100, p95: 100, max: 100 },
+        duplicateCandidateRatio: 0.1,
+        selectedFileRatio: 1,
+        hitAt5Per1kResponseTokens: 10,
+        mrrAt10Per1kResponseTokens: 10,
+      },
       failureBuckets: {
         "wrong-file": 0,
         "wrong-symbol": 0,
@@ -68,6 +76,13 @@ function comparisonWithBaselineP95(baselineP95: number): EvalComparison {
       latencyP99Ms: { current: 5, baseline: baselineP95, absolute: 5 - baselineP95, relativePct: 0 },
       embeddingCallCount: { current: 1, baseline: 1, absolute: 0, relativePct: 0 },
       estimatedCostUsd: { current: 0, baseline: 0, absolute: 0, relativePct: 0 },
+      contextResponseTokensAverage: { current: 100, baseline: 100, absolute: 0, relativePct: 0 },
+      contextResponseTokensP95: { current: 100, baseline: 100, absolute: 0, relativePct: 0 },
+      contextResponseTokensMax: { current: 100, baseline: 100, absolute: 0, relativePct: 0 },
+      contextDuplicateCandidateRatio: { current: 0.1, baseline: 0.1, absolute: 0, relativePct: 0 },
+      contextSelectedFileRatio: { current: 1, baseline: 1, absolute: 0, relativePct: 0 },
+      contextHitAt5Per1kResponseTokens: { current: 10, baseline: 10, absolute: 0, relativePct: 0 },
+      contextMrrAt10Per1kResponseTokens: { current: 10, baseline: 10, absolute: 0, relativePct: 0 },
     },
   };
 }
@@ -160,5 +175,46 @@ describe("eval budget gate", () => {
     );
     expect(gate.passed).toBe(false);
     expect(gate.violations.some((v) => v.metric === "rawDistinctTop3RatioMaxDrop")).toBe(true);
+  });
+
+  it("enforces context response, duplicate, and quality-per-token thresholds", () => {
+    const budget: EvalBudget = {
+      name: "context",
+      failOnMissingBaseline: false,
+      thresholds: {
+        maxContextResponseTokensAverage: 80,
+        maxContextResponseTokensP95: 90,
+        maxContextResponseTokensMax: 95,
+        maxContextDuplicateCandidateRatio: 0.05,
+        minContextSelectedFileRatio: 1.1,
+        minContextHitAt5Per1kResponseTokens: 11,
+        minContextMrrAt10Per1kResponseTokens: 11,
+      },
+    };
+
+    const gate = evaluateBudgetGate(budget, summary(5));
+
+    expect(gate.passed).toBe(false);
+    expect(gate.violations.map((violation) => violation.metric)).toEqual([
+      "maxContextResponseTokensAverage",
+      "maxContextResponseTokensP95",
+      "maxContextResponseTokensMax",
+      "maxContextDuplicateCandidateRatio",
+      "minContextSelectedFileRatio",
+      "minContextHitAt5Per1kResponseTokens",
+      "minContextMrrAt10Per1kResponseTokens",
+    ]);
+  });
+
+  it("skips context-specific gates when a dataset has no context queries", () => {
+    const withoutContext = summary(5);
+    withoutContext.metrics.contextEfficiency.queryCount = 0;
+    const gate = evaluateBudgetGate({
+      name: "search-only",
+      failOnMissingBaseline: false,
+      thresholds: { maxContextResponseTokensMax: 1 },
+    }, withoutContext);
+
+    expect(gate.passed).toBe(true);
   });
 });

--- a/tests/eval-compare.test.ts
+++ b/tests/eval-compare.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { compareSummaries } from "../src/eval/compare.js";
+import type { EvalSummary } from "../src/eval/types.js";
+
+function summary(overrides: Partial<Pick<EvalSummary, "datasetName" | "datasetVersion" | "queryCount">> = {}): EvalSummary {
+  return {
+    generatedAt: "2026-07-25T00:00:00.000Z",
+    projectRoot: "/repo",
+    datasetPath: "dataset.json",
+    datasetName: overrides.datasetName ?? "agent-context",
+    datasetVersion: overrides.datasetVersion ?? "1.0.0",
+    queryCount: overrides.queryCount ?? 12,
+    topK: 10,
+    searchConfig: { fusionStrategy: "rrf", hybridWeight: 0.4, rrfK: 60, rerankTopN: 20 },
+    metrics: {
+      hitAt1: 0,
+      hitAt3: 0,
+      hitAt5: 0,
+      hitAt10: 0,
+      mrrAt10: 0,
+      ndcgAt10: 0,
+      distinctTop3Ratio: 0,
+      rawDistinctTop3Ratio: 0,
+      latencyMs: { p50: 0, p95: 0, p99: 0 },
+      tokenEstimate: { queryTokens: 0, embeddingTokensUsed: 0 },
+      embedding: { callCount: 0, estimatedCostUsd: 0, costPer1MTokensUsd: 0 },
+      contextEfficiency: {
+        queryCount: 0,
+        responseTokens: { total: 0, average: 0, p95: 0, max: 0 },
+        duplicateCandidateRatio: 0,
+        selectedFileRatio: 0,
+        hitAt5Per1kResponseTokens: 0,
+        mrrAt10Per1kResponseTokens: 0,
+      },
+      failureBuckets: {
+        "wrong-file": 0,
+        "wrong-symbol": 0,
+        "docs-tests-outranking-source": 0,
+        "no-relevant-hit-top-k": 0,
+      },
+    },
+  };
+}
+
+describe("evaluation comparison", () => {
+  it("compares matching datasets", () => {
+    expect(compareSummaries(summary(), summary(), "baseline.json").deltas.hitAt5.absolute).toBe(0);
+  });
+
+  it.each([
+    [{ datasetName: "other" }, "other@1.0.0"],
+    [{ datasetVersion: "2.0.0" }, "agent-context@2.0.0"],
+    [{ queryCount: 11 }, "11 queries"],
+  ] as const)("rejects an incompatible baseline %#", (overrides, expected) => {
+    expect(() => compareSummaries(summary(), summary(overrides), "baseline.json"))
+      .toThrow(new RegExp(`incompatible evaluation datasets.*${expected}`));
+  });
+});

--- a/tests/eval-metrics.test.ts
+++ b/tests/eval-metrics.test.ts
@@ -209,6 +209,50 @@ describe("eval metrics", () => {
     expect(perQuery[0].rawTop3DistinctRatio).toBeCloseTo(2 / 3, 6);
   });
 
+  it("measures context response tokens, candidate compression, and quality per token", () => {
+    const queries: GoldenQuery[] = [
+      query({ id: "q1", retrievalMode: "context" }),
+      query({ id: "q2", retrievalMode: "context" }),
+    ];
+    const result = (id: string, responseTokens: number, relevant: boolean) => buildPerQueryResult(
+      { ...queries[0], id },
+      [{
+        filePath: relevant ? "/repo/src/indexer/index.ts" : "/repo/src/tools/index.ts",
+        startLine: 1,
+        endLine: 2,
+        score: 1,
+        chunkType: "function",
+        name: relevant ? "rankHybridResults" : "other",
+      }],
+      10,
+      10,
+      { resolvedRoute: "definition", routedQuery: "rankHybridResults" },
+      {
+        tokenBudget: 1200,
+        responseTokens,
+        candidateCount: 4,
+        deduplicatedCount: 3,
+        omittedCount: 3,
+      },
+    );
+    const perQuery = [result("q1", 100, true), result("q2", 300, false)];
+
+    const metrics = computeEvalMetrics(queries, perQuery, 0, 0, 0);
+
+    expect(perQuery[0].duplicateCandidateRatio).toBe(0.25);
+    expect(perQuery[0].selectedFileRatio).toBe(1);
+    expect(metrics.contextEfficiency.queryCount).toBe(2);
+    expect(metrics.contextEfficiency.responseTokens).toEqual({
+      total: 400,
+      average: 200,
+      p95: 290,
+      max: 300,
+    });
+    expect(metrics.contextEfficiency.duplicateCandidateRatio).toBe(0.25);
+    expect(metrics.contextEfficiency.hitAt5Per1kResponseTokens).toBe(2.5);
+    expect(metrics.contextEfficiency.mrrAt10Per1kResponseTokens).toBe(2.5);
+  });
+
   it("uses deterministic percentile behavior for tiny samples", () => {
     const q = query();
     const build = (id: string, latencyMs: number) =>

--- a/tests/eval-reports.test.ts
+++ b/tests/eval-reports.test.ts
@@ -1,0 +1,39 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createSummaryMarkdown, loadSummary } from "../src/eval/reports.js";
+
+describe("eval reports", () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("loads legacy summaries without context efficiency metrics", () => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "eval-reports-"));
+    const source = JSON.parse(
+      readFileSync("benchmarks/baselines/eval-baseline-summary.json", "utf-8"),
+    ) as { metrics: Record<string, unknown> };
+    delete source.metrics.contextEfficiency;
+    const summaryPath = path.join(tempDir, "legacy-summary.json");
+    writeFileSync(summaryPath, JSON.stringify(source), "utf-8");
+
+    const summary = loadSummary(summaryPath);
+
+    expect(summary.metrics.contextEfficiency).toEqual({
+      queryCount: 0,
+      responseTokens: { total: 0, average: 0, p95: 0, max: 0 },
+      duplicateCandidateRatio: 0,
+      selectedFileRatio: 0,
+      hitAt5Per1kResponseTokens: 0,
+      mrrAt10Per1kResponseTokens: 0,
+    });
+    const markdown = createSummaryMarkdown(summary);
+    expect(markdown).toContain("Context response tokens total");
+    expect(markdown).toContain("Context response tokens max");
+  });
+});

--- a/tests/eval-runner.test.ts
+++ b/tests/eval-runner.test.ts
@@ -126,9 +126,14 @@ describe("eval runner", () => {
     expect(result.perQuery[0]?.routedQuery).toBe("rankHybridResults");
     expect(typeof result.summary.metrics.distinctTop3Ratio).toBe("number");
     expect(typeof result.summary.metrics.rawDistinctTop3Ratio).toBe("number");
+    expect(result.perQuery[0]?.tokenBudget).toBe(1200);
+    expect(result.perQuery[0]?.responseTokens).toBeGreaterThan(0);
+    expect(result.summary.metrics.contextEfficiency.queryCount).toBe(1);
+    expect(result.summary.metrics.contextEfficiency.responseTokens.p95).toBeLessThanOrEqual(1200);
     expect(readFileSync(path.join(result.outputDir, "summary.json"), "utf-8")).toContain("\"metrics\"");
     expect(readFileSync(path.join(result.outputDir, "summary.md"), "utf-8")).toContain("Distinct Top@3");
     expect(readFileSync(path.join(result.outputDir, "summary.md"), "utf-8")).toContain("Raw Distinct Top@3");
+    expect(readFileSync(path.join(result.outputDir, "summary.md"), "utf-8")).toContain("Context response tokens max");
     expect(readFileSync(path.join(result.outputDir, "summary.md"), "utf-8")).toContain("# Evaluation Summary");
     expect(readFileSync(path.join(result.outputDir, "per-query.json"), "utf-8")).toContain("\"queries\"");
   });

--- a/tests/eval-schema.test.ts
+++ b/tests/eval-schema.test.ts
@@ -140,6 +140,13 @@ describe("eval schema", () => {
           rawDistinctTop3RatioMaxDrop: 0.1,
           p95LatencyMaxMultiplier: 1.5,
           minRawDistinctTop3Ratio: 0.7,
+          maxContextResponseTokensAverage: 800,
+          maxContextResponseTokensP95: 1200,
+          maxContextResponseTokensMax: 1200,
+          maxContextDuplicateCandidateRatio: 0.25,
+          minContextSelectedFileRatio: 0.5,
+          minContextHitAt5Per1kResponseTokens: 0.5,
+          minContextMrrAt10Per1kResponseTokens: 0.25,
         },
       },
       "budget.json"
@@ -148,6 +155,13 @@ describe("eval schema", () => {
     expect(budget.thresholds.hitAt5MaxDrop).toBe(0.05);
     expect(budget.thresholds.rawDistinctTop3RatioMaxDrop).toBe(0.1);
     expect(budget.thresholds.minRawDistinctTop3Ratio).toBe(0.7);
+    expect(budget.thresholds.maxContextResponseTokensAverage).toBe(800);
+    expect(budget.thresholds.maxContextResponseTokensP95).toBe(1200);
+    expect(budget.thresholds.maxContextResponseTokensMax).toBe(1200);
+    expect(budget.thresholds.maxContextDuplicateCandidateRatio).toBe(0.25);
+    expect(budget.thresholds.minContextSelectedFileRatio).toBe(0.5);
+    expect(budget.thresholds.minContextHitAt5Per1kResponseTokens).toBe(0.5);
+    expect(budget.thresholds.minContextMrrAt10Per1kResponseTokens).toBe(0.25);
     expect(budget.failOnMissingBaseline).toBe(true);
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -5,6 +5,7 @@ import { IndexLockContentionError } from "../src/indexer/index-lock.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import * as fs from "fs";
+import { estimateTokens } from "../src/utils/cost.js";
 
 const { testMainRepo } = vi.hoisted(() => ({
   testMainRepo: `/tmp/codebase-index-mcp-vitest-main-repo-${process.pid}`,
@@ -436,12 +437,15 @@ describe("MCP server tools and prompts", () => {
         maxDepth: null,
         fileType: null,
         directory: null,
+        tokenBudget: null,
       },
     });
 
     const content = result.content as Array<{ type: string; text?: string }>;
-    expect(content[0].text).toContain("Found 1 locations");
-    expect(content[0].text).toContain("implementation_lookup");
+    expect(content[0].text).toContain("Codebase evidence");
+    expect(content[0].text).toContain("src/auth.ts:10-25");
+    expect(content[0].text).not.toContain("return token.length");
+    expect(estimateTokens(content[0].text ?? "")).toBeLessThanOrEqual(1200);
   });
 
   it("should route codebase_context known symbols to definition lookup", async () => {
@@ -452,6 +456,7 @@ describe("MCP server tools and prompts", () => {
 
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain('function "validateToken"');
+    expect(content[0].text).not.toContain("return token.length");
     const indexer = indexerMockState.instances.at(-1);
     expect(indexer?.search).toHaveBeenCalledWith(
       "validateToken",
@@ -508,7 +513,7 @@ describe("MCP server tools and prompts", () => {
     });
 
     const content = result.content as Array<{ type: string; text?: string }>;
-    expect(content[0].text).toContain("Found 1 locations for \"Find definition for `missingDefinition`\":");
+    expect(content[0].text).toContain("Codebase evidence for \"Find definition for `missingDefinition`\"");
     expect(indexer?.search).toHaveBeenCalledWith(
       "Find definition for `missingDefinition`",
       10,
@@ -526,6 +531,54 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("Path (2 hops)");
     const indexer = indexerMockState.instances.at(-1);
     expect(indexer?.findCallPath).toHaveBeenCalledWith("fromNode", "toNode", 7);
+  });
+
+  it("should keep conceptual and graph responses within the minimum token budget", async () => {
+    const indexer = indexerMockState.instances.at(-1);
+    indexer?.search.mockResolvedValueOnce(Array.from({ length: 20 }, (_, index) => ({
+      filePath: `src/${"long-directory/".repeat(8)}file-${index}.ts`,
+      startLine: index * 10 + 1,
+      endLine: index * 10 + 8,
+      name: `handler${index}`,
+      chunkType: "function",
+      content: `function handler${index}() { return "full source"; }`,
+      score: 1 - index / 100,
+    })));
+
+    const conceptual = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "find all request handlers", tokenBudget: 128 },
+    });
+    const conceptualText = (conceptual.content as Array<{ text?: string }>)[0]?.text ?? "";
+    expect(estimateTokens(conceptualText)).toBeLessThanOrEqual(128);
+    expect(conceptualText).not.toContain("full source");
+
+    indexer?.findCallPath.mockResolvedValueOnce(Array.from({ length: 30 }, (_, index) => ({
+      symbolName: `symbol${index}`,
+      filePath: `src/path-${index}.ts`,
+      line: index + 1,
+      callType: "Call",
+    })));
+    const graph = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "trace start to finish", from: "start", to: "finish", tokenBudget: 128 },
+    });
+    const graphText = (graph.content as Array<{ text?: string }>)[0]?.text ?? "";
+    expect(estimateTokens(graphText)).toBeLessThanOrEqual(128);
+  });
+
+  it("should enforce the MCP token budget schema range", async () => {
+    const accepted = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "find authentication", tokenBudget: 4000 },
+    });
+    expect(accepted.isError).not.toBe(true);
+
+    const rejected = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "find authentication", tokenBudget: 4001 },
+    });
+    expect(rejected.isError).toBe(true);
   });
 
   it("should recover direct unresolved edges when path traversal returns no hops", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -6,6 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import * as fs from "fs";
 import { estimateTokens } from "../src/utils/cost.js";
+import { countContextTokens } from "../src/tools/utils.js";
 
 const { testMainRepo } = vi.hoisted(() => ({
   testMainRepo: `/tmp/codebase-index-mcp-vitest-main-repo-${process.pid}`,
@@ -445,7 +446,7 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("Codebase evidence");
     expect(content[0].text).toContain("src/auth.ts:10-25");
     expect(content[0].text).not.toContain("return token.length");
-    expect(estimateTokens(content[0].text ?? "")).toBeLessThanOrEqual(1200);
+    expect(countContextTokens(content[0].text ?? "")).toBeLessThanOrEqual(1200);
   });
 
   it("should route codebase_context known symbols to definition lookup", async () => {
@@ -550,7 +551,7 @@ describe("MCP server tools and prompts", () => {
       arguments: { query: "find all request handlers", tokenBudget: 128 },
     });
     const conceptualText = (conceptual.content as Array<{ text?: string }>)[0]?.text ?? "";
-    expect(estimateTokens(conceptualText)).toBeLessThanOrEqual(128);
+    expect(countContextTokens(conceptualText)).toBeLessThanOrEqual(128);
     expect(conceptualText).not.toContain("full source");
 
     indexer?.findCallPath.mockResolvedValueOnce(Array.from({ length: 30 }, (_, index) => ({
@@ -564,7 +565,7 @@ describe("MCP server tools and prompts", () => {
       arguments: { query: "trace start to finish", from: "start", to: "finish", tokenBudget: 128 },
     });
     const graphText = (graph.content as Array<{ text?: string }>)[0]?.text ?? "";
-    expect(estimateTokens(graphText)).toBeLessThanOrEqual(128);
+    expect(countContextTokens(graphText)).toBeLessThanOrEqual(128);
   });
 
   it("should enforce the MCP token budget schema range", async () => {
@@ -579,6 +580,18 @@ describe("MCP server tools and prompts", () => {
       arguments: { query: "find authentication", tokenBudget: 4001 },
     });
     expect(rejected.isError).toBe(true);
+
+    for (const arguments_ of [
+      { query: "find authentication", limit: 0 },
+      { query: "find authentication", limit: 101 },
+      { query: "find authentication", limit: 1.5 },
+      { query: "trace authentication", maxDepth: 0 },
+      { query: "trace authentication", maxDepth: 101 },
+      { query: "trace authentication", maxDepth: 1.5 },
+    ]) {
+      const invalid = await client.callTool({ name: "codebase_context", arguments: arguments_ });
+      expect(invalid.isError).toBe(true);
+    }
   });
 
   it("should recover direct unresolved edges when path traversal returns no hops", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -461,7 +461,7 @@ describe("MCP server tools and prompts", () => {
     const indexer = indexerMockState.instances.at(-1);
     expect(indexer?.search).toHaveBeenCalledWith(
       "validateToken",
-      10,
+      100,
       expect.objectContaining({ definitionIntent: true }),
     );
   });
@@ -477,7 +477,7 @@ describe("MCP server tools and prompts", () => {
     const indexer = indexerMockState.instances.at(-1);
     expect(indexer?.search).toHaveBeenCalledWith(
       "getStatus",
-      10,
+      100,
       expect.objectContaining({ definitionIntent: true }),
     );
   });
@@ -517,7 +517,7 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("Codebase evidence for \"Find definition for `missingDefinition`\"");
     expect(indexer?.search).toHaveBeenCalledWith(
       "Find definition for `missingDefinition`",
-      10,
+      100,
       expect.objectContaining({ metadataOnly: true }),
     );
   });

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { estimateTokens } from "../src/utils/cost.js";
+import { countContextTokens } from "../src/tools/utils.js";
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
@@ -37,6 +37,7 @@ interface RegisteredTool {
       readonly default?: number;
       readonly minimum?: number;
       readonly maximum?: number;
+      readonly anyOf?: ReadonlyArray<{ readonly minimum?: number; readonly maximum?: number; readonly type?: string }>;
     }>;
   };
   readonly execute: (
@@ -91,8 +92,19 @@ describe("Pi adapter conformance", () => {
     expect(names).toContain("codebase_search");
     expect(names).toContain("implementation_lookup");
     expect(tools.get("codebase_context")?.parameters?.properties?.tokenBudget).toEqual(
-      expect.objectContaining({ default: 1200, minimum: 128, maximum: 4000 }),
+      expect.objectContaining({
+        default: 1200,
+        anyOf: expect.arrayContaining([expect.objectContaining({ minimum: 128, maximum: 4000 })]),
+      }),
     );
+    expect(tools.get("codebase_context")?.parameters?.properties?.limit).toEqual(expect.objectContaining({
+      default: 10,
+      anyOf: expect.arrayContaining([expect.objectContaining({ minimum: 1, maximum: 100 })]),
+    }));
+    expect(tools.get("codebase_context")?.parameters?.properties?.maxDepth).toEqual(expect.objectContaining({
+      default: 10,
+      anyOf: expect.arrayContaining([expect.objectContaining({ minimum: 1, maximum: 100 })]),
+    }));
   });
 
   it("formats caller results like other host adapters", async () => {
@@ -197,7 +209,7 @@ describe("Pi adapter conformance", () => {
       { cwd: "/repo" },
     );
 
-    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "pi", "callerFn", "targetFn", undefined);
+    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "pi", "callerFn", "targetFn", 10);
     expect(operationMocks.getCallGraphData).toHaveBeenCalledWith("/repo", "pi", { name: "targetFn", direction: "callers" });
     expect(result?.content[0]?.text).toContain("Direct path: callerFn --Call--> targetFn");
     expect(result?.content[0]?.text).toContain("src/app.ts:19");
@@ -234,7 +246,7 @@ describe("Pi adapter conformance", () => {
     });
     expect(result?.content[0]?.text).toContain("src/auth.ts:12-30");
     expect(result?.content[0]?.text).not.toContain("function validateToken() {}");
-    expect(estimateTokens(result?.content[0]?.text ?? "")).toBeLessThanOrEqual(128);
+    expect(countContextTokens(result?.content[0]?.text ?? "")).toBeLessThanOrEqual(128);
     expect(result?.details).toEqual(expect.objectContaining({
       tokenBudget: 128,
       selectedCount: 1,
@@ -347,8 +359,38 @@ describe("Pi adapter conformance", () => {
       metadataOnly: true,
     });
     expect(result?.content[0]?.text).toContain("Codebase evidence for \"validation helper\"");
-    expect(estimateTokens(result?.content[0]?.text ?? "")).toBeLessThanOrEqual(128);
+    expect(countContextTokens(result?.content[0]?.text ?? "")).toBeLessThanOrEqual(128);
     expect(JSON.stringify(result?.details)).not.toContain("function validateToken() {}");
+  });
+
+  it("accepts explicit null optional codebase_context arguments", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([]);
+    const { tools } = await registerPiTools();
+
+    await tools.get("codebase_context")?.execute(
+      "tool-call",
+      {
+        query: "validation helper",
+        from: null,
+        to: null,
+        symbol: null,
+        limit: null,
+        maxDepth: null,
+        fileType: null,
+        directory: null,
+        tokenBudget: null,
+      },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "validation helper", {
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+      metadataOnly: true,
+    });
   });
 
   it("injects client-neutral repository guidance on before_agent_start", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { estimateTokens } from "../src/utils/cost.js";
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
@@ -31,6 +32,13 @@ vi.mock("../src/tools/operations.js", () => ({
 
 interface RegisteredTool {
   readonly name: string;
+  readonly parameters?: {
+    readonly properties?: Record<string, {
+      readonly default?: number;
+      readonly minimum?: number;
+      readonly maximum?: number;
+    }>;
+  };
   readonly execute: (
     toolCallId: string,
     params: Record<string, unknown>,
@@ -82,6 +90,9 @@ describe("Pi adapter conformance", () => {
     expect(names[0]).toBe("codebase_context");
     expect(names).toContain("codebase_search");
     expect(names).toContain("implementation_lookup");
+    expect(tools.get("codebase_context")?.parameters?.properties?.tokenBudget).toEqual(
+      expect.objectContaining({ default: 1200, minimum: 128, maximum: 4000 }),
+    );
   });
 
   it("formats caller results like other host adapters", async () => {
@@ -208,9 +219,9 @@ describe("Pi adapter conformance", () => {
 
     const { tools } = await registerPiTools();
 
-    await tools.get("codebase_context")?.execute(
+    const result = await tools.get("codebase_context")?.execute(
       "tool-call",
-      { query: "unused", symbol: "validateToken", limit: 8 },
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128 },
       new AbortController().signal,
       () => {},
       { cwd: "/repo" },
@@ -221,6 +232,15 @@ describe("Pi adapter conformance", () => {
       fileType: undefined,
       directory: undefined,
     });
+    expect(result?.content[0]?.text).toContain("src/auth.ts:12-30");
+    expect(result?.content[0]?.text).not.toContain("function validateToken() {}");
+    expect(estimateTokens(result?.content[0]?.text ?? "")).toBeLessThanOrEqual(128);
+    expect(result?.details).toEqual(expect.objectContaining({
+      tokenBudget: 128,
+      selectedCount: 1,
+      results: [expect.objectContaining({ filePath: "src/auth.ts", name: "validateToken" })],
+    }));
+    expect(JSON.stringify(result?.details)).not.toContain("content");
   });
 
   it("routes inferred symbol-style codebase_context queries through implementation lookup", async () => {
@@ -294,7 +314,7 @@ describe("Pi adapter conformance", () => {
         metadataOnly: true,
       },
     );
-    expect(result?.content[0]?.text).toContain("Found 1 locations for \"show definition for `missingDefinition`\":");
+    expect(result?.content[0]?.text).toContain("Codebase evidence for \"show definition for `missingDefinition`\"");
   });
 
   it("routes codebase_context query-only lookups with metadata-only search", async () => {
@@ -314,7 +334,7 @@ describe("Pi adapter conformance", () => {
 
     const result = await tools.get("codebase_context")?.execute(
       "tool-call",
-      { query: "validation helper", limit: 4, fileType: "ts", directory: "src" },
+      { query: "validation helper", limit: 4, fileType: "ts", directory: "src", tokenBudget: 128 },
       new AbortController().signal,
       () => {},
       { cwd: "/repo" },
@@ -326,7 +346,9 @@ describe("Pi adapter conformance", () => {
       directory: "src",
       metadataOnly: true,
     });
-    expect(result?.content[0]?.text).toContain("Found 1 locations for \"validation helper\":");
+    expect(result?.content[0]?.text).toContain("Codebase evidence for \"validation helper\"");
+    expect(estimateTokens(result?.content[0]?.text ?? "")).toBeLessThanOrEqual(128);
+    expect(JSON.stringify(result?.details)).not.toContain("function validateToken() {}");
   });
 
   it("injects client-neutral repository guidance on before_agent_start", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -240,7 +240,7 @@ describe("Pi adapter conformance", () => {
     );
 
     expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "pi", "validateToken", {
-      limit: 8,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
     });
@@ -279,7 +279,7 @@ describe("Pi adapter conformance", () => {
     );
 
     expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "pi", "getStatus", {
-      limit: 10,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
     });
@@ -311,7 +311,7 @@ describe("Pi adapter conformance", () => {
     );
 
     expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "pi", "missingDefinition", {
-      limit: 10,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
     });
@@ -320,7 +320,7 @@ describe("Pi adapter conformance", () => {
       "pi",
       "show definition for `missingDefinition`",
       {
-        limit: 10,
+        limit: 100,
         fileType: undefined,
         directory: undefined,
         metadataOnly: true,
@@ -353,7 +353,7 @@ describe("Pi adapter conformance", () => {
     );
 
     expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "validation helper", {
-      limit: 4,
+      limit: 100,
       fileType: "ts",
       directory: "src",
       metadataOnly: true,
@@ -386,7 +386,7 @@ describe("Pi adapter conformance", () => {
     );
 
     expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "validation helper", {
-      limit: 10,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -50,6 +50,7 @@ vi.mock("../src/tools/index.js", () => {
   };
 
   return {
+    codebase_context: toolStub,
     codebase_search: toolStub,
     codebase_peek: toolStub,
     index_codebase: toolStub,
@@ -109,6 +110,14 @@ describe("plugin routing hint hook selection", () => {
     };
     mockState.hints = ["runtime-routing-hint"];
     mockState.routingControllers.length = 0;
+  });
+
+  it("registers codebase_context in the native OpenCode tool map", async () => {
+    const runtime = await plugin({ directory: "/tmp/project" } as Parameters<typeof plugin>[0]);
+
+    expect(runtime.tool).toEqual(expect.objectContaining({
+      codebase_context: expect.any(Object),
+    }));
   });
 
   it("injects hints through system transform when role is system", async () => {

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { estimateTokens } from "../src/utils/cost.js";
+import { countContextTokens } from "../src/tools/utils.js";
 
 const operationMocks = vi.hoisted(() => ({
   searchCodebase: vi.fn(),
@@ -67,7 +67,7 @@ describe("native OpenCode codebase_context", () => {
     });
     expect(result).toContain("Codebase evidence");
     expect(result).not.toContain("secret source");
-    expect(estimateTokens(result)).toBeLessThanOrEqual(128);
+    expect(countContextTokens(result)).toBeLessThanOrEqual(128);
   });
 
   it("routes explicit definitions to compact location evidence", async () => {
@@ -94,7 +94,7 @@ describe("native OpenCode codebase_context", () => {
     });
     expect(result).toContain("src/auth.ts:12-30");
     expect(result).not.toContain("fullSource");
-    expect(estimateTokens(result)).toBeLessThanOrEqual(128);
+    expect(countContextTokens(result)).toBeLessThanOrEqual(128);
   });
 
   it("routes dependency endpoints through bounded call-path output", async () => {
@@ -114,6 +114,27 @@ describe("native OpenCode codebase_context", () => {
 
     expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "opencode", "start", "finish", 10);
     expect(result).toContain("Path (30 hops)");
-    expect(estimateTokens(result)).toBeLessThanOrEqual(128);
+    expect(countContextTokens(result)).toBeLessThanOrEqual(128);
+  });
+
+  it("accepts explicit null optional arguments like the other adapters", async () => {
+    await codebase_context.execute({
+      query: "request handling",
+      from: null,
+      to: null,
+      symbol: null,
+      limit: null,
+      maxDepth: null,
+      fileType: null,
+      directory: null,
+      tokenBudget: null,
+    }, context);
+
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "opencode", "request handling", {
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+      metadataOnly: true,
+    });
   });
 });

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { estimateTokens } from "../src/utils/cost.js";
+
+const operationMocks = vi.hoisted(() => ({
+  searchCodebase: vi.fn(),
+  implementationLookup: vi.fn(),
+  getCallGraphPath: vi.fn(),
+  getCallGraphData: vi.fn(),
+}));
+
+vi.mock("../src/tools/operations.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/tools/operations.js")>("../src/tools/operations.js");
+  return {
+    ...actual,
+    searchCodebase: operationMocks.searchCodebase,
+    implementationLookup: operationMocks.implementationLookup,
+    getCallGraphPath: operationMocks.getCallGraphPath,
+    getCallGraphData: operationMocks.getCallGraphData,
+  };
+});
+
+import { codebase_context } from "../src/tools/index.js";
+
+const context = { worktree: "/repo" };
+const commonArgs = {
+  from: undefined,
+  to: undefined,
+  symbol: undefined,
+  limit: 10,
+  maxDepth: 10,
+  fileType: undefined,
+  directory: undefined,
+  tokenBudget: 128,
+};
+
+describe("native OpenCode codebase_context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    operationMocks.searchCodebase.mockResolvedValue([]);
+    operationMocks.implementationLookup.mockResolvedValue([]);
+    operationMocks.getCallGraphPath.mockResolvedValue([]);
+    operationMocks.getCallGraphData.mockResolvedValue({ direction: "callers", callers: [], callees: [] });
+  });
+
+  it("returns a bounded conceptual evidence pack without source content", async () => {
+    operationMocks.searchCodebase.mockResolvedValue(Array.from({ length: 12 }, (_, index) => ({
+      filePath: `src/${"long-directory/".repeat(8)}file-${index}.ts`,
+      startLine: index * 10 + 1,
+      endLine: index * 10 + 8,
+      name: `handler${index}`,
+      chunkType: "function",
+      content: `function handler${index}() { return "secret source"; }`,
+      score: 1 - index / 100,
+    })));
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "where is request handling implemented",
+    }, context);
+
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "opencode", "where is request handling implemented", {
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+      metadataOnly: true,
+    });
+    expect(result).toContain("Codebase evidence");
+    expect(result).not.toContain("secret source");
+    expect(estimateTokens(result)).toBeLessThanOrEqual(128);
+  });
+
+  it("routes explicit definitions to compact location evidence", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      filePath: "src/auth.ts",
+      startLine: 12,
+      endLine: 30,
+      name: "validateToken",
+      chunkType: "function",
+      content: "function validateToken() { return fullSource; }",
+      score: 0.99,
+    }]);
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "where is validateToken defined",
+      symbol: "validateToken",
+    }, context);
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "opencode", "validateToken", {
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+    });
+    expect(result).toContain("src/auth.ts:12-30");
+    expect(result).not.toContain("fullSource");
+    expect(estimateTokens(result)).toBeLessThanOrEqual(128);
+  });
+
+  it("routes dependency endpoints through bounded call-path output", async () => {
+    operationMocks.getCallGraphPath.mockResolvedValue(Array.from({ length: 30 }, (_, index) => ({
+      symbolName: `symbol${index}`,
+      filePath: `src/path-${index}.ts`,
+      line: index + 1,
+      callType: "Call",
+    })));
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "trace start to finish",
+      from: "start",
+      to: "finish",
+    }, context);
+
+    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "opencode", "start", "finish", 10);
+    expect(result).toContain("Path (30 hops)");
+    expect(estimateTokens(result)).toBeLessThanOrEqual(128);
+  });
+});

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -60,12 +60,13 @@ describe("native OpenCode codebase_context", () => {
     }, context);
 
     expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "opencode", "where is request handling implemented", {
-      limit: 10,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,
     });
     expect(result).toContain("Codebase evidence");
+    expect(result).toContain("2 additional results excluded by result limit");
     expect(result).not.toContain("secret source");
     expect(countContextTokens(result)).toBeLessThanOrEqual(128);
   });
@@ -88,7 +89,7 @@ describe("native OpenCode codebase_context", () => {
     }, context);
 
     expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "opencode", "validateToken", {
-      limit: 10,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
     });
@@ -131,10 +132,40 @@ describe("native OpenCode codebase_context", () => {
     }, context);
 
     expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "opencode", "request handling", {
-      limit: 10,
+      limit: 100,
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,
     });
+  });
+
+  it("falls back from an inferred definition miss to conceptual search", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([{
+      filePath: "src/fallback.ts",
+      startLine: 1,
+      endLine: 4,
+      name: "actualHandler",
+      chunkType: "function",
+      content: "hidden",
+      score: 0.8,
+    }]);
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "where is missingHandler defined",
+    }, context);
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith("/repo", "opencode", "missingHandler", {
+      limit: 100,
+      fileType: undefined,
+      directory: undefined,
+    });
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "opencode", "where is missingHandler defined", {
+      limit: 100,
+      fileType: undefined,
+      directory: undefined,
+      metadataOnly: true,
+    });
+    expect(result).toContain("src/fallback.ts:1-4");
   });
 });

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -9,13 +9,13 @@ import {
   formatLogs,
   formatSearchResults,
   buildContextPack,
+  countContextTokens,
   fitTextToContextBudget,
   MIN_CONTEXT_PACK_TOKEN_BUDGET,
   MAX_CONTEXT_PACK_TOKEN_BUDGET,
 } from "../src/tools/utils.js";
 import type { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../src/indexer/index.js";
 import type { LogEntry } from "../src/utils/logger.js";
-import { estimateTokens } from "../src/utils/cost.js";
 
 function createBaseStats(overrides: Partial<IndexStats> = {}): IndexStats {
   return {
@@ -622,7 +622,7 @@ describe("tools utils", () => {
       expect(tooSmall.tokenBudget).toBe(MIN_CONTEXT_PACK_TOKEN_BUDGET);
       expect(tooLarge.tokenBudget).toBe(MAX_CONTEXT_PACK_TOKEN_BUDGET);
       expect(tooSmall.results).toHaveLength(1);
-      expect(tooSmall.tokenEstimate).toBe(estimateTokens(tooSmall.text));
+      expect(tooSmall.tokenEstimate).toBe(countContextTokens(tooSmall.text));
       expect(tooSmall.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
     });
 
@@ -785,7 +785,7 @@ describe("tools utils", () => {
       const packed = buildContextPack(results, { tokenBudget: 1 });
       const maxBudget = packed.tokenBudget;
       expect(packed.results.length).toBeGreaterThan(0);
-      expect(estimateTokens(packed.text)).toBeLessThanOrEqual(maxBudget);
+      expect(countContextTokens(packed.text)).toBeLessThanOrEqual(maxBudget);
     });
 
     it("adds a clear omitted-count footer when candidates are dropped", () => {
@@ -822,7 +822,7 @@ describe("tools utils", () => {
       const packed = buildContextPack(results, { tokenBudget: 1 });
       expect(packed.results.length + packed.omittedCount).toBe(results.length);
       expect(packed.text).toContain("omitted by token budget");
-      expect(estimateTokens(packed.text)).toBeLessThanOrEqual(packed.tokenBudget);
+      expect(countContextTokens(packed.text)).toBeLessThanOrEqual(packed.tokenBudget);
     });
 
     it("honors maxResults and reports budget omissions separately from duplicates", () => {
@@ -840,8 +840,11 @@ describe("tools utils", () => {
 
       expect(packed.selectedCount).toBe(2);
       expect(packed.duplicateCount).toBe(0);
-      expect(packed.budgetOmittedCount).toBe(2);
+      expect(packed.limitOmittedCount).toBe(2);
+      expect(packed.budgetOmittedCount).toBe(0);
       expect(packed.omittedCount).toBe(2);
+      expect(packed.text).toContain("excluded by result limit");
+      expect(packed.text).not.toContain("omitted by token budget");
     });
 
     it("keeps worst-case headings and paths within the minimum budget", () => {
@@ -861,7 +864,7 @@ describe("tools utils", () => {
       });
 
       expect(packed.selectedCount).toBe(1);
-      expect(packed.tokenEstimate).toBe(estimateTokens(packed.text));
+      expect(packed.tokenEstimate).toBe(countContextTokens(packed.text));
       expect(packed.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
       expect(packed.text).not.toContain(result.content);
     });
@@ -880,9 +883,16 @@ describe("tools utils", () => {
       const fitted = fitTextToContextBudget("x".repeat(5000), MIN_CONTEXT_PACK_TOKEN_BUDGET);
 
       expect(fitted.truncated).toBe(true);
-      expect(fitted.tokenEstimate).toBe(estimateTokens(fitted.text));
+      expect(fitted.tokenEstimate).toBe(countContextTokens(fitted.text));
       expect(fitted.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
       expect(fitted.text).toContain("truncated to context token budget");
+    });
+
+    it("enforces the budget with multilingual and emoji input", () => {
+      const fitted = fitTextToContextBudget("😀 漢字 café مرحبا ".repeat(500), MIN_CONTEXT_PACK_TOKEN_BUDGET);
+
+      expect(fitted.tokenEstimate).toBe(countContextTokens(fitted.text));
+      expect(fitted.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
     });
   });
 

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -8,9 +8,14 @@ import {
   formatHealthCheck,
   formatLogs,
   formatSearchResults,
+  buildContextPack,
+  fitTextToContextBudget,
+  MIN_CONTEXT_PACK_TOKEN_BUDGET,
+  MAX_CONTEXT_PACK_TOKEN_BUDGET,
 } from "../src/tools/utils.js";
 import type { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../src/indexer/index.js";
 import type { LogEntry } from "../src/utils/logger.js";
+import { estimateTokens } from "../src/utils/cost.js";
 
 function createBaseStats(overrides: Partial<IndexStats> = {}): IndexStats {
   return {
@@ -596,6 +601,288 @@ describe("tools utils", () => {
       expect(result).toContain("orphan embeddings: 5");
       expect(result).toContain("orphan chunks: 3");
       expect(result).toContain("a.ts");
+    });
+  });
+
+  describe("buildContextPack", () => {
+    it("caps and validates token budgets", () => {
+      const sampleResult: SearchResult = {
+        filePath: "src/example.ts",
+        startLine: 10,
+        endLine: 20,
+        content: "const ok = true;",
+        score: 0.98,
+        chunkType: "function",
+        name: "example",
+      };
+
+      const tooSmall = buildContextPack([sampleResult], { tokenBudget: 1 });
+      const tooLarge = buildContextPack([sampleResult], { tokenBudget: Number.MAX_SAFE_INTEGER });
+
+      expect(tooSmall.tokenBudget).toBe(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+      expect(tooLarge.tokenBudget).toBe(MAX_CONTEXT_PACK_TOKEN_BUDGET);
+      expect(tooSmall.results).toHaveLength(1);
+      expect(tooSmall.tokenEstimate).toBe(estimateTokens(tooSmall.text));
+      expect(tooSmall.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+    });
+
+    it("deduplicates exact and overlapping same-file hits", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "src/foo.ts",
+          startLine: 10,
+          endLine: 30,
+          content: "a",
+          score: 0.90,
+          chunkType: "function",
+          name: "outer",
+        },
+        {
+          filePath: "src/foo.ts",
+          startLine: 12,
+          endLine: 18,
+          content: "b",
+          score: 0.95,
+          chunkType: "function",
+          name: "inner",
+        },
+        {
+          filePath: "src/foo.ts",
+          startLine: 40,
+          endLine: 45,
+          content: "c",
+          score: 0.85,
+          chunkType: "function",
+          name: "later",
+        },
+        {
+          filePath: "src/foo.ts",
+          startLine: 10,
+          endLine: 30,
+          content: "d",
+          score: 0.40,
+          chunkType: "function",
+          name: "exactDup",
+        },
+      ];
+
+      const packed = buildContextPack(results, { tokenBudget: 2048 });
+      expect(packed.results).toHaveLength(2);
+      expect(packed.candidateCount).toBe(4);
+      expect(packed.deduplicatedCount).toBe(2);
+      expect(packed.duplicateCount).toBe(2);
+      expect(packed.omittedCount).toBe(2);
+      const names = packed.results.map((r) => r.name);
+      expect(names).toEqual(["inner", "later"]);
+      expect(names).not.toContain("overlap");
+    });
+
+    it("diversifies selection across files before taking additional same-file matches", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "src/a.ts",
+          startLine: 1,
+          endLine: 10,
+          content: "a1",
+          score: 0.99,
+          chunkType: "function",
+          name: "a1",
+        },
+        {
+          filePath: "src/a.ts",
+          startLine: 20,
+          endLine: 22,
+          content: "a2",
+          score: 0.95,
+          chunkType: "function",
+          name: "a2",
+        },
+        {
+          filePath: "src/b.ts",
+          startLine: 1,
+          endLine: 8,
+          content: "b1",
+          score: 0.98,
+          chunkType: "function",
+          name: "b1",
+        },
+        {
+          filePath: "src/c.ts",
+          startLine: 1,
+          endLine: 5,
+          content: "c1",
+          score: 0.97,
+          chunkType: "function",
+          name: "c1",
+        },
+      ];
+
+      const packed = buildContextPack(results, { tokenBudget: 2048 });
+      const names = packed.results.map((result) => result.name);
+      expect(names).toEqual(["a1", "b1", "c1", "a2"]);
+    });
+
+    it("is deterministic for identical input", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "src/b.ts",
+          startLine: 1,
+          endLine: 3,
+          content: "b",
+          score: 0.88,
+          chunkType: "function",
+          name: "b",
+        },
+        {
+          filePath: "src/a.ts",
+          startLine: 2,
+          endLine: 4,
+          content: "a",
+          score: 0.88,
+          chunkType: "function",
+          name: "a",
+        },
+      ];
+
+      const first = buildContextPack(results, { tokenBudget: 2048 });
+      const second = buildContextPack(results, { tokenBudget: 2048 });
+
+      expect(first.text).toBe(second.text);
+      expect(first.results).toEqual(second.results);
+    });
+
+    it("handles tiny budgets and still tracks omitted candidates when budget is tight", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "src/foo.ts",
+          startLine: 1,
+          endLine: 2,
+          content: "a",
+          score: 0.99,
+          chunkType: "function",
+          name: "first",
+        },
+        {
+          filePath: "src/foo.ts",
+          startLine: 3,
+          endLine: 4,
+          content: "b",
+          score: 0.98,
+          chunkType: "function",
+          name: "second",
+        },
+        {
+          filePath: "src/foo.ts",
+          startLine: 5,
+          endLine: 6,
+          content: "c",
+          score: 0.97,
+          chunkType: "function",
+          name: "third",
+        },
+      ];
+
+      const packed = buildContextPack(results, { tokenBudget: 1 });
+      const maxBudget = packed.tokenBudget;
+      expect(packed.results.length).toBeGreaterThan(0);
+      expect(estimateTokens(packed.text)).toBeLessThanOrEqual(maxBudget);
+    });
+
+    it("adds a clear omitted-count footer when candidates are dropped", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: `/tmp/example/${"a".repeat(180)}/a.ts`,
+          startLine: 1,
+          endLine: 6,
+          content: "a",
+          score: 0.95,
+          chunkType: "function",
+          name: "a1",
+        },
+        {
+          filePath: `/tmp/example/${"b".repeat(180)}/b.ts`,
+          startLine: 1,
+          endLine: 6,
+          content: "b",
+          score: 0.94,
+          chunkType: "function",
+          name: "b1",
+        },
+        {
+          filePath: `/tmp/example/${"c".repeat(180)}/c.ts`,
+          startLine: 1,
+          endLine: 6,
+          content: "c",
+          score: 0.93,
+          chunkType: "function",
+          name: "c1",
+        },
+      ];
+
+      const packed = buildContextPack(results, { tokenBudget: 1 });
+      expect(packed.results.length + packed.omittedCount).toBe(results.length);
+      expect(packed.text).toContain("omitted by token budget");
+      expect(estimateTokens(packed.text)).toBeLessThanOrEqual(packed.tokenBudget);
+    });
+
+    it("honors maxResults and reports budget omissions separately from duplicates", () => {
+      const results: SearchResult[] = Array.from({ length: 4 }, (_, index) => ({
+        filePath: `src/file-${index}.ts`,
+        startLine: 1,
+        endLine: 5,
+        content: `content-${index}`,
+        score: 1 - index / 10,
+        chunkType: "function",
+        name: `symbol${index}`,
+      }));
+
+      const packed = buildContextPack(results, { tokenBudget: 2048, maxResults: 2 });
+
+      expect(packed.selectedCount).toBe(2);
+      expect(packed.duplicateCount).toBe(0);
+      expect(packed.budgetOmittedCount).toBe(2);
+      expect(packed.omittedCount).toBe(2);
+    });
+
+    it("keeps worst-case headings and paths within the minimum budget", () => {
+      const result: SearchResult = {
+        filePath: `${"very-long-directory/".repeat(40)}implementation.ts`,
+        startLine: 1,
+        endLine: 999999,
+        content: "full source must not appear",
+        score: 0.99,
+        chunkType: "function",
+        name: "extremelyLongSymbolName".repeat(30),
+      };
+
+      const packed = buildContextPack([result], {
+        tokenBudget: MIN_CONTEXT_PACK_TOKEN_BUDGET,
+        heading: "Extremely long context heading ".repeat(30),
+      });
+
+      expect(packed.selectedCount).toBe(1);
+      expect(packed.tokenEstimate).toBe(estimateTokens(packed.text));
+      expect(packed.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+      expect(packed.text).not.toContain(result.content);
+    });
+
+    it("returns a bounded empty evidence pack", () => {
+      const packed = buildContextPack([], { tokenBudget: MIN_CONTEXT_PACK_TOKEN_BUDGET });
+
+      expect(packed.results).toEqual([]);
+      expect(packed.candidateCount).toBe(0);
+      expect(packed.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+    });
+  });
+
+  describe("fitTextToContextBudget", () => {
+    it("truncates long text without exceeding the effective budget", () => {
+      const fitted = fitTextToContextBudget("x".repeat(5000), MIN_CONTEXT_PACK_TOKEN_BUDGET);
+
+      expect(fitted.truncated).toBe(true);
+      expect(fitted.tokenEstimate).toBe(estimateTokens(fitted.text));
+      expect(fitted.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+      expect(fitted.text).toContain("truncated to context token budget");
     });
   });
 

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -869,6 +869,43 @@ describe("tools utils", () => {
       expect(packed.text).not.toContain(result.content);
     });
 
+    it("does not split Unicode surrogate pairs while compacting evidence", () => {
+      const result: SearchResult = {
+        filePath: `src/${"😀".repeat(160)}.ts`,
+        startLine: 1,
+        endLine: 2,
+        content: "hidden",
+        score: 1,
+        chunkType: "function",
+        name: "𐐷".repeat(100),
+      };
+
+      const packed = buildContextPack([result], { tokenBudget: 4000 });
+
+      expect(Buffer.from(packed.text, "utf8").toString("utf8")).toBe(packed.text);
+    });
+
+    it("does not claim a result was selected when no evidence line fits", () => {
+      const rareCharacter = String.fromCodePoint(0x10ffff);
+      const result: SearchResult = {
+        filePath: rareCharacter.repeat(300),
+        startLine: 1,
+        endLine: 2,
+        content: "hidden",
+        score: 1,
+        chunkType: rareCharacter.repeat(100),
+        name: rareCharacter.repeat(100),
+      };
+
+      const packed = buildContextPack([result], { tokenBudget: MIN_CONTEXT_PACK_TOKEN_BUDGET });
+
+      expect(packed.selectedCount).toBe(0);
+      expect(packed.results).toEqual([]);
+      expect(packed.budgetOmittedCount).toBe(1);
+      expect(packed.text).toContain("omitted by token budget");
+      expect(packed.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+    });
+
     it("returns a bounded empty evidence pack", () => {
       const packed = buildContextPack([], { tokenBudget: MIN_CONTEXT_PACK_TOKEN_BUDGET });
 


### PR DESCRIPTION
## Summary

Add a shared token-budgeted, metadata-first `codebase_context` response path for native OpenCode, MCP clients, and Pi so coding agents can understand repositories with bounded token usage while retaining location quality.

## Changes

- Add deterministic context packing with a configurable 128–4000 token budget (default 1200), `cl100k_base` tokenizer-counted hard caps, overlap deduplication, cross-file diversification, compact location evidence, and separate result-limit versus token-budget omission metadata.
- Route conceptual discovery, exact definitions, and dependency paths through one shared resolver across native OpenCode, MCP-based harnesses, and Pi without returning source bodies in the first response.
- Align optional-null handling and bounded integer schemas across OpenCode, MCP, and Pi for context limits, graph depth, filters, and token budgets.
- Add context-efficiency evaluation metrics and reports for total/average/p95/max response tokens, duplicate and selected-file ratios, and Hit@5/MRR per 1k response tokens.
- Add dataset-matched agent-context CI gates and reject comparisons between incompatible evaluation datasets to avoid misleading baseline regressions.
- Harden concurrent crashed-owner lock recovery when another reclaimer removes a publication candidate during creation, writing, or rename.
- Document the token-budget workflow, tokenizer semantics, drilldown guidance, evaluation commands, thresholds, and changelog entry.

## Testing

- Same-index raw versus packed evaluation: Hit@5 remained 41.67%; MRR@10 improved from 0.2500 to 0.2597.
- Fresh real-index `npm run eval:agent:ci`: passed its dataset-matched gate at Hit@5 33.33%, MRR@10 0.2444, and p95 latency 50.2 ms. Packed responses averaged 404.5 actual `cl100k_base` tokens with p95 438.2 and max 442; context token, duplicate, diversity, and quality-per-token gates all passed.
- Unicode hard-cap reproduction: a 128-token budget produced exactly 128 `cl100k_base` tokens after truncation; supplementary-plane paths and symbols preserve valid Unicode without lone surrogates, and evidence-free truncation reports zero selected results.
- Concurrent crashed-owner recovery stress test: 20/20 repeated two-reclaimer runs passed.
- Production and evaluation now share the same inferred-definition fallback and packing path; retrieval-limit omissions are measured from up to 100 candidates before output selection.
- Full repository validation: 52 test files and 987 tests passed.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

No linked issue.

