### PR TITLE
feat: route call graph queries by symbol name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Name-based call graph routing**: Callers, callees, and dependency paths now resolve unique symbol names automatically across native OpenCode, MCP, Pi, and `codebase_context`. Duplicate names return bounded candidate locations with optional file-path disambiguators, while `symbolId` remains an optional compatibility escape hatch.
 - **Self-recovering context lookup**: `codebase_context` now retries empty scoped searches without file filters, retries inferred symbol text after definition-style misses, reports bounded recovery metadata, and keeps all fallback responses within the requested token budget across MCP, native OpenCode, Pi, and evaluation.
 
 ## [0.18.1] - 2026-07-26

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Query the call graph to find callers or callees of a function/method. Automatica
 For Swift, resolution remains name-based, so overloads, extension duplicates, and protocol dispatch can remain ambiguous. Syntax alone cannot always distinguish a superclass from a protocol conformance or an enum raw-value type from a protocol. Constructor classification uses an uppercase ASCII initial heuristic while retaining the exact name for resolution. `tree-sitter-swift` 0.7.3 also has limitations around `sending`, abbreviated collection constructors such as `[Int]()`, and some generic calls after `self`, `super`, optional chaining, or chained calls. The index does not infer SourceKit semantics for these cases.
 
 - **Use for**: Understanding code flow, tracing dependencies, impact analysis.
-- **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `symbolId` (required for `callees`, returned by previous queries), `relationshipType` (optional: `Call`, `MethodCall`, `Constructor`, `Import`, `Inherits`, `Implements`).
+- **Parameters**: `name` (function name), `direction` (`callers` or `callees`), `filePath` (optional duplicate-name disambiguator), `symbolId` (optional backward-compatible escape hatch), `relationshipType` (optional: `Call`, `MethodCall`, `Constructor`, `Import`, `Inherits`, `Implements`). Unique names resolve automatically; ambiguous names return bounded candidate locations.
 - **Example**: Find who calls `validateToken` → `call_graph(name="validateToken", direction="callers")`
 
 ### `call_graph_path`
@@ -552,7 +552,7 @@ For Swift, resolution remains name-based, so overloads, extension duplicates, an
 Find the shortest known call-graph path between two symbols. Use it after `codebase_peek`, `implementation_lookup`, or `call_graph` identifies the important source and target names.
 
 - **Use for**: Blast-radius checks, dependency-chain discovery, explaining how one subsystem reaches another.
-- **Parameters**: `from` (source symbol name), `to` (target symbol name), `maxDepth` (optional, default `10`).
+- **Parameters**: `from` (source symbol name), `to` (target symbol name), `fromFilePath` and `toFilePath` (optional duplicate-name disambiguators), `maxDepth` (optional, default `10`).
 - **Example**: Trace how `createOrder` reaches `chargeCard` → `call_graph_path(from="createOrder", to="chargeCard")`
 
 ### `pr_impact`

--- a/commands/call-graph.md
+++ b/commands/call-graph.md
@@ -10,19 +10,20 @@ Interpret input as follows:
 - If input asks for a path, connection, route, chain, or "from X to Y", use `call_graph_path`.
 - Default to `direction="callers"` unless input asks for callees/calls/makes calls.
 - `name=<function>` or plain text function name sets `name`.
-- `symbolId=<id>` is required for `direction="callees"`.
+- Unique names resolve automatically for both directions. Use optional `filePath=<path>` only when duplicate names are reported.
+- `symbolId=<id>` remains an optional backward-compatible escape hatch.
 - For path queries, parse `from=<function>`, `to=<function>`, and optional `maxDepth=<number>`.
 
 Execution flow:
 1. If input asks for a path and has source/target names, call `call_graph_path` with `{ from, to, maxDepth? }`.
 2. If direction is `callers`, call `call_graph` with `{ name, direction: "callers" }`.
-3. If direction is `callees` and `symbolId` is present, call `call_graph` with `{ name, direction: "callees", symbolId }`.
-4. If direction is `callees` and `symbolId` is missing, first call `call_graph` with `direction="callers"` to get symbol IDs, then ask the user to choose one if multiple are returned.
+3. If direction is `callees`, call `call_graph` with `{ name, direction: "callees" }`.
+4. If the tool reports duplicate names, retry with the suggested `filePath`; for paths use `fromFilePath` or `toFilePath`.
 
 Examples:
 - `/call-graph Database` → callers for `Database`
 - `/call-graph callers name=Indexer` → callers for `Indexer`
-- `/call-graph callees name=Database symbolId=sym_abc123` → callees for selected symbol
+- `/call-graph callees name=Database filePath=src/database.ts` → callees for a duplicate name at that location
 - `/call-graph path from=createOrder to=chargeCard` → shortest known path between the two symbols
 
 If output says no callers found, suggest running `/index force` first.

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5962,6 +5962,34 @@ export class Indexer {
     return results;
   }
 
+  async getCallersForSymbol(
+    symbolId: string,
+    targetName: string,
+    includeUnresolved: boolean,
+    callTypeFilter?: string,
+  ): Promise<CallEdgeData[]> {
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
+    const seen = new Set<string>();
+    const results: CallEdgeData[] = [];
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      const branchSymbolIds = new Set(database.getBranchSymbolIds(branchKey));
+      if (!branchSymbolIds.has(symbolId)) continue;
+
+      for (const edge of database.getCallersWithContext(targetName, branchKey, callTypeFilter)) {
+        const matchesResolvedSymbol = edge.toSymbolId === symbolId;
+        const safelyMatchesUnresolvedSymbol = includeUnresolved && !edge.toSymbolId;
+        if ((!matchesResolvedSymbol && !safelyMatchesUnresolvedSymbol) || seen.has(edge.id)) continue;
+
+        seen.add(edge.id);
+        results.push(edge);
+      }
+    }
+
+    return results;
+  }
+
   async getCallees(symbolId: string, callTypeFilter?: string): Promise<CallEdgeData[]> {
     const { database, readIssues } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "database");
@@ -5993,6 +6021,106 @@ export class Indexer {
     }
 
     return shortest;
+  }
+
+  async findCallPathBySymbolIds(
+    fromSymbolId: string,
+    toSymbolId: string,
+    maxDepth = 10,
+  ): Promise<PathHopData[]> {
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
+    let shortest: PathHopData[] = [];
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      const symbols = database.getSymbolsForBranch(branchKey);
+      const symbolsById = new Map(symbols.map((symbol) => [symbol.id, symbol]));
+      if (!symbolsById.has(fromSymbolId) || !symbolsById.has(toSymbolId)) continue;
+
+      const parentBySymbolId = new Map<string, { parentId: string; callType: string }>();
+      const visited = new Set([fromSymbolId]);
+      const queue: Array<{ symbolId: string; depth: number }> = [{ symbolId: fromSymbolId, depth: 0 }];
+      let queueIndex = 0;
+      let found = fromSymbolId === toSymbolId;
+
+      while (!found && queueIndex < queue.length) {
+        const current = queue[queueIndex++];
+        if (current.depth >= maxDepth) continue;
+
+        const currentSymbol = symbolsById.get(current.symbolId);
+        if (!currentSymbol) continue;
+
+        for (const edge of database.getCallees(current.symbolId, branchKey)) {
+          let nextSymbolId = edge.toSymbolId && symbolsById.has(edge.toSymbolId)
+            ? edge.toSymbolId
+            : undefined;
+
+          if (!nextSymbolId) {
+            const caseInsensitive = CASE_INSENSITIVE_LANGUAGES.has(currentSymbol.language);
+            const matchingTargets = symbols.filter((candidate) => caseInsensitive
+              ? candidate.name.toLowerCase() === edge.targetName.toLowerCase()
+              : candidate.name === edge.targetName);
+            if (matchingTargets.length === 1) {
+              nextSymbolId = matchingTargets[0].id;
+            }
+          }
+
+          if (!nextSymbolId || visited.has(nextSymbolId)) continue;
+          visited.add(nextSymbolId);
+          parentBySymbolId.set(nextSymbolId, {
+            parentId: current.symbolId,
+            callType: edge.callType,
+          });
+
+          if (nextSymbolId === toSymbolId) {
+            found = true;
+            break;
+          }
+
+          queue.push({ symbolId: nextSymbolId, depth: current.depth + 1 });
+        }
+      }
+
+      if (!found) continue;
+
+      const path: PathHopData[] = [];
+      let currentSymbolId = toSymbolId;
+      while (true) {
+        const symbol = symbolsById.get(currentSymbolId);
+        if (!symbol) break;
+        const parent = parentBySymbolId.get(currentSymbolId);
+        path.push({
+          symbolId: symbol.id,
+          symbolName: symbol.name,
+          filePath: symbol.filePath,
+          line: symbol.startLine,
+          callType: parent?.callType ?? "source",
+        });
+        if (!parent) break;
+        currentSymbolId = parent.parentId;
+      }
+      path.reverse();
+
+      if (path.length > 0 && (shortest.length === 0 || path.length < shortest.length)) {
+        shortest = path;
+      }
+    }
+
+    return shortest;
+  }
+
+  async getCallGraphSymbols(): Promise<SymbolData[]> {
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
+    const symbols = new Map<string, SymbolData>();
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      for (const symbol of database.getSymbolsForBranch(branchKey)) {
+        symbols.set(symbol.id, symbol);
+      }
+    }
+
+    return [...symbols.values()];
   }
 
   async getSymbolsForBranch(branch?: string): Promise<SymbolData[]> {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -6049,13 +6049,12 @@ export class Indexer {
 
         const currentSymbol = symbolsById.get(current.symbolId);
         if (!currentSymbol) continue;
-
         for (const edge of database.getCallees(current.symbolId, branchKey)) {
-          let nextSymbolId = edge.toSymbolId && symbolsById.has(edge.toSymbolId)
-            ? edge.toSymbolId
-            : undefined;
+          let nextSymbolId: string | undefined;
 
-          if (!nextSymbolId) {
+          if (edge.toSymbolId && symbolsById.has(edge.toSymbolId)) {
+            nextSymbolId = edge.toSymbolId;
+          } else if (edge.toSymbolId === undefined) {
             const caseInsensitive = CASE_INSENSITIVE_LANGUAGES.has(currentSymbol.language);
             const matchingTargets = symbols.filter((candidate) => caseInsensitive
               ? candidate.name.toLowerCase() === edge.targetName.toLowerCase()

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -4,9 +4,8 @@ import { z } from "zod";
 import { formatCostEstimate } from "../utils/cost.js";
 import {
   DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
-  formatCallGraphCallees,
-  formatCallGraphCallers,
-  formatCallGraphPath,
+  formatCallGraphPathResult,
+  formatCallGraphResult,
   formatCodebasePeek,
   formatDefinitionLookup,
   formatHealthCheck,
@@ -46,11 +45,13 @@ function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
   server.tool(
     "codebase_context",
-    "PREFERRED FIRST TOOL for any question about this repository. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Use before built-in code search, grep, shell search, or broad file reads. Provide from+to for a dependency path, symbol for a definition, or only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
+    "PREFERRED FIRST TOOL for any question about this repository. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Use before built-in code search, grep, shell search, or broad file reads. Provide from+to for a dependency path, with optional fromFilePath/toFilePath when names are ambiguous; provide symbol for a definition; or provide only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
     {
       query: z.string().describe("The codebase question or behavior to locate. Always provide the user's repository question here."),
       from: allowNullAsUndefined(z.string().optional()).describe("Source symbol. For dependency-path questions, extract the first endpoint and provide it here."),
       to: allowNullAsUndefined(z.string().optional()).describe("Target symbol. For dependency-path questions, extract the second endpoint and provide it here."),
+      fromFilePath: allowNullAsUndefined(z.string().optional()).describe("Optional source file path used only to disambiguate duplicate source names."),
+      toFilePath: allowNullAsUndefined(z.string().optional()).describe("Optional target file path used only to disambiguate duplicate target names."),
       symbol: allowNullAsUndefined(z.string().optional()).describe("Exact symbol for an authoritative definition lookup. Omit when from and to are supplied."),
       limit: allowNullAsUndefined(
         z.number().int().min(MIN_CONTEXT_RESULT_LIMIT).max(MAX_CONTEXT_RESULT_LIMIT).optional().default(10),
@@ -260,43 +261,46 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "call_graph",
-    "Use after identifying a symbol to find its direct callers or callees and understand code flow. Use implementation_lookup first if the symbol or definition is still ambiguous."
+    "Find direct callers or callees by function or method name. Unique names resolve automatically; when duplicate names are reported, retry with filePath."
       + " Supports relationship types: Call, MethodCall, Constructor, Import, Inherits, Implements.",
     {
       name: z.string().describe("Function or method name to query"),
       direction: allowNullAsUndefined(
         z.enum(["callers", "callees"]).default("callers"),
       ).describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
-      symbolId: allowNullAsUndefined(z.string().optional()).describe("Symbol ID (required for 'callees' direction)"),
+      filePath: allowNullAsUndefined(z.string().optional()).describe("Optional file path used to disambiguate duplicate symbol names"),
+      symbolId: allowNullAsUndefined(z.string().optional()).describe("Optional backward-compatible symbol ID escape hatch"),
       relationshipType: allowNullAsUndefined(
         z.enum(["Call", "MethodCall", "Constructor", "Import", "Inherits", "Implements"]).optional(),
       ).describe("Filter by relationship type. Omit to show all."),
     },
     async (args) => {
-      if (args.direction === "callees") {
-        if (!args.symbolId) {
-          return { content: [{ type: "text", text: "Error: 'symbolId' is required when direction is 'callees'." }] };
-        }
-        const { callees } = await getCallGraphData(runtime.projectRoot, runtime.host, args);
-        return { content: [{ type: "text", text: formatCallGraphCallees(args.symbolId, callees, args.relationshipType) }] };
-      }
-
-      const { callers } = await getCallGraphData(runtime.projectRoot, runtime.host, args);
-      return { content: [{ type: "text", text: formatCallGraphCallers(args.name, callers, args.relationshipType) }] };
+      const graph = await getCallGraphData(runtime.projectRoot, runtime.host, args);
+      return { content: [{ type: "text", text: formatCallGraphResult(graph) }] };
     },
   );
 
   server.tool(
     "call_graph_path",
-    "Use after identifying both endpoint symbols to find the shortest known call path between them. Use codebase_peek or implementation_lookup first when either endpoint is unknown.",
+    "Find the shortest known call path between two named functions or methods. Unique names resolve automatically; when duplicate endpoints are reported, retry with fromFilePath or toFilePath.",
     {
       from: z.string().describe("Source function/method name (starting point)"),
       to: z.string().describe("Target function/method name (destination)"),
+      fromFilePath: allowNullAsUndefined(z.string().optional()).describe("Optional source file path used to disambiguate duplicate source names"),
+      toFilePath: allowNullAsUndefined(z.string().optional()).describe("Optional target file path used to disambiguate duplicate target names"),
       maxDepth: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum traversal depth (default: 10)"),
     },
     async (args) => {
-      const path = await getCallGraphPath(runtime.projectRoot, runtime.host, args.from, args.to, args.maxDepth);
-      return { content: [{ type: "text", text: formatCallGraphPath(args.from, args.to, path) }] };
+      const path = await getCallGraphPath(
+        runtime.projectRoot,
+        runtime.host,
+        args.from,
+        args.to,
+        args.maxDepth,
+        args.fromFilePath,
+        args.toFilePath,
+      );
+      return { content: [{ type: "text", text: formatCallGraphPathResult(path) }] };
     },
   );
   server.tool(

--- a/src/pi-call-graph.ts
+++ b/src/pi-call-graph.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
 import { getCallGraphData, getCallGraphPath } from "./tools/operations.js";
-import { formatCallGraphCallees, formatCallGraphCallers, formatCallGraphPath } from "./tools/utils.js";
+import { formatCallGraphPathResult, formatCallGraphResult } from "./tools/utils.js";
 
 const HOST = "pi" as const;
 
@@ -27,40 +27,42 @@ export function registerPiCallGraphTools(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "call_graph",
     label: "Call Graph",
-    description: "Find callers or callees of a function/method in the indexed call graph.",
+    description: "Find callers or callees by function or method name. Unique names resolve automatically; use filePath when duplicate names are reported.",
     parameters: Type.Object({
       name: Type.String(),
       direction: Type.Optional(Type.Union([Type.Literal("callers"), Type.Literal("callees")])),
+      filePath: Type.Optional(Type.String()),
       symbolId: Type.Optional(Type.String()),
       relationshipType: Type.Optional(RelationshipType),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const result = await getCallGraphData(projectRoot(ctx), HOST, params);
-      if (result.direction === "callees") {
-        return text(
-          params.symbolId
-            ? formatCallGraphCallees(params.symbolId, result.callees, params.relationshipType)
-            : "Error: 'symbolId' is required when direction is 'callees'.",
-          result,
-        );
-      }
-
-      return text(formatCallGraphCallers(params.name, result.callers, params.relationshipType), result);
+      return text(formatCallGraphResult(result), result);
     },
   });
 
   pi.registerTool({
     name: "call_graph_path",
     label: "Call Graph Path",
-    description: "Find a call path between two functions/methods.",
+    description: "Find a call path between two named functions or methods. Use fromFilePath or toFilePath when duplicate endpoints are reported.",
     parameters: Type.Object({
       from: Type.String(),
       to: Type.String(),
+      fromFilePath: Type.Optional(Type.String()),
+      toFilePath: Type.Optional(Type.String()),
       maxDepth: Type.Optional(Type.Number({ default: 10 })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await getCallGraphPath(projectRoot(ctx), HOST, params.from, params.to, params.maxDepth);
-      return text(formatCallGraphPath(params.from, params.to, result), result);
+      const result = await getCallGraphPath(
+        projectRoot(ctx),
+        HOST,
+        params.from,
+        params.to,
+        params.maxDepth,
+        params.fromFilePath,
+        params.toFilePath,
+      );
+      return text(formatCallGraphPathResult(result), result);
     },
   });
 }

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -60,11 +60,13 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "codebase_context",
     label: "Codebase Context",
-    description: "PREFERRED FIRST TOOL for any repository question. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Check index_status when freshness is unknown, then use this tool for low-token location discovery and dependency flow.",
+    description: "PREFERRED FIRST TOOL for any repository question. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Check index_status when freshness is unknown, then use this tool for low-token location discovery and dependency flow. Use fromFilePath/toFilePath only when duplicate path endpoints are reported.",
     parameters: Type.Object({
       query: Type.String({ description: "Natural language description of what code you're trying to locate" }),
       from: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Source symbol when asking for a dependency path." })),
       to: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Target symbol when asking for a dependency path." })),
+      fromFilePath: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Optional source file path used to disambiguate duplicate source names." })),
+      toFilePath: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Optional target file path used to disambiguate duplicate target names." })),
       symbol: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Exact symbol name for an authoritative definition lookup." })),
       limit: Type.Optional(Type.Union([
         Type.Integer({ minimum: MIN_CONTEXT_RESULT_LIMIT, maximum: MAX_CONTEXT_RESULT_LIMIT }),

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -10,13 +10,15 @@ import { inferExactSymbolFromQuery } from "./symbol-inference.js";
 import {
   buildContextPack,
   fitTextToContextBudget,
-  formatCallGraphPath,
+  formatCallGraphPathResult,
 } from "./utils.js";
 
 export interface CodebaseContextInput {
   query: string;
   from?: string | null;
   to?: string | null;
+  fromFilePath?: string | null;
+  toFilePath?: string | null;
   symbol?: string | null;
   limit?: number | null;
   maxDepth?: number | null;
@@ -505,8 +507,10 @@ export async function resolveCodebaseContext(
   host: HostMode,
   input: CodebaseContextInput,
 ): Promise<CodebaseContextResult> {
-  const from = input.from ?? undefined;
-  const to = input.to ?? undefined;
+  const from = trimOrUndefined(input.from);
+  const to = trimOrUndefined(input.to);
+  const fromFilePath = trimOrUndefined(input.fromFilePath);
+  const toFilePath = trimOrUndefined(input.toFilePath);
   const symbol = input.symbol ?? undefined;
   const limit = input.limit ?? 10;
   const maxDepth = input.maxDepth ?? 10;
@@ -514,10 +518,19 @@ export async function resolveCodebaseContext(
   const directory = input.directory ?? undefined;
   const tokenBudget = input.tokenBudget ?? undefined;
   if (from && to) {
-    const path = await getCallGraphPath(projectRoot, host, from, to, maxDepth);
-    if (path.length > 0) {
+    const path = await getCallGraphPath(
+      projectRoot,
+      host,
+      from,
+      to,
+      maxDepth,
+      fromFilePath,
+      toFilePath,
+    );
+    const pathText = formatCallGraphPathResult(path);
+    if (path.path.length > 0) {
       const fitted = fitTextToContextBudget(
-        formatCallGraphPath(from, to, path),
+        pathText,
         tokenBudget,
       );
       return {
@@ -526,11 +539,21 @@ export async function resolveCodebaseContext(
       };
     }
 
+    if (path.from.status !== "resolved" || path.to.status !== "resolved") {
+      const fitted = fitTextToContextBudget(pathText, tokenBudget);
+      return {
+        text: fitted.text,
+        details: fittedDetails("path", fitted),
+      };
+    }
+    const resolvedFrom = path.from;
+
     const { callers } = await getCallGraphData(projectRoot, host, {
       name: to,
       direction: "callers",
+      filePath: toFilePath,
     });
-    const directEdge = callers.find((edge) => edge.fromSymbolName === from);
+    const directEdge = callers.find((edge) => edge.fromSymbolId === resolvedFrom.symbolId);
     if (directEdge) {
       const location = directEdge.fromSymbolFilePath
         ? ` at ${directEdge.fromSymbolFilePath}:${directEdge.line}`
@@ -547,7 +570,7 @@ export async function resolveCodebaseContext(
     }
 
     const fitted = fitTextToContextBudget(
-      formatCallGraphPath(from, to, path),
+      pathText,
       tokenBudget,
     );
     return {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,9 +7,8 @@ import { formatCostEstimate } from "../utils/cost.js";
 import {
   DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
   formatCodebasePeek,
-  formatCallGraphCallees,
-  formatCallGraphCallers,
-  formatCallGraphPath,
+  formatCallGraphPathResult,
+  formatCallGraphResult,
   formatDefinitionLookup,
   formatHealthCheck,
   formatIndexStats,
@@ -81,11 +80,13 @@ export function getIndexerForProject(directory: string): Indexer {
 
 export const codebase_context: ToolDefinition = tool({
   description:
-    "PREFERRED FIRST TOOL for repository questions. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Provide from and to for dependency paths, symbol for definitions, or only query for conceptual discovery.",
+    "PREFERRED FIRST TOOL for repository questions. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Provide from and to for dependency paths, with optional fromFilePath/toFilePath when names are ambiguous; provide symbol for definitions; or provide only query for conceptual discovery.",
   args: {
     query: z.string().describe("The repository question or behavior to locate"),
     from: z.string().nullable().optional().describe("Source symbol for a dependency path"),
     to: z.string().nullable().optional().describe("Target symbol for a dependency path"),
+    fromFilePath: z.string().nullable().optional().describe("Optional source file path used only to disambiguate duplicate source names"),
+    toFilePath: z.string().nullable().optional().describe("Optional target file path used only to disambiguate duplicate target names"),
     symbol: z.string().nullable().optional().describe("Exact symbol for authoritative definition lookup"),
     limit: z.number().int().min(MIN_CONTEXT_RESULT_LIMIT).max(MAX_CONTEXT_RESULT_LIMIT).nullable().optional().default(10)
       .describe(`Maximum number of results (${MIN_CONTEXT_RESULT_LIMIT}-${MAX_CONTEXT_RESULT_LIMIT})`),
@@ -278,39 +279,42 @@ export const implementation_lookup: ToolDefinition = tool({
 
 export const call_graph: ToolDefinition = tool({
   description:
-    "Query the call graph to find callers or callees of a function/method. Use to understand code flow and dependencies between functions."
+    "Query the call graph by function or method name to find direct callers or callees. Unique names resolve automatically; use filePath only when duplicate names are reported."
     + " Supports relationship types: Call, MethodCall, Constructor, Import, Inherits, Implements.",
   args: {
     name: z.string().describe("Function or method name to query"),
     direction: z.enum(["callers", "callees"]).default("callers").describe("Direction: 'callers' finds who calls this function, 'callees' finds what this function calls"),
-    symbolId: z.string().optional().describe("Symbol ID (required for 'callees' direction, returned by previous call_graph queries)"),
+    filePath: z.string().optional().describe("Optional file path used to disambiguate duplicate symbol names"),
+    symbolId: z.string().optional().describe("Optional backward-compatible symbol ID escape hatch"),
     relationshipType: z.enum(RELATIONSHIP_TYPE_VALUES).optional().describe("Filter by relationship type. Omit to show all."),
   },
   async execute(args, context) {
-    if (args.direction === "callees") {
-      if (!args.symbolId) {
-        return "Error: 'symbolId' is required when direction is 'callees'. First use direction='callers' to find the symbol ID.";
-      }
-      const { callees } = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
-      return formatCallGraphCallees(args.symbolId, callees, args.relationshipType);
-    }
-
-    const { callers } = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
-    return formatCallGraphCallers(args.name, callers, args.relationshipType);
+    const graph = await getCallGraphData(context?.worktree, DEFAULT_HOST, args);
+    return formatCallGraphResult(graph);
   },
 });
 
 export const call_graph_path: ToolDefinition = tool({
   description:
-    "Find the shortest connection path between two symbols in the call graph. Given a source and target function/method name, returns the chain of calls connecting them.",
+    "Find the shortest connection path between two named symbols. Unique names resolve automatically; use fromFilePath or toFilePath only when duplicate endpoint names are reported.",
   args: {
     from: z.string().describe("Source function/method name (starting point)"),
     to: z.string().describe("Target function/method name (destination)"),
+    fromFilePath: z.string().optional().describe("Optional source file path used to disambiguate duplicate source names"),
+    toFilePath: z.string().optional().describe("Optional target file path used to disambiguate duplicate target names"),
     maxDepth: z.number().optional().default(10).describe("Maximum traversal depth (default: 10)"),
   },
   async execute(args, context) {
-    const path = await getCallGraphPath(context?.worktree, DEFAULT_HOST, args.from, args.to, args.maxDepth);
-    return formatCallGraphPath(args.from, args.to, path);
+    const path = await getCallGraphPath(
+      context?.worktree,
+      DEFAULT_HOST,
+      args.from,
+      args.to,
+      args.maxDepth,
+      args.fromFilePath,
+      args.toFilePath,
+    );
+    return formatCallGraphPathResult(path);
   },
 });
 

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -74,9 +74,14 @@ function trimOrUndefined(value: string | undefined): string | undefined {
 }
 
 function normalizeCallGraphPath(value: string): string {
-  const normalized = value.trim().replace(/\\/g, "/").replace(/\/+/g, "/");
-  const withoutDotPrefix = normalized.replace(/^\.\/+/, "");
-  return withoutDotPrefix.length > 1 ? withoutDotPrefix.replace(/\/+$/, "") : withoutDotPrefix;
+  let normalized = path.posix.normalize(value.trim().replaceAll("\\", "/"));
+  if (normalized.startsWith("./")) {
+    normalized = normalized.slice(2);
+  }
+  while (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
 }
 
 function isAbsoluteCallGraphPath(value: string): boolean {

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { parseConfig, type ParsedCodebaseIndexConfig } from "../config/schema.js";
 import { getHostProjectConfigRelativePath } from "../config/paths.js";
 import type { HostMode } from "../config/host.js";
+import type { CallEdgeData, PathHopData, SymbolData } from "../native/index.js";
 import { Indexer } from "../indexer/index.js";
 import { isIndexLockContentionError } from "../indexer/index-lock.js";
 import { findKnowledgeBasePathIndex, hasMatchingKnowledgeBasePath, resolveKnowledgeBasePath } from "./knowledge-base-paths.js";
@@ -15,7 +16,6 @@ import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from
 type IndexerCacheKey = `${HostMode}::${string}`;
 
 type SearchResult = Awaited<ReturnType<Indexer["search"]>>[number];
-type CallGraphEdge = Awaited<ReturnType<Indexer["getCallers"]>>[number];
 type IndexStats = Awaited<ReturnType<Indexer["index"]>>;
 type StatusResult = Awaited<ReturnType<Indexer["getStatus"]>>;
 type HealthCheckResult = Awaited<ReturnType<Indexer["healthCheck"]>>;
@@ -27,6 +27,152 @@ type ProgressCb = (title: string, metadata: Record<string, unknown>) => void | P
 const indexerCache = new Map<IndexerCacheKey, Indexer>();
 const configCache = new Map<IndexerCacheKey, ParsedCodebaseIndexConfig>();
 const defaultProjectRoots = new Map<HostMode, string>();
+const MAX_CALL_GRAPH_CANDIDATES = 5;
+
+export interface CallGraphSymbolCandidate {
+  filePath: string;
+  startLine: number;
+  kind: string;
+}
+
+export type CallGraphSymbolResolution =
+  | {
+    status: "resolved";
+    name: string;
+    symbolId: string;
+    filePath: string;
+    startLine: number;
+    kind: string;
+    matchedBy: "name" | "symbolId";
+  }
+  | {
+    status: "ambiguous" | "not_found";
+    name: string;
+    filePath?: string;
+    candidates: CallGraphSymbolCandidate[];
+    totalCandidates: number;
+    invalidSymbolId?: boolean;
+  };
+
+export interface CallGraphDataResult {
+  direction: "callers" | "callees";
+  resolution: CallGraphSymbolResolution;
+  callers: CallEdgeData[];
+  callees: CallEdgeData[];
+  relationshipType?: string;
+}
+
+export interface CallGraphPathResult {
+  from: CallGraphSymbolResolution;
+  to: CallGraphSymbolResolution;
+  path: PathHopData[];
+}
+
+function trimOrUndefined(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function normalizeCallGraphPath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/").replace(/\/+/g, "/");
+  const withoutDotPrefix = normalized.replace(/^\.\/+/, "");
+  return withoutDotPrefix.length > 1 ? withoutDotPrefix.replace(/\/+$/, "") : withoutDotPrefix;
+}
+
+function isAbsoluteCallGraphPath(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:\//.test(value);
+}
+
+function filePathMatches(candidatePath: string, requestedPath: string): boolean {
+  const candidate = normalizeCallGraphPath(candidatePath);
+  const requested = normalizeCallGraphPath(requestedPath);
+  if (isAbsoluteCallGraphPath(requested)) {
+    return candidate === requested;
+  }
+  return candidate === requested || candidate.endsWith(`/${requested}`);
+}
+
+function displayCallGraphPath(filePath: string, projectRoot: string): string {
+  const normalizedFilePath = normalizeCallGraphPath(filePath);
+  const normalizedRoot = normalizeCallGraphPath(projectRoot);
+  if (normalizedFilePath === normalizedRoot) return ".";
+  if (normalizedFilePath.startsWith(`${normalizedRoot}/`)) {
+    return normalizedFilePath.slice(normalizedRoot.length + 1);
+  }
+  return normalizedFilePath;
+}
+
+function symbolNameMatches(symbol: SymbolData, requestedName: string): boolean {
+  return symbol.language === "apex" || symbol.language === "php"
+    ? symbol.name.toLowerCase() === requestedName.toLowerCase()
+    : symbol.name === requestedName;
+}
+
+function toCandidate(symbol: SymbolData, projectRoot: string): CallGraphSymbolCandidate {
+  return {
+    filePath: displayCallGraphPath(symbol.filePath, projectRoot),
+    startLine: symbol.startLine,
+    kind: symbol.kind,
+  };
+}
+
+function resolvedSymbol(symbol: SymbolData, projectRoot: string, matchedBy: "name" | "symbolId"): CallGraphSymbolResolution {
+  return {
+    status: "resolved",
+    name: symbol.name,
+    symbolId: symbol.id,
+    filePath: displayCallGraphPath(symbol.filePath, projectRoot),
+    startLine: symbol.startLine,
+    kind: symbol.kind,
+    matchedBy,
+  };
+}
+
+function resolveCallGraphSymbol(
+  symbols: SymbolData[],
+  projectRoot: string,
+  requestedName: string,
+  requestedFilePath?: string,
+  requestedSymbolId?: string,
+): CallGraphSymbolResolution {
+  const name = requestedName.trim();
+  const filePath = trimOrUndefined(requestedFilePath);
+  const symbolId = trimOrUndefined(requestedSymbolId);
+
+  if (symbolId) {
+    const symbol = symbols.find((candidate) => candidate.id === symbolId);
+    if (symbol) {
+      return resolvedSymbol(symbol, projectRoot, "symbolId");
+    }
+    return {
+      status: "not_found",
+      name,
+      filePath,
+      candidates: [],
+      totalCandidates: 0,
+      invalidSymbolId: true,
+    };
+  }
+
+  const nameCandidates = symbols.filter((symbol) => symbolNameMatches(symbol, name));
+  const matchingCandidates = filePath
+    ? nameCandidates.filter((symbol) => filePathMatches(symbol.filePath, filePath))
+    : nameCandidates;
+
+  if (matchingCandidates.length === 1) {
+    return resolvedSymbol(matchingCandidates[0], projectRoot, "name");
+  }
+
+  const candidates = (matchingCandidates.length > 0 ? matchingCandidates : nameCandidates)
+    .sort((left, right) => left.filePath.localeCompare(right.filePath) || left.startLine - right.startLine);
+  return {
+    status: matchingCandidates.length > 1 ? "ambiguous" : "not_found",
+    name,
+    filePath: filePath ? normalizeCallGraphPath(filePath) : undefined,
+    candidates: candidates.slice(0, MAX_CALL_GRAPH_CANDIDATES).map((symbol) => toCandidate(symbol, projectRoot)),
+    totalCandidates: candidates.length,
+  };
+}
 
 function getIndexBusyResult(error: unknown): IndexBusyResult | null {
   if (!isIndexLockContentionError(error)) return null;
@@ -186,20 +332,32 @@ export async function getCallGraphData(
     name: string;
     direction?: "callers" | "callees";
     symbolId?: string;
+    filePath?: string;
     relationshipType?: "Call" | "MethodCall" | "Constructor" | "Import" | "Inherits" | "Implements";
   },
-): Promise<{ direction: "callers" | "callees"; callers: CallGraphEdge[]; callees: CallGraphEdge[]; }> {
-  const indexer = getIndexerForProject(projectRoot, host);
-  if (params.direction === "callees") {
-    if (!params.symbolId) {
-      return { direction: "callees", callees: [], callers: [] };
-    }
-    const callees = await indexer.getCallees(params.symbolId, params.relationshipType);
-    return { direction: "callees", callees, callers: [] };
+): Promise<CallGraphDataResult> {
+  const root = getProjectRoot(projectRoot, host);
+  const indexer = getIndexerForProject(root, host);
+  const symbols = await indexer.getCallGraphSymbols();
+  const resolution = resolveCallGraphSymbol(symbols, root, params.name, params.filePath, params.symbolId);
+  const direction = params.direction === "callees" ? "callees" : "callers";
+  if (resolution.status !== "resolved") {
+    return { direction, resolution, callers: [], callees: [], relationshipType: params.relationshipType };
   }
 
-  const callers = await indexer.getCallers(params.name, params.relationshipType);
-  return { direction: "callers", callers, callees: [] };
+  if (params.direction === "callees") {
+    const callees = await indexer.getCallees(resolution.symbolId, params.relationshipType);
+    return { direction: "callees", resolution, callees, callers: [], relationshipType: params.relationshipType };
+  }
+
+  const includeUnresolved = symbols.filter((symbol) => symbolNameMatches(symbol, resolution.name)).length === 1;
+  const callers = await indexer.getCallersForSymbol(
+    resolution.symbolId,
+    resolution.name,
+    includeUnresolved,
+    params.relationshipType,
+  );
+  return { direction: "callers", resolution, callers, callees: [], relationshipType: params.relationshipType };
 }
 
 export async function getCallGraphPath(
@@ -208,9 +366,24 @@ export async function getCallGraphPath(
   from: string,
   to: string,
   maxDepth?: number,
-): Promise<Awaited<ReturnType<Indexer["findCallPath"]>>> {
-  const indexer = getIndexerForProject(projectRoot, host);
-  return indexer.findCallPath(from, to, maxDepth);
+  fromFilePath?: string,
+  toFilePath?: string,
+): Promise<CallGraphPathResult> {
+  const root = getProjectRoot(projectRoot, host);
+  const indexer = getIndexerForProject(root, host);
+  const symbols = await indexer.getCallGraphSymbols();
+  const fromResolution = resolveCallGraphSymbol(symbols, root, from, fromFilePath);
+  const toResolution = resolveCallGraphSymbol(symbols, root, to, toFilePath);
+  if (fromResolution.status !== "resolved" || toResolution.status !== "resolved") {
+    return { from: fromResolution, to: toResolution, path: [] };
+  }
+
+  const path = await indexer.findCallPathBySymbolIds(
+    fromResolution.symbolId,
+    toResolution.symbolId,
+    maxDepth,
+  );
+  return { from: fromResolution, to: toResolution, path };
 }
 
 export async function runIndexCodebase(

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,5 +1,5 @@
 import type { IndexStats, IndexProgress, SearchResult, HealthCheckResult, StatusResult } from "../indexer/index.js";
-import type { CallEdgeData, PathHopData } from "../native/index.js";
+import type { CallGraphDataResult, CallGraphPathResult, CallGraphSymbolResolution } from "./operations.js";
 import type { LogEntry } from "../utils/logger.js";
 import { get_encoding } from "tiktoken";
 
@@ -454,42 +454,83 @@ export function formatLogs(logs: LogEntry[]): string {
   }).join("\n");
 }
 
-export function formatCallGraphCallers(name: string, callers: CallEdgeData[], relationshipType?: string): string {
-  if (callers.length === 0) {
-    return `No callers found for "${name}"${relationshipType ? ` with type ${relationshipType}` : ""}. It may not be called by any tracked function, or the index needs updating.`;
+function formatCallGraphCandidates(resolution: Exclude<CallGraphSymbolResolution, { status: "resolved" }>): string {
+  if (resolution.candidates.length === 0) return "";
+  const lines = resolution.candidates.map((candidate) =>
+    `- ${candidate.filePath}:${candidate.startLine} (${candidate.kind})`);
+  if (resolution.totalCandidates > resolution.candidates.length) {
+    lines.push(`- ...and ${resolution.totalCandidates - resolution.candidates.length} more`);
+  }
+  return `\nCandidates:\n${lines.join("\n")}`;
+}
+
+function formatCallGraphResolution(
+  resolution: CallGraphSymbolResolution,
+  label: "symbol" | "source symbol" | "target symbol",
+  filePathParameter: "filePath" | "fromFilePath" | "toFilePath",
+): string | null {
+  if (resolution.status === "resolved") return null;
+  if (resolution.invalidSymbolId) {
+    return `No active ${label} matched the supplied symbolId. Omit symbolId and retry with name${resolution.filePath ? ` and ${filePathParameter}` : ""}.`;
   }
 
-  const formatted = callers.map((edge, index) => {
+  const candidates = formatCallGraphCandidates(resolution);
+  if (resolution.status === "ambiguous") {
+    return `Ambiguous ${label} "${resolution.name}". Pass ${filePathParameter} to choose one location.${candidates}`;
+  }
+  if (resolution.filePath && resolution.totalCandidates > 0) {
+    return `No ${label} named "${resolution.name}" matched ${filePathParameter}="${resolution.filePath}". Choose one of the available locations.${candidates}`;
+  }
+  return `No indexed ${label} named "${resolution.name}" was found. Check the spelling or refresh the index.`;
+}
+
+export function formatCallGraphResult(result: CallGraphDataResult): string {
+  const resolutionFailure = formatCallGraphResolution(result.resolution, "symbol", "filePath");
+  if (resolutionFailure) return resolutionFailure;
+  if (result.resolution.status !== "resolved") return "Unable to resolve the requested symbol.";
+
+  const resolution = result.resolution;
+  const relationship = result.relationshipType ? ` with type ${result.relationshipType}` : "";
+  const location = `${resolution.filePath}:${resolution.startLine}`;
+  if (result.direction === "callers") {
+    if (result.callers.length === 0) {
+      return `No callers found for "${resolution.name}" at ${location}${relationship}. It may not be called by any tracked function, or the index needs updating.`;
+    }
+    const formatted = result.callers.map((edge, index) => {
+      const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
+      return `[${index + 1}] \u2190 from ${edge.fromSymbolName ?? "<unknown>"} in ${edge.fromSymbolFilePath ?? "<unknown file>"} (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? " [resolved]" : " [unresolved]"}`;
+    });
+    return `"${resolution.name}" at ${location} is called by ${result.callers.length} function(s):\n\n${formatted.join("\n")}`;
+  }
+
+  if (result.callees.length === 0) {
+    return `No callees found for "${resolution.name}" at ${location}${relationship}. The function may not call any other tracked functions.`;
+  }
+  const formatted = result.callees.map((edge, index) => {
     const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
-    return `[${index + 1}] \u2190 from ${edge.fromSymbolName ?? "<unknown>"} in ${edge.fromSymbolFilePath ?? "<unknown file>"} [${edge.fromSymbolId}] (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? " [resolved]" : " [unresolved]"}`;
+    return `[${index + 1}] \u2192 ${edge.targetName} (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? " [resolved]" : " [unresolved]"}`;
   });
-
-  return `"${name}" is called by ${callers.length} function(s):\n\n${formatted.join("\n")}`;
+  return `"${resolution.name}" at ${location} calls ${result.callees.length} function(s):\n\n${formatted.join("\n")}`;
 }
 
-export function formatCallGraphCallees(symbolId: string, callees: CallEdgeData[], relationshipType?: string): string {
-  if (callees.length === 0) {
-    return `No callees found for symbol ${symbolId}${relationshipType ? ` with type ${relationshipType}` : ""}. The function may not call any other tracked functions.`;
+export function formatCallGraphPathResult(result: CallGraphPathResult): string {
+  const failures = [
+    formatCallGraphResolution(result.from, "source symbol", "fromFilePath"),
+    formatCallGraphResolution(result.to, "target symbol", "toFilePath"),
+  ].filter((failure): failure is string => failure !== null);
+  if (failures.length > 0) return failures.join("\n\n");
+
+  if (result.path.length === 0) {
+    return `No path found between "${result.from.name}" and "${result.to.name}". They may be in disconnected components, or the call graph index needs updating.`;
   }
 
-  return callees.map((edge, index) => {
-    const confidence = edge.confidence !== "Direct" ? ` [${edge.confidence.toLowerCase()}]` : "";
-    return `[${index + 1}] \u2192 ${edge.targetName} (${edge.callType})${confidence} at line ${edge.line}${edge.isResolved ? ` [resolved: ${edge.toSymbolId}]` : " [unresolved]"}`;
-  }).join("\n");
-}
-
-export function formatCallGraphPath(from: string, to: string, path: PathHopData[]): string {
-  if (path.length === 0) {
-    return `No path found between "${from}" and "${to}". They may be in disconnected components, or the call graph index needs updating.`;
-  }
-
-  const formatted = path.map((hop, index) => {
+  const formatted = result.path.map((hop, index) => {
     const prefix = index === 0 ? "[start]" : `--${hop.callType}-->`;
     const location = hop.filePath ? ` (${hop.filePath}:${hop.line})` : "";
     return `${prefix} ${hop.symbolName}${location}`;
   });
 
-  return `Path (${path.length} hops):\n${formatted.join("\n")}`;
+  return `Path (${result.path.length} hops):\n${formatted.join("\n")}`;
 }
 
 function formatResultHeader(result: SearchResult, index: number): string {

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -3200,143 +3200,109 @@ main() {
     });
 
     describe("findCallPathBySymbolIds", () => {
+      const functionSymbol = (id: string, filePath: string, name: string): SymbolData => ({
+        id,
+        filePath,
+        name,
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 10,
+        endCol: 0,
+        language: "typescript",
+      });
+
+      const callEdge = ({
+        id,
+        fromSymbolId,
+        targetName,
+        toSymbolId,
+        callType = "Call",
+        confidence = "Direct",
+        line = 1,
+        col = 0,
+        isResolved = true,
+      }: Pick<CallEdgeData, "id" | "fromSymbolId" | "targetName"> &
+        Partial<Pick<CallEdgeData, "toSymbolId" | "callType" | "confidence" | "line" | "col" | "isResolved">>):
+        CallEdgeData => ({
+        id,
+        fromSymbolId,
+        targetName,
+        toSymbolId,
+        callType,
+        confidence,
+        line,
+        col,
+        isResolved,
+      });
+
+      const callPath = async (fromSymbolId: string, toSymbolId: string, maxDepth = 10) => {
+        const indexer = new Indexer(tempDir, createIndexerConfig());
+        try {
+          return await indexer.findCallPathBySymbolIds(fromSymbolId, toSymbolId, maxDepth);
+        } finally {
+          await indexer.close();
+        }
+      };
+
       it("does not retarget resolved edges to a different symbol on another branch", async () => {
         writeGitBranchHead("main");
         const db = openIndexerDb();
 
-        db.upsertSymbol({
-          id: "sym_caller",
-          filePath: "src/caller.ts",
-          name: "caller",
-          kind: "function",
-          startLine: 1,
-          startCol: 0,
-          endLine: 10,
-          endCol: 0,
-          language: "typescript",
-        });
-        db.upsertSymbol({
-          id: "sym_target_main",
-          filePath: "src/target-main.ts",
-          name: "target",
-          kind: "function",
-          startLine: 1,
-          startCol: 0,
-          endLine: 10,
-          endCol: 0,
-          language: "typescript",
-        });
-        db.upsertSymbol({
-          id: "sym_target_feature",
-          filePath: "src/target-feature.ts",
-          name: "target",
-          kind: "function",
-          startLine: 1,
-          startCol: 0,
-          endLine: 10,
-          endCol: 0,
-          language: "typescript",
-        });
+        db.upsertSymbolsBatch([
+          functionSymbol("sym_caller", "src/caller.ts", "caller"),
+          functionSymbol("sym_target_main", "src/target-main.ts", "target"),
+          functionSymbol("sym_target_feature", "src/target-feature.ts", "target"),
+        ]);
 
         db.addSymbolsToBranch("main", ["sym_caller", "sym_target_main"]);
         db.addSymbolsToBranch("feature", ["sym_target_feature"]);
 
-        db.upsertCallEdge({
-          id: "edge_cross_branch",
-          fromSymbolId: "sym_caller",
-          targetName: "target",
-          toSymbolId: "sym_target_feature",
-          callType: "Call",
-          confidence: "Direct",
-          line: 5,
-          col: 0,
-          isResolved: true,
-        });
+        db.upsertCallEdge(
+          callEdge({
+            id: "edge_cross_branch",
+            fromSymbolId: "sym_caller",
+            targetName: "target",
+            toSymbolId: "sym_target_feature",
+            line: 5,
+          }),
+        );
 
-        const indexer = new Indexer(tempDir, createIndexerConfig());
-        try {
-          const path = await indexer.findCallPathBySymbolIds("sym_caller", "sym_target_main", 10);
-          expect(path).toEqual([]);
-        } finally {
-          await indexer.close();
-        }
+        const path = await callPath("sym_caller", "sym_target_main", 10);
+        expect(path).toEqual([]);
       });
 
       it("uses name fallback only for unresolved edges", async () => {
         writeGitBranchHead("main");
         const db = openIndexerDb();
 
-        db.upsertSymbol({
-          id: "sym_entry",
-          filePath: "src/entry.ts",
-          name: "entry",
-          kind: "function",
-          startLine: 1,
-          startCol: 0,
-          endLine: 10,
-          endCol: 0,
-          language: "typescript",
-        });
-        db.upsertSymbol({
-          id: "sym_mid",
-          filePath: "src/mid.ts",
-          name: "mid",
-          kind: "function",
-          startLine: 1,
-          startCol: 0,
-          endLine: 10,
-          endCol: 0,
-          language: "typescript",
-        });
-        db.upsertSymbol({
-          id: "sym_exit",
-          filePath: "src/exit.ts",
-          name: "exit",
-          kind: "function",
-          startLine: 1,
-          startCol: 0,
-          endLine: 10,
-          endCol: 0,
-          language: "typescript",
-        });
+        db.upsertSymbolsBatch([
+          functionSymbol("sym_entry", "src/entry.ts", "entry"),
+          functionSymbol("sym_mid", "src/mid.ts", "mid"),
+          functionSymbol("sym_exit", "src/exit.ts", "exit"),
+        ]);
 
         db.addSymbolsToBranch("main", ["sym_entry", "sym_mid", "sym_exit"]);
 
         db.upsertCallEdgesBatch([
-          {
+          callEdge({
             id: "edge_entry_mid",
             fromSymbolId: "sym_entry",
             targetName: "mid",
-            callType: "Call",
-            confidence: "Direct",
             line: 2,
-            col: 0,
             isResolved: false,
-          },
-          {
+          }),
+          callEdge({
             id: "edge_mid_exit",
             fromSymbolId: "sym_mid",
             targetName: "exit",
             toSymbolId: "sym_exit",
-            callType: "Call",
-            confidence: "Direct",
             line: 4,
-            col: 0,
-            isResolved: true,
-          },
+          }),
         ]);
 
-        const indexer = new Indexer(tempDir, createIndexerConfig());
-        try {
-          const path = await indexer.findCallPathBySymbolIds("sym_entry", "sym_exit", 10);
-          expect(path.map((item) => item.symbolId)).toEqual([
-            "sym_entry",
-            "sym_mid",
-            "sym_exit",
-          ]);
-        } finally {
-          await indexer.close();
-        }
+        const path = await callPath("sym_entry", "sym_exit", 10);
+        expect(path.map((item) => item.symbolId)).toEqual(["sym_entry", "sym_mid", "sym_exit"]);
       });
 
       it("respects branch catalog filtering", async () => {
@@ -3344,124 +3310,47 @@ main() {
         const db = openIndexerDb();
 
         db.upsertSymbolsBatch([
-          {
-            id: "sym_main_call",
-            filePath: "src/main-call.ts",
-            name: "call",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
-          {
-            id: "sym_main_target",
-            filePath: "src/main-target.ts",
-            name: "target",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
-          {
-            id: "sym_feature_call",
-            filePath: "src/feature-call.ts",
-            name: "call",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
-          {
-            id: "sym_feature_target",
-            filePath: "src/feature-target.ts",
-            name: "target",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
+          functionSymbol("sym_main_call", "src/main-call.ts", "call"),
+          functionSymbol("sym_main_target", "src/main-target.ts", "target"),
+          functionSymbol("sym_feature_call", "src/feature-call.ts", "call"),
+          functionSymbol("sym_feature_target", "src/feature-target.ts", "target"),
         ]);
 
         db.addSymbolsToBranch("main", ["sym_main_call", "sym_main_target"]);
         db.addSymbolsToBranch("feature", ["sym_feature_call", "sym_feature_target"]);
 
         db.upsertCallEdgesBatch([
-          {
+          callEdge({
             id: "edge_main",
             fromSymbolId: "sym_main_call",
             targetName: "target",
             toSymbolId: "sym_main_target",
-            callType: "Call",
-            confidence: "Direct",
             line: 3,
-            col: 0,
-            isResolved: true,
-          },
-          {
+          }),
+          callEdge({
             id: "edge_feature",
             fromSymbolId: "sym_feature_call",
             targetName: "target",
             toSymbolId: "sym_feature_target",
-            callType: "Call",
-            confidence: "Direct",
             line: 3,
-            col: 0,
-            isResolved: true,
-          },
+          }),
         ]);
 
-        const indexerOnMain = new Indexer(tempDir, createIndexerConfig());
-        try {
-          const mainPath = await indexerOnMain.findCallPathBySymbolIds(
-            "sym_main_call",
-            "sym_main_target",
-            10,
-          );
-          expect(mainPath.map((item) => item.symbolId)).toEqual([
-            "sym_main_call",
-            "sym_main_target",
-          ]);
+        const mainPath = await callPath("sym_main_call", "sym_main_target", 10);
+        expect(mainPath.map((item) => item.symbolId)).toEqual(["sym_main_call", "sym_main_target"]);
 
-          const mainToFeature = await indexerOnMain.findCallPathBySymbolIds(
-            "sym_main_call",
-            "sym_feature_target",
-            10,
-          );
-          expect(mainToFeature).toEqual([]);
-        } finally {
-          await indexerOnMain.close();
-        }
+        const mainToFeature = await callPath("sym_main_call", "sym_feature_target", 10);
+        expect(mainToFeature).toEqual([]);
 
         writeGitBranchHead("feature");
-        const indexerOnFeature = new Indexer(tempDir, createIndexerConfig());
-        try {
-          const featurePath = await indexerOnFeature.findCallPathBySymbolIds(
-            "sym_feature_call",
-            "sym_feature_target",
-            10,
-          );
-          expect(featurePath.map((item) => item.symbolId)).toEqual([
-            "sym_feature_call",
-            "sym_feature_target",
-          ]);
+        const featurePath = await callPath("sym_feature_call", "sym_feature_target", 10);
+        expect(featurePath.map((item) => item.symbolId)).toEqual([
+          "sym_feature_call",
+          "sym_feature_target",
+        ]);
 
-          const featureToMain = await indexerOnFeature.findCallPathBySymbolIds(
-            "sym_feature_call",
-            "sym_main_target",
-            10,
-          );
-          expect(featureToMain).toEqual([]);
-        } finally {
-          await indexerOnFeature.close();
-        }
+        const featureToMain = await callPath("sym_feature_call", "sym_main_target", 10);
+        expect(featureToMain).toEqual([]);
       });
 
       it("respects maxDepth boundary", async () => {
@@ -3469,82 +3358,35 @@ main() {
         const db = openIndexerDb();
 
         db.upsertSymbolsBatch([
-          {
-            id: "sym_depth_a",
-            filePath: "src/depth-a.ts",
-            name: "depthA",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
-          {
-            id: "sym_depth_b",
-            filePath: "src/depth-b.ts",
-            name: "depthB",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
-          {
-            id: "sym_depth_c",
-            filePath: "src/depth-c.ts",
-            name: "depthC",
-            kind: "function",
-            startLine: 1,
-            startCol: 0,
-            endLine: 10,
-            endCol: 0,
-            language: "typescript",
-          },
+          functionSymbol("sym_depth_a", "src/depth-a.ts", "depthA"),
+          functionSymbol("sym_depth_b", "src/depth-b.ts", "depthB"),
+          functionSymbol("sym_depth_c", "src/depth-c.ts", "depthC"),
         ]);
 
         db.addSymbolsToBranch("main", ["sym_depth_a", "sym_depth_b", "sym_depth_c"]);
 
         db.upsertCallEdgesBatch([
-          {
+          callEdge({
             id: "edge_depth_ab",
             fromSymbolId: "sym_depth_a",
             targetName: "depthB",
             toSymbolId: "sym_depth_b",
-            callType: "Call",
-            confidence: "Direct",
             line: 1,
-            col: 0,
-            isResolved: true,
-          },
-          {
+          }),
+          callEdge({
             id: "edge_depth_bc",
             fromSymbolId: "sym_depth_b",
             targetName: "depthC",
             toSymbolId: "sym_depth_c",
-            callType: "Call",
-            confidence: "Direct",
             line: 2,
-            col: 0,
-            isResolved: true,
-          },
+          }),
         ]);
 
-        const indexer = new Indexer(tempDir, createIndexerConfig());
-        try {
-          const tooShallow = await indexer.findCallPathBySymbolIds("sym_depth_a", "sym_depth_c", 1);
-          expect(tooShallow).toEqual([]);
+        const tooShallow = await callPath("sym_depth_a", "sym_depth_c", 1);
+        expect(tooShallow).toEqual([]);
 
-          const sufficient = await indexer.findCallPathBySymbolIds("sym_depth_a", "sym_depth_c", 2);
-          expect(sufficient.map((item) => item.symbolId)).toEqual([
-            "sym_depth_a",
-            "sym_depth_b",
-            "sym_depth_c",
-          ]);
-        } finally {
-          await indexer.close();
-        }
+        const sufficient = await callPath("sym_depth_a", "sym_depth_c", 2);
+        expect(sufficient.map((item) => item.symbolId)).toEqual(["sym_depth_a", "sym_depth_b", "sym_depth_c"]);
       });
     });
   });

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -19,11 +19,41 @@ describe("call-graph", () => {
   let tempDir: string;
   let _dbs: Database[] = [];
 
-  function openDb(): Database {
-    const d = new Database(path.join(tempDir, "test.db"));
-    _dbs.push(d);
-    return d;
-  }
+function openDb(): Database {
+  const d = new Database(path.join(tempDir, "test.db"));
+  _dbs.push(d);
+  return d;
+}
+
+function openIndexerDb(): Database {
+  const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const d = new Database(dbPath);
+  _dbs.push(d);
+  return d;
+}
+
+function writeGitBranchHead(branchName: string): void {
+  const gitDir = path.join(tempDir, ".git");
+  fs.mkdirSync(path.join(gitDir, "refs", "heads"), { recursive: true });
+  fs.writeFileSync(path.join(gitDir, "HEAD"), `ref: refs/heads/${branchName}\n`);
+  fs.writeFileSync(
+    path.join(gitDir, "refs", "heads", branchName),
+    "1111111111111111111111111111111111111111\n",
+  );
+}
+
+function createIndexerConfig(): ReturnType<typeof parseConfig> {
+  return parseConfig({
+    embeddingProvider: "custom",
+    customProvider: {
+      baseUrl: "http://localhost:11434/v1",
+      model: "mock-model",
+      dimensions: 8,
+    },
+    indexing: { watchFiles: false },
+  });
+}
 
   function buildFileSymbols(filePath: string, content: string): SymbolData[] {
     const parsed = parseFiles([{ path: filePath, content }])[0];
@@ -3167,6 +3197,355 @@ main() {
       // Should use the specific resolved target (dest_b), not arbitrary first match
       expect(result[1].filePath).toBe("src/dest-b.ts");
       expect(result[1].symbolId).toBe("sym_dest_b");
+    });
+
+    describe("findCallPathBySymbolIds", () => {
+      it("does not retarget resolved edges to a different symbol on another branch", async () => {
+        writeGitBranchHead("main");
+        const db = openIndexerDb();
+
+        db.upsertSymbol({
+          id: "sym_caller",
+          filePath: "src/caller.ts",
+          name: "caller",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        });
+        db.upsertSymbol({
+          id: "sym_target_main",
+          filePath: "src/target-main.ts",
+          name: "target",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        });
+        db.upsertSymbol({
+          id: "sym_target_feature",
+          filePath: "src/target-feature.ts",
+          name: "target",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        });
+
+        db.addSymbolsToBranch("main", ["sym_caller", "sym_target_main"]);
+        db.addSymbolsToBranch("feature", ["sym_target_feature"]);
+
+        db.upsertCallEdge({
+          id: "edge_cross_branch",
+          fromSymbolId: "sym_caller",
+          targetName: "target",
+          toSymbolId: "sym_target_feature",
+          callType: "Call",
+          confidence: "Direct",
+          line: 5,
+          col: 0,
+          isResolved: true,
+        });
+
+        const indexer = new Indexer(tempDir, createIndexerConfig());
+        try {
+          const path = await indexer.findCallPathBySymbolIds("sym_caller", "sym_target_main", 10);
+          expect(path).toEqual([]);
+        } finally {
+          await indexer.close();
+        }
+      });
+
+      it("uses name fallback only for unresolved edges", async () => {
+        writeGitBranchHead("main");
+        const db = openIndexerDb();
+
+        db.upsertSymbol({
+          id: "sym_entry",
+          filePath: "src/entry.ts",
+          name: "entry",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        });
+        db.upsertSymbol({
+          id: "sym_mid",
+          filePath: "src/mid.ts",
+          name: "mid",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        });
+        db.upsertSymbol({
+          id: "sym_exit",
+          filePath: "src/exit.ts",
+          name: "exit",
+          kind: "function",
+          startLine: 1,
+          startCol: 0,
+          endLine: 10,
+          endCol: 0,
+          language: "typescript",
+        });
+
+        db.addSymbolsToBranch("main", ["sym_entry", "sym_mid", "sym_exit"]);
+
+        db.upsertCallEdgesBatch([
+          {
+            id: "edge_entry_mid",
+            fromSymbolId: "sym_entry",
+            targetName: "mid",
+            callType: "Call",
+            confidence: "Direct",
+            line: 2,
+            col: 0,
+            isResolved: false,
+          },
+          {
+            id: "edge_mid_exit",
+            fromSymbolId: "sym_mid",
+            targetName: "exit",
+            toSymbolId: "sym_exit",
+            callType: "Call",
+            confidence: "Direct",
+            line: 4,
+            col: 0,
+            isResolved: true,
+          },
+        ]);
+
+        const indexer = new Indexer(tempDir, createIndexerConfig());
+        try {
+          const path = await indexer.findCallPathBySymbolIds("sym_entry", "sym_exit", 10);
+          expect(path.map((item) => item.symbolId)).toEqual([
+            "sym_entry",
+            "sym_mid",
+            "sym_exit",
+          ]);
+        } finally {
+          await indexer.close();
+        }
+      });
+
+      it("respects branch catalog filtering", async () => {
+        writeGitBranchHead("main");
+        const db = openIndexerDb();
+
+        db.upsertSymbolsBatch([
+          {
+            id: "sym_main_call",
+            filePath: "src/main-call.ts",
+            name: "call",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+          {
+            id: "sym_main_target",
+            filePath: "src/main-target.ts",
+            name: "target",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+          {
+            id: "sym_feature_call",
+            filePath: "src/feature-call.ts",
+            name: "call",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+          {
+            id: "sym_feature_target",
+            filePath: "src/feature-target.ts",
+            name: "target",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+        ]);
+
+        db.addSymbolsToBranch("main", ["sym_main_call", "sym_main_target"]);
+        db.addSymbolsToBranch("feature", ["sym_feature_call", "sym_feature_target"]);
+
+        db.upsertCallEdgesBatch([
+          {
+            id: "edge_main",
+            fromSymbolId: "sym_main_call",
+            targetName: "target",
+            toSymbolId: "sym_main_target",
+            callType: "Call",
+            confidence: "Direct",
+            line: 3,
+            col: 0,
+            isResolved: true,
+          },
+          {
+            id: "edge_feature",
+            fromSymbolId: "sym_feature_call",
+            targetName: "target",
+            toSymbolId: "sym_feature_target",
+            callType: "Call",
+            confidence: "Direct",
+            line: 3,
+            col: 0,
+            isResolved: true,
+          },
+        ]);
+
+        const indexerOnMain = new Indexer(tempDir, createIndexerConfig());
+        try {
+          const mainPath = await indexerOnMain.findCallPathBySymbolIds(
+            "sym_main_call",
+            "sym_main_target",
+            10,
+          );
+          expect(mainPath.map((item) => item.symbolId)).toEqual([
+            "sym_main_call",
+            "sym_main_target",
+          ]);
+
+          const mainToFeature = await indexerOnMain.findCallPathBySymbolIds(
+            "sym_main_call",
+            "sym_feature_target",
+            10,
+          );
+          expect(mainToFeature).toEqual([]);
+        } finally {
+          await indexerOnMain.close();
+        }
+
+        writeGitBranchHead("feature");
+        const indexerOnFeature = new Indexer(tempDir, createIndexerConfig());
+        try {
+          const featurePath = await indexerOnFeature.findCallPathBySymbolIds(
+            "sym_feature_call",
+            "sym_feature_target",
+            10,
+          );
+          expect(featurePath.map((item) => item.symbolId)).toEqual([
+            "sym_feature_call",
+            "sym_feature_target",
+          ]);
+
+          const featureToMain = await indexerOnFeature.findCallPathBySymbolIds(
+            "sym_feature_call",
+            "sym_main_target",
+            10,
+          );
+          expect(featureToMain).toEqual([]);
+        } finally {
+          await indexerOnFeature.close();
+        }
+      });
+
+      it("respects maxDepth boundary", async () => {
+        writeGitBranchHead("main");
+        const db = openIndexerDb();
+
+        db.upsertSymbolsBatch([
+          {
+            id: "sym_depth_a",
+            filePath: "src/depth-a.ts",
+            name: "depthA",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+          {
+            id: "sym_depth_b",
+            filePath: "src/depth-b.ts",
+            name: "depthB",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+          {
+            id: "sym_depth_c",
+            filePath: "src/depth-c.ts",
+            name: "depthC",
+            kind: "function",
+            startLine: 1,
+            startCol: 0,
+            endLine: 10,
+            endCol: 0,
+            language: "typescript",
+          },
+        ]);
+
+        db.addSymbolsToBranch("main", ["sym_depth_a", "sym_depth_b", "sym_depth_c"]);
+
+        db.upsertCallEdgesBatch([
+          {
+            id: "edge_depth_ab",
+            fromSymbolId: "sym_depth_a",
+            targetName: "depthB",
+            toSymbolId: "sym_depth_b",
+            callType: "Call",
+            confidence: "Direct",
+            line: 1,
+            col: 0,
+            isResolved: true,
+          },
+          {
+            id: "edge_depth_bc",
+            fromSymbolId: "sym_depth_b",
+            targetName: "depthC",
+            toSymbolId: "sym_depth_c",
+            callType: "Call",
+            confidence: "Direct",
+            line: 2,
+            col: 0,
+            isResolved: true,
+          },
+        ]);
+
+        const indexer = new Indexer(tempDir, createIndexerConfig());
+        try {
+          const tooShallow = await indexer.findCallPathBySymbolIds("sym_depth_a", "sym_depth_c", 1);
+          expect(tooShallow).toEqual([]);
+
+          const sufficient = await indexer.findCallPathBySymbolIds("sym_depth_a", "sym_depth_c", 2);
+          expect(sufficient.map((item) => item.symbolId)).toEqual([
+            "sym_depth_a",
+            "sym_depth_b",
+            "sym_depth_c",
+          ]);
+        } finally {
+          await indexer.close();
+        }
+      });
     });
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -38,13 +38,28 @@ const indexerMockState = vi.hoisted(() => ({
     initialize: ReturnType<typeof vi.fn>;
     search: ReturnType<typeof vi.fn>;
     getStatus: ReturnType<typeof vi.fn>;
-    getCallers: ReturnType<typeof vi.fn>;
+    getCallGraphSymbols: ReturnType<typeof vi.fn>;
+    getCallersForSymbol: ReturnType<typeof vi.fn>;
     getCallees: ReturnType<typeof vi.fn>;
-    findCallPath: ReturnType<typeof vi.fn>;
+    findCallPathBySymbolIds: ReturnType<typeof vi.fn>;
     clearIndex: ReturnType<typeof vi.fn>;
     forceIndex: ReturnType<typeof vi.fn>;
   }>,
 }));
+
+function graphSymbol(id: string, name: string, filePath: string, startLine = 1) {
+  return {
+    id,
+    filePath,
+    name,
+    kind: "function",
+    startLine,
+    startCol: 0,
+    endLine: startLine + 4,
+    endCol: 0,
+    language: "typescript",
+  };
+}
 
 vi.mock("../src/config/merger.js", () => mergerMocks);
 
@@ -101,9 +116,10 @@ vi.mock("../src/indexer/index.js", () => {
         initialize: this.initialize,
         search: this.search,
         getStatus: this.getStatus,
-        getCallers: this.getCallers,
+        getCallGraphSymbols: this.getCallGraphSymbols,
+        getCallersForSymbol: this.getCallersForSymbol,
         getCallees: this.getCallees,
-        findCallPath: this.findCallPath,
+        findCallPathBySymbolIds: this.findCallPathBySymbolIds,
         clearIndex: this.clearIndex,
         forceIndex: this.forceIndex,
       });
@@ -137,7 +153,64 @@ vi.mock("../src/indexer/index.js", () => {
     getStatus = vi.fn().mockImplementation(async () => mockStatusResult);
     healthCheck = vi.fn().mockImplementation(async () => mockHealthCheckResult);
     clearIndex = vi.fn().mockResolvedValue(undefined);
-    getCallers = vi.fn().mockResolvedValue([
+    getCallGraphSymbols = vi.fn().mockResolvedValue([
+      {
+        id: "sym_validate",
+        filePath: "/tmp/test-project/src/auth.ts",
+        name: "validateToken",
+        kind: "function",
+        startLine: 10,
+        startCol: 0,
+        endLine: 25,
+        endCol: 0,
+        language: "typescript",
+      },
+      {
+        id: "from-node-id",
+        filePath: "/tmp/test-project/src/start.ts",
+        name: "fromNode",
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 5,
+        endCol: 0,
+        language: "typescript",
+      },
+      {
+        id: "to-node-id",
+        filePath: "/tmp/test-project/src/end.ts",
+        name: "toNode",
+        kind: "function",
+        startLine: 2,
+        startCol: 0,
+        endLine: 6,
+        endCol: 0,
+        language: "typescript",
+      },
+      {
+        id: "start-id",
+        filePath: "/tmp/test-project/src/start-long.ts",
+        name: "start",
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 5,
+        endCol: 0,
+        language: "typescript",
+      },
+      {
+        id: "finish-id",
+        filePath: "/tmp/test-project/src/finish.ts",
+        name: "finish",
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 5,
+        endCol: 0,
+        language: "typescript",
+      },
+    ]);
+    getCallersForSymbol = vi.fn().mockResolvedValue([
       {
         id: "edge_1",
         fromSymbolId: "sym_caller",
@@ -164,7 +237,7 @@ vi.mock("../src/indexer/index.js", () => {
         toSymbolId: "sym_called",
       },
     ]);
-    findCallPath = vi.fn().mockResolvedValue([
+    findCallPathBySymbolIds = vi.fn().mockResolvedValue([
       {
         symbolName: "fromNode",
         filePath: "src/start.ts",
@@ -335,8 +408,8 @@ describe("MCP server tools and prompts", () => {
     expect(descriptions.get("implementation_lookup")).toContain("Do not use for callers");
     expect(descriptions.get("codebase_search")).toContain("after codebase_peek");
     expect(descriptions.get("codebase_search")).toContain("grep");
-    expect(descriptions.get("call_graph")).toContain("after identifying a symbol");
-    expect(descriptions.get("call_graph_path")).toContain("both endpoint symbols");
+    expect(descriptions.get("call_graph")).toContain("Unique names resolve automatically");
+    expect(descriptions.get("call_graph_path")).toContain("fromFilePath or toFilePath");
     expect(descriptions.get("pr_impact")).toContain("FIRST TOOL");
   });
 
@@ -531,7 +604,7 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("Path (2 hops)");
     const indexer = indexerMockState.instances.at(-1);
-    expect(indexer?.findCallPath).toHaveBeenCalledWith("fromNode", "toNode", 7);
+    expect(indexer?.findCallPathBySymbolIds).toHaveBeenCalledWith("from-node-id", "to-node-id", 7);
   });
 
   it("should keep conceptual and graph responses within the minimum token budget", async () => {
@@ -554,7 +627,7 @@ describe("MCP server tools and prompts", () => {
     expect(countContextTokens(conceptualText)).toBeLessThanOrEqual(128);
     expect(conceptualText).not.toContain("full source");
 
-    indexer?.findCallPath.mockResolvedValueOnce(Array.from({ length: 30 }, (_, index) => ({
+    indexer?.findCallPathBySymbolIds.mockResolvedValueOnce(Array.from({ length: 30 }, (_, index) => ({
       symbolName: `symbol${index}`,
       filePath: `src/path-${index}.ts`,
       line: index + 1,
@@ -596,8 +669,8 @@ describe("MCP server tools and prompts", () => {
 
   it("should recover direct unresolved edges when path traversal returns no hops", async () => {
     const indexer = indexerMockState.instances.at(-1);
-    indexer?.findCallPath.mockResolvedValueOnce([]);
-    indexer?.getCallers.mockResolvedValueOnce([{
+    indexer?.findCallPathBySymbolIds.mockResolvedValueOnce([]);
+    indexer?.getCallersForSymbol.mockResolvedValueOnce([{
       fromSymbolId: "from-node-id",
       fromSymbolName: "fromNode",
       fromSymbolFilePath: "src/start.ts",
@@ -906,6 +979,7 @@ describe("MCP server tools and prompts", () => {
       arguments: {
         name: "validateToken",
         direction: null,
+        filePath: null,
         symbolId: null,
         relationshipType: null,
       },
@@ -917,7 +991,80 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("called by 1 function");
     const indexer = indexerMockState.instances[0];
-    expect(indexer.getCallers).toHaveBeenCalledWith("validateToken", undefined);
+    expect(indexer.getCallersForSymbol).toHaveBeenCalledWith("sym_validate", "validateToken", true, undefined);
+  });
+
+  it("should report bounded candidate locations instead of unioning duplicate names", async () => {
+    const indexer = indexerMockState.instances[0];
+    indexer.getCallersForSymbol.mockClear();
+    indexer.getCallGraphSymbols.mockResolvedValueOnce(Array.from({ length: 7 }, (_, index) =>
+      graphSymbol(`sym_run_${index}`, "run", `/tmp/test-project/src/worker-${index}.ts`, index + 1)));
+
+    const result = await client.callTool({ name: "call_graph", arguments: { name: " run ", direction: "callers" } });
+    const text = (result.content as Array<{ text?: string }>)[0]?.text ?? "";
+    expect(text).toContain('Ambiguous symbol "run"');
+    expect(text).toContain("Pass filePath");
+    expect(text).toContain("src/worker-0.ts:1");
+    expect(text).toContain("...and 2 more");
+    expect(text).not.toContain("sym_run_");
+    expect(indexer.getCallersForSymbol).not.toHaveBeenCalled();
+  });
+
+  it("should normalize file paths and resolve callees by name", async () => {
+    const indexer = indexerMockState.instances[0];
+    indexer.getCallGraphSymbols.mockResolvedValueOnce([
+      graphSymbol("sym_run_a", "run", "/tmp/test-project/src/a.ts"),
+      graphSymbol("sym_run_b", "run", "/tmp/test-project/src/nested/b.ts"),
+    ]);
+
+    const result = await client.callTool({
+      name: "call_graph",
+      arguments: { name: " run ", direction: "callees", filePath: " ./src\\nested//b.ts/ " },
+    });
+    const text = (result.content as Array<{ text?: string }>)[0]?.text ?? "";
+    expect(text).toContain('"run" at src/nested/b.ts:1 calls 1 function');
+    expect(indexer.getCallees).toHaveBeenCalledWith("sym_run_b", undefined);
+  });
+
+  it("should return a concise missing-name result", async () => {
+    const indexer = indexerMockState.instances[0];
+    indexer.getCallGraphSymbols.mockResolvedValueOnce([]);
+    const result = await client.callTool({ name: "call_graph", arguments: { name: "missing", direction: "callers" } });
+    const text = (result.content as Array<{ text?: string }>)[0]?.text ?? "";
+    expect(text).toContain('No indexed symbol named "missing" was found');
+  });
+
+  it("should preserve symbolId as a backward-compatible escape hatch", async () => {
+    const indexer = indexerMockState.instances[0];
+    indexer.getCallGraphSymbols.mockResolvedValueOnce([
+      graphSymbol("sym_run_a", "run", "/tmp/test-project/src/a.ts"),
+      graphSymbol("sym_run_b", "run", "/tmp/test-project/src/b.ts"),
+    ]);
+    await client.callTool({
+      name: "call_graph",
+      arguments: { name: "run", direction: "callees", symbolId: " sym_run_b " },
+    });
+    expect(indexer.getCallees).toHaveBeenCalledWith("sym_run_b", undefined);
+  });
+
+  it("should disambiguate both path endpoints with normalized file paths", async () => {
+    const indexer = indexerMockState.instances[0];
+    indexer.getCallGraphSymbols.mockResolvedValueOnce([
+      graphSymbol("sym_start_a", "start", "/tmp/test-project/src/a.ts"),
+      graphSymbol("sym_start_b", "start", "/tmp/test-project/src/nested/start.ts"),
+      graphSymbol("sym_finish_a", "finish", "/tmp/test-project/src/c.ts"),
+      graphSymbol("sym_finish_b", "finish", "/tmp/test-project/src/nested/finish.ts"),
+    ]);
+    await client.callTool({
+      name: "call_graph_path",
+      arguments: {
+        from: " start ",
+        to: " finish ",
+        fromFilePath: " src\\nested/start.ts ",
+        toFilePath: " ./src/nested//finish.ts ",
+      },
+    });
+    expect(indexer.findCallPathBySymbolIds).toHaveBeenCalledWith("sym_start_b", "sym_finish_b", 10);
   });
 
   it("should get search prompt", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -110,6 +110,15 @@ describe("Pi adapter conformance", () => {
   it("formats caller results like other host adapters", async () => {
     operationMocks.getCallGraphData.mockResolvedValue({
       direction: "callers",
+      resolution: {
+        status: "resolved",
+        name: "validateToken",
+        symbolId: "sym_validate",
+        filePath: "src/auth.ts",
+        startLine: 4,
+        kind: "function",
+        matchedBy: "name",
+      },
       callers: [{
         fromSymbolName: "entryPoint",
         fromSymbolFilePath: "src/app.ts",
@@ -131,7 +140,7 @@ describe("Pi adapter conformance", () => {
       { cwd: "/repo" },
     );
 
-    expect(result?.content[0]?.text).toContain("\"validateToken\" is called by 1 function(s)");
+    expect(result?.content[0]?.text).toContain("\"validateToken\" at src/auth.ts:4 is called by 1 function(s)");
     expect(result?.content[0]?.text).toContain("entryPoint in src/app.ts");
     expect(result?.details).toEqual(expect.objectContaining({ direction: "callers" }));
   });
@@ -139,6 +148,15 @@ describe("Pi adapter conformance", () => {
   it("formats callee results like other host adapters", async () => {
     operationMocks.getCallGraphData.mockResolvedValue({
       direction: "callees",
+      resolution: {
+        status: "resolved",
+        name: "entryPoint",
+        symbolId: "sym_entry",
+        filePath: "src/app.ts",
+        startLine: 10,
+        kind: "function",
+        matchedBy: "name",
+      },
       callers: [],
       callees: [{
         targetName: "validateToken",
@@ -159,15 +177,25 @@ describe("Pi adapter conformance", () => {
       { cwd: "/repo" },
     );
 
-    expect(result?.content[0]?.text).toContain("[1] \u2192 validateToken (Call) at line 21 [resolved: sym_validate]");
+    expect(result?.content[0]?.text).toContain("[1] \u2192 validateToken (Call) at line 21 [resolved]");
     expect(result?.details).toEqual(expect.objectContaining({ direction: "callees" }));
   });
 
   it("formats call path results like other host adapters", async () => {
-    operationMocks.getCallGraphPath.mockResolvedValue([
-      { symbolName: "createOrder", filePath: "src/order.ts", line: 10, callType: "Call" },
-      { symbolName: "chargeCard", filePath: "src/pay.ts", line: 33, callType: "MethodCall" },
-    ]);
+    operationMocks.getCallGraphPath.mockResolvedValue({
+      from: {
+        status: "resolved", name: "createOrder", symbolId: "sym_order", filePath: "src/order.ts",
+        startLine: 10, kind: "function", matchedBy: "name",
+      },
+      to: {
+        status: "resolved", name: "chargeCard", symbolId: "sym_charge", filePath: "src/pay.ts",
+        startLine: 33, kind: "function", matchedBy: "name",
+      },
+      path: [
+        { symbolName: "createOrder", filePath: "src/order.ts", line: 10, callType: "source" },
+        { symbolName: "chargeCard", filePath: "src/pay.ts", line: 33, callType: "MethodCall" },
+      ],
+    });
     const { tools } = await registerPiTools();
 
     const result = await tools.get("call_graph_path")?.execute(
@@ -181,13 +209,27 @@ describe("Pi adapter conformance", () => {
     expect(result?.content[0]?.text).toContain("Path (2 hops):");
     expect(result?.content[0]?.text).toContain("[start] createOrder (src/order.ts:10)");
     expect(result?.content[0]?.text).toContain("--MethodCall--> chargeCard (src/pay.ts:33)");
-    expect(result?.details).toHaveLength(2);
+    expect(result?.details).toEqual(expect.objectContaining({ path: expect.any(Array) }));
   });
 
   it("routes codebase_context from/to through call-graph lookup with fallback", async () => {
-    operationMocks.getCallGraphPath.mockResolvedValue([]);
+    operationMocks.getCallGraphPath.mockResolvedValue({
+      from: {
+        status: "resolved", name: "callerFn", symbolId: "sym_caller", filePath: "src/app.ts",
+        startLine: 10, kind: "function", matchedBy: "name",
+      },
+      to: {
+        status: "resolved", name: "targetFn", symbolId: "sym_target", filePath: "src/target.ts",
+        startLine: 1, kind: "function", matchedBy: "name",
+      },
+      path: [],
+    });
     operationMocks.getCallGraphData.mockResolvedValue({
       direction: "callers",
+      resolution: {
+        status: "resolved", name: "targetFn", symbolId: "sym_target", filePath: "src/target.ts",
+        startLine: 1, kind: "function", matchedBy: "name",
+      },
       callers: [{
         fromSymbolName: "callerFn",
         fromSymbolFilePath: "src/app.ts",
@@ -209,8 +251,12 @@ describe("Pi adapter conformance", () => {
       { cwd: "/repo" },
     );
 
-    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "pi", "callerFn", "targetFn", 10);
-    expect(operationMocks.getCallGraphData).toHaveBeenCalledWith("/repo", "pi", { name: "targetFn", direction: "callers" });
+    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "pi", "callerFn", "targetFn", 10, undefined, undefined);
+    expect(operationMocks.getCallGraphData).toHaveBeenCalledWith("/repo", "pi", {
+      name: "targetFn",
+      direction: "callers",
+      filePath: undefined,
+    });
     expect(result?.content[0]?.text).toContain("Direct path: callerFn --Call--> targetFn");
     expect(result?.content[0]?.text).toContain("src/app.ts:19");
     expect(result?.content[0]?.text).toContain("edge is unresolved");

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -27,6 +27,8 @@ const context = { worktree: "/repo" };
 const commonArgs = {
   from: undefined,
   to: undefined,
+  fromFilePath: undefined,
+  toFilePath: undefined,
   symbol: undefined,
   limit: 10,
   maxDepth: 10,
@@ -40,8 +42,17 @@ describe("native OpenCode codebase_context", () => {
     vi.clearAllMocks();
     operationMocks.searchCodebase.mockResolvedValue([]);
     operationMocks.implementationLookup.mockResolvedValue([]);
-    operationMocks.getCallGraphPath.mockResolvedValue([]);
-    operationMocks.getCallGraphData.mockResolvedValue({ direction: "callers", callers: [], callees: [] });
+    operationMocks.getCallGraphPath.mockResolvedValue({
+      from: { status: "not_found", name: "", candidates: [], totalCandidates: 0 },
+      to: { status: "not_found", name: "", candidates: [], totalCandidates: 0 },
+      path: [],
+    });
+    operationMocks.getCallGraphData.mockResolvedValue({
+      direction: "callers",
+      resolution: { status: "not_found", name: "", candidates: [], totalCandidates: 0 },
+      callers: [],
+      callees: [],
+    });
   });
 
   it("returns a bounded conceptual evidence pack without source content", async () => {
@@ -100,12 +111,16 @@ describe("native OpenCode codebase_context", () => {
   });
 
   it("routes dependency endpoints through bounded call-path output", async () => {
-    operationMocks.getCallGraphPath.mockResolvedValue(Array.from({ length: 30 }, (_, index) => ({
-      symbolName: `symbol${index}`,
-      filePath: `src/path-${index}.ts`,
-      line: index + 1,
-      callType: "Call",
-    })));
+    operationMocks.getCallGraphPath.mockResolvedValue({
+      from: { status: "resolved", name: "start", symbolId: "start-id", filePath: "src/start.ts", startLine: 1, kind: "function", matchedBy: "name" },
+      to: { status: "resolved", name: "finish", symbolId: "finish-id", filePath: "src/finish.ts", startLine: 30, kind: "function", matchedBy: "name" },
+      path: Array.from({ length: 30 }, (_, index) => ({
+        symbolName: `symbol${index}`,
+        filePath: `src/path-${index}.ts`,
+        line: index + 1,
+        callType: index === 0 ? "source" : "Call",
+      })),
+    });
 
     const result = await codebase_context.execute({
       ...commonArgs,
@@ -114,7 +129,7 @@ describe("native OpenCode codebase_context", () => {
       to: "finish",
     }, context);
 
-    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "opencode", "start", "finish", 10);
+    expect(operationMocks.getCallGraphPath).toHaveBeenCalledWith("/repo", "opencode", "start", "finish", 10, undefined, undefined);
     expect(result).toContain("Path (30 hops)");
     expect(countContextTokens(result)).toBeLessThanOrEqual(128);
   });
@@ -124,6 +139,8 @@ describe("native OpenCode codebase_context", () => {
       query: "request handling",
       from: null,
       to: null,
+      fromFilePath: null,
+      toFilePath: null,
       symbol: null,
       limit: null,
       maxDepth: null,


### PR DESCRIPTION
## Summary

Let agents query callers, callees, and call paths with human-readable symbol names while safely handling duplicate names through file-path disambiguation.

## Changes

- resolve unique call-graph symbols by name and return bounded, actionable candidates when a name is ambiguous
- add optional `filePath`, `fromFilePath`, and `toFilePath` qualifiers while retaining `symbolId` as a backward-compatible escape hatch
- route callers, callees, paths, Pi, MCP, native OpenCode, and `codebase_context` through shared branch-aware resolution
- add ID-specific path traversal that preserves resolved targets and only applies name fallback to unresolved edges
- update tool guidance, command docs, README, changelog, and host conformance coverage

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Validation evidence:

- focused graph and host suites: 166 tests passed
- full Vitest suite: 52 files, 1,053 tests passed
- complete TypeScript and native build passed
- independent review found and verified the resolved-edge retargeting fix

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

Follow-up to the real-agent adoption and token-efficiency audit.
