### PR TITLE
chore: prepare v0.17.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.17.0"
+      "version": "0.17.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-07-25
+
+### Fixed
+
+- **Published MCP CLI startup**: Keep `tiktoken` external to the ESM bundle so the installed `opencode-codebase-index-mcp` executable no longer crashes with `__dirname is not defined`; every TypeScript build now smoke-tests the built ESM CLI.
+
 ## [0.17.0] - 2026-07-25
 
 ### Added
@@ -450,7 +456,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...v0.15.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.17.0");
+    expect(pluginManifest.version).toBe("0.17.1");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -42,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.17.0",
+      version: "0.17.1",
     }));
   });
 });


### PR DESCRIPTION
## Summary

Prepare the v0.17.1 patch release for the published MCP CLI startup regression fixed in PR #168.

## Changes

- Add the v0.17.1 changelog entry and comparison links.
- Bump package, lockfile, Codex, Claude, and marketplace versions to 0.17.1.
- Update Claude manifest assertions for the patch version.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`), including the built ESM CLI smoke check
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`), 52 files and 987 tests
- [x] Lint passes (`npm run lint`)
- [x] `npm pack --dry-run` reports `opencode-codebase-index@0.17.1`

## Release Labels

- [x] Release category label: `skip-changelog`
- [x] Semver label: `semver:patch`

## Related Issues

Publishes the fix from #168.
