### PR TITLE
chore: prepare v0.17.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.16.0"
+      "version": "0.17.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-25
+
 ### Added
 
 - **Agent-facing retrieval evaluation**: Added a versioned `codebase_context` golden dataset, `npm run eval:agent`, and per-query route metadata for measuring definition routing and conceptual discovery.
-- **Token-budgeted context packs**: Added deterministic, overlapping-result deduplication and cross-file evidence selection with configurable 128-4000 token response budgets across native OpenCode, MCP, and Pi clients.
+- **Token-budgeted context packs**: Added deterministic overlapping-result deduplication and cross-file evidence selection with configurable 128-4000 token response budgets across native OpenCode, MCP, and Pi clients.
 - **Context efficiency gates**: Added returned-token, duplicate-candidate, file-diversity, and quality-per-1,000-token evaluation metrics with configurable CI thresholds.
 
 ### Changed
 
-- **Automatic definition routing**: MCP and Pi `codebase_context` now conservatively infer unambiguous symbol names from definition-style questions before falling back to conceptual search.
+- **Automatic definition routing**: `codebase_context` now conservatively infers unambiguous symbol names from definition-style questions before falling back to conceptual search, using shared routing across native OpenCode, MCP, Pi, and evaluation.
 - **Large-file retrieval coverage**: Files exceeding `maxChunksPerFile` now retain representative chunks from across the file instead of silently indexing only the beginning.
-- **Location-first context details**: `codebase_context` definition and conceptual routes now return compact locations rather than full source bodies; Pi details expose metadata only.
+- **Location-first context details**: Definition and conceptual routes now return compact locations rather than full source bodies, deduplicate overlapping evidence, diversify results across files, and report why candidates were omitted.
+- **Hard token caps**: Context budgets are enforced with the `cl100k_base` tokenizer, including Unicode-safe compaction, so agent harnesses can bound retrieval responses before requesting exact source.
+
+### Fixed
+
+- **Concurrent lock recovery**: Hardened crashed-owner index lock reclamation so concurrent recovery attempts publish a single valid lock without losing the winning candidate.
+- **Packed-context edge cases**: Preserve valid Unicode and report zero selected results when even one evidence item cannot fit the requested token budget.
 
 ## [0.16.0] - 2026-07-24
 
@@ -442,7 +450,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.2...v0.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.16.0");
+    expect(pluginManifest.version).toBe("0.17.0");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -42,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.16.0",
+      version: "0.17.0",
     }));
   });
 });


### PR DESCRIPTION
## Summary

Prepare the v0.17.0 release for the agent-context retrieval and token-budgeted context improvements merged since v0.16.0.

## Changes

- Reconcile `CHANGELOG.md` against the complete `v0.16.0..HEAD` delta and add the dated v0.17.0 release section.
- Bump package, lockfile, Codex plugin, Claude plugin, and Claude marketplace metadata to 0.17.0.
- Update Claude plugin manifest assertions to cover the released version.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`), 52 files and 987 tests
- [x] Lint passes (`npm run lint`)
- [x] `npm pack --dry-run` reports `opencode-codebase-index@0.17.0`
- [x] Version parity verified across package, lockfile, Codex, Claude, and marketplace manifests

The first full-suite run encountered the known watcher timing flake. The affected test passed in isolation, then the complete 987-test suite passed on rerun.

## Release Labels

- [x] Added at least one release category label (`skip-changelog` because this PR is the release metadata/changelog itself)
- [x] Added at most one semver label (`semver:minor`)

## Related Issues

None.
