### PR TITLE
release: v0.18.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.18.0"
+      "version": "0.18.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-07-26
+
+### Fixed
+
+- **CommonJS package import**: Bundle the ESM-only OpenCode plugin dependency into CommonJS artifacts so the advertised `require("opencode-codebase-index")` entry point works in clean installations, and regression-test both published module formats during every TypeScript build.
+
 ## [0.18.0] - 2026-07-26
 
 ### Added
@@ -473,7 +479,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...v0.17.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/smoke-test-built-cli.mjs
+++ b/scripts/smoke-test-built-cli.mjs
@@ -1,4 +1,7 @@
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 const cliPath = process.argv[2] ?? "dist/cli.js";
 const child = spawn(process.execPath, [cliPath, "--host", "jcode"], {
@@ -25,4 +28,9 @@ const result = await new Promise((resolve, reject) => {
 
 if (!result.survived && result.code !== 0) {
   throw new Error(`Built ESM CLI failed with exit code ${result.code}:\n${stderr}`);
+}
+
+const cjsModule = require("../dist/index.cjs");
+if (typeof cjsModule.default !== "function") {
+  throw new Error("Built CommonJS entry point is missing its default plugin export");
 }

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.18.0");
+    expect(pluginManifest.version).toBe("0.18.1");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -42,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.18.0",
+      version: "0.18.1",
     }));
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   treeshake: false,
   bundle: true,
   noExternal: [
+    "@opencode-ai/plugin",
     "chokidar",
     "ignore",
     "p-queue",
@@ -18,7 +19,6 @@ export default defineConfig({
   external: [
     "@modelcontextprotocol/sdk",
     "zod",
-    "@opencode-ai/plugin",
     "@earendil-works/pi-coding-agent",
     "typebox",
     /^node:/,


### PR DESCRIPTION
## Summary

Patch the published CommonJS entry point discovered during clean-install verification of v0.18.0.

- bundle the ESM-only `@opencode-ai/plugin` dependency into CommonJS artifacts
- smoke-test the advertised `require("opencode-codebase-index")` export during every TypeScript build
- bump package and plugin metadata to v0.18.1

## Validation

- clean packed-artifact ESM import passed
- clean packed-artifact CommonJS require passed
- native Swift parsing from the packed artifact passed
- `npm run build && npm run typecheck && npm run lint && npm run test:run` passed
- `cargo test && cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings` passed
- production dependency audit reports zero vulnerabilities
