### PR TITLE
release: v0.18.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.17.1"
+      "version": "0.18.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-26
+
 ### Added
 
 - **Ollama model discovery**: Added support for arbitrary local embedding models by reading their capabilities, dimensions, and context length from the Ollama API at runtime.
 - **Swift language support**: Added Tree-sitter semantic parsing, nested symbols, source ranges, and case-sensitive call graph extraction for Swift.
-- **PHP 8.x coverage**: Added grammar, semantic chunking, and call graph regression coverage for PHP 8.0 through supported PHP 8.5 syntax, and updated `tree-sitter-php` to 0.24.2.
+- **PHP 8.x coverage**: Expanded semantic chunking and call graph regression coverage for PHP 8.0 through supported PHP 8.5 syntax, and updated `tree-sitter-php` to 0.24.2.
 - **C and C++ call graphs**: Added Tree-sitter extraction for direct, member, and qualified calls, constructors, includes, and namespace imports.
 - **Metal Shading Language**: Added default `.metal` discovery, semantic chunks for Metal declarations, and direct, template, member, and qualified call extraction.
 
 ### Fixed
 
+- **Language-aware call graph lookup**: Preserve case-sensitive caller and path queries for Swift, C, C++, Metal, and other case-sensitive languages while retaining case-insensitive matching for PHP and Apex.
+- **Ollama upgrade safety**: Keep built-in `:latest` model names compatible with existing indexes, bound embedding requests with a timeout, and reject malformed or dimensionally invalid vectors.
+- **PHP call graph resolution**: Resolve same-file PHP function and constructor calls case-insensitively, disambiguate function and class name collisions by call type, and refresh cached PHP call edges after resolution upgrades.
 - **Git worktree index isolation**: Keep project indexes local to each worktree while continuing to inherit project configuration from the main checkout, preventing cross-worktree index mutations and stale absolute paths.
 
 ## [0.17.1] - 2026-07-25
@@ -468,7 +473,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...v0.16.0

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ graph TD
 
 1. **Parsing**: We use `tree-sitter` to intelligently parse your code into meaningful blocks (functions, classes, interfaces). JSDoc comments and docstrings are automatically included with their associated code.
 
-**Supported Languages (Tree-sitter semantic parsing)**: TypeScript, JavaScript, Python, Rust, Swift, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, JSON, TOML, YAML, Zig, GDScript, MATLAB†
+**Supported Languages (Tree-sitter semantic parsing)**: TypeScript, JavaScript, Python, Rust, Swift, Go, Java, C#, Ruby, PHP, Apex, Bash, C, C++, Metal, JSON, TOML, YAML, Zig, GDScript, MATLAB†
 
 Swift support uses [`tree-sitter-swift` 0.7.3](https://github.com/alex-pinkus/tree-sitter-swift/tree/0.7.3), distributed under the MIT license. It provides Tree-sitter syntax analysis for chunks, symbols, and calls, but does not replace SourceKit semantic analysis.
 
@@ -393,6 +393,7 @@ PHP 8.5 support remains partial in upstream grammar 0.24.2. Final promoted prope
 **/*.{md,mdx}                   **/*.{sh,bash,zsh}
 **/*.{txt,html,htm}              **/*.{cls,trigger}
 **/*.zig                         **/*.gd
+**/*.metal
 ```
 
 Use `include` to replace defaults, or `additionalInclude` to extend (e.g. `"**/*.pdf"`, `"**/*.csv"`).
@@ -1090,11 +1091,20 @@ ollama pull nomic-embed-text
 }
 ```
 
-The built-in `ollama` provider uses Ollama's native `/api/embeddings` endpoint and is the simplest setup when you want to use `nomic-embed-text`.
+The built-in `ollama` provider uses Ollama's native API. It discovers installed embedding-capable models and reads their vector dimensions and context length from `/api/show`.
 
 For the built-in Ollama path, the plugin budgets `nomic-embed-text` against an observed effective input limit of about **2048 tokens**, not the model's higher advertised theoretical context. This keeps batching and chunk text generation aligned with real Ollama embedding runtime behavior.
 
-If you want to use a different Ollama embedding model through its OpenAI-compatible API, use the `custom` provider instead and set `customProvider.baseUrl` to `http://127.0.0.1:11434/v1` so the plugin calls `.../v1/embeddings`.
+To select another installed embedding model, configure it directly:
+
+```json
+{
+  "embeddingProvider": "ollama",
+  "embeddingModel": "qwen3-embedding:0.6b"
+}
+```
+
+When `embeddingModel` is omitted, auto-detection selects the first installed model that advertises embedding capability. Set `OLLAMA_HOST` only to a trusted Ollama server because source text is sent to that endpoint for embedding.
 
 ## 📈 Performance
 
@@ -1155,8 +1165,8 @@ Works with any server that implements the OpenAI `/v1/embeddings` API format (ll
 ```
 Required fields: `baseUrl`, `model`, `dimensions` (positive integer). Optional: `apiKey`, `maxTokens`, `timeoutMs` (default: 30000), `maxBatchSize` (or `max_batch_size`) to cap inputs per `/embeddings` request for servers like text-embeddings-inference. `{env:VAR_NAME}` placeholders are resolved before config validation for fields that are actually used and throw if the referenced environment variable is missing or malformed.
 
-**Custom Ollama models via OpenAI-compatible API**
-If you are running Ollama locally and want to use an embedding model other than the built-in `ollama` setup, point the custom provider at Ollama's OpenAI-compatible base URL with the `/v1` suffix:
+**Ollama through an OpenAI-compatible proxy**
+Use the `custom` provider only when Ollama is exposed through an OpenAI-compatible proxy or when you need to override metadata manually:
 
 ```json
 {
@@ -1173,7 +1183,7 @@ If you are running Ollama locally and want to use an embedding model other than 
 Notes:
 - The plugin appends `/embeddings`, so `baseUrl` should be `http://127.0.0.1:11434/v1`, not just `http://127.0.0.1:11434`.
 - Ollama ignores the API key, but some OpenAI-compatible clients expect one, so a placeholder like `"ollama"` is fine.
-- Make sure `dimensions` matches the actual output size of the model you pulled locally.
+- Make sure `dimensions` matches the actual model output. The built-in `ollama` provider discovers this value automatically and is preferred for direct Ollama connections.
 
 ## ⚠️ Tradeoffs
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,6 +2,37 @@
 
 This file records third-party license notices added with their respective components. It does not claim to retroactively inventory every project dependency.
 
+## tree-sitter-php 0.24.2
+
+- Project: [tree-sitter/tree-sitter-php](https://github.com/tree-sitter/tree-sitter-php)
+- Source: [crate 0.24.2](https://crates.io/crates/tree-sitter-php/0.24.2)
+- License: MIT
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2017 Josh Vera, GitHub
+Copyright (c) 2019 Max Brunsfeld, Amaan Qureshi, Christian Frøystad, Caleb White
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ## tree-sitter-swift 0.7.3
 
 - Project: [alex-pinkus/tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift)

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -1320,8 +1320,21 @@ pub fn upsert_call_edges_batch(conn: &mut Connection, edges: &[CallEdgeRow]) -> 
     Ok(())
 }
 
-/// Get all call edges calling a symbol name (filtered by branch)
-/// Uses COLLATE NOCASE for target_name to support case-insensitive languages like PHP.
+fn is_case_insensitive_language(language: &str) -> bool {
+    // Keep this aligned with the SQL IN lists below and CASE_INSENSITIVE_LANGUAGES in the indexer.
+    matches!(language, "apex" | "php")
+}
+
+fn symbol_names_match(language: &str, left: &str, right: &str) -> bool {
+    if is_case_insensitive_language(language) {
+        left.eq_ignore_ascii_case(right)
+    } else {
+        left == right
+    }
+}
+
+/// Get all call edges calling a symbol name (filtered by branch).
+/// Name matching follows the source symbol's language semantics.
 pub fn get_callers(
     conn: &Connection,
     symbol_name: &str,
@@ -1335,7 +1348,11 @@ pub fn get_callers(
             FROM call_edges ce
             INNER JOIN symbols s ON ce.from_symbol_id = s.id
             INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?1
-            WHERE ce.target_name = ?2 COLLATE NOCASE AND ce.call_type = ?3
+            WHERE (
+                (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
+                OR
+                (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
+            ) AND ce.call_type = ?3
             "#,
             vec![branch.to_string(), symbol_name.to_string(), ct.to_string()],
         )
@@ -1346,7 +1363,10 @@ pub fn get_callers(
             FROM call_edges ce
             INNER JOIN symbols s ON ce.from_symbol_id = s.id
             INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?1
-            WHERE ce.target_name = ?2 COLLATE NOCASE
+            WHERE
+                (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
+                OR
+                (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
             "#,
             vec![branch.to_string(), symbol_name.to_string()],
         )
@@ -1403,7 +1423,11 @@ pub fn get_callers_with_context(
             FROM call_edges ce
             INNER JOIN symbols s ON ce.from_symbol_id = s.id
             INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?1
-            WHERE ce.target_name = ?2 COLLATE NOCASE AND ce.call_type = ?3
+            WHERE (
+                (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
+                OR
+                (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
+            ) AND ce.call_type = ?3
             "#,
             vec![branch.to_string(), symbol_name.to_string(), ct.to_string()],
         )
@@ -1425,7 +1449,10 @@ pub fn get_callers_with_context(
             FROM call_edges ce
             INNER JOIN symbols s ON ce.from_symbol_id = s.id
             INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?1
-            WHERE ce.target_name = ?2 COLLATE NOCASE
+            WHERE
+                (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
+                OR
+                (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
             "#,
             vec![branch.to_string(), symbol_name.to_string()],
         )
@@ -1592,19 +1619,23 @@ pub fn find_shortest_path(
     // Find all source symbols matching from_name on this branch
     let mut start_stmt = conn.prepare(
         r#"
-        SELECT s.id, s.name, s.file_path, s.start_line
+        SELECT s.id, s.name, s.file_path, s.start_line, s.language
         FROM symbols s
-        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
-        WHERE s.name = ? COLLATE NOCASE
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?1
+        WHERE
+            (s.language IN ('apex', 'php') AND s.name = ?2 COLLATE NOCASE)
+            OR
+            (s.language NOT IN ('apex', 'php') AND s.name = ?2 COLLATE BINARY)
         "#,
     )?;
-    let starts: Vec<(String, String, String, u32)> = start_stmt
+    let starts: Vec<(String, String, String, u32, String)> = start_stmt
         .query_map(params![branch, from_name], |row| {
             Ok((
                 row.get::<_, String>(0)?,
                 row.get::<_, String>(1)?,
                 row.get::<_, String>(2)?,
                 row.get::<_, u32>(3)?,
+                row.get::<_, String>(4)?,
             ))
         })?
         .filter_map(|r| r.ok())
@@ -1635,28 +1666,39 @@ pub fn find_shortest_path(
     // Resolve a target_name to symbol IDs on this branch
     let mut resolve_stmt = conn.prepare(
         r#"
-        SELECT s.id, s.name, s.file_path, s.start_line
+        SELECT s.id, s.name, s.file_path, s.start_line, s.language
         FROM symbols s
-        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
-        WHERE s.name = ? COLLATE NOCASE
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?1
+        WHERE
+            (?2 IN ('apex', 'php') AND s.name = ?3 COLLATE NOCASE)
+            OR
+            (?2 NOT IN ('apex', 'php') AND s.name = ?3 COLLATE BINARY)
         "#,
     )?;
 
-    // BFS state: queue entries are (symbol_id, depth)
+    let mut branch_symbol_language_stmt = conn.prepare(
+        r#"
+        SELECT s.language
+        FROM symbols s
+        INNER JOIN branch_symbols bs ON s.id = bs.symbol_id AND bs.branch = ?
+        WHERE s.id = ?
+        "#,
+    )?;
+
+    // BFS state: queue entries are (symbol_id, language, depth)
     // parent map: symbol_id -> (parent_symbol_id, call_type, line)
     let mut visited: HashMap<String, (String, String, u32)> = HashMap::new(); // child -> (parent_id, call_type, line)
-    let mut queue: VecDeque<(String, u32)> = VecDeque::new();
+    let mut queue: VecDeque<(String, String, u32)> = VecDeque::new();
 
     // Seed BFS with all start symbols
-    for (sid, _name, _fp, _line) in &starts {
+    for (sid, _name, _fp, _line, language) in &starts {
         visited.insert(sid.clone(), (String::new(), String::new(), 0)); // sentinel parent
-        queue.push_back((sid.clone(), 0));
+        queue.push_back((sid.clone(), language.clone(), 0));
     }
 
-    let target_name_lower = to_name.to_lowercase();
     let mut target_found: Option<String> = None;
 
-    'bfs: while let Some((current_id, depth)) = queue.pop_front() {
+    'bfs: while let Some((current_id, current_language, depth)) = queue.pop_front() {
         if depth >= max_depth {
             continue;
         }
@@ -1675,16 +1717,17 @@ pub fn find_shortest_path(
             .collect();
 
         for (callee_target_name, to_symbol_id, call_type, line) in callees {
-            // Check if target_name matches our target (case-insensitive)
-            if callee_target_name.to_lowercase() == target_name_lower {
+            // Check if target_name matches using the current/source symbol's language.
+            if symbol_names_match(&current_language, &callee_target_name, to_name) {
                 // Resolve the target to real symbol(s) on this branch
-                let resolved_targets: Vec<(String, String, String, u32)> = resolve_stmt
-                    .query_map(params![branch, to_name], |row| {
+                let resolved_targets: Vec<(String, String, String, u32, String)> = resolve_stmt
+                    .query_map(params![branch, &current_language, to_name], |row| {
                         Ok((
                             row.get::<_, String>(0)?,
                             row.get::<_, String>(1)?,
                             row.get::<_, String>(2)?,
                             row.get::<_, u32>(3)?,
+                            row.get::<_, String>(4)?,
                         ))
                     })?
                     .filter_map(|r| r.ok())
@@ -1736,48 +1779,52 @@ pub fn find_shortest_path(
             // If resolved, continue BFS through the resolved symbol (verify it's on branch)
             if let Some(ref resolved_id) = to_symbol_id {
                 if !visited.contains_key(resolved_id) {
-                    // Verify the resolved symbol exists on this branch
-                    let on_branch: bool = conn
-                        .query_row(
-                            "SELECT COUNT(*) FROM branch_symbols WHERE branch = ? AND symbol_id = ?",
-                            params![branch, resolved_id],
-                            |row| row.get::<_, i64>(0),
-                        )
-                        .unwrap_or(0)
-                        > 0;
-                    if on_branch {
+                    // Verify the resolved symbol exists on this branch and carry its language
+                    // into the next BFS expansion.
+                    let resolved_language: Option<String> = branch_symbol_language_stmt
+                        .query_row(params![branch, resolved_id], |row| row.get(0))
+                        .optional()?;
+                    if let Some(resolved_language) = resolved_language {
                         visited.insert(
                             resolved_id.clone(),
                             (current_id.clone(), call_type.clone(), line),
                         );
-                        queue.push_back((resolved_id.clone(), depth + 1));
+                        queue.push_back((resolved_id.clone(), resolved_language, depth + 1));
                     }
                 }
             } else {
                 // Unresolved: try resolving by target_name
                 // Only traverse if unambiguous (single match) to avoid fabricating paths
-                let resolved: Vec<(String, String, String, u32)> = resolve_stmt
-                    .query_map(params![branch, &callee_target_name], |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, String>(2)?,
-                            row.get::<_, u32>(3)?,
-                        ))
-                    })?
+                let resolved: Vec<(String, String, String, u32, String)> = resolve_stmt
+                    .query_map(
+                        params![branch, &current_language, &callee_target_name],
+                        |row| {
+                            Ok((
+                                row.get::<_, String>(0)?,
+                                row.get::<_, String>(1)?,
+                                row.get::<_, String>(2)?,
+                                row.get::<_, u32>(3)?,
+                                row.get::<_, String>(4)?,
+                            ))
+                        },
+                    )?
                     .filter_map(|r| r.ok())
                     .collect();
 
                 // Only traverse unambiguous (single) resolution to avoid fabricating paths
                 // through implementations the call graph never actually resolved
                 if resolved.len() == 1 {
-                    let (resolved_id, _name, _fp, _line) = &resolved[0];
+                    let (resolved_id, _name, _fp, _line, resolved_language) = &resolved[0];
                     if !visited.contains_key(resolved_id) {
                         visited.insert(
                             resolved_id.clone(),
                             (current_id.clone(), call_type.clone(), line),
                         );
-                        queue.push_back((resolved_id.clone(), depth + 1));
+                        queue.push_back((
+                            resolved_id.clone(),
+                            resolved_language.clone(),
+                            depth + 1,
+                        ));
                     }
                 }
             }
@@ -2154,6 +2201,39 @@ mod tests {
         (temp_dir, conn)
     }
 
+    fn call_graph_symbol(id: &str, name: &str, language: &str) -> SymbolRow {
+        SymbolRow {
+            id: id.to_string(),
+            file_path: format!("src/{id}"),
+            name: name.to_string(),
+            kind: "function".to_string(),
+            start_line: 1,
+            start_col: 0,
+            end_line: 5,
+            end_col: 0,
+            language: language.to_string(),
+        }
+    }
+
+    fn call_graph_edge(
+        id: &str,
+        from_symbol_id: &str,
+        target_name: &str,
+        to_symbol_id: Option<&str>,
+    ) -> CallEdgeRow {
+        CallEdgeRow {
+            id: id.to_string(),
+            from_symbol_id: from_symbol_id.to_string(),
+            target_name: target_name.to_string(),
+            to_symbol_id: to_symbol_id.map(str::to_string),
+            call_type: "Call".to_string(),
+            confidence: "Direct".to_string(),
+            line: 3,
+            col: 0,
+            is_resolved: to_symbol_id.is_some(),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn upsert_chunk(
         conn: &Connection,
@@ -2468,6 +2548,163 @@ mod tests {
         assert_eq!(deleted, 1);
         let callees = get_callees(&conn, "sym_main", "main", None).unwrap();
         assert!(callees.is_empty());
+    }
+
+    #[test]
+    fn test_callers_match_target_names_using_source_language() {
+        let (_temp_dir, mut conn) = setup_test_db();
+        let symbols = vec![
+            call_graph_symbol("swift_lower_caller", "swiftLowerCaller", "swift"),
+            call_graph_symbol("swift_upper_caller", "swiftUpperCaller", "swift"),
+            call_graph_symbol("cpp_lower_caller", "cppLowerCaller", "cpp"),
+            call_graph_symbol("cpp_upper_caller", "cppUpperCaller", "cpp"),
+            call_graph_symbol("php_caller", "phpCaller", "php"),
+        ];
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+        add_symbols_to_branch_batch(
+            &mut conn,
+            "main",
+            &symbols
+                .iter()
+                .map(|symbol| symbol.id.clone())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+        let edges = vec![
+            call_graph_edge("swift_lower_edge", "swift_lower_caller", "load", None),
+            call_graph_edge("swift_upper_edge", "swift_upper_caller", "Load", None),
+            call_graph_edge("cpp_lower_edge", "cpp_lower_caller", "render", None),
+            call_graph_edge("cpp_upper_edge", "cpp_upper_caller", "Render", None),
+            call_graph_edge("php_edge", "php_caller", "handler", None),
+        ];
+        upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let swift_lower = get_callers(&conn, "load", "main", None).unwrap();
+        assert_eq!(swift_lower.len(), 1);
+        assert_eq!(swift_lower[0].id, "swift_lower_edge");
+
+        let swift_upper = get_callers(&conn, "Load", "main", Some("Call")).unwrap();
+        assert_eq!(swift_upper.len(), 1);
+        assert_eq!(swift_upper[0].id, "swift_upper_edge");
+
+        let cpp_lower = get_callers_with_context(&conn, "render", "main", None).unwrap();
+        assert_eq!(cpp_lower.len(), 1);
+        assert_eq!(cpp_lower[0].id, "cpp_lower_edge");
+        assert_eq!(cpp_lower[0].from_symbol_name, "cppLowerCaller");
+
+        let cpp_upper = get_callers_with_context(&conn, "Render", "main", Some("Call")).unwrap();
+        assert_eq!(cpp_upper.len(), 1);
+        assert_eq!(cpp_upper[0].id, "cpp_upper_edge");
+
+        let php = get_callers_with_context(&conn, "HANDLER", "main", None).unwrap();
+        assert_eq!(php.len(), 1);
+        assert_eq!(php[0].id, "php_edge");
+    }
+
+    #[test]
+    fn test_shortest_path_uses_each_source_language_for_name_matching() {
+        let (_temp_dir, mut conn) = setup_test_db();
+        let symbols = vec![
+            call_graph_symbol("swift_start_lower", "start", "swift"),
+            call_graph_symbol("swift_start_upper", "Start", "swift"),
+            call_graph_symbol("swift_target_lower", "load", "swift"),
+            call_graph_symbol("swift_target_upper", "Load", "swift"),
+            call_graph_symbol("cpp_entry", "renderEntry", "cpp"),
+            call_graph_symbol("cpp_target_lower", "render", "cpp"),
+            call_graph_symbol("cpp_target_upper", "Render", "cpp"),
+            call_graph_symbol("php_entry", "PhpEntry", "php"),
+            call_graph_symbol("php_target", "Handle", "php"),
+            call_graph_symbol("swift_bridge_entry", "bridgeEntry", "swift"),
+            call_graph_symbol("php_bridge", "PhpBridge", "php"),
+            call_graph_symbol("php_bridge_target", "Finish", "php"),
+        ];
+        upsert_symbols_batch(&mut conn, &symbols).unwrap();
+        add_symbols_to_branch_batch(
+            &mut conn,
+            "main",
+            &symbols
+                .iter()
+                .map(|symbol| symbol.id.clone())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap();
+
+        let edges = vec![
+            call_graph_edge(
+                "swift_lower_edge",
+                "swift_start_lower",
+                "load",
+                Some("swift_target_lower"),
+            ),
+            call_graph_edge(
+                "swift_upper_edge",
+                "swift_start_upper",
+                "Load",
+                Some("swift_target_upper"),
+            ),
+            call_graph_edge("cpp_edge", "cpp_entry", "render", None),
+            call_graph_edge("php_edge", "php_entry", "handle", None),
+            call_graph_edge(
+                "swift_bridge_edge",
+                "swift_bridge_entry",
+                "PhpBridge",
+                Some("php_bridge"),
+            ),
+            call_graph_edge("php_bridge_edge", "php_bridge", "finish", None),
+        ];
+        upsert_call_edges_batch(&mut conn, &edges).unwrap();
+
+        let swift_lower = find_shortest_path(&conn, "start", "load", "main", 10).unwrap();
+        assert_eq!(
+            swift_lower
+                .iter()
+                .map(|hop| hop.symbol_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["swift_start_lower", "swift_target_lower"]
+        );
+        let swift_upper = find_shortest_path(&conn, "Start", "Load", "main", 10).unwrap();
+        assert_eq!(
+            swift_upper
+                .iter()
+                .map(|hop| hop.symbol_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["swift_start_upper", "swift_target_upper"]
+        );
+        assert!(find_shortest_path(&conn, "start", "Load", "main", 10)
+            .unwrap()
+            .is_empty());
+
+        let cpp = find_shortest_path(&conn, "renderEntry", "render", "main", 10).unwrap();
+        assert_eq!(
+            cpp.iter()
+                .map(|hop| hop.symbol_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["cpp_entry", "cpp_target_lower"]
+        );
+        assert!(
+            find_shortest_path(&conn, "renderEntry", "Render", "main", 10)
+                .unwrap()
+                .is_empty()
+        );
+
+        let php = find_shortest_path(&conn, "phpentry", "HANDLE", "main", 10).unwrap();
+        assert_eq!(
+            php.iter()
+                .map(|hop| hop.symbol_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["php_entry", "php_target"]
+        );
+
+        let cross_language =
+            find_shortest_path(&conn, "bridgeEntry", "FINISH", "main", 10).unwrap();
+        assert_eq!(
+            cross_language
+                .iter()
+                .map(|hop| hop.symbol_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["swift_bridge_entry", "php_bridge", "php_bridge_target"]
+        );
     }
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/src/embeddings/detector.ts
+++ b/src/embeddings/detector.ts
@@ -234,6 +234,16 @@ interface OllamaShowResponse {
   model_info?: Record<string, unknown>;
 }
 
+function findCatalogOllamaModel(
+  model: string,
+): EmbeddingProviderModelInfo["ollama"] | null {
+  const stableName = model.endsWith(":latest")
+    ? model.slice(0, -":latest".length)
+    : model;
+  return Object.values(EMBEDDING_MODELS.ollama)
+    .find((candidate) => candidate.model === stableName) ?? null;
+}
+
 function getPositiveIntegerMetadata(
   modelInfo: Record<string, unknown>,
   suffix: string,
@@ -299,8 +309,7 @@ async function detectOllamaProvider(model?: string): Promise<ConfiguredProviderI
 
   const requestedModel = model?.trim();
   if (requestedModel) {
-    const catalogModel = Object.values(EMBEDDING_MODELS.ollama)
-      .find((candidate) => candidate.model === requestedModel);
+    const catalogModel = findCatalogOllamaModel(requestedModel);
     if (catalogModel) {
       return { provider: "ollama", credentials, modelInfo: catalogModel };
     }
@@ -312,7 +321,11 @@ async function detectOllamaProvider(model?: string): Promise<ConfiguredProviderI
   for (const candidate of candidates) {
     const modelInfo = await fetchOllamaModelInfo(credentials, candidate);
     if (modelInfo) {
-      return { provider: "ollama", credentials, modelInfo };
+      return {
+        provider: "ollama",
+        credentials,
+        modelInfo: findCatalogOllamaModel(candidate) ?? modelInfo,
+      };
     }
   }
 

--- a/src/embeddings/providers/ollama.ts
+++ b/src/embeddings/providers/ollama.ts
@@ -5,6 +5,7 @@ import { BaseEmbeddingProvider, type EmbeddingBatchResult } from "../provider-ty
 
 export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProviderModelInfo["ollama"]> {
   private static readonly MIN_TRUNCATION_CHARS = 512;
+  private static readonly REQUEST_TIMEOUT_MS = 120_000;
 
   public constructor(
     credentials: ProviderCredentials,
@@ -102,26 +103,51 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
   }
 
   private async embedSingle(text: string): Promise<{ embedding: number[]; tokensUsed: number }> {
-    const response = await fetch(`${this.credentials.baseUrl}/api/embeddings`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: this.modelInfo.model,
-        prompt: text,
-        truncate: false,
-      }),
-    });
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS,
+    );
+    let response: Response;
+    try {
+      response = await fetch(`${this.credentials.baseUrl}/api/embeddings`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: this.modelInfo.model,
+          prompt: text,
+          truncate: false,
+        }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(
+          `Ollama embedding request timed out after ${OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS}ms`,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
 
     if (!response.ok) {
       const error = (await response.text()).slice(0, 500);
       throw new Error(`Ollama embedding API error: ${response.status} - ${error}`);
     }
 
-    const data = (await response.json()) as {
-      embedding: number[];
-    };
+    const data = (await response.json()) as { embedding?: unknown };
+    if (
+      !Array.isArray(data.embedding)
+      || data.embedding.length !== this.modelInfo.dimensions
+      || data.embedding.some((value) => typeof value !== "number" || !Number.isFinite(value))
+    ) {
+      throw new Error(
+        `Ollama returned an invalid embedding; expected ${this.modelInfo.dimensions} finite dimensions`,
+      );
+    }
 
     return {
       embedding: data.embedding,

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.17.1");
+    expect(pluginManifest.version).toBe("0.18.0");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -42,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.17.1",
+      version: "0.18.0",
     }));
   });
 });

--- a/tests/custom-provider.test.ts
+++ b/tests/custom-provider.test.ts
@@ -574,6 +574,36 @@ describe("OllamaEmbeddingProvider", () => {
     const provider = createOllamaProvider();
     await expect(provider.embedBatch(["hello"])).rejects.toThrow("Ollama embedding API error: 500");
   });
+
+  it("aborts ollama embedding requests after the bounded timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchSpy.mockImplementation(async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      }));
+
+      const provider = createOllamaProvider();
+      const assertion = expect(provider.embedBatch(["hello"]))
+        .rejects.toThrow("Ollama embedding request timed out after 120000ms");
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects ollama embeddings with the wrong vector dimensions", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({
+      embedding: new Array(384).fill(0.1),
+    }), { status: 200 }));
+
+    const provider = createOllamaProvider();
+    await expect(provider.embedBatch(["hello"]))
+      .rejects.toThrow("expected 768 finite dimensions");
+  });
 });
 
 describe("Indexer custom provider initialization", () => {

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -102,6 +102,29 @@ describe("embeddings detector", () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it("canonicalizes auto-detected latest tags for built-in models", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        if (String(input).endsWith("/api/tags")) {
+          return new Response(JSON.stringify({
+            models: [{ name: "nomic-embed-text:latest" }],
+          }));
+        }
+        return new Response(JSON.stringify({
+          capabilities: ["embedding"],
+          model_info: {
+            "nomic-bert.context_length": 2048,
+            "nomic-bert.embedding_length": 768,
+          },
+        }));
+      });
+
+      const provider = await tryDetectProvider();
+
+      expect(provider.provider).toBe("ollama");
+      expect(provider.modelInfo.model).toBe("nomic-embed-text");
+      expect(provider.modelInfo.dimensions).toBe(768);
+    });
+
     it("discovers metadata for an explicitly configured local model", async () => {
       vi.stubEnv("OLLAMA_HOST", "http://localhost:11434/");
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {


### PR DESCRIPTION
## Summary

Prepare v0.18.0 with all features merged since v0.17.1:

- C, C++, Swift, and Metal semantic parsing and call graph support
- expanded PHP 8.x parsing and case-insensitive PHP call resolution
- per-worktree project index isolation
- arbitrary built-in Ollama embedding model discovery

## Release hardening

- preserve case-sensitive caller and shortest-path lookup for case-sensitive languages while retaining PHP/Apex case-insensitive behavior
- keep Ollama `:latest` model discovery compatible with existing indexes
- add bounded Ollama embedding requests and strict vector validation
- reconcile English documentation, changelog coverage, versions, and third-party MIT notices

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run`
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- package dry run: v0.18.0, 35 files, licenses included, no `bun.lock`
- `npm audit --omit=dev`: 0 vulnerabilities
