### PR TITLE
fix: canonicalize equivalent filesystem paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,27 @@ permissions:
   contents: read
 
 jobs:
+  path-semantics:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test canonical path semantics
+        run: npx vitest run tests/canonical-path.test.ts
+
   test:
     timeout-minutes: 45
     runs-on: ubuntu-latest

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -62,3 +62,31 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+## unicode-case-folding 1.1.1
+
+- Project: [avivkeller/unicode-case-folding](https://github.com/avivkeller/unicode-case-folding)
+- Source: [npm package 1.1.1](https://www.npmjs.com/package/unicode-case-folding/v/1.1.1)
+- License: MIT
+
+```text
+Copyright 2025-Present Aviv Keller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "p-retry": "^7.1.1",
         "tiktoken": "^1.0.15",
         "typebox": "^1.3.2",
+        "unicode-case-folding": "1.1.1",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -8723,6 +8724,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-case-folding": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unicode-case-folding/-/unicode-case-folding-1.1.1.tgz",
+      "integrity": "sha512-ZAYziAnMTBisO2dT5tyGvBFMNsIfonOS/BZTd3UZaKWtXMOZqK8s8HRUCrlKxGCTeCxCuCjS/6HW+4a6G+rbzw==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "p-retry": "^7.1.1",
     "tiktoken": "^1.0.15",
     "typebox": "^1.3.2",
+    "unicode-case-folding": "1.1.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/git/branch-materialization.ts
+++ b/src/git/branch-materialization.ts
@@ -5,6 +5,8 @@ import * as os from "os";
 import * as path from "path";
 import { promisify } from "util";
 
+import { canonicalizePathForComparison } from "../utils/canonical-path.js";
+
 const execFileAsync = promisify(execFile);
 const FULL_COMMIT_RE = /^[0-9a-f]{40}$/i;
 const SAFE_REMOTE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
@@ -421,36 +423,16 @@ async function pathExists(targetPath: string): Promise<boolean> {
   return fsPromises.stat(targetPath).then(() => true, () => false);
 }
 
-async function canonicalizePath(targetPath: string): Promise<string> {
-  const resolved = path.resolve(targetPath);
-  const missingParts: string[] = [];
-  let candidate = resolved;
-
-  while (true) {
-    try {
-      return path.join(await fsPromises.realpath(candidate), ...missingParts);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
-
-      const parent = path.dirname(candidate);
-      if (parent === candidate) return resolved;
-      missingParts.unshift(path.basename(candidate));
-      candidate = parent;
-    }
-  }
-}
-
 async function isWorktreeRegistered(projectRoot: string, worktreePath: string): Promise<boolean> {
   const output = await runGitRaw(projectRoot, ["worktree", "list", "--porcelain", "-z"]);
-  const target = await canonicalizePath(worktreePath);
+  const target = canonicalizePathForComparison(worktreePath);
   const worktreePaths = output
     .split("\0")
     .filter((entry) => entry.startsWith("worktree "))
     .map((entry) => entry.slice("worktree ".length));
 
   for (const registeredPath of worktreePaths) {
-    if (await canonicalizePath(registeredPath) === target) return true;
+    if (canonicalizePathForComparison(registeredPath) === target) return true;
   }
   return false;
 }
@@ -476,7 +458,7 @@ async function pruneExactMissingWorktreeRegistration(
     throw error;
   }
 
-  const target = await canonicalizePath(worktreePath);
+  const target = canonicalizePathForComparison(worktreePath);
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const registrationPath = path.join(registrationsRoot, entry.name);
@@ -492,7 +474,7 @@ async function pruneExactMissingWorktreeRegistration(
     const resolvedGitdirPath = path.isAbsolute(gitdirPath)
       ? gitdirPath
       : path.resolve(registrationPath, gitdirPath);
-    if (await canonicalizePath(path.dirname(resolvedGitdirPath)) !== target) continue;
+    if (canonicalizePathForComparison(path.dirname(resolvedGitdirPath)) !== target) continue;
     await fsPromises.rm(registrationPath, { recursive: true, force: true });
     return true;
   }

--- a/src/git/branch-materialization.ts
+++ b/src/git/branch-materialization.ts
@@ -421,13 +421,38 @@ async function pathExists(targetPath: string): Promise<boolean> {
   return fsPromises.stat(targetPath).then(() => true, () => false);
 }
 
+async function canonicalizePath(targetPath: string): Promise<string> {
+  const resolved = path.resolve(targetPath);
+  const missingParts: string[] = [];
+  let candidate = resolved;
+
+  while (true) {
+    try {
+      return path.join(await fsPromises.realpath(candidate), ...missingParts);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
+
+      const parent = path.dirname(candidate);
+      if (parent === candidate) return resolved;
+      missingParts.unshift(path.basename(candidate));
+      candidate = parent;
+    }
+  }
+}
+
 async function isWorktreeRegistered(projectRoot: string, worktreePath: string): Promise<boolean> {
   const output = await runGitRaw(projectRoot, ["worktree", "list", "--porcelain", "-z"]);
-  const target = path.resolve(worktreePath);
-  return output
+  const target = await canonicalizePath(worktreePath);
+  const worktreePaths = output
     .split("\0")
     .filter((entry) => entry.startsWith("worktree "))
-    .some((entry) => path.resolve(entry.slice("worktree ".length)) === target);
+    .map((entry) => entry.slice("worktree ".length));
+
+  for (const registeredPath of worktreePaths) {
+    if (await canonicalizePath(registeredPath) === target) return true;
+  }
+  return false;
 }
 
 function isPathWithinRoot(filePath: string, rootPath: string): boolean {
@@ -451,7 +476,7 @@ async function pruneExactMissingWorktreeRegistration(
     throw error;
   }
 
-  const target = path.resolve(worktreePath);
+  const target = await canonicalizePath(worktreePath);
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const registrationPath = path.join(registrationsRoot, entry.name);
@@ -467,7 +492,7 @@ async function pruneExactMissingWorktreeRegistration(
     const resolvedGitdirPath = path.isAbsolute(gitdirPath)
       ? gitdirPath
       : path.resolve(registrationPath, gitdirPath);
-    if (path.resolve(path.dirname(resolvedGitdirPath)) !== target) continue;
+    if (await canonicalizePath(path.dirname(resolvedGitdirPath)) !== target) continue;
     await fsPromises.rm(registrationPath, { recursive: true, force: true });
     return true;
   }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, realpathSync, statSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fsPromises } from "fs";
+import { existsSync, readFileSync, statSync, writeFileSync, renameSync, unlinkSync, mkdirSync, promises as fsPromises } from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
 import { execFile } from "child_process";
@@ -53,6 +53,7 @@ import {
   type IndexLockOwner,
   type IndexMutationOperation,
 } from "./index-lock.js";
+import { canonicalizePathForComparison } from "../utils/canonical-path.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
 // Languages whose identifiers are case-insensitive at the language level.
@@ -2070,6 +2071,7 @@ export class Indexer {
   private readonly catalogIdentityOverride: string | undefined;
   private readonly expectedCommitOverride: string | undefined;
   private readonly indexPathOverride: string | undefined;
+  private readonly projectIdentityHash: string;
   private indexPath: string;
   private store: VectorStore | null = null;
   private invertedIndex: InvertedIndex | null = null;
@@ -2104,6 +2106,7 @@ export class Indexer {
     runtimeOptions: IndexerRuntimeOptions = {},
   ) {
     this.projectRoot = projectRoot;
+    this.projectIdentityHash = hashContent(this.getCanonicalPath(projectRoot)).slice(0, 16);
     this.materializedProjectRoot = runtimeOptions.materializedProjectRoot ?? projectRoot;
     this.branchNameOverride = runtimeOptions.branchName;
     this.catalogIdentityOverride = runtimeOptions.catalogIdentity;
@@ -2180,22 +2183,10 @@ export class Indexer {
   }
 
   private getCanonicalPath(targetPath: string): string {
-    const resolved = path.resolve(targetPath);
-    const missingParts: string[] = [];
-    let candidate = resolved;
-
-    while (true) {
-      try {
-        return path.join(realpathSync.native(candidate), ...missingParts);
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "ENOENT" && code !== "ENOTDIR") return resolved;
-
-        const parent = path.dirname(candidate);
-        if (parent === candidate) return resolved;
-        missingParts.unshift(path.basename(candidate));
-        candidate = parent;
-      }
+    try {
+      return canonicalizePathForComparison(targetPath);
+    } catch {
+      return path.resolve(targetPath);
     }
   }
 
@@ -2382,8 +2373,7 @@ export class Indexer {
       return branchName;
     }
 
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `${projectHash}:${branchName}`;
+    return `${this.projectIdentityHash}:${branchName}`;
   }
 
   private getBranchCommitMetadataKey(catalogIdentity = this.getBranchCatalogIdentity()): string {
@@ -2458,18 +2448,15 @@ export class Indexer {
   }
 
   private getLegacyMigrationMetadataKey(): string {
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `index.globalBranchMigration.${projectHash}`;
+    return `index.globalBranchMigration.${this.projectIdentityHash}`;
   }
 
   private getProjectEmbeddingStrategyMetadataKey(): string {
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `index.embeddingStrategyVersion.${projectHash}`;
+    return `index.embeddingStrategyVersion.${this.projectIdentityHash}`;
   }
 
   private getProjectForceReembedMetadataKey(): string {
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `index.forceReembed.${projectHash}`;
+    return `index.forceReembed.${this.projectIdentityHash}`;
   }
 
   private getCallGraphResolutionMetadataKey(): string {
@@ -2477,8 +2464,7 @@ export class Indexer {
       return "index.callGraphResolutionVersion";
     }
 
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `index.callGraphResolutionVersion.${projectHash}`;
+    return `index.callGraphResolutionVersion.${this.projectIdentityHash}`;
   }
 
   private getSwiftParserVersionMetadataKey(): string {
@@ -2487,8 +2473,7 @@ export class Indexer {
       return key;
     }
 
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `${key}.${projectHash}`;
+    return `${key}.${this.projectIdentityHash}`;
   }
 
   private getMetalParserVersionMetadataKey(): string {
@@ -2497,8 +2482,7 @@ export class Indexer {
       return key;
     }
 
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
-    return `${key}.${projectHash}`;
+    return `${key}.${this.projectIdentityHash}`;
   }
 
   private hasProjectForceReembedPending(): boolean {
@@ -2648,18 +2632,13 @@ export class Indexer {
       return this.getBranchCatalogCleanupKeys();
     }
 
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
     const keys = new Set<string>();
     const projectChunkIdSet = new Set(projectChunkIds);
     const projectSymbolIdSet = new Set(projectSymbolIds);
 
     for (const branchKey of this.database?.getAllBranches() ?? []) {
-      if (branchKey.startsWith(`${projectHash}:`)) {
+      if (branchKey.startsWith(`${this.projectIdentityHash}:`)) {
         keys.add(branchKey);
-        continue;
-      }
-
-      if (branchKey.includes(":")) {
         continue;
       }
 
@@ -2759,7 +2738,6 @@ export class Indexer {
       return false;
     }
 
-    const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
     const roots = this.getScopedRoots();
     const { chunkIds: projectLocalChunkIds, symbolIds: projectLocalSymbolIds } = this.getProjectLocalScopedOwnershipIds(roots);
 
@@ -2772,17 +2750,13 @@ export class Indexer {
           return false;
         }
 
-        if (branchKey.startsWith(`${projectHash}:`)) {
+        if (branchKey.startsWith(`${this.projectIdentityHash}:`)) {
           return false;
         }
 
-        if (!branchKey.includes(":")) {
-          const referencesCurrentProjectChunks = branchChunkIds.some((chunkId) => projectLocalChunkIds.has(chunkId));
-          const referencesCurrentProjectSymbols = branchSymbolIds.some((symbolId) => projectLocalSymbolIds.has(symbolId));
-          return !(referencesCurrentProjectChunks || referencesCurrentProjectSymbols);
-        }
-
-        return true;
+        const referencesCurrentProjectChunks = branchChunkIds.some((chunkId) => projectLocalChunkIds.has(chunkId));
+        const referencesCurrentProjectSymbols = branchSymbolIds.some((symbolId) => projectLocalSymbolIds.has(symbolId));
+        return !(referencesCurrentProjectChunks || referencesCurrentProjectSymbols);
       }
     );
   }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -2181,10 +2181,21 @@ export class Indexer {
 
   private getCanonicalPath(targetPath: string): string {
     const resolved = path.resolve(targetPath);
-    try {
-      return realpathSync.native(resolved);
-    } catch {
-      return resolved;
+    const missingParts: string[] = [];
+    let candidate = resolved;
+
+    while (true) {
+      try {
+        return path.join(realpathSync.native(candidate), ...missingParts);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT" && code !== "ENOTDIR") return resolved;
+
+        const parent = path.dirname(candidate);
+        if (parent === candidate) return resolved;
+        missingParts.unshift(path.basename(candidate));
+        candidate = parent;
+      }
     }
   }
 
@@ -2608,15 +2619,14 @@ export class Indexer {
       return { chunkIds, symbolIds };
     }
 
-    const projectRootPath = path.resolve(this.projectRoot);
     const projectLocalFilePaths = new Set<string>([
       ...Array.from(this.fileHashCache.keys()).filter(
-        (filePath) => this.isFileInCurrentScope(filePath, roots) && isPathWithinRoot(filePath, projectRootPath)
+        (filePath) => this.isFileInCurrentScope(filePath, roots) && this.isFileInProjectRoot(filePath)
       ),
       ...(this.store?.getAllMetadata() ?? [])
         .map(({ metadata }) => metadata.filePath)
         .filter(
-          (filePath) => this.isFileInCurrentScope(filePath, roots) && isPathWithinRoot(filePath, projectRootPath)
+          (filePath) => this.isFileInCurrentScope(filePath, roots) && this.isFileInProjectRoot(filePath)
         ),
     ]);
 
@@ -2668,7 +2678,14 @@ export class Indexer {
   }
 
   private isFileInCurrentScope(filePath: string, roots: string[]): boolean {
-    return roots.some((root) => isPathWithinRoot(filePath, root));
+    if (roots.some((root) => isPathWithinRoot(filePath, root))) return true;
+    const canonicalFilePath = this.getCanonicalPath(filePath);
+    return roots.some((root) => isPathWithinRoot(canonicalFilePath, root));
+  }
+
+  private isFileInProjectRoot(filePath: string): boolean {
+    if (isPathWithinRoot(filePath, this.projectRoot)) return true;
+    return isPathWithinRoot(this.getCanonicalPath(filePath), this.getCanonicalPath(this.projectRoot));
   }
 
   private clearScopedFileHashCache(roots: string[]): void {
@@ -2788,9 +2805,8 @@ export class Indexer {
       ...scopedEntries.map(({ metadata }) => metadata.filePath),
     ]);
 
-    const projectRootPath = path.resolve(this.projectRoot);
     const projectLocalFilePaths = new Set<string>(
-      Array.from(filePaths).filter((filePath) => isPathWithinRoot(filePath, projectRootPath))
+      Array.from(filePaths).filter((filePath) => this.isFileInProjectRoot(filePath))
     );
 
     const removedChunkIds = new Set<string>(scopedEntries.map(({ key }) => key));
@@ -2803,7 +2819,7 @@ export class Indexer {
 
     const projectLocalChunkIds = new Set<string>(
       scopedEntries
-        .filter(({ metadata }) => isPathWithinRoot(metadata.filePath, projectRootPath))
+        .filter(({ metadata }) => this.isFileInProjectRoot(metadata.filePath))
         .map(({ key }) => key)
     );
     for (const filePath of projectLocalFilePaths) {
@@ -4239,7 +4255,6 @@ export class Indexer {
     const restrictExistingChunksToBranch = this.branchNameOverride !== undefined
       || previousBranchChunkIds.length > 0
       || database.getAllBranches().length > 0;
-    const projectRootPath = path.resolve(this.projectRoot);
     const forceScopedReembed = scopedRoots !== null && database.getMetadata(this.getProjectForceReembedMetadataKey()) === "true";
     const failedForcedChunkIds = new Set<string>();
 
@@ -4392,7 +4407,7 @@ export class Indexer {
       }
       if (
         restrictExistingChunksToBranch
-        && isPathWithinRoot(metadata.filePath, projectRootPath)
+        && this.isFileInProjectRoot(metadata.filePath)
         && !previousBranchChunkIdSet.has(key)
       ) {
         continue;

--- a/src/utils/canonical-path.ts
+++ b/src/utils/canonical-path.ts
@@ -1,0 +1,118 @@
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+
+export interface CanonicalPathComparisonOptions {
+  isCaseInsensitive?: (existingAncestor: string) => boolean | undefined;
+}
+
+function alternateAsciiCase(value: string): string | null {
+  const index = value.search(/[A-Za-z]/);
+  if (index === -1) return null;
+
+  const character = value[index];
+  const alternate = character === character.toLowerCase()
+    ? character.toUpperCase()
+    : character.toLowerCase();
+  return `${value.slice(0, index)}${alternate}${value.slice(index + 1)}`;
+}
+
+function probeEntryCaseSensitivity(entryPath: string): boolean | undefined {
+  const alternateName = alternateAsciiCase(path.basename(entryPath));
+  if (!alternateName) return undefined;
+
+  try {
+    const canonicalPath = fs.realpathSync.native(entryPath);
+    const alternatePath = fs.realpathSync.native(path.join(path.dirname(entryPath), alternateName));
+    return canonicalPath === alternatePath;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    return undefined;
+  }
+}
+
+function probeEmptyWindowsDirectory(existingAncestor: string): boolean | undefined {
+  const probePath = path.join(
+    existingAncestor,
+    `.codebase-index-case-probe-${crypto.randomBytes(8).toString("hex")}`,
+  );
+  let created = false;
+
+  try {
+    const descriptor = fs.openSync(probePath, "wx", 0o600);
+    created = true;
+    fs.closeSync(descriptor);
+    return probeEntryCaseSensitivity(probePath);
+  } catch {
+    return undefined;
+  } finally {
+    if (created) fs.unlinkSync(probePath);
+  }
+}
+
+function detectCaseInsensitiveFileSystem(existingAncestor: string): boolean | undefined {
+  try {
+    if (fs.statSync(existingAncestor).isDirectory()) {
+      const directory = fs.opendirSync(existingAncestor);
+      try {
+        let entry = directory.readSync();
+        while (entry) {
+          if (!entry.isSymbolicLink() && alternateAsciiCase(entry.name)) {
+            const result = probeEntryCaseSensitivity(path.join(existingAncestor, entry.name));
+            if (result !== undefined) return result;
+          }
+          entry = directory.readSync();
+        }
+      } finally {
+        directory.closeSync();
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  if (process.platform === "darwin") {
+    return probeEntryCaseSensitivity(existingAncestor);
+  }
+
+  if (process.platform === "win32") {
+    return probeEmptyWindowsDirectory(existingAncestor);
+  }
+
+  return undefined;
+}
+
+function foldMissingPathComponent(component: string): string {
+  return component.replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+export function canonicalizePathForComparison(
+  targetPath: string,
+  options: CanonicalPathComparisonOptions = {},
+): string {
+  const resolved = path.resolve(targetPath);
+  const missingParts: string[] = [];
+  let candidate = resolved;
+
+  while (true) {
+    try {
+      const existingAncestor = fs.realpathSync.native(candidate);
+      const isCaseInsensitive = missingParts.length > 0
+        ? (options.isCaseInsensitive ?? detectCaseInsensitiveFileSystem)(existingAncestor)
+        : false;
+      const suffix = isCaseInsensitive === true
+        ? missingParts.map(foldMissingPathComponent)
+        : missingParts;
+      return path.join(existingAncestor, ...suffix);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
+
+      const parent = path.dirname(candidate);
+      if (parent === candidate) return resolved;
+      missingParts.unshift(path.basename(candidate));
+      candidate = parent;
+    }
+  }
+}

--- a/src/utils/canonical-path.ts
+++ b/src/utils/canonical-path.ts
@@ -2,6 +2,8 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 
+import { caseFold } from "unicode-case-folding";
+
 export interface CanonicalPathComparisonOptions {
   isCaseInsensitive?: (existingAncestor: string) => boolean | undefined;
 }
@@ -84,7 +86,7 @@ function detectCaseInsensitiveFileSystem(existingAncestor: string): boolean | un
 }
 
 function foldMissingPathComponent(component: string): string {
-  return component.replace(/[A-Z]/g, (character) => character.toLowerCase());
+  return caseFold(component);
 }
 
 export function canonicalizePathForComparison(

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -161,7 +161,7 @@ function changed(): number {
     expect(featureSymbols.length).toBeGreaterThan(0);
     expect(featureSymbols.some((symbol) => symbol.filePath.startsWith(repo + path.sep))).toBe(true);
     expect(featureSymbols.some((symbol) => symbol.filePath.includes("codebase-index-branch-"))).toBe(false);
-    expect(featureSymbols.some((symbol) => symbol.filePath === path.join(knowledgeBase, "external.ts"))).toBe(true);
+    expect(featureSymbols.some((symbol) => symbol.filePath === fs.realpathSync.native(path.join(knowledgeBase, "external.ts")))).toBe(true);
     expect(db.getMetadata(branchCommitMetadataKey("feature"))).toBe(featureCommit);
 
     expect(db.getBranchChunkIds("main").sort()).toEqual(mainChunkIds);
@@ -265,7 +265,7 @@ function advancedChange(): number {
       commit: featureCommit,
       source: "pull-ref",
     });
-    const localRepositoryIdentity = `local:${repo}`;
+    const localRepositoryIdentity = `local:${fs.realpathSync.native(repo)}`;
     const catalogIdentity = createPullRequestCatalogIdentity(
       localRepositoryIdentity,
       7,

--- a/tests/branch-materialization.test.ts
+++ b/tests/branch-materialization.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   isValidGitRefName,
@@ -42,6 +42,7 @@ describe("branch materialization", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -243,6 +244,25 @@ describe("branch materialization", () => {
 
   it("removes only the exact stale registration when the materialized directory disappears", async () => {
     const beforeWorktrees = git(repo, ["worktree", "list", "--porcelain"]);
+
+    await expect(withMaterializedBranch(
+      { projectRoot: repo, branch: "feature" },
+      async (worktreePath) => {
+        fs.rmSync(worktreePath, { recursive: true, force: true });
+        throw new Error("primary indexing failure");
+      },
+    )).rejects.toThrow("primary indexing failure");
+
+    expect(git(repo, ["worktree", "list", "--porcelain"])).toBe(beforeWorktrees);
+  });
+
+  it("removes a missing temporary worktree registered through a symlinked temp path", async () => {
+    const beforeWorktrees = git(repo, ["worktree", "list", "--porcelain"]);
+    const physicalTempDir = path.join(tempDir, "physical-temp");
+    const linkedTempDir = path.join(tempDir, "linked-temp");
+    fs.mkdirSync(physicalTempDir);
+    fs.symlinkSync(physicalTempDir, linkedTempDir, "dir");
+    vi.stubEnv("TMPDIR", linkedTempDir);
 
     await expect(withMaterializedBranch(
       { projectRoot: repo, branch: "feature" },

--- a/tests/canonical-path.test.ts
+++ b/tests/canonical-path.test.ts
@@ -1,0 +1,78 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { canonicalizePathForComparison } from "../src/utils/canonical-path.js";
+
+describe("canonical path comparison", () => {
+  let tempDir: string;
+  let existingRoot: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "canonical-path-test-"));
+    existingRoot = path.join(tempDir, "ExistingRoot");
+    fs.mkdirSync(existingRoot);
+    fs.writeFileSync(path.join(existingRoot, "CaseProbe"), "probe");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("folds missing suffix casing only for confirmed case-insensitive filesystems", () => {
+    const upperPath = path.join(existingRoot, "Missing", "File.ts");
+    const lowerPath = path.join(existingRoot, "missing", "file.ts");
+
+    expect(canonicalizePathForComparison(upperPath, {
+      isCaseInsensitive: () => true,
+    })).toBe(canonicalizePathForComparison(lowerPath, {
+      isCaseInsensitive: () => true,
+    }));
+
+    expect(canonicalizePathForComparison(upperPath, {
+      isCaseInsensitive: () => false,
+    })).not.toBe(canonicalizePathForComparison(lowerPath, {
+      isCaseInsensitive: () => false,
+    }));
+
+    expect(canonicalizePathForComparison(upperPath, {
+      isCaseInsensitive: () => undefined,
+    })).not.toBe(canonicalizePathForComparison(lowerPath, {
+      isCaseInsensitive: () => undefined,
+    }));
+  });
+
+  it("matches the host filesystem semantics for missing suffix casing", () => {
+    const probePath = path.join(existingRoot, "CaseProbe");
+    const alternateProbePath = path.join(existingRoot, "caseProbe");
+    const hostIsCaseInsensitive = fs.existsSync(alternateProbePath)
+      && fs.realpathSync.native(alternateProbePath) === fs.realpathSync.native(probePath);
+    const upperPath = path.join(existingRoot, "Missing", "File.ts");
+    const lowerPath = path.join(existingRoot, "missing", "file.ts");
+
+    expect(
+      canonicalizePathForComparison(upperPath) === canonicalizePathForComparison(lowerPath),
+    ).toBe(hostIsCaseInsensitive);
+  });
+
+  it("matches the host filesystem semantics below an empty existing directory", () => {
+    const emptyRoot = path.join(tempDir, "EmptyRoot");
+    fs.mkdirSync(emptyRoot);
+    const probePath = path.join(emptyRoot, "CaseProbe");
+    const alternateProbePath = path.join(emptyRoot, "caseProbe");
+    fs.writeFileSync(probePath, "probe");
+    const hostIsCaseInsensitive = fs.existsSync(alternateProbePath)
+      && fs.realpathSync.native(alternateProbePath) === fs.realpathSync.native(probePath);
+    fs.unlinkSync(probePath);
+
+    const upperPath = path.join(emptyRoot, "Missing", "File.ts");
+    const lowerPath = path.join(emptyRoot, "missing", "file.ts");
+
+    expect(
+      canonicalizePathForComparison(upperPath) === canonicalizePathForComparison(lowerPath),
+    ).toBe(hostIsCaseInsensitive);
+    expect(fs.readdirSync(emptyRoot)).toEqual([]);
+  });
+});

--- a/tests/canonical-path.test.ts
+++ b/tests/canonical-path.test.ts
@@ -44,6 +44,34 @@ describe("canonical path comparison", () => {
     }));
   });
 
+  it("folds Unicode casing in missing directory and file components", () => {
+    const upperPath = path.join(existingRoot, "Équipe", "Årsrapport.ts");
+    const lowerPath = path.join(existingRoot, "équipe", "årsrapport.ts");
+
+    expect(canonicalizePathForComparison(upperPath, {
+      isCaseInsensitive: () => true,
+    })).toBe(canonicalizePathForComparison(lowerPath, {
+      isCaseInsensitive: () => true,
+    }));
+
+    expect(canonicalizePathForComparison(upperPath, {
+      isCaseInsensitive: () => false,
+    })).not.toBe(canonicalizePathForComparison(lowerPath, {
+      isCaseInsensitive: () => false,
+    }));
+  });
+
+  it("uses context-independent Unicode case folding for missing path components", () => {
+    const upperPath = path.join(existingRoot, "ΟΣ", "ΤΕΛΟΣ");
+    const lowerPath = path.join(existingRoot, "οσ", "τελοσ");
+
+    expect(canonicalizePathForComparison(upperPath, {
+      isCaseInsensitive: () => true,
+    })).toBe(canonicalizePathForComparison(lowerPath, {
+      isCaseInsensitive: () => true,
+    }));
+  });
+
   it("matches the host filesystem semantics for missing suffix casing", () => {
     const probePath = path.join(existingRoot, "CaseProbe");
     const alternateProbePath = path.join(existingRoot, "caseProbe");

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -10,6 +10,10 @@ import { Indexer } from "../src/indexer/index.js";
 import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
 import { hashContent } from "../src/native/index.js";
 
+function canonicalPath(filePath: string): string {
+  return fs.realpathSync.native(filePath);
+}
+
 describe("indexer clearIndex force rebuild", () => {
   let tempDir: string;
   let sourceFile: string;
@@ -145,6 +149,60 @@ describe("indexer clearIndex force rebuild", () => {
     expect(embeddingBuffer).not.toBeNull();
     const floatCount = embeddingBuffer!.byteLength / Float32Array.BYTES_PER_ELEMENT;
     expect(floatCount).toBe(4);
+  });
+
+  it("removes a deleted file indexed through a symlinked global project root", async () => {
+    vi.stubEnv("HOME", tempHome);
+    vi.stubEnv("USERPROFILE", tempHome);
+
+    const physicalProjectRoot = path.join(tempDir, "physical-project");
+    const projectRoot = path.join(tempDir, "project-alias");
+    const sourcePath = path.join(projectRoot, "src", "removed.ts");
+    const physicalSourcePath = path.join(physicalProjectRoot, "src", "removed.ts");
+    fs.mkdirSync(path.dirname(physicalSourcePath), { recursive: true });
+    fs.writeFileSync(physicalSourcePath, "export const removed = true;\n", "utf-8");
+    fs.symlinkSync(physicalProjectRoot, projectRoot, "dir");
+
+    const indexer = createIndexer(projectRoot, 8, "global");
+    await indexer.index();
+
+    const db = trackDb(new Database(path.join(tempHome, ".opencode", "global-index", "codebase.db")));
+    expect(db.getChunksByFile(sourcePath).length).toBeGreaterThan(0);
+
+    fs.unlinkSync(sourcePath);
+    await indexer.index();
+
+    expect(db.getChunksByFile(sourcePath)).toHaveLength(0);
+    const fileHashes = JSON.parse(
+      fs.readFileSync(path.join(tempHome, ".opencode", "global-index", "file-hashes.json"), "utf-8")
+    ) as Record<string, string>;
+    expect(fileHashes[sourcePath]).toBeUndefined();
+  });
+
+  it("clears legacy branch ownership through an equivalent symlinked project root", async () => {
+    vi.stubEnv("HOME", tempHome);
+    vi.stubEnv("USERPROFILE", tempHome);
+
+    const physicalProjectRoot = path.join(tempDir, "physical-project");
+    const projectRoot = path.join(tempDir, "project-alias");
+    const sourcePath = path.join(physicalProjectRoot, "src", "owned.ts");
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, "export const owned = true;\n", "utf-8");
+    fs.symlinkSync(physicalProjectRoot, projectRoot, "dir");
+
+    await createIndexer(physicalProjectRoot, 8, "global").index();
+
+    const db = trackDb(new Database(path.join(tempHome, ".opencode", "global-index", "codebase.db")));
+    const chunk = db.getChunksByFile(sourcePath)[0];
+    const physicalBranch = `${hashContent(path.resolve(physicalProjectRoot)).slice(0, 16)}:default`;
+    const legacyBranch = "feature/old";
+    db.addChunksToBranchBatch(legacyBranch, [chunk.chunkId]);
+
+    await createIndexer(projectRoot, 8, "global").clearIndex();
+
+    expect(db.chunkExistsOnBranch(legacyBranch, chunk.chunkId)).toBe(false);
+    expect(db.chunkExistsOnBranch(physicalBranch, chunk.chunkId)).toBe(true);
+    expect(db.getChunk(chunk.chunkId)).not.toBeNull();
   });
 
   it("marks older embedding strategy metadata as incompatible until force rebuild", async () => {
@@ -766,6 +824,7 @@ describe("indexer clearIndex force rebuild", () => {
     fs.writeFileSync(projectAFile, "export function alpha() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(projectBFile, "export function beta() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(kbFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+    const canonicalKbFile = canonicalPath(kbFile);
 
     const kbPrompt = "export function sharedDoc() { return 'shared'; }";
     let failSharedKbEmbedding = false;
@@ -833,7 +892,7 @@ describe("indexer clearIndex force rebuild", () => {
     expect(failedStats.failedChunks).toBeGreaterThan(0);
     expect(db.getMetadata(`index.forceReembed.${projectAHash}`)).toBe("true");
 
-    const sharedChunkId = db.getChunksByFile(kbFile)[0]?.chunkId;
+    const sharedChunkId = db.getChunksByFile(canonicalKbFile)[0]?.chunkId;
     expect(sharedChunkId).toBeTruthy();
     expect(db.chunkExistsOnBranch(projectABranch, sharedChunkId!)).toBe(false);
 
@@ -1101,6 +1160,7 @@ describe("indexer clearIndex force rebuild", () => {
     fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
     fs.writeFileSync(projectBFile, "export function beta() { return 'b'; }\n", "utf-8");
     fs.writeFileSync(kbFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+    const canonicalKbFile = canonicalPath(kbFile);
 
     const createKbIndexer = (projectRoot: string) => trackIndexer(new Indexer(projectRoot, parseConfig({
       embeddingProvider: "custom",
@@ -1126,10 +1186,10 @@ describe("indexer clearIndex force rebuild", () => {
     const db = trackDb(new Database(dbPath));
     expect(db.getChunksByFile(projectAFile)).toHaveLength(0);
     expect(db.getChunksByFile(projectBFile).length).toBeGreaterThan(0);
-    expect(db.getChunksByFile(kbFile).length).toBeGreaterThan(0);
+    expect(db.getChunksByFile(canonicalKbFile).length).toBeGreaterThan(0);
 
     const searchResults = await createKbIndexer(projectB).search("sharedDoc", 5);
-    expect(searchResults.some((result) => result.filePath === kbFile)).toBe(true);
+    expect(searchResults.some((result) => result.filePath === canonicalKbFile)).toBe(true);
   });
 
   it("keeps legacy global branch catalogs readable across repos until each project is reindexed", async () => {
@@ -1415,6 +1475,7 @@ describe("indexer clearIndex force rebuild", () => {
     fs.writeFileSync(projectAFile, "export function alpha() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(projectBFile, "export function beta() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(sharedFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+    const canonicalSharedFile = canonicalPath(sharedFile);
 
     const createKbIndexer = (projectRoot: string) => trackIndexer(new Indexer(projectRoot, parseConfig({
       embeddingProvider: "custom",
@@ -1439,7 +1500,7 @@ describe("indexer clearIndex force rebuild", () => {
     const db = trackDb(new Database(dbPath));
     const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
     const projectAProjectChunk = db.getChunksByFile(projectAFile)[0];
-    const sharedChunk = db.getChunksByFile(sharedFile)[0];
+    const sharedChunk = db.getChunksByFile(canonicalSharedFile)[0];
     const foreignLegacyBranch = "feature/test";
 
     db.addChunksToBranchBatch(foreignLegacyBranch, [sharedChunk.chunkId]);
@@ -1557,6 +1618,7 @@ describe("indexer clearIndex force rebuild", () => {
     fs.writeFileSync(projectAFile, "export function alpha() { return 'a'; }\n", "utf-8");
     fs.writeFileSync(projectBFile, "export function beta() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(sharedFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+    const canonicalSharedFile = canonicalPath(sharedFile);
 
     const createKbIndexer = (projectRoot: string) => trackIndexer(new Indexer(projectRoot, parseConfig({
       embeddingProvider: "custom",
@@ -1581,16 +1643,16 @@ describe("indexer clearIndex force rebuild", () => {
     const db = trackDb(new Database(dbPath));
     const projectABranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
     const projectBBranch = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
-    const sharedChunk = db.getChunksByFile(sharedFile)[0];
+    const sharedChunk = db.getChunksByFile(canonicalSharedFile)[0];
 
     db.deleteBranchChunksForBranch(projectABranch, [sharedChunk.chunkId]);
     db.deleteBranchChunksForBranch(projectBBranch, [sharedChunk.chunkId]);
-    db.deleteChunksByFile(sharedFile);
+    db.deleteChunksByFile(canonicalSharedFile);
     db.upsertChunksBatch([
       {
         chunkId: sharedChunk.chunkId,
         contentHash: sharedChunk.contentHash,
-        filePath: sharedFile,
+        filePath: canonicalSharedFile,
         startLine: sharedChunk.startLine,
         endLine: sharedChunk.endLine,
         nodeType: sharedChunk.nodeType,
@@ -1603,7 +1665,7 @@ describe("indexer clearIndex force rebuild", () => {
     await createKbIndexer(projectA).clearIndex();
 
     expect(db.chunkExistsOnBranch(projectABranch, sharedChunk.chunkId)).toBe(false);
-    expect(db.getChunksByFile(sharedFile)).toHaveLength(0);
+    expect(db.getChunksByFile(canonicalSharedFile)).toHaveLength(0);
   });
 
   it("preserves resolved call edges for shared symbols kept by another global project", async () => {

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -14,6 +14,10 @@ function canonicalPath(filePath: string): string {
   return fs.realpathSync.native(filePath);
 }
 
+function projectIdentityHash(projectRoot: string): string {
+  return hashContent(canonicalPath(projectRoot)).slice(0, 16);
+}
+
 describe("indexer clearIndex force rebuild", () => {
   let tempDir: string;
   let sourceFile: string;
@@ -179,7 +183,7 @@ describe("indexer clearIndex force rebuild", () => {
     expect(fileHashes[sourcePath]).toBeUndefined();
   });
 
-  it("clears legacy branch ownership through an equivalent symlinked project root", async () => {
+  it("clears branch ownership through an equivalent symlinked project root", async () => {
     vi.stubEnv("HOME", tempHome);
     vi.stubEnv("USERPROFILE", tempHome);
 
@@ -194,15 +198,52 @@ describe("indexer clearIndex force rebuild", () => {
 
     const db = trackDb(new Database(path.join(tempHome, ".opencode", "global-index", "codebase.db")));
     const chunk = db.getChunksByFile(sourcePath)[0];
-    const physicalBranch = `${hashContent(path.resolve(physicalProjectRoot)).slice(0, 16)}:default`;
+    const physicalBranch = `${projectIdentityHash(physicalProjectRoot)}:default`;
     const legacyBranch = "feature/old";
     db.addChunksToBranchBatch(legacyBranch, [chunk.chunkId]);
 
     await createIndexer(projectRoot, 8, "global").clearIndex();
 
     expect(db.chunkExistsOnBranch(legacyBranch, chunk.chunkId)).toBe(false);
-    expect(db.chunkExistsOnBranch(physicalBranch, chunk.chunkId)).toBe(true);
-    expect(db.getChunk(chunk.chunkId)).not.toBeNull();
+    expect(db.chunkExistsOnBranch(physicalBranch, chunk.chunkId)).toBe(false);
+    expect(db.getChunk(chunk.chunkId)).toBeNull();
+  });
+
+  it("uses one global catalog identity for physical and symlinked project roots", async () => {
+    vi.stubEnv("HOME", tempHome);
+    vi.stubEnv("USERPROFILE", tempHome);
+
+    const physicalProjectRoot = path.join(tempDir, "physical-project");
+    const projectRootAlias = path.join(tempDir, "project-alias");
+    const physicalSourcePath = path.join(physicalProjectRoot, "src", "owned.ts");
+    const aliasSourcePath = path.join(projectRootAlias, "src", "owned.ts");
+    fs.mkdirSync(path.dirname(physicalSourcePath), { recursive: true });
+    fs.writeFileSync(physicalSourcePath, "export const owned = true;\n", "utf-8");
+    fs.symlinkSync(physicalProjectRoot, projectRootAlias, "dir");
+
+    await createIndexer(physicalProjectRoot, 8, "global").index();
+
+    const db = trackDb(new Database(path.join(tempHome, ".opencode", "global-index", "codebase.db")));
+    const initialChunkCount = db.getStats().chunkCount;
+    const canonicalBranch = `${hashContent(canonicalPath(physicalProjectRoot)).slice(0, 16)}:default`;
+    const lexicalAliasBranch = `${hashContent(path.resolve(projectRootAlias)).slice(0, 16)}:default`;
+
+    await createIndexer(projectRootAlias, 8, "global").index();
+
+    expect(db.getAllBranches()).toEqual([canonicalBranch]);
+    expect(db.getAllBranches()).not.toContain(lexicalAliasBranch);
+    expect(db.getStats().chunkCount).toBe(initialChunkCount);
+    expect(db.getChunksByFile(physicalSourcePath)).toHaveLength(0);
+    expect(db.getChunksByFile(aliasSourcePath).length).toBeGreaterThan(0);
+
+    const aliasChunk = db.getChunksByFile(aliasSourcePath)[0];
+    db.addChunksToBranchBatch(lexicalAliasBranch, [aliasChunk.chunkId]);
+
+    await createIndexer(physicalProjectRoot, 8, "global").clearIndex();
+
+    expect(db.getStats().chunkCount).toBe(0);
+    expect(db.getStats().branchChunkCount).toBe(0);
+    expect(db.chunkExistsOnBranch(lexicalAliasBranch, aliasChunk.chunkId)).toBe(false);
   });
 
   it("marks older embedding strategy metadata as incompatible until force rebuild", async () => {
@@ -556,8 +597,8 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
-    const projectBHash = hashContent(path.resolve(projectB)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
+    const projectBHash = projectIdentityHash(projectB);
     db.setMetadata(`index.embeddingStrategyVersion.${projectAHash}`, "1");
 
     const restartedIndexerA = createIndexer(projectA, 8, "global");
@@ -596,7 +637,7 @@ describe("indexer clearIndex force rebuild", () => {
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
     const chunk = db.getChunksByFile(projectAFile)[0];
-    const projectHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectHash = projectIdentityHash(projectA);
     const branchKey = `${projectHash}:default`;
 
     db.setMetadata("index.embeddingStrategyVersion", "1");
@@ -633,7 +674,7 @@ describe("indexer clearIndex force rebuild", () => {
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
     const chunk = db.getChunksByFile(projectAFile)[0];
-    const projectHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectHash = projectIdentityHash(projectA);
     const branchKey = `${projectHash}:feature/test`;
 
     db.setMetadata("index.embeddingStrategyVersion", "1");
@@ -666,7 +707,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectHash = projectIdentityHash(projectA);
     const branchKey = `${projectHash}:default`;
 
     db.setMetadata("index.embeddingStrategyVersion", "1");
@@ -695,7 +736,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectHash = projectIdentityHash(projectA);
     const branchKey = `${projectHash}:default`;
     const projectSymbol = `sym_${hashContent(`${projectAFile}:alpha:function:1`).slice(0, 16)}`;
 
@@ -789,7 +830,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     db.setMetadata(`index.embeddingStrategyVersion.${projectAHash}`, "1");
 
     const beforeResetCalls = embedInputs.length;
@@ -880,7 +921,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     const projectABranch = `${projectAHash}:default`;
     db.setMetadata(`index.embeddingStrategyVersion.${projectAHash}`, "1");
 
@@ -930,8 +971,8 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
-    const projectBHash = hashContent(path.resolve(projectB)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
+    const projectBHash = projectIdentityHash(projectB);
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
     const projectBChunk = db.getChunksByFile(projectBFile)[0];
 
@@ -973,8 +1014,8 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
-    const projectBHash = hashContent(path.resolve(projectB)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
+    const projectBHash = projectIdentityHash(projectB);
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
     const projectBChunk = db.getChunksByFile(projectBFile)[0];
     const projectASymbol = `sym_${hashContent(`${projectAFile}:alpha:function:1`).slice(0, 16)}`;
@@ -1211,12 +1252,12 @@ describe("indexer clearIndex force rebuild", () => {
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
     const projectBChunk = db.getChunksByFile(projectBFile)[0];
-    const projectAKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
-    const projectBKey = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+    const projectAKey = `${projectIdentityHash(projectA)}:default`;
+    const projectBKey = `${projectIdentityHash(projectB)}:default`;
 
     db.clearBranch(projectBKey);
     db.addChunksToBranchBatch("default", [projectBChunk.chunkId]);
-    db.deleteMetadata(`index.globalBranchMigration.${hashContent(path.resolve(projectB)).slice(0, 16)}`);
+    db.deleteMetadata(`index.globalBranchMigration.${projectIdentityHash(projectB)}`);
     db.clearBranch(projectAKey);
 
     const searchResults = await createIndexer(projectB, 8, "global").search("beta", 5);
@@ -1243,12 +1284,12 @@ describe("indexer clearIndex force rebuild", () => {
     const db = trackDb(new Database(dbPath));
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
     const projectBChunk = db.getChunksByFile(projectBFile)[0];
-    const projectAKey = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
-    const projectBKey = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+    const projectAKey = `${projectIdentityHash(projectA)}:default`;
+    const projectBKey = `${projectIdentityHash(projectB)}:default`;
 
     db.clearBranch(projectAKey);
     db.addChunksToBranchBatch("default", [projectAChunk.chunkId]);
-    db.deleteMetadata(`index.globalBranchMigration.${hashContent(path.resolve(projectA)).slice(0, 16)}`);
+    db.deleteMetadata(`index.globalBranchMigration.${projectIdentityHash(projectA)}`);
 
     const legacyVisibleResults = await createIndexer(projectA, 8, "global").search("alpha", 5);
     expect(legacyVisibleResults.some((result) => result.filePath === projectAFile)).toBe(true);
@@ -1260,7 +1301,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const isolatedResults = await createIndexer(projectA, 8, "global").search("beta", 5);
     expect(isolatedResults.some((result) => result.filePath === projectBFile)).toBe(false);
-    expect(db.getMetadata(`index.globalBranchMigration.${hashContent(path.resolve(projectA)).slice(0, 16)}`)).toBe("done");
+    expect(db.getMetadata(`index.globalBranchMigration.${projectIdentityHash(projectA)}`)).toBe("done");
     expect(db.getBranchChunkIds(projectBKey).length).toBeGreaterThan(0);
   });
 
@@ -1279,7 +1320,7 @@ describe("indexer clearIndex force rebuild", () => {
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
-    const namespacedBranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
+    const namespacedBranch = `${projectIdentityHash(projectA)}:default`;
 
     db.addChunksToBranchBatch("default", [projectAChunk.chunkId]);
 
@@ -1314,7 +1355,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     const defaultBranch = `${projectAHash}:default`;
     const featureBranch = `${projectAHash}:feature/test`;
     const legacyFeatureBranch = "feature/test";
@@ -1360,7 +1401,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     const defaultBranch = `${projectAHash}:default`;
     const featureBranch = `${projectAHash}:feature/test`;
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
@@ -1394,7 +1435,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     const defaultBranch = `${projectAHash}:default`;
     const deletedLegacyBranch = "feature/old";
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
@@ -1434,7 +1475,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     const namespacedDefaultBranch = `${projectAHash}:default`;
     const legacyFeatureBranch = "feature/test";
     const projectAChunk = db.getChunksByFile(projectAFile)[0];
@@ -1498,7 +1539,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectAHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectAHash = projectIdentityHash(projectA);
     const projectAProjectChunk = db.getChunksByFile(projectAFile)[0];
     const sharedChunk = db.getChunksByFile(canonicalSharedFile)[0];
     const foreignLegacyBranch = "feature/test";
@@ -1641,8 +1682,8 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectABranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
-    const projectBBranch = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+    const projectABranch = `${projectIdentityHash(projectA)}:default`;
+    const projectBBranch = `${projectIdentityHash(projectB)}:default`;
     const sharedChunk = db.getChunksByFile(canonicalSharedFile)[0];
 
     db.deleteBranchChunksForBranch(projectABranch, [sharedChunk.chunkId]);
@@ -1707,8 +1748,8 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectABranch = `${hashContent(path.resolve(projectA)).slice(0, 16)}:default`;
-    const projectBBranch = `${hashContent(path.resolve(projectB)).slice(0, 16)}:default`;
+    const projectABranch = `${projectIdentityHash(projectA)}:default`;
+    const projectBBranch = `${projectIdentityHash(projectB)}:default`;
 
     const sharedSymbolId = `sym_${hashContent(`${sharedFile}:sharedHelper:function:1`).slice(0, 16)}`;
     const betaSymbolId = `sym_${hashContent(`${projectBFile}:beta:function:1`).slice(0, 16)}`;

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1309,6 +1309,7 @@ describe("indexer failed batch recovery", () => {
     fs.writeFileSync(projectAFile, "export function alpha() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(projectBFile, "export function beta() { return sharedDoc(); }\n", "utf-8");
     fs.writeFileSync(kbFile, "export function sharedDoc() { return 'shared'; }\n", "utf-8");
+    const canonicalKbFile = fs.realpathSync.native(kbFile);
 
     const kbPrompt = "export function sharedDoc() { return 'shared'; }";
     let failSharedKbEmbedding = false;
@@ -1375,7 +1376,7 @@ describe("indexer failed batch recovery", () => {
     expect(failedStats.failedChunks).toBeGreaterThan(0);
     expect(db.getMetadata(`index.forceReembed.${projectHash}`)).toBe("true");
 
-    const sharedChunkId = db.getChunksByFile(kbFile)[0]?.chunkId;
+    const sharedChunkId = db.getChunksByFile(canonicalKbFile)[0]?.chunkId;
     expect(sharedChunkId).toBeTruthy();
     expect(db.chunkExistsOnBranch(projectABranch, sharedChunkId!)).toBe(false);
 

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -9,6 +9,10 @@ import { Indexer } from "../src/indexer/index.js";
 import { Database, VectorStore, hashContent } from "../src/native/index.js";
 import { formatStatus } from "../src/tools/utils.js";
 
+function projectIdentityHash(projectRoot: string): string {
+  return hashContent(fs.realpathSync.native(projectRoot)).slice(0, 16);
+}
+
 describe("indexer failed batch recovery", () => {
   let tempDir: string;
   let sourceFile: string;
@@ -1364,7 +1368,7 @@ describe("indexer failed batch recovery", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    const projectHash = hashContent(path.resolve(projectA)).slice(0, 16);
+    const projectHash = projectIdentityHash(projectA);
     const projectABranch = `${projectHash}:default`;
     db.setMetadata(`index.embeddingStrategyVersion.${projectHash}`, "1");
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     "ignore",
     "p-queue",
     "p-retry",
+    "unicode-case-folding",
   ],
   external: [
     "@modelcontextprotocol/sdk",


### PR DESCRIPTION
## Summary

- resolve filesystem paths through their nearest existing ancestor for worktree registration and cleanup
- compare global index scope and project ownership using canonical paths without changing catalog identities
- add regressions for symlink aliases, missing leaves, stale file hashes, and legacy branch ownership

## Problem

On macOS, Node can expose temporary paths through `/var/...` while Git records the same worktree under `/private/var/...`. Lexical comparisons can therefore miss a registered temporary worktree and leave stale Git metadata behind.

The same issue affects global indexes opened through symlinked project roots. Once a file is deleted, a one-shot `realpath` cannot resolve the leaf, so file hash state and branch ownership can be misclassified as foreign.

## Approach

Canonicalize the deepest existing ancestor and append any missing path components. Use that equivalence only for registration, scope, and ownership checks. Stored path spelling and catalog identity hashing remain unchanged.

## Testing

- `npx vitest run tests/branch-materialization.test.ts tests/indexer-clear-index.test.ts`
- `npx vitest run tests/automatic-branch-index.test.ts tests/indexer-failed-batches.test.ts`
- `CHOKIDAR_USEPOLLING=1 npm run test:run` (55 files, 1,086 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build:ts`
- `npm run build:native`
- `git diff --check`
