### PR TITLE
feat: suggest exact searches after semantic discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Exact-search handoffs**: Metadata-only semantic discovery and conceptual context packs now return bounded, result-derived symbol suggestions for exact usage or exhaustive-match searches, with handoffs included in context token-budget accounting across OpenCode, MCP, and Pi.
 - **Automatic branch and PR index preparation**: `pr_impact` now safely materializes and indexes missing branch or pull-request commits in isolated hook-disabled worktrees, verifies commit-aware fork-specific catalogs, and reuses or replaces indexes without changing the caller's worktree.
 - **Name-based call graph routing**: Callers, callees, and dependency paths now resolve unique symbol names automatically across native OpenCode, MCP, Pi, and `codebase_context`. Duplicate names return bounded candidate locations with optional file-path disambiguators, while `symbolId` remains an optional compatibility escape hatch.
 - **Self-recovering context lookup**: `codebase_context` now retries empty scoped searches without file filters, retries inferred symbol text after definition-style misses, reports bounded recovery metadata, and keeps all fallback responses within the requested token budget across MCP, native OpenCode, Pi, and evaluation.

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -136,7 +136,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
       }
 
-      return { content: [{ type: "text", text: `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}\n\nUse Read tool to examine specific files.` }] };
+      return { content: [{ type: "text", text: `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}` }] };
     },
   );
 

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -19,6 +19,7 @@ import {
 } from "./tools/operations.js";
 import {
   DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
+  formatCodebasePeek,
   formatDefinitionLookup,
   formatHealthCheck,
   formatIndexStats,
@@ -129,7 +130,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const results = await searchCodebase(projectRoot(ctx), HOST, params.query, { ...params, metadataOnly: true });
-      return text(formatSearchResults(results), results);
+      return text(formatCodebasePeek(results), results);
     },
   });
 

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -468,6 +468,7 @@ export async function resolveSearchContext(
           tokenBudget,
           maxResults: limit,
           heading,
+          includeExactSearchHandoff: true,
         }),
       );
     }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -17,6 +17,7 @@ export interface ContextPackOptions {
   tokenBudget?: number;
   heading?: string;
   maxResults?: number;
+  includeExactSearchHandoff?: boolean;
 }
 
 export interface ContextPackResult {
@@ -141,6 +142,43 @@ function compactEvidenceValue(value: string, maxChars: number): string {
   return `…${characters.slice(-(maxChars - 1)).join("")}`;
 }
 
+const MAX_EXACT_SEARCH_HANDOFF_NAMES = 3;
+const MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS = 64;
+
+function compactEvidenceName(value: string): string {
+  return compactEvidenceValue(value, MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS);
+}
+
+function formatExactSearchHandoff(results: SearchResult[]): string | null {
+  const suggestedNames: string[] = [];
+  const seen = new Set<string>();
+
+  for (const result of results) {
+    const rawName = result.name?.trim();
+    if (!rawName) {
+      continue;
+    }
+
+    if (seen.has(rawName)) {
+      continue;
+    }
+
+    seen.add(rawName);
+    suggestedNames.push(compactEvidenceName(rawName));
+
+    if (suggestedNames.length >= MAX_EXACT_SEARCH_HANDOFF_NAMES) {
+      break;
+    }
+  }
+
+  if (suggestedNames.length === 0) {
+    return null;
+  }
+
+  const quotedNames = suggestedNames.map((name) => JSON.stringify(name)).join(", ");
+  return `Exact-search handoff: use exact grep/search for ${quotedNames} to find usages or exhaustive matches.`;
+}
+
 function formatContextEvidence(result: SearchResult, index: number): string {
   const symbol = result.name ? ` ${JSON.stringify(compactEvidenceValue(result.name, 80))}` : "";
   const path = compactEvidenceValue(result.filePath, 120);
@@ -154,6 +192,7 @@ function formatContextPack(
   duplicateCount: number,
   limitOmittedCount: number,
   budgetOmittedCount: number,
+  includeExactSearchHandoff: boolean,
 ): string {
   const lines = selected.map((result, index) => formatContextEvidence(result, index + 1));
   const notes: string[] = [];
@@ -163,7 +202,8 @@ function formatContextPack(
   const footer = notes.length > 0
     ? `Selected ${selected.length} of ${candidateCount} candidates; ${notes.join("; ")}.`
     : `Selected ${selected.length} of ${candidateCount} candidates.`;
-  return `${heading}\n\n${lines.join("\n")}\n\n${footer}`;
+  const handoff = includeExactSearchHandoff ? formatExactSearchHandoff(selected) : null;
+  return [heading, lines.join("\n"), footer, handoff].filter(Boolean).join("\n\n");
 }
 
 export function buildContextPack(results: SearchResult[], options: ContextPackOptions = {}): ContextPackResult {
@@ -171,6 +211,7 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const tokenBudget = clampContextPackTokenBudget(options.tokenBudget);
   const heading = compactEvidenceValue(options.heading?.trim() || "Codebase evidence", 160);
   const maxResults = Math.max(0, Math.floor(options.maxResults ?? results.length));
+  const includeExactSearchHandoff = options.includeExactSearchHandoff ?? false;
   const candidateCount = results.length;
   const deduplicated = deduplicateContextCandidates(rankContextCandidates(results));
   const diversified = diversifyContextCandidates(deduplicated);
@@ -178,7 +219,15 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const selectable = diversified.slice(0, maxResults);
   const limitOmittedCount = deduplicated.length - selectable.length;
   let selected: SearchResult[] = [];
-  let text = formatContextPack(heading, selected, candidateCount, duplicateCount, limitOmittedCount, selectable.length);
+  let text = formatContextPack(
+    heading,
+    selected,
+    candidateCount,
+    duplicateCount,
+    limitOmittedCount,
+    selectable.length,
+    includeExactSearchHandoff,
+  );
 
   for (let count = 1; count <= selectable.length; count += 1) {
     const candidateSelection = selectable.slice(0, count);
@@ -190,6 +239,7 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
       duplicateCount,
       limitOmittedCount,
       budgetOmittedCount,
+      includeExactSearchHandoff,
     );
     if (countContextTokens(candidateText) > tokenBudget) break;
     selected = candidateSelection;
@@ -402,7 +452,8 @@ export function formatCodebasePeek(results: SearchResult[]): string {
     return `[${idx + 1}] ${r.chunkType} ${name} at ${location} (score: ${r.score.toFixed(2)})${formatBlame(r)}`;
   });
 
-  return formatted.join("\n");
+  const handoff = formatExactSearchHandoff(results);
+  return handoff ? `${formatted.join("\n")}\n\n${handoff}` : formatted.join("\n");
 }
 
 export function formatHealthCheck(result: HealthCheckResult): string {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -145,10 +145,6 @@ function compactEvidenceValue(value: string, maxChars: number): string {
 const MAX_EXACT_SEARCH_HANDOFF_NAMES = 3;
 const MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS = 64;
 
-function compactEvidenceName(value: string): string {
-  return compactEvidenceValue(value, MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS);
-}
-
 function formatExactSearchHandoff(results: SearchResult[]): string | null {
   const suggestedNames: string[] = [];
   const seen = new Set<string>();
@@ -159,12 +155,16 @@ function formatExactSearchHandoff(results: SearchResult[]): string | null {
       continue;
     }
 
+    if (Array.from(rawName).length > MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS) {
+      continue;
+    }
+
     if (seen.has(rawName)) {
       continue;
     }
 
     seen.add(rawName);
-    suggestedNames.push(compactEvidenceName(rawName));
+    suggestedNames.push(rawName);
 
     if (suggestedNames.length >= MAX_EXACT_SEARCH_HANDOFF_NAMES) {
       break;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -473,6 +473,7 @@ describe("MCP server tools and prompts", () => {
     expect(content).toHaveLength(1);
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("Found 1 locations");
+    expect(content[0].text).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
   });
 
   it("should execute codebase_peek with null optional fields", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -107,6 +107,32 @@ describe("Pi adapter conformance", () => {
     }));
   });
 
+  it("formats metadata-only peek results with the shared exact-search handoff", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([{
+      filePath: "src/auth.ts",
+      startLine: 4,
+      endLine: 12,
+      name: "validateToken",
+      chunkType: "function",
+      content: "",
+      score: 0.98,
+    }]);
+    const { tools } = await registerPiTools();
+
+    const result = await tools.get("codebase_peek")?.execute(
+      "tool-call",
+      { query: "authentication validation" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(result?.content[0]?.text).toContain('function "validateToken" at src/auth.ts:4-12');
+    expect(result?.content[0]?.text).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
+    expect(result?.content[0]?.text).not.toContain("```");
+    expect(result?.details).toEqual(expect.arrayContaining([expect.objectContaining({ name: "validateToken" })]));
+  });
+
   it("formats caller results like other host adapters", async () => {
     operationMocks.getCallGraphData.mockResolvedValue({
       direction: "callers",

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -83,6 +83,28 @@ describe("native OpenCode codebase_context", () => {
     expect(countContextTokens(result)).toBeLessThanOrEqual(128);
   });
 
+  it("includes result-derived exact-search handoffs in conceptual packs", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([{
+      filePath: "src/auth.ts",
+      startLine: 12,
+      endLine: 30,
+      name: "validateToken",
+      chunkType: "function",
+      content: "secret source",
+      score: 0.99,
+    }]);
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "how is authentication validated",
+      tokenBudget: 512,
+    }, context);
+
+    expect(result).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
+    expect(result).not.toContain("secret source");
+    expect(countContextTokens(result)).toBeLessThanOrEqual(512);
+  });
+
   it("routes explicit definitions to compact location evidence", async () => {
     operationMocks.implementationLookup.mockResolvedValue([{
       filePath: "src/auth.ts",

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -532,7 +532,7 @@ describe("tools utils", () => {
       expect(result).not.toContain('grep/search for "first", "second", "third", "fourth"');
     });
 
-    it("omits handoffs for anonymous results and safely quotes compacted names", () => {
+    it("omits anonymous and overlong names while safely quoting exact names", () => {
       const anonymous = formatCodebasePeek([{
         filePath: "src/anonymous.ts",
         startLine: 1,
@@ -541,13 +541,22 @@ describe("tools utils", () => {
         score: 1,
         chunkType: "other",
       }]);
-      const unsafeName = `${"x".repeat(100)}\"\nrm -rf example`;
+      const overlongName = `${"x".repeat(100)}dangerous`;
+      const unsafeName = `dangerous\"\nrm example`;
       const named = formatCodebasePeek([{
         filePath: "src/named.ts",
         startLine: 1,
         endLine: 2,
         content: "",
         score: 1,
+        chunkType: "function",
+        name: overlongName,
+      }, {
+        filePath: "src/short.ts",
+        startLine: 3,
+        endLine: 4,
+        content: "",
+        score: 0.9,
         chunkType: "function",
         name: unsafeName,
       }]);
@@ -556,7 +565,8 @@ describe("tools utils", () => {
       expect(anonymous).not.toContain("Exact-search handoff");
       expect(handoff).toContain("Exact-search handoff");
       expect(handoff).toContain("\\n");
-      expect(handoff).not.toContain(unsafeName);
+      expect(handoff).not.toContain(overlongName);
+      expect(handoff).toContain(JSON.stringify(unsafeName));
     });
   });
 
@@ -990,7 +1000,7 @@ describe("tools utils", () => {
         content: "hidden",
         score: 1 - index / 100,
         chunkType: "function",
-        name: `veryLongExactSearchSymbol${index}${"x".repeat(50)}`,
+        name: `exactSearchSymbol${index}`,
       }));
 
       const packed = buildContextPack(results, {

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -514,6 +514,50 @@ describe("tools utils", () => {
 
       expect(result).toContain("abc1234 | Jane Doe | 2025-03-14 | auth: add session validation");
     });
+
+    it("adds a bounded, deduplicated exact-search handoff from named results", () => {
+      const results: SearchResult[] = ["first", "first", "second", "third", "fourth"].map((name, index) => ({
+        filePath: `src/${index}.ts`,
+        startLine: 1,
+        endLine: 2,
+        content: "",
+        score: 1 - index / 10,
+        chunkType: "function",
+        name,
+      }));
+
+      const result = formatCodebasePeek(results);
+
+      expect(result).toContain('Exact-search handoff: use exact grep/search for "first", "second", "third"');
+      expect(result).not.toContain('grep/search for "first", "second", "third", "fourth"');
+    });
+
+    it("omits handoffs for anonymous results and safely quotes compacted names", () => {
+      const anonymous = formatCodebasePeek([{
+        filePath: "src/anonymous.ts",
+        startLine: 1,
+        endLine: 2,
+        content: "",
+        score: 1,
+        chunkType: "other",
+      }]);
+      const unsafeName = `${"x".repeat(100)}\"\nrm -rf example`;
+      const named = formatCodebasePeek([{
+        filePath: "src/named.ts",
+        startLine: 1,
+        endLine: 2,
+        content: "",
+        score: 1,
+        chunkType: "function",
+        name: unsafeName,
+      }]);
+      const handoff = named.split("\n\n").at(-1) ?? "";
+
+      expect(anonymous).not.toContain("Exact-search handoff");
+      expect(handoff).toContain("Exact-search handoff");
+      expect(handoff).toContain("\\n");
+      expect(handoff).not.toContain(unsafeName);
+    });
   });
 
   describe("formatHealthCheck", () => {
@@ -912,6 +956,54 @@ describe("tools utils", () => {
       expect(packed.results).toEqual([]);
       expect(packed.candidateCount).toBe(0);
       expect(packed.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+    });
+
+    it("includes exact-search handoffs only when requested and only for selected evidence", () => {
+      const results: SearchResult[] = Array.from({ length: 4 }, (_, index) => ({
+        filePath: `src/file-${index}.ts`,
+        startLine: 1,
+        endLine: 2,
+        content: "hidden",
+        score: 1 - index / 10,
+        chunkType: "function",
+        name: `symbol${index}`,
+      }));
+
+      const withoutHandoff = buildContextPack(results, { tokenBudget: 2048, maxResults: 2 });
+      const withHandoff = buildContextPack(results, {
+        tokenBudget: 2048,
+        maxResults: 2,
+        includeExactSearchHandoff: true,
+      });
+
+      expect(withoutHandoff.text).not.toContain("Exact-search handoff");
+      expect(withHandoff.text).toContain('exact grep/search for "symbol0", "symbol1"');
+      expect(withHandoff.text).not.toContain('"symbol2"');
+      expect(withHandoff.tokenEstimate).toBe(countContextTokens(withHandoff.text));
+    });
+
+    it("accounts for the handoff while selecting evidence under the minimum token budget", () => {
+      const results: SearchResult[] = Array.from({ length: 8 }, (_, index) => ({
+        filePath: `src/${"long-directory/".repeat(4)}file-${index}.ts`,
+        startLine: 1,
+        endLine: 20,
+        content: "hidden",
+        score: 1 - index / 100,
+        chunkType: "function",
+        name: `veryLongExactSearchSymbol${index}${"x".repeat(50)}`,
+      }));
+
+      const packed = buildContextPack(results, {
+        tokenBudget: MIN_CONTEXT_PACK_TOKEN_BUDGET,
+        includeExactSearchHandoff: true,
+      });
+
+      expect(packed.tokenEstimate).toBe(countContextTokens(packed.text));
+      expect(packed.tokenEstimate).toBeLessThanOrEqual(MIN_CONTEXT_PACK_TOKEN_BUDGET);
+      expect(packed.results.length + packed.omittedCount).toBe(results.length);
+      for (const result of packed.results) {
+        expect(packed.text).toContain(result.name!.slice(-20));
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Add compact, result-derived exact-search handoffs after low-token semantic discovery so agents can move directly to exhaustive identifier searches without guessing symbol names.

## Changes

- Append at most three ranked, deduplicated, literal symbol suggestions to `codebase_peek` results across OpenCode, MCP, and Pi.
- Include the same handoff in conceptual `codebase_context` packs during selection so token estimates, selected evidence, and omission counts remain exact.
- Omit anonymous and overlong names, JSON-quote unsafe characters, align Pi with the shared metadata-only formatter, and add cross-host and adversarial regression coverage.

## Testing

Validated locally on macOS arm64 and independently rereviewed after fixing the initial long-name exactness blocker.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`): 55 files, 1,083 tests
- [x] Lint passes (`npm run lint`)

Focused OpenCode, MCP, Pi, formatter, token-budget, Unicode, injection-like-name, deduplication, and minimum-budget tests passed. `git diff --check` passed. Independent rereview approved with no findings.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

No linked issue.
