### PR TITLE
fix: fall back to polling when file watchers exhaust handles

### DIFF
--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -49,17 +49,21 @@ export class FileWatcher {
 
     this.onChanges = handler;
     this.pollingFallbackAttempted = false;
+    this.resetReady();
+    this.createWatcher();
+  }
+
+  private resetReady(): void {
     this.readyPromise = new Promise<void>((resolve) => {
       this.resolveReady = resolve;
     });
-    this.createWatcher();
   }
 
   private createWatcher(usePolling = false): void {
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
     const watchTargets = this.configPath ? [this.projectRoot, this.configPath] : this.projectRoot;
 
-    const watcher = new FSWatcher({
+    const watcherOptions = {
       ignored: (filePath: string) => {
         const relativePath = path.relative(this.projectRoot, filePath);
         if (!relativePath) return false;
@@ -89,7 +93,23 @@ export class FileWatcher {
         stabilityThreshold: 300,
         pollInterval: 100,
       },
-    });
+    };
+    let watcher: FSWatcher;
+    if (usePolling) {
+      const previousUsePolling = process.env.CHOKIDAR_USEPOLLING;
+      process.env.CHOKIDAR_USEPOLLING = "true";
+      try {
+        watcher = new FSWatcher(watcherOptions);
+      } finally {
+        if (previousUsePolling === undefined) {
+          delete process.env.CHOKIDAR_USEPOLLING;
+        } else {
+          process.env.CHOKIDAR_USEPOLLING = previousUsePolling;
+        }
+      }
+    } else {
+      watcher = new FSWatcher(watcherOptions);
+    }
     this.watcher = watcher;
     watcher.once("ready", () => {
       if (this.watcher !== watcher) return;
@@ -104,13 +124,21 @@ export class FileWatcher {
         return;
       }
 
-      if (err?.code === "EMFILE" && !usePolling && !this.pollingFallbackAttempted && this.watcher === watcher) {
+      if (
+        err?.code === "EMFILE"
+        && !watcher.options.usePolling
+        && !this.pollingFallbackAttempted
+        && this.watcher === watcher
+      ) {
         this.pollingFallbackAttempted = true;
         console.warn("[codebase-index] File watcher exhausted open file handles; retrying with polling.");
         this.pendingClose = watcher.close().catch((closeError: unknown) => {
           console.error("[codebase-index] Failed to close exhausted file watcher:", closeError);
         });
         if (this.onChanges) {
+          if (!this.resolveReady) {
+            this.resetReady();
+          }
           this.createWatcher(true);
         } else {
           this.watcher = null;
@@ -121,13 +149,17 @@ export class FileWatcher {
       console.error("[codebase-index] Watcher error:", err?.message ?? error);
     });
 
-    watcher.on("add", (filePath) => this.handleChange("add", filePath));
-    watcher.on("change", (filePath) => this.handleChange("change", filePath));
-    watcher.on("unlink", (filePath) => this.handleChange("unlink", filePath));
+    watcher.on("add", (filePath) => this.handleChange(watcher, "add", filePath));
+    watcher.on("change", (filePath) => this.handleChange(watcher, "change", filePath));
+    watcher.on("unlink", (filePath) => this.handleChange(watcher, "unlink", filePath));
     watcher.add(watchTargets);
   }
 
-  private handleChange(type: FileChangeType, filePath: string): void {
+  private handleChange(watcher: FSWatcher, type: FileChangeType, filePath: string): void {
+    if (this.watcher !== watcher) {
+      return;
+    }
+
     if (this.isProjectConfigPath(filePath)) {
       this.pendingChanges.set(filePath, type);
       this.scheduleFlush();
@@ -211,16 +243,16 @@ export class FileWatcher {
 
     const watcher = this.watcher;
     const pendingClose = this.pendingClose;
+    const resolveReady = this.resolveReady;
     this.watcher = null;
     this.pendingClose = null;
-    await Promise.all([watcher?.close(), pendingClose]);
-
-    this.resolveReady?.();
     this.resolveReady = null;
     this.readyPromise = null;
-
     this.pendingChanges.clear();
     this.onChanges = null;
+    await Promise.all([watcher?.close(), pendingClose]);
+
+    resolveReady?.();
   }
 
   isRunning(): boolean {

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -1,4 +1,4 @@
-import chokidar, { FSWatcher } from "chokidar";
+import { FSWatcher } from "chokidar";
 import * as path from "path";
 
 import type { HostMode } from "../config/host.js";
@@ -32,6 +32,8 @@ export class FileWatcher {
   private onChanges: ChangeHandler | null = null;
   private readyPromise: Promise<void> | null = null;
   private resolveReady: (() => void) | null = null;
+  private pollingFallbackAttempted = false;
+  private pendingClose: Promise<void> | null = null;
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode = "opencode", options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -46,10 +48,18 @@ export class FileWatcher {
     }
 
     this.onChanges = handler;
+    this.pollingFallbackAttempted = false;
+    this.readyPromise = new Promise<void>((resolve) => {
+      this.resolveReady = resolve;
+    });
+    this.createWatcher();
+  }
+
+  private createWatcher(usePolling = false): void {
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
     const watchTargets = this.configPath ? [this.projectRoot, this.configPath] : this.projectRoot;
 
-    this.watcher = chokidar.watch(watchTargets, {
+    const watcher = new FSWatcher({
       ignored: (filePath: string) => {
         const relativePath = path.relative(this.projectRoot, filePath);
         if (!relativePath) return false;
@@ -74,31 +84,47 @@ export class FileWatcher {
       },
       persistent: true,
       ignoreInitial: true,
+      ...(usePolling ? { usePolling: true } : {}),
       awaitWriteFinish: {
         stabilityThreshold: 300,
         pollInterval: 100,
       },
     });
-    this.readyPromise = new Promise<void>((resolve) => {
-      this.resolveReady = resolve;
-    });
-    this.watcher.once("ready", () => {
+    this.watcher = watcher;
+    watcher.once("ready", () => {
+      if (this.watcher !== watcher) return;
       this.resolveReady?.();
       this.resolveReady = null;
     });
 
-    this.watcher.on("error", (error: unknown) => {
+    watcher.on("error", (error: unknown) => {
       const err = error instanceof Error ? (error as NodeJS.ErrnoException) : null;
       if (err?.code === "EPERM" || err?.code === "EACCES") {
         // Silently ignore permission errors — common on macOS restricted paths
         return;
       }
+
+      if (err?.code === "EMFILE" && !usePolling && !this.pollingFallbackAttempted && this.watcher === watcher) {
+        this.pollingFallbackAttempted = true;
+        console.warn("[codebase-index] File watcher exhausted open file handles; retrying with polling.");
+        this.pendingClose = watcher.close().catch((closeError: unknown) => {
+          console.error("[codebase-index] Failed to close exhausted file watcher:", closeError);
+        });
+        if (this.onChanges) {
+          this.createWatcher(true);
+        } else {
+          this.watcher = null;
+        }
+        return;
+      }
+
       console.error("[codebase-index] Watcher error:", err?.message ?? error);
     });
 
-    this.watcher.on("add", (filePath) => this.handleChange("add", filePath));
-    this.watcher.on("change", (filePath) => this.handleChange("change", filePath));
-    this.watcher.on("unlink", (filePath) => this.handleChange("unlink", filePath));
+    watcher.on("add", (filePath) => this.handleChange("add", filePath));
+    watcher.on("change", (filePath) => this.handleChange("change", filePath));
+    watcher.on("unlink", (filePath) => this.handleChange("unlink", filePath));
+    watcher.add(watchTargets);
   }
 
   private handleChange(type: FileChangeType, filePath: string): void {
@@ -183,11 +209,11 @@ export class FileWatcher {
       this.debounceTimer = null;
     }
 
-    if (this.watcher) {
-      const watcher = this.watcher;
-      this.watcher = null;
-      await watcher.close();
-    }
+    const watcher = this.watcher;
+    const pendingClose = this.pendingClose;
+    this.watcher = null;
+    this.pendingClose = null;
+    await Promise.all([watcher?.close(), pendingClose]);
 
     this.resolveReady?.();
     this.resolveReady = null;

--- a/tests/watcher-emfile.test.ts
+++ b/tests/watcher-emfile.test.ts
@@ -5,11 +5,14 @@ import { parseConfig } from "../src/config/schema.js";
 import { FileWatcher } from "../src/watcher/file-watcher.js";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("FileWatcher EMFILE recovery", () => {
   it("falls back to polling without breaking readiness or asynchronous stop", async () => {
+    vi.stubEnv("CHOKIDAR_USEPOLLING", "false");
     let resolveNativeClose: (() => void) | null = null;
     const nativeClose = new Promise<void>((resolve) => {
       resolveNativeClose = resolve;
@@ -66,5 +69,106 @@ describe("FileWatcher EMFILE recovery", () => {
     expect(stopSettled).toBe(true);
     expect(closeSpy).toHaveBeenCalledTimes(2);
     expect(closeSpy.mock.instances[1]).toBe(addSpy.mock.instances[1]);
+  });
+
+  it("waits for a polling replacement that starts after native readiness", async () => {
+    vi.stubEnv("CHOKIDAR_USEPOLLING", "false");
+    const addSpy = vi.spyOn(FSWatcher.prototype, "add").mockImplementation(function (this: FSWatcher) {
+      return this;
+    });
+    vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+
+    watcher.start(vi.fn());
+    const nativeWatcher = addSpy.mock.instances[0] as FSWatcher;
+    nativeWatcher.emit("ready");
+    await watcher.waitUntilReady();
+    nativeWatcher.emit("error", Object.assign(new Error("too many open files"), { code: "EMFILE" }));
+
+    expect(addSpy).toHaveBeenCalledTimes(2);
+    const pollingWatcher = addSpy.mock.instances[1] as FSWatcher;
+    let replacementReady = false;
+    const replacementReadyPromise = watcher.waitUntilReady().then(() => {
+      replacementReady = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(replacementReady).toBe(false);
+
+    pollingWatcher.emit("ready");
+    await replacementReadyPromise;
+    expect(replacementReady).toBe(true);
+    await watcher.stop();
+  });
+
+  it("preserves a new start while an older stop is still closing", async () => {
+    vi.useFakeTimers();
+    let resolveFirstClose: (() => void) | null = null;
+    const firstClose = new Promise<void>((resolve) => {
+      resolveFirstClose = resolve;
+    });
+    const addSpy = vi.spyOn(FSWatcher.prototype, "add").mockImplementation(function (this: FSWatcher) {
+      return this;
+    });
+    vi.spyOn(FSWatcher.prototype, "close").mockImplementation(function (this: FSWatcher) {
+      return this === addSpy.mock.instances[0] ? firstClose : Promise.resolve();
+    });
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+
+    watcher.start(firstHandler);
+    (addSpy.mock.instances[0] as FSWatcher).emit("ready");
+    await watcher.waitUntilReady();
+    const firstStop = watcher.stop();
+    watcher.start(secondHandler);
+
+    const firstWatcher = addSpy.mock.instances[0] as FSWatcher;
+    const secondWatcher = addSpy.mock.instances[1] as FSWatcher;
+    firstWatcher.emit("add", "/tmp/project/src/stale.ts");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(secondHandler).not.toHaveBeenCalled();
+
+    let secondReady = false;
+    const secondReadyPromise = watcher.waitUntilReady().then(() => {
+      secondReady = true;
+    });
+    resolveFirstClose?.();
+    await firstStop;
+    await Promise.resolve();
+    expect(secondReady).toBe(false);
+
+    secondWatcher.emit("ready");
+    await secondReadyPromise;
+    secondWatcher.emit("add", "/tmp/project/src/restarted.ts");
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledWith([
+      { type: "add", path: "/tmp/project/src/restarted.ts" },
+    ]);
+    await watcher.stop();
+  });
+
+  it("forces polling for recovery when the environment disables it", async () => {
+    vi.stubEnv("CHOKIDAR_USEPOLLING", "false");
+    let addCount = 0;
+    const addSpy = vi.spyOn(FSWatcher.prototype, "add").mockImplementation(function (this: FSWatcher) {
+      addCount += 1;
+      if (addCount === 1) {
+        this.emit("error", Object.assign(new Error("too many open files"), { code: "EMFILE" }));
+      }
+      return this;
+    });
+    vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+
+    watcher.start(vi.fn());
+
+    expect(addSpy).toHaveBeenCalledTimes(2);
+    expect((addSpy.mock.instances[1] as FSWatcher).options.usePolling).toBe(true);
+    expect(process.env.CHOKIDAR_USEPOLLING).toBe("false");
+    await watcher.stop();
   });
 });

--- a/tests/watcher-emfile.test.ts
+++ b/tests/watcher-emfile.test.ts
@@ -1,0 +1,70 @@
+import { FSWatcher } from "chokidar";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { FileWatcher } from "../src/watcher/file-watcher.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("FileWatcher EMFILE recovery", () => {
+  it("falls back to polling without breaking readiness or asynchronous stop", async () => {
+    let resolveNativeClose: (() => void) | null = null;
+    const nativeClose = new Promise<void>((resolve) => {
+      resolveNativeClose = resolve;
+    });
+    let resolvePollingClose: (() => void) | null = null;
+    const pollingClose = new Promise<void>((resolve) => {
+      resolvePollingClose = resolve;
+    });
+    let addCount = 0;
+    const addSpy = vi.spyOn(FSWatcher.prototype, "add").mockImplementation(function (this: FSWatcher) {
+      addCount += 1;
+      if (addCount === 1) {
+        this.emit("error", Object.assign(new Error("too many open files"), { code: "EMFILE" }));
+      }
+      return this;
+    });
+    const closeSpy = vi.spyOn(FSWatcher.prototype, "close").mockImplementation(function (this: FSWatcher) {
+      return this === addSpy.mock.instances[0] ? nativeClose : pollingClose;
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+
+    watcher.start(vi.fn());
+
+    expect(addSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy.mock.instances[0]).toBe(addSpy.mock.instances[0]);
+    expect((addSpy.mock.instances[1] as FSWatcher).options.usePolling).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[codebase-index] File watcher exhausted open file handles; retrying with polling.",
+    );
+    expect(watcher.isRunning()).toBe(true);
+
+    const readyPromise = watcher.waitUntilReady();
+    let readySettled = false;
+    void readyPromise.then(() => {
+      readySettled = true;
+    });
+    (addSpy.mock.instances[0] as FSWatcher).emit("ready");
+    await Promise.resolve();
+    expect(readySettled).toBe(false);
+    (addSpy.mock.instances[1] as FSWatcher).emit("ready");
+    await expect(readyPromise).resolves.toBeUndefined();
+
+    let stopSettled = false;
+    const stopPromise = watcher.stop().then(() => {
+      stopSettled = true;
+    });
+    expect(watcher.isRunning()).toBe(false);
+    resolveNativeClose?.();
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+    resolvePollingClose?.();
+    await stopPromise;
+    expect(stopSettled).toBe(true);
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy.mock.instances[1]).toBe(addSpy.mock.instances[1]);
+  });
+});


### PR DESCRIPTION
## Summary

- attach `FileWatcher` listeners before initial path registration
- retry once with Chokidar polling when native startup reports `EMFILE`
- keep `waitUntilReady()` tied to the active watcher and await both watcher shutdowns
- cover synchronous startup exhaustion, stale readiness, and asynchronous stop behavior

## Why

`chokidar.watch()` registers paths before returning. An `EMFILE` raised during that initial registration can occur before `FileWatcher` installs its error listener, leaving file watching unavailable on systems with exhausted native watch handles.

Native watching remains the default. Polling is used only as a one-time fallback after the initial native watcher reports `EMFILE`.

## Validation

- `npx vitest run tests/watcher-emfile.test.ts tests/watcher.test.ts tests/watcher-config-refresh.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build:native`
- `npm run build:ts`
- `git diff --check`