### PR TITLE
feat: add privacy-safe effectiveness metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Privacy-safe effectiveness metrics**: Added explicit opt-in, memory-only, schema-versioned fixed counters and histograms for repository tool routes, hosts, outcomes, recovery, result counts, latency, token budgets, returned-token estimates, exact-search handoffs, and scope relaxation across OpenCode, MCP, and Pi, with reset support and adversarial privacy coverage.
-- **Offline effectiveness evaluation**: Added deterministic synthetic fixtures and a no-network report comparing context-pack and metadata-only peek token output against a defined exact-read/grep-style baseline with median/p95 tokens and evidence recall, without causal or production-performance claims.
+- **Privacy-safe effectiveness metrics**: Added independent top-level opt-in, process-lifetime memory-only, schema-versioned fixed counters and histograms for repository tool routes, hosts, outcomes, recovery, result counts, latency, token budgets, returned-token estimates, exact-search handoffs, and scope relaxation across OpenCode, MCP, and Pi. The process-wide collector survives Indexer and config-watcher refreshes without repository or user identity dimensions, supports explicit reset, and has adversarial privacy, saturation, disabled-overhead, final-response, and error-path coverage.
+- **Offline effectiveness evaluation**: Added deterministic synthetic fixtures and a no-network formatting report with equal `maxResults` and final-response token budgets across routes. Evidence is credited only when visible in returned text, and the oracle exact-search baseline emits only matching lines without arbitrary complete reads. The report states that fixed rankings and markers do not measure retrieval quality, latency, end-to-end agent success, causal impact, or production performance.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Privacy-safe effectiveness metrics**: Added explicit opt-in, memory-only, schema-versioned fixed counters and histograms for repository tool routes, hosts, outcomes, recovery, result counts, latency, token budgets, returned-token estimates, exact-search handoffs, and scope relaxation across OpenCode, MCP, and Pi, with reset support and adversarial privacy coverage.
+- **Offline effectiveness evaluation**: Added deterministic synthetic fixtures and a no-network report comparing context-pack and metadata-only peek token output against a defined exact-read/grep-style baseline with median/p95 tokens and evidence recall, without causal or production-performance claims.
+
 ### Changed
 
 - **Exact-search handoffs**: Metadata-only semantic discovery and conceptual context packs now return bounded, result-derived symbol suggestions for exact usage or exhaustive-match searches, with handoffs included in context token-budget accounting across OpenCode, MCP, and Pi.

--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ Maintenance tool to remove stale entries from deleted files and orphaned embeddi
 ### `index_metrics`
 Returns collected metrics about indexing and search performance. Requires `debug.enabled` and `debug.metrics` to be `true`.
 - **Metrics include**: Files indexed, chunks created, cache hit rate, search timing breakdown, GC stats, embedding API call stats.
+- **Privacy-safe effectiveness metrics**: Set `debug.effectivenessMetrics` to `true` to opt in to fixed route/host/outcome counters and bounded result-count, latency, token-budget, and returned-token histograms. They are disabled by default, memory-only, process-scoped, and never retain queries, source, symbols, paths, repository names, or stable identifiers.
+- **Reset**: Pass `reset: true` to clear both operational and effectiveness metrics before returning the new zeroed snapshot.
 
 ### `index_logs`
 Returns recent debug logs with optional filtering.
@@ -833,7 +835,8 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "logCache": true,                         // Log cache hits/misses
     "logGc": true,                            // Log garbage collection
     "logBranch": true,                        // Log branch detection
-    "metrics": false                          // Enable metrics collection
+    "metrics": false,                         // Enable operational metrics collection
+    "effectivenessMetrics": false             // Opt in to privacy-safe repository-tool aggregates
   }
 }
 ```
@@ -906,6 +909,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `logGc` | `true` | Log garbage collection operations |
 | `logBranch` | `true` | Log branch detection and switches |
 | `metrics` | `false` | Enable metrics collection (indexing stats, search timing, cache performance) |
+| `effectivenessMetrics` | `false` | Opt in to memory-only, fixed-cardinality repository-tool effectiveness counters. Requires `enabled` and `metrics`; stores no queries, code, symbols, paths, repo names, or stable identifiers. |
 
 ### Recovery warnings in debug logs
 
@@ -938,12 +942,16 @@ npm run eval
 npm run eval:ci
 npm run eval:ci:ollama
 npm run eval:compare -- --against benchmarks/baselines/eval-baseline-summary.json
+npm run eval:effectiveness
 ```
 
 CI usage split:
 
 - `npm run eval:smoke`: harness smoke check with local mock embeddings (used in main CI)
 - `npm run eval:ci`: real quality gate against baseline/budget (for scheduled/manual quality workflow)
+- `npm run eval:effectiveness`: deterministic offline synthetic-fixture report comparing `codebase_context` and `codebase_peek` token output with a defined exact-read/grep-style baseline. It performs no network calls and writes `benchmarks/baselines/privacy-safe-effectiveness.json`.
+
+The effectiveness report includes median/p95 `cl100k_base` token counts and evidence recall. It intentionally reports only aggregate fixture measurements and makes no causal claim about agent improvement or production repositories.
 
 For `eval-quality.yml`, the default CI path uses **GitHub Models** with the workflow `GITHUB_TOKEN` plus `models: read`, so you do not need a separate OpenAI API key just to run the scheduled gate.
 

--- a/README.md
+++ b/README.md
@@ -530,10 +530,12 @@ Checks if the index is ready and healthy.
 Maintenance tool to remove stale entries from deleted files and orphaned embeddings/chunks from the database.
 
 ### `index_metrics`
-Returns collected metrics about indexing and search performance. Requires `debug.enabled` and `debug.metrics` to be `true`.
+Returns collected metrics about indexing and search performance. Operational metrics require `debug.enabled` and `debug.metrics` to be `true`.
 - **Metrics include**: Files indexed, chunks created, cache hit rate, search timing breakdown, GC stats, embedding API call stats.
-- **Privacy-safe effectiveness metrics**: Set `debug.effectivenessMetrics` to `true` to opt in to fixed route/host/outcome counters and bounded result-count, latency, token-budget, and returned-token histograms. They are disabled by default, memory-only, process-scoped, and never retain queries, source, symbols, paths, repository names, or stable identifiers.
-- **Reset**: Pass `reset: true` to clear both operational and effectiveness metrics before returning the new zeroed snapshot.
+- **Privacy-safe effectiveness metrics**: Set top-level `effectivenessMetrics.enabled` to `true`. This path does not enable debug logging. It records only fixed route/host/outcome counters and bounded result-count, latency, token-budget, and returned-token histograms. Counters are disabled by default, memory-only, fixed-cardinality, and process-lifetime across Indexer replacement and configuration-watcher refresh. One process-wide collector aggregates opted-in calls without project or repository identity dimensions. It never retains queries, response text, source, symbols, paths, repository names, user identity, or stable identifiers.
+- **Effectiveness-only privacy boundary**: With only `effectivenessMetrics.enabled` set, `debug.enabled` remains `false`, `index_logs` remains disabled, operational debug metrics remain off, and no query, path, source, secret, or response text is emitted by metrics output or written to index files. Only the bounded aggregate snapshot is returned by `index_metrics`.
+- **Debug logging is separate**: Explicitly enabling `debug.enabled` with `debug.logSearch` preserves the existing diagnostic behavior and may retain raw queries and repository details in memory. Do not enable debug search logs when only privacy-safe aggregates are wanted.
+- **Reset**: Pass `reset: true` to clear both operational and process-wide effectiveness metrics before returning the new zeroed snapshot. Process exit also clears effectiveness metrics because they are never persisted.
 
 ### `index_logs`
 Returns recent debug logs with optional filtering.
@@ -835,8 +837,10 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "logCache": true,                         // Log cache hits/misses
     "logGc": true,                            // Log garbage collection
     "logBranch": true,                        // Log branch detection
-    "metrics": false,                         // Enable operational metrics collection
-    "effectivenessMetrics": false             // Opt in to privacy-safe repository-tool aggregates
+    "metrics": false                          // Enable operational metrics collection
+  },
+  "effectivenessMetrics": {
+    "enabled": false                          // Opt in without enabling debug logs
   }
 }
 ```
@@ -909,7 +913,8 @@ String values in `codebase-index.json` can reference environment variables with 
 | `logGc` | `true` | Log garbage collection operations |
 | `logBranch` | `true` | Log branch detection and switches |
 | `metrics` | `false` | Enable metrics collection (indexing stats, search timing, cache performance) |
-| `effectivenessMetrics` | `false` | Opt in to memory-only, fixed-cardinality repository-tool effectiveness counters. Requires `enabled` and `metrics`; stores no queries, code, symbols, paths, repo names, or stable identifiers. |
+| **effectivenessMetrics** | | |
+| `enabled` | `false` | Independently opt in to memory-only, fixed-cardinality repository-tool effectiveness counters. Does not enable debug logs; stores no queries, response text, code, symbols, paths, repo names, user identity, or stable identifiers. |
 
 ### Recovery warnings in debug logs
 
@@ -949,9 +954,9 @@ CI usage split:
 
 - `npm run eval:smoke`: harness smoke check with local mock embeddings (used in main CI)
 - `npm run eval:ci`: real quality gate against baseline/budget (for scheduled/manual quality workflow)
-- `npm run eval:effectiveness`: deterministic offline synthetic-fixture report comparing `codebase_context` and `codebase_peek` token output with a defined exact-read/grep-style baseline. It performs no network calls and writes `benchmarks/baselines/privacy-safe-effectiveness.json`.
+- `npm run eval:effectiveness`: deterministic offline synthetic-fixture formatting report. Every route receives the same capped ranked result list and final-response token budget. Evidence is credited only when its literal marker is visible in returned text. The baseline emits only exact matching source lines, performs no arbitrary complete reads, makes no network calls, and writes `benchmarks/baselines/privacy-safe-effectiveness.json`.
 
-The effectiveness report includes median/p95 `cl100k_base` token counts and evidence recall. It intentionally reports only aggregate fixture measurements and makes no causal claim about agent improvement or production repositories.
+The effectiveness report includes median/p95 `cl100k_base` token counts and final-text evidence recall. Context and peek are metadata-oriented in this benchmark, so they receive no content-evidence credit unless the marker is actually visible in their response. The exact-search snippet baseline uses oracle markers and excludes discovery cost. The report does not measure retrieval quality, latency, end-to-end agent success, causal impact, or production-repository performance.
 
 For `eval-quality.yml`, the default CI path uses **GitHub Models** with the workflow `GITHUB_TOKEN` plus `models: read`, so you do not need a separate OpenAI API key just to run the scheduled gate.
 

--- a/benchmarks/baselines/privacy-safe-effectiveness.json
+++ b/benchmarks/baselines/privacy-safe-effectiveness.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "benchmark": "privacy-safe-repository-tool-effectiveness",
+  "methodology": {
+    "fixtures": "versioned-synthetic-offline",
+    "networkCalls": 0,
+    "tokenizer": "cl100k_base",
+    "tokenStatistic": "median-and-nearest-rank-p95-across-fixtures",
+    "evidenceRecall": "expected-evidence-items-covered-divided-by-expected-evidence-items",
+    "exactReadGrepBaseline": "For each synthetic fixture, concatenate deterministic exact-match lines with complete reads of the exact fixture files selected by those matches, then count the full response tokens.",
+    "limitation": "This report describes only the checked-in synthetic fixtures. It does not establish causal agent improvement or production-repository performance."
+  },
+  "fixtureCount": 5,
+  "routes": {
+    "context": {
+      "tokens": {
+        "median": 103,
+        "p95": 103
+      },
+      "evidenceRecall": {
+        "mean": 0.9,
+        "median": 1,
+        "minimum": 0.5
+      }
+    },
+    "peek": {
+      "tokens": {
+        "median": 119,
+        "p95": 121
+      },
+      "evidenceRecall": {
+        "mean": 1,
+        "median": 1,
+        "minimum": 1
+      }
+    },
+    "exactReadGrepBaseline": {
+      "tokens": {
+        "median": 842,
+        "p95": 906
+      },
+      "evidenceRecall": {
+        "mean": 1,
+        "median": 1,
+        "minimum": 1
+      }
+    }
+  },
+  "comparisons": {
+    "contextMedianTokenRatioToBaseline": 0.1223,
+    "peekMedianTokenRatioToBaseline": 0.1413
+  }
+}

--- a/benchmarks/baselines/privacy-safe-effectiveness.json
+++ b/benchmarks/baselines/privacy-safe-effectiveness.json
@@ -1,53 +1,61 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 3,
   "benchmark": "privacy-safe-repository-tool-effectiveness",
   "methodology": {
     "fixtures": "versioned-synthetic-offline",
+    "queryModel": "Five checked-in scenario labels map to fixed ranked synthetic results; no retrieval model or embedding provider runs during this report.",
+    "sourceCorpus": "Every route starts from the same fixed ranked synthetic result objects. Context and peek format their actual metadata-oriented response text, while the baseline emits only exact matching lines from those same objects.",
+    "maxResultsCap": "Every route receives only the first fixture.maxResults ranked results before formatting.",
+    "tokenBudgetParity": "Every final route response is constrained by the same fixture.tokenBudget before token counting or evidence scoring.",
     "networkCalls": 0,
+    "warmupRuns": 0,
+    "measuredRunsPerFixture": 1,
+    "timing": "not-measured-deterministic-format-and-token-evaluation-only",
     "tokenizer": "cl100k_base",
     "tokenStatistic": "median-and-nearest-rank-p95-across-fixtures",
-    "evidenceRecall": "expected-evidence-items-covered-divided-by-expected-evidence-items",
-    "exactReadGrepBaseline": "For each synthetic fixture, concatenate deterministic exact-match lines with complete reads of the exact fixture files selected by those matches, then count the full response tokens.",
-    "limitation": "This report describes only the checked-in synthetic fixtures. It does not establish causal agent improvement or production-repository performance."
+    "evidenceRecall": "Expected evidence markers visibly present in the final budgeted route text divided by expected evidence markers. Metadata-only results receive no hidden content credit.",
+    "determinism": "No clocks, randomness, embeddings, repository indexing, or network calls affect the generated aggregate report.",
+    "exactSearchSnippetBaseline": "An oracle exact-search baseline emits only matching source lines from the capped ranked chunks. It performs no arbitrary or complete file reads and excludes discovery cost.",
+    "limitation": "This synthetic formatting benchmark fixes rankings and uses oracle evidence markers. It does not measure retrieval quality, latency, end-to-end agent success, causal impact, or production-repository performance. Context and peek responses are metadata-oriented here, so content evidence is credited only if its literal marker is visible in returned text."
   },
   "fixtureCount": 5,
   "routes": {
     "context": {
       "tokens": {
-        "median": 103,
-        "p95": 103
+        "median": 94,
+        "p95": 94
+      },
+      "evidenceRecall": {
+        "mean": 0,
+        "median": 0,
+        "minimum": 0
+      }
+    },
+    "peek": {
+      "tokens": {
+        "median": 84,
+        "p95": 84
+      },
+      "evidenceRecall": {
+        "mean": 0,
+        "median": 0,
+        "minimum": 0
+      }
+    },
+    "exactSearchSnippetBaseline": {
+      "tokens": {
+        "median": 55,
+        "p95": 55
       },
       "evidenceRecall": {
         "mean": 0.9,
         "median": 1,
         "minimum": 0.5
       }
-    },
-    "peek": {
-      "tokens": {
-        "median": 119,
-        "p95": 121
-      },
-      "evidenceRecall": {
-        "mean": 1,
-        "median": 1,
-        "minimum": 1
-      }
-    },
-    "exactReadGrepBaseline": {
-      "tokens": {
-        "median": 842,
-        "p95": 906
-      },
-      "evidenceRecall": {
-        "mean": 1,
-        "median": 1,
-        "minimum": 1
-      }
     }
   },
   "comparisons": {
-    "contextMedianTokenRatioToBaseline": 0.1223,
-    "peekMedianTokenRatioToBaseline": 0.1413
+    "contextMedianTokenRatioToBaseline": 1.7091,
+    "peekMedianTokenRatioToBaseline": 1.5273
   }
 }

--- a/benchmarks/fixtures/privacy-safe-effectiveness.ts
+++ b/benchmarks/fixtures/privacy-safe-effectiveness.ts
@@ -2,13 +2,17 @@ import type {
   EffectivenessFixture,
   EffectivenessFixtureResult,
 } from "../../src/eval/effectiveness-report.js";
+import { effectivenessEvidenceMarker } from "../../src/eval/effectiveness-report.js";
 
-export const EFFECTIVENESS_FIXTURE_SCHEMA_VERSION = 1 as const;
+export const EFFECTIVENESS_FIXTURE_SCHEMA_VERSION = 2 as const;
 
-function sourceBlock(name: string, marker: string, lines: number): string {
-  const body = Array.from({ length: lines }, (_, index) =>
-    `  const step${index + 1} = ${JSON.stringify(`${marker}-${index + 1}`)};`
-  ).join("\n");
+function sourceBlock(name: string, evidenceId: string, topic: string, lines: number): string {
+  const body = [
+    `  const evidence = ${JSON.stringify(effectivenessEvidenceMarker(evidenceId))};`,
+    ...Array.from({ length: lines - 1 }, (_, index) =>
+      `  const step${index + 1} = ${JSON.stringify(`${topic}-${index + 1}`)};`
+    ),
+  ].join("\n");
   return `export function ${name}() {\n${body}\n  return true;\n}`;
 }
 
@@ -24,7 +28,7 @@ function result(
     filePath,
     startLine,
     endLine: startLine + 18,
-    content: sourceBlock(name, marker, 16),
+    content: sourceBlock(name, evidenceId, marker, 16),
     score,
     chunkType: "function",
     name,
@@ -66,24 +70,14 @@ function fixture(
     distractorEvidence,
     `${topic}-example`,
   );
+  const semanticResults = [primary, secondary, distractor];
 
   return {
     id: `fixture-${index}`,
     tokenBudget: index % 2 === 0 ? 256 : 384,
     maxResults,
     expectedEvidenceIds: [primaryEvidence, secondaryEvidence],
-    semanticResults: [primary, secondary, distractor],
-    baseline: {
-      grepOutput: [
-        `${primary.filePath}:${primary.startLine}:${primary.name}`,
-        `${secondary.filePath}:${secondary.startLine}:${secondary.name}`,
-      ].join("\n"),
-      exactReadOutput: [
-        `FILE ${primary.filePath}\n${sourceBlock(primaryName, `${topic}-primary-read`, 34)}`,
-        `FILE ${secondary.filePath}\n${sourceBlock(secondaryName, `${topic}-secondary-read`, 30)}`,
-      ].join("\n\n"),
-      evidenceIds: [primaryEvidence, secondaryEvidence],
-    },
+    semanticResults,
   };
 }
 

--- a/benchmarks/fixtures/privacy-safe-effectiveness.ts
+++ b/benchmarks/fixtures/privacy-safe-effectiveness.ts
@@ -1,0 +1,96 @@
+import type {
+  EffectivenessFixture,
+  EffectivenessFixtureResult,
+} from "../../src/eval/effectiveness-report.js";
+
+export const EFFECTIVENESS_FIXTURE_SCHEMA_VERSION = 1 as const;
+
+function sourceBlock(name: string, marker: string, lines: number): string {
+  const body = Array.from({ length: lines }, (_, index) =>
+    `  const step${index + 1} = ${JSON.stringify(`${marker}-${index + 1}`)};`
+  ).join("\n");
+  return `export function ${name}() {\n${body}\n  return true;\n}`;
+}
+
+function result(
+  filePath: string,
+  name: string,
+  startLine: number,
+  score: number,
+  evidenceId: string,
+  marker: string,
+): EffectivenessFixtureResult {
+  return {
+    filePath,
+    startLine,
+    endLine: startLine + 18,
+    content: sourceBlock(name, marker, 16),
+    score,
+    chunkType: "function",
+    name,
+    evidenceIds: [evidenceId],
+  };
+}
+
+function fixture(
+  index: number,
+  topic: string,
+  primaryName: string,
+  secondaryName: string,
+  maxResults = 2,
+): EffectivenessFixture {
+  const primaryEvidence = `evidence-${index}-primary`;
+  const secondaryEvidence = `evidence-${index}-secondary`;
+  const distractorEvidence = `evidence-${index}-distractor`;
+  const primary = result(
+    `fixture-${index}/primary.ts`,
+    primaryName,
+    10,
+    0.98,
+    primaryEvidence,
+    `${topic}-primary`,
+  );
+  const secondary = result(
+    `fixture-${index}/secondary.ts`,
+    secondaryName,
+    40,
+    0.91,
+    secondaryEvidence,
+    `${topic}-secondary`,
+  );
+  const distractor = result(
+    `fixture-${index}/notes.ts`,
+    `${primaryName}Example`,
+    75,
+    0.55,
+    distractorEvidence,
+    `${topic}-example`,
+  );
+
+  return {
+    id: `fixture-${index}`,
+    tokenBudget: index % 2 === 0 ? 256 : 384,
+    maxResults,
+    expectedEvidenceIds: [primaryEvidence, secondaryEvidence],
+    semanticResults: [primary, secondary, distractor],
+    baseline: {
+      grepOutput: [
+        `${primary.filePath}:${primary.startLine}:${primary.name}`,
+        `${secondary.filePath}:${secondary.startLine}:${secondary.name}`,
+      ].join("\n"),
+      exactReadOutput: [
+        `FILE ${primary.filePath}\n${sourceBlock(primaryName, `${topic}-primary-read`, 34)}`,
+        `FILE ${secondary.filePath}\n${sourceBlock(secondaryName, `${topic}-secondary-read`, 30)}`,
+      ].join("\n\n"),
+      evidenceIds: [primaryEvidence, secondaryEvidence],
+    },
+  };
+}
+
+export const EFFECTIVENESS_FIXTURES: EffectivenessFixture[] = [
+  fixture(1, "authentication", "validateSession", "loadSessionPolicy"),
+  fixture(2, "configuration", "parseRuntimeConfig", "mergeProjectConfig"),
+  fixture(3, "cache", "readQueryCache", "evictExpiredEntries", 1),
+  fixture(4, "call-graph", "resolveCallTarget", "buildCallPath"),
+  fixture(5, "parser", "parseSourceFile", "chunkSyntaxTree"),
+];

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -23,6 +23,14 @@ Run the agent-facing dataset with its matching quality and context-efficiency ga
 npm run eval:agent:ci
 ```
 
+Generate the deterministic privacy-safe effectiveness report without embeddings, network access, or repository indexing:
+
+```bash
+npm run eval:effectiveness
+```
+
+This command evaluates versioned synthetic fixtures only. It compares the production context packer and metadata-only peek formatter with a defined exact-read/grep-style baseline: deterministic exact-match lines plus complete reads of the exact synthetic fixture files selected by those matches. The checked-in report at `benchmarks/baselines/privacy-safe-effectiveness.json` contains only aggregate median/p95 `cl100k_base` token counts, evidence recall, and token ratios. It contains no fixture source, symbols, paths, repository names, queries, or identifiers, and it does not claim causal agent improvement or production performance.
+
 Evaluation comparisons require the same dataset name, version, and query count. Use the
 agent-context budget rather than the default search baseline when evaluating `agent-context.json`.
 
@@ -267,6 +275,13 @@ Context response budgets and response-token metrics use the `cl100k_base` tokeni
   - `wrong-symbol`
   - `docs-tests-outranking-source`
   - `no-relevant-hit-top-k`
+
+The separate `npm run eval:effectiveness` report uses:
+
+- median and nearest-rank p95 returned-token counts across synthetic fixtures
+- evidence recall = expected evidence items covered / expected evidence items
+- a versioned exact-read/grep baseline defined in the report methodology
+- byte-stable JSON output with no network calls and no raw fixture content in the report
 
 ## Artifact layout
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -29,7 +29,9 @@ Generate the deterministic privacy-safe effectiveness report without embeddings,
 npm run eval:effectiveness
 ```
 
-This command evaluates versioned synthetic fixtures only. It compares the production context packer and metadata-only peek formatter with a defined exact-read/grep-style baseline: deterministic exact-match lines plus complete reads of the exact synthetic fixture files selected by those matches. The checked-in report at `benchmarks/baselines/privacy-safe-effectiveness.json` contains only aggregate median/p95 `cl100k_base` token counts, evidence recall, and token ratios. It contains no fixture source, symbols, paths, repository names, queries, or identifiers, and it does not claim causal agent improvement or production performance.
+This command evaluates five versioned synthetic scenarios only. Each scenario supplies one fixed ranked result list. Context, peek, and the exact-search snippet baseline receive the same first `maxResults` objects and the same final-response `tokenBudget`. Evidence recall is computed only from evidence markers visibly present in each final budgeted response. Context and peek are metadata-oriented here, so fixture result metadata does not receive hidden source-evidence credit. The oracle baseline emits only exact matching source lines from the capped objects and performs no arbitrary or complete file reads. There are no warmups, one deterministic formatting/token-count run per fixture, no latency measurements, and no embeddings, repository indexing, randomness, clocks, or network calls. Tokens use `cl100k_base`; reports aggregate median and nearest-rank p95 token counts plus mean/median/minimum final-text evidence recall across fixtures. The generator is run twice during validation and the outputs must be byte-identical.
+
+The checked-in report at `benchmarks/baselines/privacy-safe-effectiveness.json` contains aggregate methodology and route statistics only. It contains no fixture source, symbols, paths, repository names, queries, scenario IDs, or evidence identifiers. This is a synthetic formatting comparison with fixed rankings and oracle markers. It excludes discovery cost and does not measure retrieval quality, latency, end-to-end agent success, causal impact, or production-repository performance.
 
 Evaluation comparisons require the same dataset name, version, and query count. Use the
 agent-context budget rather than the default search baseline when evaluating `agent-context.json`.
@@ -58,7 +60,7 @@ The eval runner accepts `--config <path>` and loads the same config shape used b
 Expected field shapes at the eval config boundary:
 
 - `knowledgeBases`, `additionalInclude`, `include`, `exclude` must be arrays of strings
-- `customProvider`, `indexing`, `search`, `debug`, `reranker` must be objects when present
+- `customProvider`, `indexing`, `search`, `debug`, `effectivenessMetrics`, `reranker` must be objects when present
 - malformed JSON fails with a file-specific parse error before evaluation starts
 
 Relative path handling during eval config materialization is also important when `--reindex` creates a local `.opencode/codebase-index.json` boundary:
@@ -279,8 +281,8 @@ Context response budgets and response-token metrics use the `cl100k_base` tokeni
 The separate `npm run eval:effectiveness` report uses:
 
 - median and nearest-rank p95 returned-token counts across synthetic fixtures
-- evidence recall = expected evidence items covered / expected evidence items
-- a versioned exact-read/grep baseline defined in the report methodology
+- final-text evidence recall = expected literal evidence markers visible after route budgeting / expected evidence markers
+- a versioned oracle exact-search snippet baseline that emits matching lines only and excludes discovery cost
 - byte-stable JSON output with no network calls and no raw fixture content in the report
 
 ## Artifact layout

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eval:ci": "npx tsx src/cli.ts eval run --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:ci:ollama": "npx tsx src/cli.ts eval run --config .github/eval-ollama-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:compare": "npx tsx src/cli.ts eval compare",
+    "eval:effectiveness": "npx tsx scripts/effectiveness-report.ts",
     "dev:link-mcp": "node scripts/link-local-mcp-bin.mjs",
     "test": "vitest",
     "pretest:run": "node scripts/run-build-native-with-rustflags.mjs",

--- a/scripts/effectiveness-report.ts
+++ b/scripts/effectiveness-report.ts
@@ -1,0 +1,13 @@
+import { mkdirSync, writeFileSync } from "fs";
+import * as path from "path";
+
+import { EFFECTIVENESS_FIXTURES } from "../benchmarks/fixtures/privacy-safe-effectiveness.js";
+import { buildEffectivenessEvaluationReport } from "../src/eval/effectiveness-report.js";
+
+const outputPath = path.resolve("benchmarks/baselines/privacy-safe-effectiveness.json");
+const report = buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES);
+const serialized = `${JSON.stringify(report, null, 2)}\n`;
+
+mkdirSync(path.dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, serialized, "utf8");
+process.stdout.write(serialized);

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -62,6 +62,5 @@ export function getDefaultDebugConfig(): DebugConfig {
     logGc: true,
     logBranch: true,
     metrics: true,
-    effectivenessMetrics: false,
   };
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -62,5 +62,6 @@ export function getDefaultDebugConfig(): DebugConfig {
     logGc: true,
     logBranch: true,
     metrics: true,
+    effectivenessMetrics: false,
   };
 }

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -15,6 +15,7 @@ const PROJECT_OVERRIDE_KEYS = [
   "indexing",
   "search",
   "debug",
+  "effectivenessMetrics",
   "scope",
 ] as const;
 
@@ -83,7 +84,7 @@ function validateConfigLayerShape(rawConfig: unknown, filePath: string): Record<
     throw new Error(`Config file ${filePath} field 'exclude' must be an array of strings.`);
   }
 
-  for (const section of ["customProvider", "indexing", "search", "debug", "reranker"] as const) {
+  for (const section of ["customProvider", "indexing", "search", "debug", "effectivenessMetrics", "reranker"] as const) {
     const value = rawConfig[section];
     if (value !== undefined && !isRecord(value)) {
       throw new Error(`Config file ${filePath} field '${section}' must be an object.`);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -103,6 +103,8 @@ export interface DebugConfig {
   logGc: boolean;
   logBranch: boolean;
   metrics: boolean;
+  /** Opt-in privacy-safe repository tool effectiveness counters and histograms. */
+  effectivenessMetrics?: boolean;
 }
 
 export interface CustomProviderConfig {
@@ -217,6 +219,9 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     logGc: typeof rawDebug.logGc === "boolean" ? rawDebug.logGc : defaultDebug.logGc,
     logBranch: typeof rawDebug.logBranch === "boolean" ? rawDebug.logBranch : defaultDebug.logBranch,
     metrics: typeof rawDebug.metrics === "boolean" ? rawDebug.metrics : defaultDebug.metrics,
+    effectivenessMetrics: typeof rawDebug.effectivenessMetrics === "boolean"
+      ? rawDebug.effectivenessMetrics
+      : defaultDebug.effectivenessMetrics,
   };
 
   const rawKnowledgeBases = input.knowledgeBases;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -103,8 +103,13 @@ export interface DebugConfig {
   logGc: boolean;
   logBranch: boolean;
   metrics: boolean;
-  /** Opt-in privacy-safe repository tool effectiveness counters and histograms. */
+  /** @deprecated Ignored. Use top-level effectivenessMetrics.enabled. */
   effectivenessMetrics?: boolean;
+}
+
+export interface EffectivenessMetricsConfig {
+  /** Opt in to process-lifetime, memory-only repository tool aggregates. */
+  enabled: boolean;
 }
 
 export interface CustomProviderConfig {
@@ -137,6 +142,8 @@ export interface CodebaseIndexConfig {
   indexing?: Partial<IndexingConfig>;
   search?: Partial<SearchConfig>;
   debug?: Partial<DebugConfig>;
+  /** Privacy-safe effectiveness aggregation, independent from debug logging. */
+  effectivenessMetrics?: Partial<EffectivenessMetricsConfig>;
   /** Reranking configuration for improving search result quality */
   reranker?: Partial<RerankerConfig>;
   /** External directories to index as knowledge bases (absolute or relative paths) */
@@ -153,6 +160,7 @@ export type ParsedCodebaseIndexConfig = CodebaseIndexConfig & {
   indexing: IndexingConfig;
   search: SearchConfig;
   debug: DebugConfig;
+  effectivenessMetrics: EffectivenessMetricsConfig;
   reranker?: RerankerConfig;
   knowledgeBases: string[];
   additionalInclude: string[];
@@ -219,9 +227,15 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     logGc: typeof rawDebug.logGc === "boolean" ? rawDebug.logGc : defaultDebug.logGc,
     logBranch: typeof rawDebug.logBranch === "boolean" ? rawDebug.logBranch : defaultDebug.logBranch,
     metrics: typeof rawDebug.metrics === "boolean" ? rawDebug.metrics : defaultDebug.metrics,
-    effectivenessMetrics: typeof rawDebug.effectivenessMetrics === "boolean"
-      ? rawDebug.effectivenessMetrics
-      : defaultDebug.effectivenessMetrics,
+  };
+
+  const rawEffectivenessMetrics = (
+    input.effectivenessMetrics && typeof input.effectivenessMetrics === "object"
+      ? input.effectivenessMetrics
+      : {}
+  ) as Record<string, unknown>;
+  const effectivenessMetrics: EffectivenessMetricsConfig = {
+    enabled: rawEffectivenessMetrics.enabled === true,
   };
 
   const rawKnowledgeBases = input.knowledgeBases;
@@ -336,6 +350,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     indexing,
     search,
     debug,
+    effectivenessMetrics,
     reranker,
     knowledgeBases,
   };

--- a/src/eval/effectiveness-report.ts
+++ b/src/eval/effectiveness-report.ts
@@ -1,0 +1,205 @@
+import type { SearchResult } from "../indexer/index.js";
+import { buildContextPack, countContextTokens, formatCodebasePeek } from "../tools/utils.js";
+
+export interface EffectivenessFixtureResult extends SearchResult {
+  evidenceIds: string[];
+}
+
+export interface EffectivenessFixture {
+  id: string;
+  tokenBudget: number;
+  maxResults: number;
+  expectedEvidenceIds: string[];
+  semanticResults: EffectivenessFixtureResult[];
+  baseline: {
+    grepOutput: string;
+    exactReadOutput: string;
+    evidenceIds: string[];
+  };
+}
+
+export interface FixtureRouteMeasurement {
+  tokens: number;
+  evidenceRecall: number;
+}
+
+export interface FixtureEffectivenessMeasurement {
+  id: string;
+  context: FixtureRouteMeasurement;
+  peek: FixtureRouteMeasurement;
+  exactReadGrepBaseline: FixtureRouteMeasurement;
+}
+
+interface AggregateRouteMeasurement {
+  tokens: {
+    median: number;
+    p95: number;
+  };
+  evidenceRecall: {
+    mean: number;
+    median: number;
+    minimum: number;
+  };
+}
+
+export interface EffectivenessEvaluationReport {
+  schemaVersion: 1;
+  benchmark: "privacy-safe-repository-tool-effectiveness";
+  methodology: {
+    fixtures: "versioned-synthetic-offline";
+    networkCalls: 0;
+    tokenizer: "cl100k_base";
+    tokenStatistic: "median-and-nearest-rank-p95-across-fixtures";
+    evidenceRecall: "expected-evidence-items-covered-divided-by-expected-evidence-items";
+    exactReadGrepBaseline: string;
+    limitation: string;
+  };
+  fixtureCount: number;
+  routes: {
+    context: AggregateRouteMeasurement;
+    peek: AggregateRouteMeasurement;
+    exactReadGrepBaseline: AggregateRouteMeasurement;
+  };
+  comparisons: {
+    contextMedianTokenRatioToBaseline: number;
+    peekMedianTokenRatioToBaseline: number;
+  };
+}
+
+function evidenceRecall(expectedEvidenceIds: string[], coveredEvidenceIds: Iterable<string>): number {
+  if (expectedEvidenceIds.length === 0) return 1;
+  const covered = new Set(coveredEvidenceIds);
+  const hits = expectedEvidenceIds.filter((id) => covered.has(id)).length;
+  return hits / expectedEvidenceIds.length;
+}
+
+function selectedEvidence(
+  selected: SearchResult[],
+  fixtureResults: EffectivenessFixtureResult[],
+): string[] {
+  const byResult = new Map<SearchResult, string[]>();
+  for (const result of fixtureResults) {
+    byResult.set(result, result.evidenceIds);
+  }
+  return selected.flatMap((result) => byResult.get(result) ?? []);
+}
+
+function exactReadGrepText(fixture: EffectivenessFixture): string {
+  return [
+    "Exact grep output:",
+    fixture.baseline.grepOutput,
+    "",
+    "Exact file reads:",
+    fixture.baseline.exactReadOutput,
+  ].join("\n");
+}
+
+export function evaluateEffectivenessFixture(fixture: EffectivenessFixture): FixtureEffectivenessMeasurement {
+  const context = buildContextPack(fixture.semanticResults, {
+    tokenBudget: fixture.tokenBudget,
+    maxResults: fixture.maxResults,
+    includeExactSearchHandoff: true,
+  });
+  const peekText = formatCodebasePeek(fixture.semanticResults);
+  const baselineText = exactReadGrepText(fixture);
+
+  return {
+    id: fixture.id,
+    context: {
+      tokens: countContextTokens(context.text),
+      evidenceRecall: evidenceRecall(
+        fixture.expectedEvidenceIds,
+        selectedEvidence(context.results, fixture.semanticResults),
+      ),
+    },
+    peek: {
+      tokens: countContextTokens(peekText),
+      evidenceRecall: evidenceRecall(
+        fixture.expectedEvidenceIds,
+        fixture.semanticResults.flatMap((result) => result.evidenceIds),
+      ),
+    },
+    exactReadGrepBaseline: {
+      tokens: countContextTokens(baselineText),
+      evidenceRecall: evidenceRecall(fixture.expectedEvidenceIds, fixture.baseline.evidenceIds),
+    },
+  };
+}
+
+function sorted(values: number[]): number[] {
+  return [...values].sort((left, right) => left - right);
+}
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const ordered = sorted(values);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0
+    ? (ordered[middle - 1] + ordered[middle]) / 2
+    : ordered[middle];
+}
+
+export function nearestRankP95(values: number[]): number {
+  if (values.length === 0) return 0;
+  const ordered = sorted(values);
+  return ordered[Math.max(0, Math.ceil(ordered.length * 0.95) - 1)];
+}
+
+function fixed(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function aggregate(
+  measurements: FixtureEffectivenessMeasurement[],
+  route: "context" | "peek" | "exactReadGrepBaseline",
+): AggregateRouteMeasurement {
+  const tokens = measurements.map((measurement) => measurement[route].tokens);
+  const recalls = measurements.map((measurement) => measurement[route].evidenceRecall);
+  return {
+    tokens: {
+      median: median(tokens),
+      p95: nearestRankP95(tokens),
+    },
+    evidenceRecall: {
+      mean: fixed(recalls.reduce((sum, value) => sum + value, 0) / Math.max(1, recalls.length)),
+      median: fixed(median(recalls)),
+      minimum: fixed(recalls.length === 0 ? 0 : Math.min(...recalls)),
+    },
+  };
+}
+
+export function buildEffectivenessEvaluationReport(
+  fixtures: EffectivenessFixture[],
+): EffectivenessEvaluationReport {
+  const measurements = fixtures.map(evaluateEffectivenessFixture);
+  const context = aggregate(measurements, "context");
+  const peek = aggregate(measurements, "peek");
+  const exactReadGrepBaseline = aggregate(measurements, "exactReadGrepBaseline");
+  const baselineMedian = exactReadGrepBaseline.tokens.median;
+
+  return {
+    schemaVersion: 1,
+    benchmark: "privacy-safe-repository-tool-effectiveness",
+    methodology: {
+      fixtures: "versioned-synthetic-offline",
+      networkCalls: 0,
+      tokenizer: "cl100k_base",
+      tokenStatistic: "median-and-nearest-rank-p95-across-fixtures",
+      evidenceRecall: "expected-evidence-items-covered-divided-by-expected-evidence-items",
+      exactReadGrepBaseline:
+        "For each synthetic fixture, concatenate deterministic exact-match lines with complete reads of the exact fixture files selected by those matches, then count the full response tokens.",
+      limitation:
+        "This report describes only the checked-in synthetic fixtures. It does not establish causal agent improvement or production-repository performance.",
+    },
+    fixtureCount: fixtures.length,
+    routes: {
+      context,
+      peek,
+      exactReadGrepBaseline,
+    },
+    comparisons: {
+      contextMedianTokenRatioToBaseline: fixed(baselineMedian === 0 ? 0 : context.tokens.median / baselineMedian),
+      peekMedianTokenRatioToBaseline: fixed(baselineMedian === 0 ? 0 : peek.tokens.median / baselineMedian),
+    },
+  };
+}

--- a/src/eval/effectiveness-report.ts
+++ b/src/eval/effectiveness-report.ts
@@ -1,5 +1,10 @@
 import type { SearchResult } from "../indexer/index.js";
-import { buildContextPack, countContextTokens, formatCodebasePeek } from "../tools/utils.js";
+import {
+  buildContextPack,
+  countContextTokens,
+  fitTextToContextBudget,
+  formatCodebasePeek,
+} from "../tools/utils.js";
 
 export interface EffectivenessFixtureResult extends SearchResult {
   evidenceIds: string[];
@@ -11,11 +16,6 @@ export interface EffectivenessFixture {
   maxResults: number;
   expectedEvidenceIds: string[];
   semanticResults: EffectivenessFixtureResult[];
-  baseline: {
-    grepOutput: string;
-    exactReadOutput: string;
-    evidenceIds: string[];
-  };
 }
 
 export interface FixtureRouteMeasurement {
@@ -27,7 +27,7 @@ export interface FixtureEffectivenessMeasurement {
   id: string;
   context: FixtureRouteMeasurement;
   peek: FixtureRouteMeasurement;
-  exactReadGrepBaseline: FixtureRouteMeasurement;
+  exactSearchSnippetBaseline: FixtureRouteMeasurement;
 }
 
 interface AggregateRouteMeasurement {
@@ -43,22 +43,30 @@ interface AggregateRouteMeasurement {
 }
 
 export interface EffectivenessEvaluationReport {
-  schemaVersion: 1;
+  schemaVersion: 3;
   benchmark: "privacy-safe-repository-tool-effectiveness";
   methodology: {
     fixtures: "versioned-synthetic-offline";
+    queryModel: string;
+    sourceCorpus: string;
+    maxResultsCap: string;
+    tokenBudgetParity: string;
     networkCalls: 0;
+    warmupRuns: 0;
+    measuredRunsPerFixture: 1;
+    timing: "not-measured-deterministic-format-and-token-evaluation-only";
     tokenizer: "cl100k_base";
     tokenStatistic: "median-and-nearest-rank-p95-across-fixtures";
-    evidenceRecall: "expected-evidence-items-covered-divided-by-expected-evidence-items";
-    exactReadGrepBaseline: string;
+    evidenceRecall: string;
+    determinism: string;
+    exactSearchSnippetBaseline: string;
     limitation: string;
   };
   fixtureCount: number;
   routes: {
     context: AggregateRouteMeasurement;
     peek: AggregateRouteMeasurement;
-    exactReadGrepBaseline: AggregateRouteMeasurement;
+    exactSearchSnippetBaseline: AggregateRouteMeasurement;
   };
   comparisons: {
     contextMedianTokenRatioToBaseline: number;
@@ -66,62 +74,57 @@ export interface EffectivenessEvaluationReport {
   };
 }
 
-function evidenceRecall(expectedEvidenceIds: string[], coveredEvidenceIds: Iterable<string>): number {
+export function effectivenessEvidenceMarker(evidenceId: string): string {
+  return `[[effectiveness-evidence:${evidenceId}]]`;
+}
+
+function evidenceRecall(expectedEvidenceIds: string[], routeText: string): number {
   if (expectedEvidenceIds.length === 0) return 1;
-  const covered = new Set(coveredEvidenceIds);
-  const hits = expectedEvidenceIds.filter((id) => covered.has(id)).length;
+  const hits = expectedEvidenceIds.filter((id) => routeText.includes(effectivenessEvidenceMarker(id))).length;
   return hits / expectedEvidenceIds.length;
 }
 
-function selectedEvidence(
-  selected: SearchResult[],
-  fixtureResults: EffectivenessFixtureResult[],
-): string[] {
-  const byResult = new Map<SearchResult, string[]>();
-  for (const result of fixtureResults) {
-    byResult.set(result, result.evidenceIds);
-  }
-  return selected.flatMap((result) => byResult.get(result) ?? []);
-}
-
-function exactReadGrepText(fixture: EffectivenessFixture): string {
-  return [
-    "Exact grep output:",
-    fixture.baseline.grepOutput,
-    "",
-    "Exact file reads:",
-    fixture.baseline.exactReadOutput,
-  ].join("\n");
+function exactSearchSnippetText(
+  fixture: EffectivenessFixture,
+  selectedResults: EffectivenessFixtureResult[],
+): string {
+  const markers = fixture.expectedEvidenceIds.map(effectivenessEvidenceMarker);
+  const matches = selectedResults.flatMap((result) => result.content
+    .split("\n")
+    .map((line, index) => ({ line, lineNumber: result.startLine + index }))
+    .filter(({ line }) => markers.some((marker) => line.includes(marker)))
+    .map(({ line, lineNumber }) => `${result.filePath}:${lineNumber}:${line.trim()}`));
+  return matches.length > 0
+    ? `Exact-search matching lines:\n${matches.join("\n")}`
+    : "Exact-search matching lines:\nNo matching evidence lines.";
 }
 
 export function evaluateEffectivenessFixture(fixture: EffectivenessFixture): FixtureEffectivenessMeasurement {
-  const context = buildContextPack(fixture.semanticResults, {
+  const cappedResults = fixture.semanticResults.slice(0, fixture.maxResults);
+  const context = buildContextPack(cappedResults, {
     tokenBudget: fixture.tokenBudget,
-    maxResults: fixture.maxResults,
+    maxResults: cappedResults.length,
     includeExactSearchHandoff: true,
   });
-  const peekText = formatCodebasePeek(fixture.semanticResults);
-  const baselineText = exactReadGrepText(fixture);
+  const peek = fitTextToContextBudget(formatCodebasePeek(cappedResults), fixture.tokenBudget);
+  const baseline = fitTextToContextBudget(
+    exactSearchSnippetText(fixture, cappedResults),
+    fixture.tokenBudget,
+  );
 
   return {
     id: fixture.id,
     context: {
       tokens: countContextTokens(context.text),
-      evidenceRecall: evidenceRecall(
-        fixture.expectedEvidenceIds,
-        selectedEvidence(context.results, fixture.semanticResults),
-      ),
+      evidenceRecall: evidenceRecall(fixture.expectedEvidenceIds, context.text),
     },
     peek: {
-      tokens: countContextTokens(peekText),
-      evidenceRecall: evidenceRecall(
-        fixture.expectedEvidenceIds,
-        fixture.semanticResults.flatMap((result) => result.evidenceIds),
-      ),
+      tokens: peek.tokenEstimate,
+      evidenceRecall: evidenceRecall(fixture.expectedEvidenceIds, peek.text),
     },
-    exactReadGrepBaseline: {
-      tokens: countContextTokens(baselineText),
-      evidenceRecall: evidenceRecall(fixture.expectedEvidenceIds, fixture.baseline.evidenceIds),
+    exactSearchSnippetBaseline: {
+      tokens: baseline.tokenEstimate,
+      evidenceRecall: evidenceRecall(fixture.expectedEvidenceIds, baseline.text),
     },
   };
 }
@@ -151,7 +154,7 @@ function fixed(value: number): number {
 
 function aggregate(
   measurements: FixtureEffectivenessMeasurement[],
-  route: "context" | "peek" | "exactReadGrepBaseline",
+  route: "context" | "peek" | "exactSearchSnippetBaseline",
 ): AggregateRouteMeasurement {
   const tokens = measurements.map((measurement) => measurement[route].tokens);
   const recalls = measurements.map((measurement) => measurement[route].evidenceRecall);
@@ -174,28 +177,36 @@ export function buildEffectivenessEvaluationReport(
   const measurements = fixtures.map(evaluateEffectivenessFixture);
   const context = aggregate(measurements, "context");
   const peek = aggregate(measurements, "peek");
-  const exactReadGrepBaseline = aggregate(measurements, "exactReadGrepBaseline");
-  const baselineMedian = exactReadGrepBaseline.tokens.median;
+  const exactSearchSnippetBaseline = aggregate(measurements, "exactSearchSnippetBaseline");
+  const baselineMedian = exactSearchSnippetBaseline.tokens.median;
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 3,
     benchmark: "privacy-safe-repository-tool-effectiveness",
     methodology: {
       fixtures: "versioned-synthetic-offline",
+      queryModel: "Five checked-in scenario labels map to fixed ranked synthetic results; no retrieval model or embedding provider runs during this report.",
+      sourceCorpus: "Every route starts from the same fixed ranked synthetic result objects. Context and peek format their actual metadata-oriented response text, while the baseline emits only exact matching lines from those same objects.",
+      maxResultsCap: "Every route receives only the first fixture.maxResults ranked results before formatting.",
+      tokenBudgetParity: "Every final route response is constrained by the same fixture.tokenBudget before token counting or evidence scoring.",
       networkCalls: 0,
+      warmupRuns: 0,
+      measuredRunsPerFixture: 1,
+      timing: "not-measured-deterministic-format-and-token-evaluation-only",
       tokenizer: "cl100k_base",
       tokenStatistic: "median-and-nearest-rank-p95-across-fixtures",
-      evidenceRecall: "expected-evidence-items-covered-divided-by-expected-evidence-items",
-      exactReadGrepBaseline:
-        "For each synthetic fixture, concatenate deterministic exact-match lines with complete reads of the exact fixture files selected by those matches, then count the full response tokens.",
+      evidenceRecall: "Expected evidence markers visibly present in the final budgeted route text divided by expected evidence markers. Metadata-only results receive no hidden content credit.",
+      determinism: "No clocks, randomness, embeddings, repository indexing, or network calls affect the generated aggregate report.",
+      exactSearchSnippetBaseline:
+        "An oracle exact-search baseline emits only matching source lines from the capped ranked chunks. It performs no arbitrary or complete file reads and excludes discovery cost.",
       limitation:
-        "This report describes only the checked-in synthetic fixtures. It does not establish causal agent improvement or production-repository performance.",
+        "This synthetic formatting benchmark fixes rankings and uses oracle evidence markers. It does not measure retrieval quality, latency, end-to-end agent success, causal impact, or production-repository performance. Context and peek responses are metadata-oriented here, so content evidence is credited only if its literal marker is visible in returned text.",
     },
     fixtureCount: fixtures.length,
     routes: {
       context,
       peek,
-      exactReadGrepBaseline,
+      exactSearchSnippetBaseline,
     },
     comparisons: {
       contextMedianTokenRatioToBaseline: fixed(baselineMedian === 0 ? 0 : context.tokens.median / baselineMedian),

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -97,6 +97,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         blameAuthor: args.blameAuthor,
         blameSha: args.blameSha,
         blameSince: args.blameSince,
+        effectivenessRoute: "search",
       });
 
       if (results.length === 0) {
@@ -127,6 +128,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         directory: args.directory,
         chunkType: args.chunkType,
         metadataOnly: true,
+        effectivenessRoute: "peek",
         blameAuthor: args.blameAuthor,
         blameSha: args.blameSha,
         blameSince: args.blameSince,
@@ -185,10 +187,12 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "index_metrics",
-    "Get metrics and performance statistics for the codebase index. Requires debug.enabled=true and debug.metrics=true in config.",
-    {},
-    async () => {
-      const result = await getIndexMetrics(runtime.projectRoot, runtime.host);
+    "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Metrics are memory-only. Set reset=true to clear them before reading. Requires debug.enabled=true and debug.metrics=true; effectiveness metrics additionally require debug.effectivenessMetrics=true.",
+    {
+      reset: z.boolean().optional().default(false).describe("Reset in-memory operational and effectiveness metrics before returning the snapshot"),
+    },
+    async (args) => {
+      const result = await getIndexMetrics(runtime.projectRoot, runtime.host, { reset: args.reset });
       return { content: [{ type: "text", text: result.text }] };
     },
   );

--- a/src/mcp-server/register-tools.ts
+++ b/src/mcp-server/register-tools.ts
@@ -34,7 +34,7 @@ import {
   implementationLookup,
   runIndexCodebase,
   runIndexHealthCheck,
-  searchCodebase,
+  searchCodebaseWithEffectiveness,
 } from "../tools/operations.js";
 import { CHUNK_TYPE_ENUM, type McpServerRuntime } from "./shared.js";
 
@@ -88,7 +88,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
     },
     async (args) => {
-      const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
+      return searchCodebaseWithEffectiveness(runtime.projectRoot, runtime.host, "search", args.query, {
         limit: args.limit ?? 5,
         fileType: args.fileType,
         directory: args.directory,
@@ -97,14 +97,12 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         blameAuthor: args.blameAuthor,
         blameSha: args.blameSha,
         blameSince: args.blameSince,
-        effectivenessRoute: "search",
+      }, (results) => {
+        const text = results.length === 0
+          ? "No matching code found. Try a different query or run index_codebase first."
+          : `Found ${results.length} results for "${args.query}":\n\n${formatSearchResults(results, "score")}`;
+        return { output: { content: [{ type: "text" as const, text }] }, text };
       });
-
-      if (results.length === 0) {
-        return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
-      }
-
-      return { content: [{ type: "text", text: `Found ${results.length} results for "${args.query}":\n\n${formatSearchResults(results, "score")}` }] };
     },
   );
 
@@ -122,23 +120,21 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
     },
     async (args) => {
-      const results = await searchCodebase(runtime.projectRoot, runtime.host, args.query, {
+      return searchCodebaseWithEffectiveness(runtime.projectRoot, runtime.host, "peek", args.query, {
         limit: args.limit ?? 10,
         fileType: args.fileType,
         directory: args.directory,
         chunkType: args.chunkType,
         metadataOnly: true,
-        effectivenessRoute: "peek",
         blameAuthor: args.blameAuthor,
         blameSha: args.blameSha,
         blameSince: args.blameSince,
+      }, (results) => {
+        const text = results.length === 0
+          ? "No matching code found. Try a different query or run index_codebase first."
+          : `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}`;
+        return { output: { content: [{ type: "text" as const, text }] }, text };
       });
-
-      if (results.length === 0) {
-        return { content: [{ type: "text", text: "No matching code found. Try a different query or run index_codebase first." }] };
-      }
-
-      return { content: [{ type: "text", text: `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}` }] };
     },
   );
 
@@ -187,7 +183,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
 
   server.tool(
     "index_metrics",
-    "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Metrics are memory-only. Set reset=true to clear them before reading. Requires debug.enabled=true and debug.metrics=true; effectiveness metrics additionally require debug.effectivenessMetrics=true.",
+    "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Metrics are memory-only. Set reset=true to clear them before reading. Operational metrics require debug.enabled=true and debug.metrics=true. Privacy-safe aggregates require only effectivenessMetrics.enabled=true.",
     {
       reset: z.boolean().optional().default(false).describe("Reset in-memory operational and effectiveness metrics before returning the snapshot"),
     },

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -15,7 +15,7 @@ import {
   removeKnowledgeBase,
   runIndexCodebase,
   runIndexHealthCheck,
-  searchCodebase,
+  searchCodebaseWithEffectiveness,
 } from "./tools/operations.js";
 import {
   DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
@@ -109,11 +109,15 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       blameSince: Type.Optional(Type.String({ description: "Filter to chunks last changed on or after this date" })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const results = await searchCodebase(projectRoot(ctx), HOST, params.query, {
+      return searchCodebaseWithEffectiveness(projectRoot(ctx), HOST, "search", params.query, {
         ...params,
-        effectivenessRoute: "search",
+      }, (results) => {
+        const renderedText = results.length === 0
+          ? "No matching code found. Try a different query or run index_codebase first."
+          : formatSearchResults(results);
+        const output = text(renderedText, results);
+        return { output, text: output.content[0].text };
       });
-      return text(formatSearchResults(results), results);
     },
   });
 
@@ -132,12 +136,13 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       blameSince: Type.Optional(Type.String()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const results = await searchCodebase(projectRoot(ctx), HOST, params.query, {
+      return searchCodebaseWithEffectiveness(projectRoot(ctx), HOST, "peek", params.query, {
         ...params,
         metadataOnly: true,
-        effectivenessRoute: "peek",
+      }, (results) => {
+        const output = text(formatCodebasePeek(results), results);
+        return { output, text: output.content[0].text };
       });
-      return text(formatCodebasePeek(results), results);
     },
   });
 

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -109,7 +109,10 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       blameSince: Type.Optional(Type.String({ description: "Filter to chunks last changed on or after this date" })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const results = await searchCodebase(projectRoot(ctx), HOST, params.query, params);
+      const results = await searchCodebase(projectRoot(ctx), HOST, params.query, {
+        ...params,
+        effectivenessRoute: "search",
+      });
       return text(formatSearchResults(results), results);
     },
   });
@@ -129,7 +132,11 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       blameSince: Type.Optional(Type.String()),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const results = await searchCodebase(projectRoot(ctx), HOST, params.query, { ...params, metadataOnly: true });
+      const results = await searchCodebase(projectRoot(ctx), HOST, params.query, {
+        ...params,
+        metadataOnly: true,
+        effectivenessRoute: "peek",
+      });
       return text(formatCodebasePeek(results), results);
     },
   });
@@ -211,10 +218,12 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "index_metrics",
     label: "Index Metrics",
-    description: "Return collected performance metrics when debug metrics are enabled.",
-    parameters: Type.Object({}),
-    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
-      const result = await getIndexMetrics(projectRoot(ctx), HOST);
+    description: "Return operational metrics and opt-in memory-only privacy-safe effectiveness counters.",
+    parameters: Type.Object({
+      reset: Type.Optional(Type.Boolean({ description: "Reset in-memory metrics before returning the snapshot" })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const result = await getIndexMetrics(projectRoot(ctx), HOST, { reset: params.reset });
       return text(result.text, result);
     },
   });

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -4,6 +4,7 @@ import {
   getCallGraphData,
   getCallGraphPath,
   implementationLookup,
+  recordToolEffectiveness,
   searchCodebase,
 } from "./operations.js";
 import { inferExactSymbolFromQuery } from "./symbol-inference.js";
@@ -48,6 +49,7 @@ export interface CodebaseContextResult {
     routedQuery?: string;
     tokenBudget: number;
     tokenEstimate: number;
+    resultCount?: number;
     truncated?: boolean;
     candidateCount?: number;
     deduplicatedCount?: number;
@@ -494,16 +496,18 @@ export async function resolveSearchContext(
 function fittedDetails(
   route: "path" | "direct-edge",
   fitted: ReturnType<typeof fitTextToContextBudget>,
+  resultCount: number,
 ): NonNullable<CodebaseContextResult["details"]> {
   return {
     route,
     tokenBudget: fitted.tokenBudget,
     tokenEstimate: fitted.tokenEstimate,
     truncated: fitted.truncated,
+    resultCount,
   };
 }
 
-export async function resolveCodebaseContext(
+async function resolveCodebaseContextUnmeasured(
   projectRoot: string | undefined,
   host: HostMode,
   input: CodebaseContextInput,
@@ -536,7 +540,7 @@ export async function resolveCodebaseContext(
       );
       return {
         text: fitted.text,
-        details: fittedDetails("path", fitted),
+        details: fittedDetails("path", fitted, path.path.length),
       };
     }
 
@@ -544,7 +548,7 @@ export async function resolveCodebaseContext(
       const fitted = fitTextToContextBudget(pathText, tokenBudget);
       return {
         text: fitted.text,
-        details: fittedDetails("path", fitted),
+        details: fittedDetails("path", fitted, 0),
       };
     }
     const resolvedFrom = path.from;
@@ -566,7 +570,7 @@ export async function resolveCodebaseContext(
       );
       return {
         text: fitted.text,
-        details: fittedDetails("direct-edge", fitted),
+        details: fittedDetails("direct-edge", fitted, 1),
       };
     }
 
@@ -576,7 +580,7 @@ export async function resolveCodebaseContext(
     );
     return {
       text: fitted.text,
-      details: fittedDetails("path", fitted),
+      details: fittedDetails("path", fitted, 0),
     };
   }
 
@@ -593,4 +597,75 @@ export async function resolveCodebaseContext(
       metadataOnly: true,
     }),
   });
+}
+
+function contextRoute(
+  route: NonNullable<CodebaseContextResult["details"]>["route"],
+): "context-conceptual" | "context-definition" | "context-path" | "context-direct-edge" {
+  return `context-${route}`;
+}
+
+function contextScopeRelaxation(
+  details: NonNullable<CodebaseContextResult["details"]>,
+): "none" | "directory" | "file-type" | "both" {
+  const fields = new Set(details.recovery?.attempts.flatMap((attempt) => attempt.relaxedFields) ?? []);
+  if (fields.has("directory") && fields.has("fileType")) return "both";
+  if (fields.has("directory")) return "directory";
+  if (fields.has("fileType")) return "file-type";
+  return "none";
+}
+
+function contextResultCount(details: NonNullable<CodebaseContextResult["details"]>): number {
+  return details.selectedCount ?? details.resultCount ?? 0;
+}
+
+function contextRecoveryUsed(details: NonNullable<CodebaseContextResult["details"]>): boolean {
+  const attempts = details.recovery?.attempts ?? [];
+  return attempts.length > 1 || attempts.some((attempt) => attempt.relaxedFields.length > 0);
+}
+
+function expectedContextRoute(input: CodebaseContextInput): "context-conceptual" | "context-definition" | "context-path" {
+  if (trimOrUndefined(input.from) && trimOrUndefined(input.to)) return "context-path";
+  if (trimOrUndefined(input.symbol)) return "context-definition";
+  return "context-conceptual";
+}
+
+export async function resolveCodebaseContext(
+  projectRoot: string | undefined,
+  host: HostMode,
+  input: CodebaseContextInput,
+): Promise<CodebaseContextResult> {
+  const startedAt = performance.now();
+  try {
+    const result = await resolveCodebaseContextUnmeasured(projectRoot, host, input);
+    const details = result.details;
+    if (details) {
+      const resultCount = contextResultCount(details);
+      recordToolEffectiveness(projectRoot, host, {
+        route: contextRoute(details.route),
+        host,
+        outcome: resultCount > 0 ? "success" : "no-result",
+        recoveryUsed: contextRecoveryUsed(details),
+        resultCount,
+        latencyMs: performance.now() - startedAt,
+        tokenBudget: details.tokenBudget,
+        returnedTokenEstimate: details.tokenEstimate,
+        exactHandoffEmitted: result.text.includes("Exact-search handoff:"),
+        scopeRelaxation: contextScopeRelaxation(details),
+      });
+    }
+    return result;
+  } catch (error) {
+    recordToolEffectiveness(projectRoot, host, {
+      route: expectedContextRoute(input),
+      host,
+      outcome: "error",
+      resultCount: 0,
+      latencyMs: performance.now() - startedAt,
+      tokenBudget: input.tokenBudget ?? undefined,
+      returnedTokenEstimate: 0,
+      scopeRelaxation: "none",
+    });
+    throw error;
+  }
 }

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -4,6 +4,7 @@ import {
   getCallGraphData,
   getCallGraphPath,
   implementationLookup,
+  isToolEffectivenessEnabled,
   recordToolEffectiveness,
   searchCodebase,
 } from "./operations.js";
@@ -635,11 +636,12 @@ export async function resolveCodebaseContext(
   host: HostMode,
   input: CodebaseContextInput,
 ): Promise<CodebaseContextResult> {
-  const startedAt = performance.now();
+  const metricsEnabled = isToolEffectivenessEnabled(projectRoot, host);
+  const startedAt = metricsEnabled ? performance.now() : 0;
   try {
     const result = await resolveCodebaseContextUnmeasured(projectRoot, host, input);
     const details = result.details;
-    if (details) {
+    if (metricsEnabled && details) {
       const resultCount = contextResultCount(details);
       recordToolEffectiveness(projectRoot, host, {
         route: contextRoute(details.route),
@@ -656,16 +658,18 @@ export async function resolveCodebaseContext(
     }
     return result;
   } catch (error) {
-    recordToolEffectiveness(projectRoot, host, {
-      route: expectedContextRoute(input),
-      host,
-      outcome: "error",
-      resultCount: 0,
-      latencyMs: performance.now() - startedAt,
-      tokenBudget: input.tokenBudget ?? undefined,
-      returnedTokenEstimate: 0,
-      scopeRelaxation: "none",
-    });
+    if (metricsEnabled) {
+      recordToolEffectiveness(projectRoot, host, {
+        route: expectedContextRoute(input),
+        host,
+        outcome: "error",
+        resultCount: 0,
+        latencyMs: performance.now() - startedAt,
+        tokenBudget: input.tokenBudget ?? undefined,
+        returnedTokenEstimate: 0,
+        scopeRelaxation: "none",
+      });
+    }
     throw error;
   }
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,7 +33,7 @@ import {
   removeKnowledgeBase,
   runIndexCodebase,
   runIndexHealthCheck,
-  searchCodebase,
+  searchCodebaseWithEffectiveness,
 } from "./operations.js";
 import { pr_impact } from "./pr-impact.js";
 import {
@@ -117,19 +117,19 @@ export const codebase_peek: ToolDefinition = tool({
     blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date (e.g., 2025-01-01)"),
   },
   async execute(args, context) {
-    const results = await searchCodebase(context?.worktree, DEFAULT_HOST, args.query, {
+    return searchCodebaseWithEffectiveness(context?.worktree, DEFAULT_HOST, "peek", args.query, {
       limit: args.limit ?? 10,
       fileType: args.fileType,
       directory: args.directory,
       chunkType: args.chunkType,
       metadataOnly: true,
-      effectivenessRoute: "peek",
       blameAuthor: args.blameAuthor,
       blameSha: args.blameSha,
       blameSince: args.blameSince,
+    }, (results) => {
+      const text = formatCodebasePeek(results);
+      return { output: text, text };
     });
-
-    return formatCodebasePeek(results);
   },
 });
 
@@ -174,7 +174,7 @@ export const index_health_check: ToolDefinition = tool({
 
 export const index_metrics: ToolDefinition = tool({
   description:
-    "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Use reset=true to clear in-memory metrics before reading. Requires debug.enabled=true and debug.metrics=true; effectiveness metrics additionally require debug.effectivenessMetrics=true.",
+    "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Use reset=true to clear in-memory metrics before reading. Operational metrics require debug.enabled=true and debug.metrics=true. Privacy-safe aggregates require only effectivenessMetrics.enabled=true.",
   args: {
     reset: z.boolean().optional().default(false).describe("Reset in-memory operational and effectiveness metrics before returning the snapshot"),
   },
@@ -239,7 +239,7 @@ export const codebase_search: ToolDefinition = tool({
     blameSince: z.string().optional().describe("Filter to chunks last changed on or after this date (e.g., 2025-01-01)"),
   },
   async execute(args, context) {
-    const results = await searchCodebase(context?.worktree, DEFAULT_HOST, args.query, {
+    return searchCodebaseWithEffectiveness(context?.worktree, DEFAULT_HOST, "search", args.query, {
       limit: args.limit ?? 5,
       fileType: args.fileType,
       directory: args.directory,
@@ -248,14 +248,12 @@ export const codebase_search: ToolDefinition = tool({
       blameAuthor: args.blameAuthor,
       blameSha: args.blameSha,
       blameSince: args.blameSince,
-      effectivenessRoute: "search",
+    }, (results) => {
+      const text = results.length === 0
+        ? "No matching code found. Try a different query or run index_codebase first."
+        : formatSearchResults(results, "score");
+      return { output: text, text };
     });
-
-    if (results.length === 0) {
-      return "No matching code found. Try a different query or run index_codebase first.";
-    }
-
-    return formatSearchResults(results, "score");
   },
 });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -123,6 +123,7 @@ export const codebase_peek: ToolDefinition = tool({
       directory: args.directory,
       chunkType: args.chunkType,
       metadataOnly: true,
+      effectivenessRoute: "peek",
       blameAuthor: args.blameAuthor,
       blameSha: args.blameSha,
       blameSince: args.blameSince,
@@ -173,10 +174,12 @@ export const index_health_check: ToolDefinition = tool({
 
 export const index_metrics: ToolDefinition = tool({
   description:
-    "Get metrics and performance statistics for the codebase index. Shows indexing stats, search timings, cache hit rates, and API usage. Requires debug.enabled=true and debug.metrics=true in config.",
-  args: {},
-  async execute(_args, context) {
-    return (await getIndexMetrics(context?.worktree, DEFAULT_HOST)).text;
+    "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Use reset=true to clear in-memory metrics before reading. Requires debug.enabled=true and debug.metrics=true; effectiveness metrics additionally require debug.effectivenessMetrics=true.",
+  args: {
+    reset: z.boolean().optional().default(false).describe("Reset in-memory operational and effectiveness metrics before returning the snapshot"),
+  },
+  async execute(args, context) {
+    return (await getIndexMetrics(context?.worktree, DEFAULT_HOST, { reset: args.reset })).text;
   },
 });
 
@@ -245,6 +248,7 @@ export const codebase_search: ToolDefinition = tool({
       blameAuthor: args.blameAuthor,
       blameSha: args.blameSha,
       blameSince: args.blameSince,
+      effectivenessRoute: "search",
     });
 
     if (results.length === 0) {

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -11,6 +11,7 @@ import { calculatePercentage, formatProgressTitle, formatStatus } from "./utils.
 import type { LogLevel } from "../config/schema.js";
 import type { LogEntry } from "../utils/logger.js";
 import type { CostEstimate } from "../utils/cost.js";
+import type { EffectivenessMetricEvent } from "../utils/effectiveness-metrics.js";
 import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from "./config-state.js";
 
 type IndexerCacheKey = `${HostMode}::${string}`;
@@ -28,6 +29,32 @@ const indexerCache = new Map<IndexerCacheKey, Indexer>();
 const configCache = new Map<IndexerCacheKey, ParsedCodebaseIndexConfig>();
 const defaultProjectRoots = new Map<HostMode, string>();
 const MAX_CALL_GRAPH_CANDIDATES = 5;
+const EMPTY_RESULT_TOKEN_ESTIMATE = 16;
+const MAX_HANDOFF_NAME_CHARS = 64;
+
+function estimateReturnedSearchTokens(results: SearchResult[], metadataOnly: boolean): number {
+  if (results.length === 0) return EMPTY_RESULT_TOKEN_ESTIMATE;
+  const characterEstimate = results.reduce((total, result) => {
+    const metadataCharacters = result.filePath.length
+      + (result.name?.length ?? 0)
+      + result.chunkType.length
+      + 48;
+    return total + metadataCharacters + (metadataOnly ? 0 : result.content.length);
+  }, 0);
+  return Math.max(1, Math.ceil(characterEstimate / 4));
+}
+
+function emitsExactSearchHandoff(results: SearchResult[], metadataOnly: boolean): boolean {
+  if (!metadataOnly) return false;
+  return results.some((result) => {
+    const name = result.name?.trim();
+    return Boolean(
+      name
+      && name.length <= MAX_HANDOFF_NAME_CHARS * 2
+      && Array.from(name).length <= MAX_HANDOFF_NAME_CHARS,
+    );
+  });
+}
 
 export interface CallGraphSymbolCandidate {
   filePath: string;
@@ -249,6 +276,18 @@ export function getIndexerForProject(projectRoot: string | undefined, host: Host
   return getOrCreateIndexer(root, host);
 }
 
+export function recordToolEffectiveness(
+  projectRoot: string | undefined,
+  host: HostMode,
+  event: EffectivenessMetricEvent,
+): void {
+  try {
+    getIndexerForProject(projectRoot, host).getLogger().recordEffectiveness(event);
+  } catch {
+    // Observability must never alter or mask repository tool behavior.
+  }
+}
+
 export function refreshIndexerForDirectory(
   projectRoot: string,
   host: HostMode = "opencode",
@@ -275,20 +314,50 @@ export async function searchCodebase(
     blameAuthor?: string;
     blameSha?: string;
     blameSince?: string;
+    effectivenessRoute?: "peek" | "search";
   } = {},
 ): Promise<SearchResult[]> {
   const indexer = getIndexerForProject(projectRoot, host);
-  return indexer.search(query, options.limit, {
-    fileType: options.fileType,
-    directory: options.directory,
-    chunkType: options.chunkType,
-    contextLines: options.contextLines,
-    metadataOnly: options.metadataOnly,
-    definitionIntent: options.definitionIntent,
-    blameAuthor: options.blameAuthor,
-    blameSha: options.blameSha,
-    blameSince: options.blameSince,
-  });
+  const startedAt = performance.now();
+  try {
+    const results = await indexer.search(query, options.limit, {
+      fileType: options.fileType,
+      directory: options.directory,
+      chunkType: options.chunkType,
+      contextLines: options.contextLines,
+      metadataOnly: options.metadataOnly,
+      definitionIntent: options.definitionIntent,
+      blameAuthor: options.blameAuthor,
+      blameSha: options.blameSha,
+      blameSince: options.blameSince,
+    });
+    if (options.effectivenessRoute) {
+      indexer.getLogger().recordEffectiveness({
+        route: options.effectivenessRoute,
+        host,
+        outcome: results.length > 0 ? "success" : "no-result",
+        resultCount: results.length,
+        latencyMs: performance.now() - startedAt,
+        returnedTokenEstimate: estimateReturnedSearchTokens(results, options.metadataOnly === true),
+        exactHandoffEmitted: emitsExactSearchHandoff(results, options.metadataOnly === true),
+        scopeRelaxation: "none",
+      });
+    }
+    return results;
+  } catch (error) {
+    if (options.effectivenessRoute) {
+      indexer.getLogger().recordEffectiveness({
+        route: options.effectivenessRoute,
+        host,
+        outcome: "error",
+        resultCount: 0,
+        latencyMs: performance.now() - startedAt,
+        returnedTokenEstimate: 0,
+        scopeRelaxation: "none",
+      });
+    }
+    throw error;
+  }
 }
 
 export async function findSimilarCode(
@@ -480,15 +549,23 @@ export async function getPrImpact(
   });
 }
 
-export async function getIndexMetrics(projectRoot: string | undefined, host: HostMode): Promise<{ enabled: boolean; metricsEnabled: boolean; text: string }> {
+export async function getIndexMetrics(
+  projectRoot: string | undefined,
+  host: HostMode,
+  args: { reset?: boolean } = {},
+): Promise<{ enabled: boolean; metricsEnabled: boolean; text: string }> {
   const indexer = getIndexerForProject(projectRoot, host);
   const logger = indexer.getLogger();
+  if (args.reset === true) {
+    logger.resetMetrics();
+  }
+  const resetNotice = args.reset === true ? "Metrics reset.\n\n" : "";
 
   if (!logger.isEnabled()) {
     return {
       enabled: false,
       metricsEnabled: false,
-      text: "Debug mode is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```",
+      text: `${resetNotice}Debug mode is disabled. Enable it in your config:\n\n\`\`\`json\n{\n  "debug": {\n    "enabled": true,\n    "metrics": true\n  }\n}\n\`\`\``,
     };
   }
 
@@ -496,14 +573,14 @@ export async function getIndexMetrics(projectRoot: string | undefined, host: Hos
     return {
       enabled: true,
       metricsEnabled: false,
-      text: "Metrics collection is disabled. Enable it in your config:\n\n```json\n{\n  \"debug\": {\n    \"enabled\": true,\n    \"metrics\": true\n  }\n}\n```",
+      text: `${resetNotice}Metrics collection is disabled. Enable it in your config:\n\n\`\`\`json\n{\n  "debug": {\n    "enabled": true,\n    "metrics": true\n  }\n}\n\`\`\``,
     };
   }
 
   return {
     enabled: true,
     metricsEnabled: true,
-    text: logger.formatMetrics(),
+    text: `${resetNotice}${logger.formatMetrics()}`,
   };
 }
 

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -7,11 +7,17 @@ import type { CallEdgeData, PathHopData, SymbolData } from "../native/index.js";
 import { Indexer } from "../indexer/index.js";
 import { isIndexLockContentionError } from "../indexer/index-lock.js";
 import { findKnowledgeBasePathIndex, hasMatchingKnowledgeBasePath, resolveKnowledgeBasePath } from "./knowledge-base-paths.js";
-import { calculatePercentage, formatProgressTitle, formatStatus } from "./utils.js";
+import { calculatePercentage, countContextTokens, formatProgressTitle, formatStatus } from "./utils.js";
 import type { LogLevel } from "../config/schema.js";
 import type { LogEntry } from "../utils/logger.js";
 import type { CostEstimate } from "../utils/cost.js";
-import type { EffectivenessMetricEvent } from "../utils/effectiveness-metrics.js";
+import {
+  formatEffectivenessMetrics,
+  getProcessEffectivenessMetrics,
+  recordProcessEffectiveness,
+  resetProcessEffectivenessMetrics,
+  type EffectivenessMetricEvent,
+} from "../utils/effectiveness-metrics.js";
 import { getConfigPath, loadEditableConfig, loadRuntimeConfig, saveConfig } from "./config-state.js";
 
 type IndexerCacheKey = `${HostMode}::${string}`;
@@ -29,32 +35,6 @@ const indexerCache = new Map<IndexerCacheKey, Indexer>();
 const configCache = new Map<IndexerCacheKey, ParsedCodebaseIndexConfig>();
 const defaultProjectRoots = new Map<HostMode, string>();
 const MAX_CALL_GRAPH_CANDIDATES = 5;
-const EMPTY_RESULT_TOKEN_ESTIMATE = 16;
-const MAX_HANDOFF_NAME_CHARS = 64;
-
-function estimateReturnedSearchTokens(results: SearchResult[], metadataOnly: boolean): number {
-  if (results.length === 0) return EMPTY_RESULT_TOKEN_ESTIMATE;
-  const characterEstimate = results.reduce((total, result) => {
-    const metadataCharacters = result.filePath.length
-      + (result.name?.length ?? 0)
-      + result.chunkType.length
-      + 48;
-    return total + metadataCharacters + (metadataOnly ? 0 : result.content.length);
-  }, 0);
-  return Math.max(1, Math.ceil(characterEstimate / 4));
-}
-
-function emitsExactSearchHandoff(results: SearchResult[], metadataOnly: boolean): boolean {
-  if (!metadataOnly) return false;
-  return results.some((result) => {
-    const name = result.name?.trim();
-    return Boolean(
-      name
-      && name.length <= MAX_HANDOFF_NAME_CHARS * 2
-      && Array.from(name).length <= MAX_HANDOFF_NAME_CHARS,
-    );
-  });
-}
 
 export interface CallGraphSymbolCandidate {
   filePath: string;
@@ -245,6 +225,43 @@ function getIndexerCacheKey(projectRoot: string, host: HostMode): IndexerCacheKe
   return `${host}::${projectRoot}`;
 }
 
+function rawEffectivenessMetricsEnabled(rawConfig: unknown): boolean {
+  if (!rawConfig || typeof rawConfig !== "object") return false;
+  const value = (rawConfig as Record<string, unknown>).effectivenessMetrics;
+  return Boolean(value && typeof value === "object" && (value as Record<string, unknown>).enabled === true);
+}
+
+export function isToolEffectivenessEnabled(
+  projectRoot: string | undefined,
+  host: HostMode,
+): boolean {
+  try {
+    const root = getProjectRoot(projectRoot, host);
+    const cached = configCache.get(getIndexerCacheKey(root, host));
+    if (cached) return cached.effectivenessMetrics.enabled;
+    return rawEffectivenessMetricsEnabled(loadRuntimeConfig(root, host));
+  } catch {
+    // Metrics are best-effort and must never alter repository tool behavior.
+    return false;
+  }
+}
+
+function safelyRecordToolEffectiveness(event: EffectivenessMetricEvent): void {
+  try {
+    recordProcessEffectiveness(event);
+  } catch {
+    // Metrics are best-effort and must never alter repository tool behavior.
+  }
+}
+
+function safelyCountReturnedTokens(text: string): number {
+  try {
+    return countContextTokens(text);
+  } catch {
+    return 0;
+  }
+}
+
 function getOrCreateIndexer(projectRoot: string, host: HostMode): Indexer {
   const key = getIndexerCacheKey(projectRoot, host);
   const cached = indexerCache.get(key);
@@ -252,19 +269,21 @@ function getOrCreateIndexer(projectRoot: string, host: HostMode): Indexer {
     return cached;
   }
 
-  const config = parseConfig(loadRuntimeConfig(projectRoot, host));
+  let config = configCache.get(key);
+  if (!config) {
+    config = parseConfig(loadRuntimeConfig(projectRoot, host));
+    configCache.set(key, config);
+  }
   const indexer = new Indexer(projectRoot, config, host);
   indexerCache.set(key, indexer);
-  configCache.set(key, config);
   return indexer;
 }
 
 export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode"): void {
   defaultProjectRoots.set(host, projectRoot);
   const key = getIndexerCacheKey(projectRoot, host);
-  const indexer = new Indexer(projectRoot, config, host);
-  indexerCache.set(key, indexer);
   configCache.set(key, config);
+  indexerCache.set(key, new Indexer(projectRoot, config, host));
 }
 
 export function getSharedIndexer(host: HostMode = "opencode"): Indexer {
@@ -281,11 +300,8 @@ export function recordToolEffectiveness(
   host: HostMode,
   event: EffectivenessMetricEvent,
 ): void {
-  try {
-    getIndexerForProject(projectRoot, host).getLogger().recordEffectiveness(event);
-  } catch {
-    // Observability must never alter or mask repository tool behavior.
-  }
+  if (!isToolEffectivenessEnabled(projectRoot, host)) return;
+  safelyRecordToolEffectiveness(event);
 }
 
 export function refreshIndexerForDirectory(
@@ -294,9 +310,8 @@ export function refreshIndexerForDirectory(
   config: ParsedCodebaseIndexConfig = parseConfig(loadRuntimeConfig(projectRoot, host)),
 ): void {
   const key = getIndexerCacheKey(projectRoot, host);
-  const indexer = new Indexer(projectRoot, config, host);
-  indexerCache.set(key, indexer);
   configCache.set(key, config);
+  indexerCache.set(key, new Indexer(projectRoot, config, host));
 }
 
 export async function searchCodebase(
@@ -314,45 +329,58 @@ export async function searchCodebase(
     blameAuthor?: string;
     blameSha?: string;
     blameSince?: string;
-    effectivenessRoute?: "peek" | "search";
   } = {},
 ): Promise<SearchResult[]> {
   const indexer = getIndexerForProject(projectRoot, host);
-  const startedAt = performance.now();
+  return indexer.search(query, options.limit, {
+    fileType: options.fileType,
+    directory: options.directory,
+    chunkType: options.chunkType,
+    contextLines: options.contextLines,
+    metadataOnly: options.metadataOnly,
+    definitionIntent: options.definitionIntent,
+    blameAuthor: options.blameAuthor,
+    blameSha: options.blameSha,
+    blameSince: options.blameSince,
+  });
+}
+
+export async function searchCodebaseWithEffectiveness<T>(
+  projectRoot: string | undefined,
+  host: HostMode,
+  route: "peek" | "search",
+  query: string,
+  options: Parameters<typeof searchCodebase>[3],
+  render: (results: SearchResult[]) => { output: T; text: string },
+): Promise<T> {
+  const metricsEnabled = isToolEffectivenessEnabled(projectRoot, host);
+  const startedAt = metricsEnabled ? performance.now() : 0;
   try {
-    const results = await indexer.search(query, options.limit, {
-      fileType: options.fileType,
-      directory: options.directory,
-      chunkType: options.chunkType,
-      contextLines: options.contextLines,
-      metadataOnly: options.metadataOnly,
-      definitionIntent: options.definitionIntent,
-      blameAuthor: options.blameAuthor,
-      blameSha: options.blameSha,
-      blameSince: options.blameSince,
-    });
-    if (options.effectivenessRoute) {
-      indexer.getLogger().recordEffectiveness({
-        route: options.effectivenessRoute,
+    const results = await searchCodebase(projectRoot, host, query, options);
+    const rendered = render(results);
+    if (metricsEnabled) {
+      safelyRecordToolEffectiveness({
+        route,
         host,
         outcome: results.length > 0 ? "success" : "no-result",
         resultCount: results.length,
         latencyMs: performance.now() - startedAt,
-        returnedTokenEstimate: estimateReturnedSearchTokens(results, options.metadataOnly === true),
-        exactHandoffEmitted: emitsExactSearchHandoff(results, options.metadataOnly === true),
+        returnedTokenEstimate: safelyCountReturnedTokens(rendered.text),
+        exactHandoffEmitted: rendered.text.includes("Exact-search handoff:"),
         scopeRelaxation: "none",
       });
     }
-    return results;
+    return rendered.output;
   } catch (error) {
-    if (options.effectivenessRoute) {
-      indexer.getLogger().recordEffectiveness({
-        route: options.effectivenessRoute,
+    if (metricsEnabled) {
+      safelyRecordToolEffectiveness({
+        route,
         host,
         outcome: "error",
         resultCount: 0,
         latencyMs: performance.now() - startedAt,
         returnedTokenEstimate: 0,
+        exactHandoffEmitted: false,
         scopeRelaxation: "none",
       });
     }
@@ -553,34 +581,64 @@ export async function getIndexMetrics(
   projectRoot: string | undefined,
   host: HostMode,
   args: { reset?: boolean } = {},
-): Promise<{ enabled: boolean; metricsEnabled: boolean; text: string }> {
-  const indexer = getIndexerForProject(projectRoot, host);
-  const logger = indexer.getLogger();
+): Promise<{ enabled: boolean; metricsEnabled: boolean; effectivenessMetricsEnabled: boolean; text: string }> {
+  const root = getProjectRoot(projectRoot, host);
+  const key = getIndexerCacheKey(root, host);
+  const cachedIndexer = indexerCache.get(key);
+  let config = configCache.get(key);
+  let rawEffectivenessEnabled = false;
+
   if (args.reset === true) {
-    logger.resetMetrics();
+    resetProcessEffectivenessMetrics();
+    try {
+      cachedIndexer?.getLogger().resetMetrics();
+    } catch {
+      // Effectiveness reset must succeed independently from operational metrics.
+    }
   }
+
+  try {
+    const rawConfig = loadRuntimeConfig(root, host);
+    rawEffectivenessEnabled = rawEffectivenessMetricsEnabled(rawConfig);
+    config ??= parseConfig(rawConfig);
+    configCache.set(key, config);
+  } catch {
+    // An explicitly enabled process collector remains viewable and resettable
+    // even when unrelated configuration is invalid.
+  }
+
   const resetNotice = args.reset === true ? "Metrics reset.\n\n" : "";
+  const effectivenessMetricsEnabled = config?.effectivenessMetrics.enabled ?? rawEffectivenessEnabled;
+  const debugEnabled = config?.debug.enabled === true;
+  const operationalMetricsEnabled = debugEnabled && config?.debug.metrics === true;
 
-  if (!logger.isEnabled()) {
+  if (!operationalMetricsEnabled && !effectivenessMetricsEnabled) {
     return {
-      enabled: false,
+      enabled: debugEnabled,
       metricsEnabled: false,
-      text: `${resetNotice}Debug mode is disabled. Enable it in your config:\n\n\`\`\`json\n{\n  "debug": {\n    "enabled": true,\n    "metrics": true\n  }\n}\n\`\`\``,
+      effectivenessMetricsEnabled: false,
+      text: `${resetNotice}Metrics collection is disabled. Enable privacy-safe aggregate telemetry without debug logs:\n\n\`\`\`json\n{\n  "effectivenessMetrics": {\n    "enabled": true\n  }\n}\n\`\`\``,
     };
   }
 
-  if (!logger.isMetricsEnabled()) {
-    return {
-      enabled: true,
-      metricsEnabled: false,
-      text: `${resetNotice}Metrics collection is disabled. Enable it in your config:\n\n\`\`\`json\n{\n  "debug": {\n    "enabled": true,\n    "metrics": true\n  }\n}\n\`\`\``,
-    };
+  const sections: string[] = [];
+  if (operationalMetricsEnabled) {
+    try {
+      const logger = cachedIndexer?.getLogger() ?? getIndexerForProject(root, host).getLogger();
+      sections.push(logger.formatMetrics());
+    } catch {
+      sections.push("Operational metrics are unavailable.");
+    }
+  }
+  if (effectivenessMetricsEnabled) {
+    sections.push(formatEffectivenessMetrics(getProcessEffectivenessMetrics()));
   }
 
   return {
-    enabled: true,
-    metricsEnabled: true,
-    text: `${resetNotice}${logger.formatMetrics()}`,
+    enabled: debugEnabled,
+    metricsEnabled: operationalMetricsEnabled,
+    effectivenessMetricsEnabled,
+    text: `${resetNotice}${sections.join("\n\n")}`,
   };
 }
 

--- a/src/utils/effectiveness-metrics.ts
+++ b/src/utils/effectiveness-metrics.ts
@@ -1,6 +1,6 @@
 import type { HostMode } from "../config/host.js";
 
-export const EFFECTIVENESS_METRICS_SCHEMA_VERSION = 1 as const;
+export const EFFECTIVENESS_METRICS_SCHEMA_VERSION = 2 as const;
 export const MAX_EFFECTIVENESS_COUNTER = 1_000_000_000;
 
 export const EFFECTIVENESS_TOOL_ROUTES = [
@@ -71,7 +71,8 @@ export interface EffectivenessMetricsSnapshot {
     storage: "memory-only";
     lifetime: "process";
     reset: "index_metrics-reset-or-process-exit";
-    maxCounterValue: typeof MAX_EFFECTIVENESS_COUNTER;
+    maxCounterValue: number;
+    dimensions: "bounded-host-and-category-only";
   };
   totalCalls: number;
   toolRoute: CounterMap<typeof EFFECTIVENESS_TOOL_ROUTES>;
@@ -147,16 +148,16 @@ function allowedValue<T extends readonly string[]>(
     : fallback;
 }
 
-function increment<T extends string>(counters: Record<T, number>, key: T): void {
-  counters[key] = Math.min(MAX_EFFECTIVENESS_COUNTER, counters[key] + 1);
-}
-
 function cloneCounterMap<T extends string>(counters: Record<T, number>): Record<T, number> {
   return { ...counters };
 }
 
 export class EffectivenessMetrics {
-  private snapshot = this.createEmptySnapshot();
+  private snapshot: EffectivenessMetricsSnapshot;
+
+  constructor(private readonly counterCap = MAX_EFFECTIVENESS_COUNTER) {
+    this.snapshot = this.createEmptySnapshot();
+  }
 
   private createEmptySnapshot(): EffectivenessMetricsSnapshot {
     return {
@@ -165,7 +166,8 @@ export class EffectivenessMetrics {
         storage: "memory-only",
         lifetime: "process",
         reset: "index_metrics-reset-or-process-exit",
-        maxCounterValue: MAX_EFFECTIVENESS_COUNTER,
+        maxCounterValue: this.counterCap,
+        dimensions: "bounded-host-and-category-only",
       },
       totalCalls: 0,
       toolRoute: emptyCounterMap(EFFECTIVENESS_TOOL_ROUTES),
@@ -181,9 +183,11 @@ export class EffectivenessMetrics {
     };
   }
 
+  private increment<T extends string>(counters: Record<T, number>, key: T): void {
+    counters[key] = Math.min(this.counterCap, counters[key] + 1);
+  }
+
   record(event: EffectivenessMetricEvent): void {
-    // All mutations are synchronous and contain no await points, so concurrent
-    // Promise completions cannot observe a partially applied event in Node.js.
     const route = allowedValue(event.route, EFFECTIVENESS_TOOL_ROUTES, "other");
     const host = allowedValue(event.host, EFFECTIVENESS_HOST_MODES, "other");
     const outcome = allowedValue(event.outcome, EFFECTIVENESS_OUTCOMES, "error");
@@ -195,17 +199,17 @@ export class EffectivenessMetrics {
     const recoveryUsed = event.recoveryUsed === true ? "yes" : "no";
     const exactHandoffEmitted = event.exactHandoffEmitted === true ? "yes" : "no";
 
-    this.snapshot.totalCalls = Math.min(MAX_EFFECTIVENESS_COUNTER, this.snapshot.totalCalls + 1);
-    increment(this.snapshot.toolRoute, route);
-    increment(this.snapshot.hostMode, host);
-    increment(this.snapshot.outcome, outcome);
-    increment(this.snapshot.recoveryUsed, recoveryUsed);
-    increment(this.snapshot.resultCount, resultCountBucket(event.resultCount));
-    increment(this.snapshot.latency, latencyBucket(event.latencyMs));
-    increment(this.snapshot.tokenBudget, tokenBudgetBucket(event.tokenBudget));
-    increment(this.snapshot.returnedTokenEstimate, returnedTokenBucket(event.returnedTokenEstimate));
-    increment(this.snapshot.exactHandoffEmitted, exactHandoffEmitted);
-    increment(this.snapshot.scopeRelaxation, scopeRelaxation);
+    this.snapshot.totalCalls = Math.min(this.counterCap, this.snapshot.totalCalls + 1);
+    this.increment(this.snapshot.toolRoute, route);
+    this.increment(this.snapshot.hostMode, host);
+    this.increment(this.snapshot.outcome, outcome);
+    this.increment(this.snapshot.recoveryUsed, recoveryUsed);
+    this.increment(this.snapshot.resultCount, resultCountBucket(event.resultCount));
+    this.increment(this.snapshot.latency, latencyBucket(event.latencyMs));
+    this.increment(this.snapshot.tokenBudget, tokenBudgetBucket(event.tokenBudget));
+    this.increment(this.snapshot.returnedTokenEstimate, returnedTokenBucket(event.returnedTokenEstimate));
+    this.increment(this.snapshot.exactHandoffEmitted, exactHandoffEmitted);
+    this.increment(this.snapshot.scopeRelaxation, scopeRelaxation);
   }
 
   getSnapshot(): EffectivenessMetricsSnapshot {
@@ -228,4 +232,47 @@ export class EffectivenessMetrics {
   reset(): void {
     this.snapshot = this.createEmptySnapshot();
   }
+}
+
+let processCollector: EffectivenessMetrics | undefined;
+
+export function recordProcessEffectiveness(event: EffectivenessMetricEvent): void {
+  (processCollector ??= new EffectivenessMetrics()).record(event);
+}
+
+export function getProcessEffectivenessMetrics(): EffectivenessMetricsSnapshot {
+  return processCollector?.getSnapshot() ?? new EffectivenessMetrics().getSnapshot();
+}
+
+export function resetProcessEffectivenessMetrics(): void {
+  processCollector = undefined;
+}
+
+export function isProcessEffectivenessCollectorAllocated(): boolean {
+  return processCollector !== undefined;
+}
+
+export function formatEffectivenessMetrics(snapshot: EffectivenessMetricsSnapshot): string {
+  const formatCounters = (counters: Record<string, number>): string => Object.entries(counters)
+    .map(([bucket, count]) => `${bucket}=${count}`)
+    .join(", ");
+  const lines = [
+    `Privacy-safe effectiveness (schema v${snapshot.schemaVersion}):`,
+    `  Retention: ${snapshot.retention.storage}, ${snapshot.retention.lifetime}-lifetime; reset with index_metrics(reset=true) or process exit`,
+    `  Dimensions: ${snapshot.retention.dimensions}`,
+    `  Counter cap: ${snapshot.retention.maxCounterValue.toLocaleString()}`,
+    `  Total tool calls: ${snapshot.totalCalls}`,
+    `  Tool route: ${formatCounters(snapshot.toolRoute)}`,
+    `  Host mode: ${formatCounters(snapshot.hostMode)}`,
+    `  Outcome: ${formatCounters(snapshot.outcome)}`,
+    `  Recovery used: ${formatCounters(snapshot.recoveryUsed)}`,
+    `  Result-count bucket: ${formatCounters(snapshot.resultCount)}`,
+    `  Latency bucket: ${formatCounters(snapshot.latency)}`,
+    `  Token-budget bucket: ${formatCounters(snapshot.tokenBudget)}`,
+    `  Returned-token estimate: ${formatCounters(snapshot.returnedTokenEstimate)}`,
+    `  Exact handoff emitted: ${formatCounters(snapshot.exactHandoffEmitted)}`,
+    `  Scope relaxation: ${formatCounters(snapshot.scopeRelaxation)}`,
+    "  Privacy: no queries, response text, source, symbols, paths, repository names, user identity, or stable identifiers are retained.",
+  ];
+  return lines.join("\n");
 }

--- a/src/utils/effectiveness-metrics.ts
+++ b/src/utils/effectiveness-metrics.ts
@@ -1,0 +1,231 @@
+import type { HostMode } from "../config/host.js";
+
+export const EFFECTIVENESS_METRICS_SCHEMA_VERSION = 1 as const;
+export const MAX_EFFECTIVENESS_COUNTER = 1_000_000_000;
+
+export const EFFECTIVENESS_TOOL_ROUTES = [
+  "context-conceptual",
+  "context-definition",
+  "context-path",
+  "context-direct-edge",
+  "peek",
+  "search",
+  "other",
+] as const;
+export const EFFECTIVENESS_HOST_MODES = [
+  "opencode",
+  "codex",
+  "claude",
+  "pi",
+  "jcode",
+  "other",
+] as const;
+export const EFFECTIVENESS_OUTCOMES = ["success", "no-result", "error"] as const;
+export const EFFECTIVENESS_BOOLEAN_BUCKETS = ["no", "yes"] as const;
+export const EFFECTIVENESS_RESULT_COUNT_BUCKETS = ["0", "1", "2-5", "6-10", "11-20", "21+"] as const;
+export const EFFECTIVENESS_LATENCY_BUCKETS = ["<10ms", "10-49ms", "50-199ms", "200-999ms", "1s+"] as const;
+export const EFFECTIVENESS_TOKEN_BUDGET_BUCKETS = [
+  "none",
+  "1-255",
+  "256-511",
+  "512-1199",
+  "1200-1999",
+  "2000-4000",
+  "4001+",
+] as const;
+export const EFFECTIVENESS_RETURNED_TOKEN_BUCKETS = [
+  "0",
+  "1-127",
+  "128-255",
+  "256-511",
+  "512-1199",
+  "1200-1999",
+  "2000-3999",
+  "4000+",
+] as const;
+export const EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS = ["none", "directory", "file-type", "both"] as const;
+
+export type EffectivenessToolRoute = typeof EFFECTIVENESS_TOOL_ROUTES[number];
+export type EffectivenessHostMode = typeof EFFECTIVENESS_HOST_MODES[number];
+export type EffectivenessOutcome = typeof EFFECTIVENESS_OUTCOMES[number];
+export type EffectivenessScopeRelaxation = typeof EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS[number];
+
+type CounterMap<T extends readonly string[]> = Record<T[number], number>;
+
+export interface EffectivenessMetricEvent {
+  route: EffectivenessToolRoute;
+  host: HostMode;
+  outcome: EffectivenessOutcome;
+  recoveryUsed?: boolean;
+  resultCount?: number;
+  latencyMs?: number;
+  tokenBudget?: number;
+  returnedTokenEstimate?: number;
+  exactHandoffEmitted?: boolean;
+  scopeRelaxation?: EffectivenessScopeRelaxation;
+}
+
+export interface EffectivenessMetricsSnapshot {
+  schemaVersion: typeof EFFECTIVENESS_METRICS_SCHEMA_VERSION;
+  retention: {
+    storage: "memory-only";
+    lifetime: "process";
+    reset: "index_metrics-reset-or-process-exit";
+    maxCounterValue: typeof MAX_EFFECTIVENESS_COUNTER;
+  };
+  totalCalls: number;
+  toolRoute: CounterMap<typeof EFFECTIVENESS_TOOL_ROUTES>;
+  hostMode: CounterMap<typeof EFFECTIVENESS_HOST_MODES>;
+  outcome: CounterMap<typeof EFFECTIVENESS_OUTCOMES>;
+  recoveryUsed: CounterMap<typeof EFFECTIVENESS_BOOLEAN_BUCKETS>;
+  resultCount: CounterMap<typeof EFFECTIVENESS_RESULT_COUNT_BUCKETS>;
+  latency: CounterMap<typeof EFFECTIVENESS_LATENCY_BUCKETS>;
+  tokenBudget: CounterMap<typeof EFFECTIVENESS_TOKEN_BUDGET_BUCKETS>;
+  returnedTokenEstimate: CounterMap<typeof EFFECTIVENESS_RETURNED_TOKEN_BUCKETS>;
+  exactHandoffEmitted: CounterMap<typeof EFFECTIVENESS_BOOLEAN_BUCKETS>;
+  scopeRelaxation: CounterMap<typeof EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS>;
+}
+
+function emptyCounterMap<T extends readonly string[]>(values: T): CounterMap<T> {
+  return Object.fromEntries(values.map((value) => [value, 0])) as CounterMap<T>;
+}
+
+function boundedNumber(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function resultCountBucket(value: number | undefined): typeof EFFECTIVENESS_RESULT_COUNT_BUCKETS[number] {
+  const count = boundedNumber(value);
+  if (count === 0) return "0";
+  if (count === 1) return "1";
+  if (count <= 5) return "2-5";
+  if (count <= 10) return "6-10";
+  if (count <= 20) return "11-20";
+  return "21+";
+}
+
+function latencyBucket(value: number | undefined): typeof EFFECTIVENESS_LATENCY_BUCKETS[number] {
+  const latencyMs = boundedNumber(value);
+  if (latencyMs < 10) return "<10ms";
+  if (latencyMs < 50) return "10-49ms";
+  if (latencyMs < 200) return "50-199ms";
+  if (latencyMs < 1000) return "200-999ms";
+  return "1s+";
+}
+
+function tokenBudgetBucket(value: number | undefined): typeof EFFECTIVENESS_TOKEN_BUDGET_BUCKETS[number] {
+  if (value === undefined || !Number.isFinite(value)) return "none";
+  const budget = boundedNumber(value);
+  if (budget <= 255) return "1-255";
+  if (budget <= 511) return "256-511";
+  if (budget <= 1199) return "512-1199";
+  if (budget <= 1999) return "1200-1999";
+  if (budget <= 4000) return "2000-4000";
+  return "4001+";
+}
+
+function returnedTokenBucket(value: number | undefined): typeof EFFECTIVENESS_RETURNED_TOKEN_BUCKETS[number] {
+  const tokens = boundedNumber(value);
+  if (tokens === 0) return "0";
+  if (tokens <= 127) return "1-127";
+  if (tokens <= 255) return "128-255";
+  if (tokens <= 511) return "256-511";
+  if (tokens <= 1199) return "512-1199";
+  if (tokens <= 1999) return "1200-1999";
+  if (tokens <= 3999) return "2000-3999";
+  return "4000+";
+}
+
+function allowedValue<T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  fallback: T[number],
+): T[number] {
+  return typeof value === "string" && (allowed as readonly string[]).includes(value)
+    ? value as T[number]
+    : fallback;
+}
+
+function increment<T extends string>(counters: Record<T, number>, key: T): void {
+  counters[key] = Math.min(MAX_EFFECTIVENESS_COUNTER, counters[key] + 1);
+}
+
+function cloneCounterMap<T extends string>(counters: Record<T, number>): Record<T, number> {
+  return { ...counters };
+}
+
+export class EffectivenessMetrics {
+  private snapshot = this.createEmptySnapshot();
+
+  private createEmptySnapshot(): EffectivenessMetricsSnapshot {
+    return {
+      schemaVersion: EFFECTIVENESS_METRICS_SCHEMA_VERSION,
+      retention: {
+        storage: "memory-only",
+        lifetime: "process",
+        reset: "index_metrics-reset-or-process-exit",
+        maxCounterValue: MAX_EFFECTIVENESS_COUNTER,
+      },
+      totalCalls: 0,
+      toolRoute: emptyCounterMap(EFFECTIVENESS_TOOL_ROUTES),
+      hostMode: emptyCounterMap(EFFECTIVENESS_HOST_MODES),
+      outcome: emptyCounterMap(EFFECTIVENESS_OUTCOMES),
+      recoveryUsed: emptyCounterMap(EFFECTIVENESS_BOOLEAN_BUCKETS),
+      resultCount: emptyCounterMap(EFFECTIVENESS_RESULT_COUNT_BUCKETS),
+      latency: emptyCounterMap(EFFECTIVENESS_LATENCY_BUCKETS),
+      tokenBudget: emptyCounterMap(EFFECTIVENESS_TOKEN_BUDGET_BUCKETS),
+      returnedTokenEstimate: emptyCounterMap(EFFECTIVENESS_RETURNED_TOKEN_BUCKETS),
+      exactHandoffEmitted: emptyCounterMap(EFFECTIVENESS_BOOLEAN_BUCKETS),
+      scopeRelaxation: emptyCounterMap(EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS),
+    };
+  }
+
+  record(event: EffectivenessMetricEvent): void {
+    // All mutations are synchronous and contain no await points, so concurrent
+    // Promise completions cannot observe a partially applied event in Node.js.
+    const route = allowedValue(event.route, EFFECTIVENESS_TOOL_ROUTES, "other");
+    const host = allowedValue(event.host, EFFECTIVENESS_HOST_MODES, "other");
+    const outcome = allowedValue(event.outcome, EFFECTIVENESS_OUTCOMES, "error");
+    const scopeRelaxation = allowedValue(
+      event.scopeRelaxation,
+      EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS,
+      "none",
+    );
+    const recoveryUsed = event.recoveryUsed === true ? "yes" : "no";
+    const exactHandoffEmitted = event.exactHandoffEmitted === true ? "yes" : "no";
+
+    this.snapshot.totalCalls = Math.min(MAX_EFFECTIVENESS_COUNTER, this.snapshot.totalCalls + 1);
+    increment(this.snapshot.toolRoute, route);
+    increment(this.snapshot.hostMode, host);
+    increment(this.snapshot.outcome, outcome);
+    increment(this.snapshot.recoveryUsed, recoveryUsed);
+    increment(this.snapshot.resultCount, resultCountBucket(event.resultCount));
+    increment(this.snapshot.latency, latencyBucket(event.latencyMs));
+    increment(this.snapshot.tokenBudget, tokenBudgetBucket(event.tokenBudget));
+    increment(this.snapshot.returnedTokenEstimate, returnedTokenBucket(event.returnedTokenEstimate));
+    increment(this.snapshot.exactHandoffEmitted, exactHandoffEmitted);
+    increment(this.snapshot.scopeRelaxation, scopeRelaxation);
+  }
+
+  getSnapshot(): EffectivenessMetricsSnapshot {
+    return {
+      ...this.snapshot,
+      retention: { ...this.snapshot.retention },
+      toolRoute: cloneCounterMap(this.snapshot.toolRoute),
+      hostMode: cloneCounterMap(this.snapshot.hostMode),
+      outcome: cloneCounterMap(this.snapshot.outcome),
+      recoveryUsed: cloneCounterMap(this.snapshot.recoveryUsed),
+      resultCount: cloneCounterMap(this.snapshot.resultCount),
+      latency: cloneCounterMap(this.snapshot.latency),
+      tokenBudget: cloneCounterMap(this.snapshot.tokenBudget),
+      returnedTokenEstimate: cloneCounterMap(this.snapshot.returnedTokenEstimate),
+      exactHandoffEmitted: cloneCounterMap(this.snapshot.exactHandoffEmitted),
+      scopeRelaxation: cloneCounterMap(this.snapshot.scopeRelaxation),
+    };
+  }
+
+  reset(): void {
+    this.snapshot = this.createEmptySnapshot();
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,9 @@
 import type { DebugConfig, LogLevel } from "../config/schema.js";
+import {
+  EffectivenessMetrics,
+  type EffectivenessMetricEvent,
+  type EffectivenessMetricsSnapshot,
+} from "./effectiveness-metrics.js";
 
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 0,
@@ -86,6 +91,7 @@ function createEmptyMetrics(): Metrics {
 export class Logger {
   private config: DebugConfig;
   private metrics: Metrics;
+  private effectivenessMetrics = new EffectivenessMetrics();
   private logs: LogEntry[] = [];
   private maxLogs = 1000;
 
@@ -289,8 +295,17 @@ export class Logger {
     });
   }
 
+  recordEffectiveness(event: EffectivenessMetricEvent): void {
+    if (!this.isEffectivenessMetricsEnabled()) return;
+    this.effectivenessMetrics.record(event);
+  }
+
   getMetrics(): Metrics {
     return { ...this.metrics };
+  }
+
+  getEffectivenessMetrics(): EffectivenessMetricsSnapshot {
+    return this.effectivenessMetrics.getSnapshot();
   }
 
   getLogs(limit?: number): LogEntry[] {
@@ -319,6 +334,7 @@ export class Logger {
 
   resetMetrics(): void {
     this.metrics = createEmptyMetrics();
+    this.effectivenessMetrics.reset();
   }
 
   clearLogs(): void {
@@ -380,6 +396,31 @@ export class Logger {
       lines.push(`  Chunks removed: ${m.gcChunksRemoved}`);
       lines.push(`  Embeddings removed: ${m.gcEmbeddingsRemoved}`);
     }
+
+    lines.push("");
+    if (!this.isEffectivenessMetricsEnabled()) {
+      lines.push("Privacy-safe effectiveness: disabled (set debug.effectivenessMetrics=true to opt in).");
+    } else {
+      const effectiveness = this.effectivenessMetrics.getSnapshot();
+      const formatCounters = (counters: Record<string, number>): string => Object.entries(counters)
+        .map(([bucket, count]) => `${bucket}=${count}`)
+        .join(", ");
+      lines.push(`Privacy-safe effectiveness (schema v${effectiveness.schemaVersion}):`);
+      lines.push(`  Retention: ${effectiveness.retention.storage}, ${effectiveness.retention.lifetime}-lifetime; reset with index_metrics(reset=true) or process exit`);
+      lines.push(`  Counter cap: ${effectiveness.retention.maxCounterValue.toLocaleString()}`);
+      lines.push(`  Total tool calls: ${effectiveness.totalCalls}`);
+      lines.push(`  Tool route: ${formatCounters(effectiveness.toolRoute)}`);
+      lines.push(`  Host mode: ${formatCounters(effectiveness.hostMode)}`);
+      lines.push(`  Outcome: ${formatCounters(effectiveness.outcome)}`);
+      lines.push(`  Recovery used: ${formatCounters(effectiveness.recoveryUsed)}`);
+      lines.push(`  Result-count bucket: ${formatCounters(effectiveness.resultCount)}`);
+      lines.push(`  Latency bucket: ${formatCounters(effectiveness.latency)}`);
+      lines.push(`  Token-budget bucket: ${formatCounters(effectiveness.tokenBudget)}`);
+      lines.push(`  Returned-token estimate: ${formatCounters(effectiveness.returnedTokenEstimate)}`);
+      lines.push(`  Exact handoff emitted: ${formatCounters(effectiveness.exactHandoffEmitted)}`);
+      lines.push(`  Scope relaxation: ${formatCounters(effectiveness.scopeRelaxation)}`);
+      lines.push("  Privacy: no queries, source, symbols, paths, repository names, or stable identifiers are retained.");
+    }
     
     return lines.join("\n");
   }
@@ -402,6 +443,10 @@ export class Logger {
 
   isMetricsEnabled(): boolean {
     return this.config.enabled && this.config.metrics;
+  }
+
+  isEffectivenessMetricsEnabled(): boolean {
+    return this.isMetricsEnabled() && this.config.effectivenessMetrics === true;
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,9 +1,4 @@
 import type { DebugConfig, LogLevel } from "../config/schema.js";
-import {
-  EffectivenessMetrics,
-  type EffectivenessMetricEvent,
-  type EffectivenessMetricsSnapshot,
-} from "./effectiveness-metrics.js";
 
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 0,
@@ -91,7 +86,6 @@ function createEmptyMetrics(): Metrics {
 export class Logger {
   private config: DebugConfig;
   private metrics: Metrics;
-  private effectivenessMetrics = new EffectivenessMetrics();
   private logs: LogEntry[] = [];
   private maxLogs = 1000;
 
@@ -295,17 +289,8 @@ export class Logger {
     });
   }
 
-  recordEffectiveness(event: EffectivenessMetricEvent): void {
-    if (!this.isEffectivenessMetricsEnabled()) return;
-    this.effectivenessMetrics.record(event);
-  }
-
   getMetrics(): Metrics {
     return { ...this.metrics };
-  }
-
-  getEffectivenessMetrics(): EffectivenessMetricsSnapshot {
-    return this.effectivenessMetrics.getSnapshot();
   }
 
   getLogs(limit?: number): LogEntry[] {
@@ -334,7 +319,6 @@ export class Logger {
 
   resetMetrics(): void {
     this.metrics = createEmptyMetrics();
-    this.effectivenessMetrics.reset();
   }
 
   clearLogs(): void {
@@ -396,31 +380,6 @@ export class Logger {
       lines.push(`  Chunks removed: ${m.gcChunksRemoved}`);
       lines.push(`  Embeddings removed: ${m.gcEmbeddingsRemoved}`);
     }
-
-    lines.push("");
-    if (!this.isEffectivenessMetricsEnabled()) {
-      lines.push("Privacy-safe effectiveness: disabled (set debug.effectivenessMetrics=true to opt in).");
-    } else {
-      const effectiveness = this.effectivenessMetrics.getSnapshot();
-      const formatCounters = (counters: Record<string, number>): string => Object.entries(counters)
-        .map(([bucket, count]) => `${bucket}=${count}`)
-        .join(", ");
-      lines.push(`Privacy-safe effectiveness (schema v${effectiveness.schemaVersion}):`);
-      lines.push(`  Retention: ${effectiveness.retention.storage}, ${effectiveness.retention.lifetime}-lifetime; reset with index_metrics(reset=true) or process exit`);
-      lines.push(`  Counter cap: ${effectiveness.retention.maxCounterValue.toLocaleString()}`);
-      lines.push(`  Total tool calls: ${effectiveness.totalCalls}`);
-      lines.push(`  Tool route: ${formatCounters(effectiveness.toolRoute)}`);
-      lines.push(`  Host mode: ${formatCounters(effectiveness.hostMode)}`);
-      lines.push(`  Outcome: ${formatCounters(effectiveness.outcome)}`);
-      lines.push(`  Recovery used: ${formatCounters(effectiveness.recoveryUsed)}`);
-      lines.push(`  Result-count bucket: ${formatCounters(effectiveness.resultCount)}`);
-      lines.push(`  Latency bucket: ${formatCounters(effectiveness.latency)}`);
-      lines.push(`  Token-budget bucket: ${formatCounters(effectiveness.tokenBudget)}`);
-      lines.push(`  Returned-token estimate: ${formatCounters(effectiveness.returnedTokenEstimate)}`);
-      lines.push(`  Exact handoff emitted: ${formatCounters(effectiveness.exactHandoffEmitted)}`);
-      lines.push(`  Scope relaxation: ${formatCounters(effectiveness.scopeRelaxation)}`);
-      lines.push("  Privacy: no queries, source, symbols, paths, repository names, or stable identifiers are retained.");
-    }
     
     return lines.join("\n");
   }
@@ -443,10 +402,6 @@ export class Logger {
 
   isMetricsEnabled(): boolean {
     return this.config.enabled && this.config.metrics;
-  }
-
-  isEffectivenessMetricsEnabled(): boolean {
-    return this.isMetricsEnabled() && this.config.effectivenessMetrics === true;
   }
 }
 

--- a/tests/effectiveness-metrics.test.ts
+++ b/tests/effectiveness-metrics.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import {
+  EFFECTIVENESS_HOST_MODES,
+  EFFECTIVENESS_OUTCOMES,
+  EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS,
+  EFFECTIVENESS_TOOL_ROUTES,
+  MAX_EFFECTIVENESS_COUNTER,
+  type EffectivenessMetricEvent,
+} from "../src/utils/effectiveness-metrics.js";
+import { Logger } from "../src/utils/logger.js";
+
+const tempDirectories: string[] = [];
+
+function enabledLogger(): Logger {
+  return new Logger({
+    enabled: true,
+    logLevel: "debug",
+    logSearch: false,
+    logEmbedding: false,
+    logCache: false,
+    logGc: false,
+    logBranch: false,
+    metrics: true,
+    effectivenessMetrics: true,
+  });
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("privacy-safe effectiveness metrics", () => {
+  it("is disabled by default and requires explicit debug-local opt-in", () => {
+    const defaults = parseConfig(undefined);
+    expect(defaults.debug.enabled).toBe(false);
+    expect(defaults.debug.effectivenessMetrics).toBe(false);
+
+    const logger = new Logger({
+      ...defaults.debug,
+      enabled: true,
+      metrics: true,
+    });
+    logger.recordEffectiveness({
+      route: "peek",
+      host: "opencode",
+      outcome: "success",
+      resultCount: 1,
+    });
+
+    expect(logger.getEffectivenessMetrics().totalCalls).toBe(0);
+    expect(logger.formatMetrics()).toContain("Privacy-safe effectiveness: disabled");
+  });
+
+  it("records only fixed-cardinality counters and histograms", () => {
+    const logger = enabledLogger();
+    logger.recordEffectiveness({
+      route: "context-conceptual",
+      host: "opencode",
+      outcome: "success",
+      recoveryUsed: true,
+      resultCount: 7,
+      latencyMs: 75,
+      tokenBudget: 1200,
+      returnedTokenEstimate: 640,
+      exactHandoffEmitted: true,
+      scopeRelaxation: "both",
+    });
+    logger.recordEffectiveness({
+      route: "search",
+      host: "pi",
+      outcome: "no-result",
+      resultCount: 0,
+      latencyMs: 1200,
+      returnedTokenEstimate: 16,
+    });
+
+    const metrics = logger.getEffectivenessMetrics();
+    expect(metrics.schemaVersion).toBe(1);
+    expect(metrics.retention).toEqual({
+      storage: "memory-only",
+      lifetime: "process",
+      reset: "index_metrics-reset-or-process-exit",
+      maxCounterValue: MAX_EFFECTIVENESS_COUNTER,
+    });
+    expect(metrics.totalCalls).toBe(2);
+    expect(metrics.toolRoute["context-conceptual"]).toBe(1);
+    expect(metrics.toolRoute.search).toBe(1);
+    expect(metrics.hostMode.opencode).toBe(1);
+    expect(metrics.hostMode.pi).toBe(1);
+    expect(metrics.outcome.success).toBe(1);
+    expect(metrics.outcome["no-result"]).toBe(1);
+    expect(metrics.recoveryUsed.yes).toBe(1);
+    expect(metrics.resultCount["6-10"]).toBe(1);
+    expect(metrics.resultCount["0"]).toBe(1);
+    expect(metrics.latency["50-199ms"]).toBe(1);
+    expect(metrics.latency["1s+"]).toBe(1);
+    expect(metrics.tokenBudget["1200-1999"]).toBe(1);
+    expect(metrics.tokenBudget.none).toBe(1);
+    expect(metrics.returnedTokenEstimate["512-1199"]).toBe(1);
+    expect(metrics.returnedTokenEstimate["1-127"]).toBe(1);
+    expect(metrics.exactHandoffEmitted.yes).toBe(1);
+    expect(metrics.scopeRelaxation.both).toBe(1);
+
+    expect(Object.keys(metrics.toolRoute)).toEqual(EFFECTIVENESS_TOOL_ROUTES);
+    expect(Object.keys(metrics.hostMode)).toEqual(EFFECTIVENESS_HOST_MODES);
+    expect(Object.keys(metrics.outcome)).toEqual(EFFECTIVENESS_OUTCOMES);
+    expect(Object.keys(metrics.scopeRelaxation)).toEqual(EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS);
+    expect(logger.formatMetrics()).toContain("Privacy-safe effectiveness (schema v1)");
+    expect(logger.formatMetrics()).toContain("memory-only, process-lifetime");
+  });
+
+  it("is concurrency-safe for interleaved Promise completions", async () => {
+    const logger = enabledLogger();
+    await Promise.all(Array.from({ length: 500 }, async (_, index) => {
+      await Promise.resolve();
+      logger.recordEffectiveness({
+        route: index % 2 === 0 ? "peek" : "search",
+        host: "jcode",
+        outcome: "success",
+        resultCount: index % 3,
+        latencyMs: index % 250,
+        returnedTokenEstimate: index,
+      });
+    }));
+
+    const metrics = logger.getEffectivenessMetrics();
+    expect(metrics.totalCalls).toBe(500);
+    expect(metrics.toolRoute.peek).toBe(250);
+    expect(metrics.toolRoute.search).toBe(250);
+    expect(metrics.hostMode.jcode).toBe(500);
+    expect(metrics.outcome.success).toBe(500);
+    expect(Object.values(metrics.resultCount).reduce((sum, count) => sum + count, 0)).toBe(500);
+  });
+
+  it("drops adversarial content and identifiers from snapshots, logs, formatted output, and persisted snapshots", () => {
+    const logger = enabledLogger();
+    const secrets = [
+      "sk-live-DO_NOT_PERSIST-123456",
+      "秘密🔐-δοκιμή-निजी",
+      "/Users/alice/SuperSecretRepo/src/passwords.ts",
+      "RepositoryNameThatMustNotPersist",
+      "stable-user-550e8400-e29b-41d4-a716-446655440000",
+      "SensitiveSymbolName",
+      "const PRIVATE_SOURCE = 'never persist me';",
+      "Q".repeat(20_000),
+    ];
+    const adversarialEvent = {
+      route: secrets[0],
+      host: secrets[1],
+      outcome: secrets[2],
+      recoveryUsed: true,
+      resultCount: Number.MAX_SAFE_INTEGER,
+      latencyMs: Number.POSITIVE_INFINITY,
+      tokenBudget: Number.NaN,
+      returnedTokenEstimate: Number.MAX_SAFE_INTEGER,
+      exactHandoffEmitted: true,
+      scopeRelaxation: secrets[3],
+      query: secrets[4],
+      sourceCode: secrets[5],
+      symbol: secrets[6],
+      filePath: secrets[7],
+      repositoryName: secrets[3],
+      stableIdentifier: secrets[4],
+    } as unknown as EffectivenessMetricEvent;
+
+    logger.recordEffectiveness(adversarialEvent);
+
+    const serialized = JSON.stringify({
+      metrics: logger.getEffectivenessMetrics(),
+      logs: logger.getLogs(),
+      output: logger.formatMetrics(),
+    });
+    const directory = mkdtempSync(path.join(os.tmpdir(), "effectiveness-privacy-"));
+    tempDirectories.push(directory);
+    const persistedPath = path.join(directory, "snapshot.json");
+    writeFileSync(persistedPath, serialized, "utf8");
+    const persisted = readFileSync(persistedPath, "utf8");
+
+    for (const secret of secrets) {
+      expect(serialized).not.toContain(secret);
+      expect(persisted).not.toContain(secret);
+    }
+    expect(logger.getLogs()).toEqual([]);
+    expect(logger.getEffectivenessMetrics().toolRoute.other).toBe(1);
+    expect(logger.getEffectivenessMetrics().hostMode.other).toBe(1);
+    expect(logger.getEffectivenessMetrics().outcome.error).toBe(1);
+    expect(logger.getEffectivenessMetrics().scopeRelaxation.none).toBe(1);
+  });
+
+  it("resets operational and effectiveness metrics together", () => {
+    const logger = enabledLogger();
+    logger.recordCacheHit();
+    logger.recordEffectiveness({
+      route: "peek",
+      host: "claude",
+      outcome: "success",
+      resultCount: 2,
+    });
+
+    logger.resetMetrics();
+
+    expect(logger.getMetrics().cacheHits).toBe(0);
+    expect(logger.getEffectivenessMetrics().totalCalls).toBe(0);
+    expect(Object.values(logger.getEffectivenessMetrics().toolRoute).every((count) => count === 0)).toBe(true);
+  });
+});

--- a/tests/effectiveness-metrics.test.ts
+++ b/tests/effectiveness-metrics.test.ts
@@ -1,67 +1,131 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { execFileSync } from "child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { parseConfig } from "../src/config/schema.js";
 import {
+  getIndexLogs,
+  getIndexMetrics,
+  initializeTools,
+  isToolEffectivenessEnabled,
+  recordToolEffectiveness,
+  refreshIndexerForDirectory,
+} from "../src/tools/operations.js";
+import {
+  EffectivenessMetrics,
   EFFECTIVENESS_HOST_MODES,
   EFFECTIVENESS_OUTCOMES,
   EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS,
   EFFECTIVENESS_TOOL_ROUTES,
+  formatEffectivenessMetrics,
+  getProcessEffectivenessMetrics,
+  isProcessEffectivenessCollectorAllocated,
   MAX_EFFECTIVENESS_COUNTER,
+  resetProcessEffectivenessMetrics,
   type EffectivenessMetricEvent,
 } from "../src/utils/effectiveness-metrics.js";
 import { Logger } from "../src/utils/logger.js";
 
 const tempDirectories: string[] = [];
 
-function enabledLogger(): Logger {
-  return new Logger({
-    enabled: true,
-    logLevel: "debug",
-    logSearch: false,
-    logEmbedding: false,
-    logCache: false,
-    logGc: false,
-    logBranch: false,
-    metrics: true,
-    effectivenessMetrics: true,
-  });
+function tempDirectory(prefix: string): string {
+  const directory = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirectories.push(directory);
+  return directory;
 }
 
+function allFileContents(root: string): string {
+  const contents: string[] = [];
+  const visit = (directory: string): void => {
+    for (const name of readdirSync(directory)) {
+      const filePath = path.join(directory, name);
+      if (statSync(filePath).isDirectory()) visit(filePath);
+      else contents.push(readFileSync(filePath, "utf8"));
+    }
+  };
+  visit(root);
+  return contents.join("\n");
+}
+
+beforeEach(() => {
+  resetProcessEffectivenessMetrics();
+});
+
 afterEach(() => {
+  resetProcessEffectivenessMetrics();
   for (const directory of tempDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
 });
 
 describe("privacy-safe effectiveness metrics", () => {
-  it("is disabled by default and requires explicit debug-local opt-in", () => {
-    const defaults = parseConfig(undefined);
-    expect(defaults.debug.enabled).toBe(false);
-    expect(defaults.debug.effectivenessMetrics).toBe(false);
+  it("is independently opt-in and cannot activate raw logging or persist secret-bearing data", async () => {
+    const projectRoot = tempDirectory("effectiveness-privacy-");
+    writeFileSync(path.join(projectRoot, "preexisting.txt"), "safe fixture", "utf8");
+    const config = parseConfig({ effectivenessMetrics: { enabled: true } });
+    initializeTools(projectRoot, config, "jcode");
+
+    const secrets = [
+      "sk-live-DO_NOT_PERSIST-123456",
+      "秘密🔐-δοκιμή-निजी",
+      "/Users/alice/SuperSecretRepo/src/passwords.ts",
+      "RepositoryNameThatMustNotPersist",
+      "stable-user-550e8400-e29b-41d4-a716-446655440000",
+      "SensitiveSymbolName",
+      "const PRIVATE_SOURCE = 'never persist me';",
+    ];
+    recordToolEffectiveness(projectRoot, "jcode", {
+      route: secrets[0],
+      host: secrets[1],
+      outcome: secrets[2],
+      scopeRelaxation: secrets[3],
+      query: secrets[4],
+      symbol: secrets[5],
+      sourceCode: secrets[6],
+      filePath: secrets[2],
+      repositoryName: secrets[3],
+      stableIdentifier: secrets[4],
+    } as unknown as EffectivenessMetricEvent);
+
+    const logs = await getIndexLogs(projectRoot, "jcode", {});
+    const metrics = await getIndexMetrics(projectRoot, "jcode");
+    const serializedOutput = JSON.stringify({ logs, metrics });
+    const persistedContents = allFileContents(projectRoot);
+
+    expect(config.debug.enabled).toBe(false);
+    expect(config.effectivenessMetrics.enabled).toBe(true);
+    expect(logs.kind).toBe("disabled");
+    expect(metrics.metricsEnabled).toBe(false);
+    expect(metrics.effectivenessMetricsEnabled).toBe(true);
+    expect(metrics.text).toContain("Privacy-safe effectiveness (schema v2)");
+    expect(getProcessEffectivenessMetrics().totalCalls).toBe(1);
+    for (const secret of secrets) {
+      expect(serializedOutput).not.toContain(secret);
+      expect(persistedContents).not.toContain(secret);
+    }
+  });
+
+  it("preserves explicit debug search logging only when the user separately enables it", () => {
+    const legacyNestedOptIn = parseConfig({ debug: { effectivenessMetrics: true } });
+    expect(legacyNestedOptIn.debug.enabled).toBe(false);
+    expect(legacyNestedOptIn.effectivenessMetrics.enabled).toBe(false);
 
     const logger = new Logger({
-      ...defaults.debug,
+      ...parseConfig(undefined).debug,
       enabled: true,
-      metrics: true,
+      logSearch: true,
     });
-    logger.recordEffectiveness({
-      route: "peek",
-      host: "opencode",
-      outcome: "success",
-      resultCount: 1,
-    });
+    logger.search("info", "Search complete", { query: "explicit-debug-query" });
 
-    expect(logger.getEffectivenessMetrics().totalCalls).toBe(0);
-    expect(logger.formatMetrics()).toContain("Privacy-safe effectiveness: disabled");
+    expect(JSON.stringify(logger.getLogs())).toContain("explicit-debug-query");
   });
 
   it("records only fixed-cardinality counters and histograms", () => {
-    const logger = enabledLogger();
-    logger.recordEffectiveness({
+    const collector = new EffectivenessMetrics();
+    collector.record({
       route: "context-conceptual",
       host: "opencode",
       outcome: "success",
@@ -73,7 +137,7 @@ describe("privacy-safe effectiveness metrics", () => {
       exactHandoffEmitted: true,
       scopeRelaxation: "both",
     });
-    logger.recordEffectiveness({
+    collector.record({
       route: "search",
       host: "pi",
       outcome: "no-result",
@@ -82,13 +146,14 @@ describe("privacy-safe effectiveness metrics", () => {
       returnedTokenEstimate: 16,
     });
 
-    const metrics = logger.getEffectivenessMetrics();
-    expect(metrics.schemaVersion).toBe(1);
+    const metrics = collector.getSnapshot();
+    expect(metrics.schemaVersion).toBe(2);
     expect(metrics.retention).toEqual({
       storage: "memory-only",
       lifetime: "process",
       reset: "index_metrics-reset-or-process-exit",
       maxCounterValue: MAX_EFFECTIVENESS_COUNTER,
+      dimensions: "bounded-host-and-category-only",
     });
     expect(metrics.totalCalls).toBe(2);
     expect(metrics.toolRoute["context-conceptual"]).toBe(1);
@@ -103,25 +168,21 @@ describe("privacy-safe effectiveness metrics", () => {
     expect(metrics.latency["50-199ms"]).toBe(1);
     expect(metrics.latency["1s+"]).toBe(1);
     expect(metrics.tokenBudget["1200-1999"]).toBe(1);
-    expect(metrics.tokenBudget.none).toBe(1);
     expect(metrics.returnedTokenEstimate["512-1199"]).toBe(1);
-    expect(metrics.returnedTokenEstimate["1-127"]).toBe(1);
     expect(metrics.exactHandoffEmitted.yes).toBe(1);
     expect(metrics.scopeRelaxation.both).toBe(1);
-
     expect(Object.keys(metrics.toolRoute)).toEqual(EFFECTIVENESS_TOOL_ROUTES);
     expect(Object.keys(metrics.hostMode)).toEqual(EFFECTIVENESS_HOST_MODES);
     expect(Object.keys(metrics.outcome)).toEqual(EFFECTIVENESS_OUTCOMES);
     expect(Object.keys(metrics.scopeRelaxation)).toEqual(EFFECTIVENESS_SCOPE_RELAXATION_BUCKETS);
-    expect(logger.formatMetrics()).toContain("Privacy-safe effectiveness (schema v1)");
-    expect(logger.formatMetrics()).toContain("memory-only, process-lifetime");
+    expect(formatEffectivenessMetrics(metrics)).toContain("bounded-host-and-category-only");
   });
 
   it("is concurrency-safe for interleaved Promise completions", async () => {
-    const logger = enabledLogger();
+    const collector = new EffectivenessMetrics();
     await Promise.all(Array.from({ length: 500 }, async (_, index) => {
       await Promise.resolve();
-      logger.recordEffectiveness({
+      collector.record({
         route: index % 2 === 0 ? "peek" : "search",
         host: "jcode",
         outcome: "success",
@@ -131,84 +192,124 @@ describe("privacy-safe effectiveness metrics", () => {
       });
     }));
 
-    const metrics = logger.getEffectivenessMetrics();
+    const metrics = collector.getSnapshot();
     expect(metrics.totalCalls).toBe(500);
     expect(metrics.toolRoute.peek).toBe(250);
     expect(metrics.toolRoute.search).toBe(250);
-    expect(metrics.hostMode.jcode).toBe(500);
-    expect(metrics.outcome.success).toBe(500);
     expect(Object.values(metrics.resultCount).reduce((sum, count) => sum + count, 0)).toBe(500);
   });
 
-  it("drops adversarial content and identifiers from snapshots, logs, formatted output, and persisted snapshots", () => {
-    const logger = enabledLogger();
-    const secrets = [
-      "sk-live-DO_NOT_PERSIST-123456",
-      "秘密🔐-δοκιμή-निजी",
-      "/Users/alice/SuperSecretRepo/src/passwords.ts",
-      "RepositoryNameThatMustNotPersist",
-      "stable-user-550e8400-e29b-41d4-a716-446655440000",
-      "SensitiveSymbolName",
-      "const PRIVATE_SOURCE = 'never persist me';",
-      "Q".repeat(20_000),
-    ];
-    const adversarialEvent = {
-      route: secrets[0],
-      host: secrets[1],
-      outcome: secrets[2],
-      recoveryUsed: true,
-      resultCount: Number.MAX_SAFE_INTEGER,
-      latencyMs: Number.POSITIVE_INFINITY,
-      tokenBudget: Number.NaN,
-      returnedTokenEstimate: Number.MAX_SAFE_INTEGER,
-      exactHandoffEmitted: true,
-      scopeRelaxation: secrets[3],
-      query: secrets[4],
-      sourceCode: secrets[5],
-      symbol: secrets[6],
-      filePath: secrets[7],
-      repositoryName: secrets[3],
-      stableIdentifier: secrets[4],
-    } as unknown as EffectivenessMetricEvent;
-
-    logger.recordEffectiveness(adversarialEvent);
-
-    const serialized = JSON.stringify({
-      metrics: logger.getEffectivenessMetrics(),
-      logs: logger.getLogs(),
-      output: logger.formatMetrics(),
+  it("resets explicitly and a fresh process starts empty", async () => {
+    const projectRoot = tempDirectory("effectiveness-reset-");
+    const config = parseConfig({ effectivenessMetrics: { enabled: true } });
+    initializeTools(projectRoot, config, "jcode");
+    recordToolEffectiveness(projectRoot, "jcode", {
+      route: "peek",
+      host: "jcode",
+      outcome: "success",
+      resultCount: 1,
     });
-    const directory = mkdtempSync(path.join(os.tmpdir(), "effectiveness-privacy-"));
-    tempDirectories.push(directory);
-    const persistedPath = path.join(directory, "snapshot.json");
-    writeFileSync(persistedPath, serialized, "utf8");
-    const persisted = readFileSync(persistedPath, "utf8");
 
-    for (const secret of secrets) {
-      expect(serialized).not.toContain(secret);
-      expect(persisted).not.toContain(secret);
-    }
-    expect(logger.getLogs()).toEqual([]);
-    expect(logger.getEffectivenessMetrics().toolRoute.other).toBe(1);
-    expect(logger.getEffectivenessMetrics().hostMode.other).toBe(1);
-    expect(logger.getEffectivenessMetrics().outcome.error).toBe(1);
-    expect(logger.getEffectivenessMetrics().scopeRelaxation.none).toBe(1);
+    expect(getProcessEffectivenessMetrics().totalCalls).toBe(1);
+    const reset = await getIndexMetrics(projectRoot, "jcode", { reset: true });
+    expect(reset.text).toContain("Metrics reset.");
+    expect(getProcessEffectivenessMetrics().totalCalls).toBe(0);
+    expect(isProcessEffectivenessCollectorAllocated()).toBe(false);
+
+    const childOutput = execFileSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "--eval",
+        "import { getProcessEffectivenessMetrics } from './src/utils/effectiveness-metrics.ts'; console.log(getProcessEffectivenessMetrics().totalCalls);",
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    ).trim();
+    expect(childOutput).toBe("0");
   });
 
-  it("resets operational and effectiveness metrics together", () => {
-    const logger = enabledLogger();
-    logger.recordCacheHit();
-    logger.recordEffectiveness({
+  it("saturates every counter at its configured cap", () => {
+    const metrics = new EffectivenessMetrics(2);
+    const event: EffectivenessMetricEvent = {
       route: "peek",
-      host: "claude",
+      host: "opencode",
       outcome: "success",
-      resultCount: 2,
+      resultCount: 1,
+      latencyMs: 1,
+      returnedTokenEstimate: 1,
+    };
+    metrics.record(event);
+    metrics.record(event);
+    metrics.record(event);
+
+    const snapshot = metrics.getSnapshot();
+    expect(snapshot.retention.maxCounterValue).toBe(2);
+    expect(snapshot.totalCalls).toBe(2);
+    expect(snapshot.toolRoute.peek).toBe(2);
+    expect(snapshot.hostMode.opencode).toBe(2);
+    expect(snapshot.outcome.success).toBe(2);
+    expect(snapshot.recoveryUsed.no).toBe(2);
+    expect(snapshot.resultCount["1"]).toBe(2);
+    expect(snapshot.latency["<10ms"]).toBe(2);
+    expect(snapshot.tokenBudget.none).toBe(2);
+    expect(snapshot.returnedTokenEstimate["1-127"]).toBe(2);
+    expect(snapshot.exactHandoffEmitted.no).toBe(2);
+    expect(snapshot.scopeRelaxation.none).toBe(2);
+  });
+
+  it("keeps the disabled recording path allocation-free with bounded overhead", () => {
+    const projectRoot = tempDirectory("effectiveness-disabled-");
+    initializeTools(projectRoot, parseConfig(undefined), "jcode");
+    expect(isToolEffectivenessEnabled(projectRoot, "jcode")).toBe(false);
+
+    const startedAt = performance.now();
+    for (let index = 0; index < 100_000; index++) {
+      recordToolEffectiveness(projectRoot, "jcode", {
+        route: "peek",
+        host: "jcode",
+        outcome: "success",
+      });
+    }
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(isProcessEffectivenessCollectorAllocated()).toBe(false);
+    expect(elapsedMs).toBeLessThan(500);
+  });
+
+  it("survives Indexer/cache replacement used by config refresh without retaining project identity", () => {
+    const firstProject = tempDirectory("effectiveness-refresh-a-");
+    const secondProject = tempDirectory("effectiveness-refresh-b-");
+    const config = parseConfig({ effectivenessMetrics: { enabled: true } });
+
+    initializeTools(firstProject, config, "jcode");
+    recordToolEffectiveness(firstProject, "jcode", {
+      route: "search",
+      host: "jcode",
+      outcome: "success",
+    });
+    refreshIndexerForDirectory(firstProject, "jcode", config);
+    initializeTools(secondProject, config, "jcode");
+    recordToolEffectiveness(firstProject, "jcode", {
+      route: "peek",
+      host: "jcode",
+      outcome: "no-result",
+    });
+    recordToolEffectiveness(secondProject, "jcode", {
+      route: "context-conceptual",
+      host: "jcode",
+      outcome: "success",
     });
 
-    logger.resetMetrics();
-
-    expect(logger.getMetrics().cacheHits).toBe(0);
-    expect(logger.getEffectivenessMetrics().totalCalls).toBe(0);
-    expect(Object.values(logger.getEffectivenessMetrics().toolRoute).every((count) => count === 0)).toBe(true);
+    const snapshot = getProcessEffectivenessMetrics();
+    const serialized = JSON.stringify(snapshot);
+    expect(snapshot.totalCalls).toBe(3);
+    expect(snapshot.hostMode.jcode).toBe(3);
+    expect(snapshot.toolRoute.search).toBe(1);
+    expect(snapshot.toolRoute.peek).toBe(1);
+    expect(snapshot.toolRoute["context-conceptual"]).toBe(1);
+    expect(serialized).not.toContain(firstProject);
+    expect(serialized).not.toContain(secondProject);
   });
 });

--- a/tests/effectiveness-report.test.ts
+++ b/tests/effectiveness-report.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "fs";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EFFECTIVENESS_FIXTURES } from "../benchmarks/fixtures/privacy-safe-effectiveness.js";
+import {
+  buildEffectivenessEvaluationReport,
+  evaluateEffectivenessFixture,
+} from "../src/eval/effectiveness-report.js";
+
+function median(values: number[]): number {
+  const ordered = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0
+    ? (ordered[middle - 1] + ordered[middle]) / 2
+    : ordered[middle];
+}
+
+function p95(values: number[]): number {
+  const ordered = [...values].sort((left, right) => left - right);
+  return ordered[Math.ceil(ordered.length * 0.95) - 1];
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("offline privacy-safe effectiveness evaluation", () => {
+  it("is deterministic, offline, and matches the checked-in report byte-for-byte", () => {
+    const fetchSpy = vi.fn(() => {
+      throw new Error("network access is forbidden in the offline effectiveness benchmark");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const first = `${JSON.stringify(buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES), null, 2)}\n`;
+    const second = `${JSON.stringify(buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES), null, 2)}\n`;
+    const checkedIn = readFileSync("benchmarks/baselines/privacy-safe-effectiveness.json", "utf8");
+
+    expect(first).toBe(second);
+    expect(first).toBe(checkedIn);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("independently recomputes median, nearest-rank p95, and evidence recall", () => {
+    const measurements = EFFECTIVENESS_FIXTURES.map(evaluateEffectivenessFixture);
+    const report = buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES);
+
+    for (const route of ["context", "peek", "exactReadGrepBaseline"] as const) {
+      const tokens = measurements.map((measurement) => measurement[route].tokens);
+      const recalls = measurements.map((measurement) => measurement[route].evidenceRecall);
+      expect(report.routes[route].tokens.median).toBe(median(tokens));
+      expect(report.routes[route].tokens.p95).toBe(p95(tokens));
+      expect(report.routes[route].evidenceRecall.mean).toBe(
+        Number((recalls.reduce((sum, value) => sum + value, 0) / recalls.length).toFixed(4)),
+      );
+      expect(report.routes[route].evidenceRecall.minimum).toBe(Math.min(...recalls));
+    }
+  });
+
+  it("defines the baseline and avoids unverifiable causal claims", () => {
+    const report = buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES);
+
+    expect(report.methodology.networkCalls).toBe(0);
+    expect(report.methodology.exactReadGrepBaseline).toContain("exact-match lines");
+    expect(report.methodology.exactReadGrepBaseline).toContain("complete reads");
+    expect(report.methodology.limitation).toContain("does not establish causal agent improvement");
+    expect(report.routes.context.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
+    expect(report.routes.peek.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
+    expect(report.routes.exactReadGrepBaseline.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
+  });
+
+  it("does not include fixture queries, source, symbols, paths, repositories, or evidence identifiers in the report", () => {
+    const serialized = JSON.stringify(buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES));
+    const sensitiveFixtureValues = EFFECTIVENESS_FIXTURES.flatMap((fixture) => [
+      fixture.id,
+      ...fixture.expectedEvidenceIds,
+      ...fixture.semanticResults.flatMap((result) => [
+        result.filePath,
+        result.name ?? "",
+        result.content,
+        ...result.evidenceIds,
+      ]),
+      fixture.baseline.grepOutput,
+      fixture.baseline.exactReadOutput,
+      ...fixture.baseline.evidenceIds,
+    ]).filter(Boolean);
+
+    for (const value of sensitiveFixtureValues) {
+      expect(serialized).not.toContain(value);
+    }
+  });
+});

--- a/tests/effectiveness-report.test.ts
+++ b/tests/effectiveness-report.test.ts
@@ -5,7 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { EFFECTIVENESS_FIXTURES } from "../benchmarks/fixtures/privacy-safe-effectiveness.js";
 import {
   buildEffectivenessEvaluationReport,
+  effectivenessEvidenceMarker,
   evaluateEffectivenessFixture,
+  type EffectivenessFixture,
 } from "../src/eval/effectiveness-report.js";
 
 function median(values: number[]): number {
@@ -45,7 +47,7 @@ describe("offline privacy-safe effectiveness evaluation", () => {
     const measurements = EFFECTIVENESS_FIXTURES.map(evaluateEffectivenessFixture);
     const report = buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES);
 
-    for (const route of ["context", "peek", "exactReadGrepBaseline"] as const) {
+    for (const route of ["context", "peek", "exactSearchSnippetBaseline"] as const) {
       const tokens = measurements.map((measurement) => measurement[route].tokens);
       const recalls = measurements.map((measurement) => measurement[route].evidenceRecall);
       expect(report.routes[route].tokens.median).toBe(median(tokens));
@@ -61,12 +63,80 @@ describe("offline privacy-safe effectiveness evaluation", () => {
     const report = buildEffectivenessEvaluationReport(EFFECTIVENESS_FIXTURES);
 
     expect(report.methodology.networkCalls).toBe(0);
-    expect(report.methodology.exactReadGrepBaseline).toContain("exact-match lines");
-    expect(report.methodology.exactReadGrepBaseline).toContain("complete reads");
-    expect(report.methodology.limitation).toContain("does not establish causal agent improvement");
+    expect(report.methodology.warmupRuns).toBe(0);
+    expect(report.methodology.measuredRunsPerFixture).toBe(1);
+    expect(report.methodology.timing).toBe("not-measured-deterministic-format-and-token-evaluation-only");
+    expect(report.methodology.sourceCorpus).toContain("same fixed ranked synthetic result objects");
+    expect(report.methodology.maxResultsCap).toContain("fixture.maxResults");
+    expect(report.methodology.tokenBudgetParity).toContain("same fixture.tokenBudget");
+    expect(report.methodology.evidenceRecall).toContain("visibly present");
+    expect(report.methodology.evidenceRecall).toContain("no hidden content credit");
+    expect(report.methodology.exactSearchSnippetBaseline).toContain("only matching source lines");
+    expect(report.methodology.exactSearchSnippetBaseline).toContain("no arbitrary or complete file reads");
+    expect(report.methodology.limitation).toContain("does not measure retrieval quality");
+    expect(report.methodology.limitation).toContain("causal impact");
     expect(report.routes.context.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
     expect(report.routes.peek.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
-    expect(report.routes.exactReadGrepBaseline.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
+    expect(report.routes.exactSearchSnippetBaseline.tokens).toEqual(expect.objectContaining({ median: expect.any(Number), p95: expect.any(Number) }));
+  });
+
+  it("enforces the same result cap and final-response token budget on every route", () => {
+    for (const fixture of EFFECTIVENESS_FIXTURES) {
+      const measurement = evaluateEffectivenessFixture(fixture);
+      expect(measurement.context.tokens).toBeLessThanOrEqual(fixture.tokenBudget);
+      expect(measurement.peek.tokens).toBeLessThanOrEqual(fixture.tokenBudget);
+      expect(measurement.exactSearchSnippetBaseline.tokens).toBeLessThanOrEqual(fixture.tokenBudget);
+      expect(measurement.peek.evidenceRecall).toBe(0);
+    }
+
+    const cappedFixture = EFFECTIVENESS_FIXTURES.find((fixture) => fixture.maxResults === 1);
+    expect(cappedFixture).toBeDefined();
+    const cappedMeasurement = evaluateEffectivenessFixture(cappedFixture!);
+    expect(cappedMeasurement.context.evidenceRecall).toBe(0);
+    expect(cappedMeasurement.peek.evidenceRecall).toBe(0);
+    expect(cappedMeasurement.exactSearchSnippetBaseline.evidenceRecall).toBe(0.5);
+  });
+
+  it("credits evidence only when its marker is visible in the final route text", () => {
+    const hiddenEvidenceFixture: EffectivenessFixture = {
+      id: "hidden-evidence",
+      tokenBudget: 128,
+      maxResults: 1,
+      expectedEvidenceIds: ["hidden"],
+      semanticResults: [{
+        filePath: "src/hidden.ts",
+        startLine: 1,
+        endLine: 3,
+        content: "export function hidden() { return true; }",
+        score: 1,
+        chunkType: "function",
+        name: "hidden",
+        evidenceIds: ["hidden"],
+      }],
+    };
+
+    const hidden = evaluateEffectivenessFixture(hiddenEvidenceFixture);
+    expect(hidden.context.evidenceRecall).toBe(0);
+    expect(hidden.peek.evidenceRecall).toBe(0);
+    expect(hidden.exactSearchSnippetBaseline.evidenceRecall).toBe(0);
+
+    const marker = effectivenessEvidenceMarker("late");
+    const budgetedFixture: EffectivenessFixture = {
+      ...hiddenEvidenceFixture,
+      id: "budgeted-evidence",
+      expectedEvidenceIds: ["late"],
+      semanticResults: [{
+        ...hiddenEvidenceFixture.semanticResults[0],
+        filePath: `src/${"very-long-segment/".repeat(80)}late.ts`,
+        content: `export function late() {\n  const evidence = ${JSON.stringify(marker)};\n}`,
+        evidenceIds: ["late"],
+      }],
+    };
+    const budgeted = evaluateEffectivenessFixture(budgetedFixture);
+    expect(budgeted.context.tokens).toBeLessThanOrEqual(128);
+    expect(budgeted.peek.tokens).toBeLessThanOrEqual(128);
+    expect(budgeted.exactSearchSnippetBaseline.tokens).toBeLessThanOrEqual(128);
+    expect(budgeted.exactSearchSnippetBaseline.evidenceRecall).toBe(0);
   });
 
   it("does not include fixture queries, source, symbols, paths, repositories, or evidence identifiers in the report", () => {
@@ -80,9 +150,6 @@ describe("offline privacy-safe effectiveness evaluation", () => {
         result.content,
         ...result.evidenceIds,
       ]),
-      fixture.baseline.grepOutput,
-      fixture.baseline.exactReadOutput,
-      ...fixture.baseline.evidenceIds,
     ]).filter(Boolean);
 
     for (const value of sensitiveFixtureValues) {

--- a/tests/effectiveness-watcher-lifetime.test.ts
+++ b/tests/effectiveness-watcher-lifetime.test.ts
@@ -1,0 +1,81 @@
+import type { Indexer } from "../src/indexer/index.js";
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import {
+  initializeTools,
+  recordToolEffectiveness,
+} from "../src/tools/operations.js";
+import {
+  getProcessEffectivenessMetrics,
+  resetProcessEffectivenessMetrics,
+} from "../src/utils/effectiveness-metrics.js";
+import { createWatcherWithIndexer } from "../src/watcher/index.js";
+
+describe("effectiveness metrics across config watcher refresh", () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(path.join(os.tmpdir(), "effectiveness-watcher-lifetime-"));
+    resetProcessEffectivenessMetrics();
+  });
+
+  afterEach(() => {
+    resetProcessEffectivenessMetrics();
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("preserves the process collector when a config change replaces the cached Indexer", async () => {
+    const config = parseConfig({ effectivenessMetrics: { enabled: true } });
+    initializeTools(projectRoot, config, "jcode");
+    recordToolEffectiveness(projectRoot, "jcode", {
+      route: "search",
+      host: "jcode",
+      outcome: "success",
+    });
+    const configDirectory = path.join(projectRoot, ".codebase-index");
+    const configPath = path.join(configDirectory, "config.json");
+    mkdirSync(configDirectory, { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ effectivenessMetrics: { enabled: true } }));
+
+    const index = vi.fn().mockResolvedValue(undefined);
+    const watcherIndexer = { index } as unknown as Indexer;
+    const watcher = createWatcherWithIndexer(
+      () => watcherIndexer,
+      projectRoot,
+      config,
+      "jcode",
+    );
+
+    try {
+      await watcher.whenReady();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          effectivenessMetrics: { enabled: true },
+          include: ["src/**/*.ts"],
+        }),
+      );
+
+      await vi.waitFor(() => expect(index).toHaveBeenCalled(), { timeout: 4000 });
+      recordToolEffectiveness(projectRoot, "jcode", {
+        route: "peek",
+        host: "jcode",
+        outcome: "no-result",
+      });
+
+      const snapshot = getProcessEffectivenessMetrics();
+      expect(snapshot.totalCalls).toBe(2);
+      expect(snapshot.toolRoute.search).toBe(1);
+      expect(snapshot.toolRoute.peek).toBe(1);
+    } finally {
+      await watcher.stop();
+    }
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -7,10 +7,31 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import * as fs from "fs";
 import { estimateTokens } from "../src/utils/cost.js";
 import { countContextTokens } from "../src/tools/utils.js";
+import {
+  getProcessEffectivenessMetrics,
+  isProcessEffectivenessCollectorAllocated,
+  resetProcessEffectivenessMetrics,
+  type EffectivenessMetricsSnapshot,
+} from "../src/utils/effectiveness-metrics.js";
+import {
+  initializeTools,
+  searchCodebaseWithEffectiveness,
+} from "../src/tools/operations.js";
 
 const { testMainRepo } = vi.hoisted(() => ({
   testMainRepo: `/tmp/codebase-index-mcp-vitest-main-repo-${process.pid}`,
 }));
+
+function returnedTokenBucket(tokens: number): keyof EffectivenessMetricsSnapshot["returnedTokenEstimate"] {
+  if (tokens === 0) return "0";
+  if (tokens <= 127) return "1-127";
+  if (tokens <= 255) return "128-255";
+  if (tokens <= 511) return "256-511";
+  if (tokens <= 1199) return "512-1199";
+  if (tokens <= 1999) return "1200-1999";
+  if (tokens <= 3999) return "2000-3999";
+  return "4000+";
+}
 
 vi.mock("fs", async () => {
   const actual = await vi.importActual<typeof import("fs")>("fs");
@@ -33,6 +54,7 @@ const mergerMocks = vi.hoisted(() => ({
 }));
 
 const indexerMockState = vi.hoisted(() => ({
+  constructorError: undefined as Error | undefined,
   constructorArgs: [] as Array<[string, unknown]>,
   instances: [] as Array<{
     initialize: ReturnType<typeof vi.fn>;
@@ -48,7 +70,6 @@ const indexerMockState = vi.hoisted(() => ({
 }));
 
 const loggerMocks = vi.hoisted(() => ({
-  recordEffectiveness: vi.fn(),
   resetMetrics: vi.fn(),
 }));
 
@@ -66,7 +87,10 @@ function graphSymbol(id: string, name: string, filePath: string, startLine = 1) 
   };
 }
 
-vi.mock("../src/config/merger.js", () => mergerMocks);
+vi.mock("../src/config/merger.js", () => ({
+  loadMergedConfig: mergerMocks.loadProjectConfigLayer,
+  loadProjectConfigLayer: mergerMocks.loadProjectConfigLayer,
+}));
 
 let mockIndexResult = {
   totalFiles: 10,
@@ -116,6 +140,7 @@ let mockHealthCheckResult = {
 vi.mock("../src/indexer/index.js", () => {
   class MockIndexer {
     constructor(projectRoot: string, config: unknown) {
+      if (indexerMockState.constructorError) throw indexerMockState.constructorError;
       indexerMockState.constructorArgs.push([projectRoot, config]);
       indexerMockState.instances.push({
         initialize: this.initialize,
@@ -273,7 +298,6 @@ vi.mock("../src/indexer/index.js", () => {
     getLogger = vi.fn().mockReturnValue({
       isEnabled: vi.fn().mockReturnValue(false),
       isMetricsEnabled: vi.fn().mockReturnValue(false),
-      recordEffectiveness: loggerMocks.recordEffectiveness,
       resetMetrics: loggerMocks.resetMetrics,
       getLogs: vi.fn().mockReturnValue([]),
       getLogsByCategory: vi.fn().mockReturnValue([]),
@@ -297,7 +321,7 @@ vi.mock("../src/indexer/index.js", () => {
 
 describe("createMcpServer", () => {
   it("should create a server instance", () => {
-    const config = parseConfig({});
+    const config = parseConfig({ effectivenessMetrics: { enabled: true } });
     const server = createMcpServer("/tmp/test-project", config);
 
     expect(server).toBeDefined();
@@ -318,11 +342,12 @@ describe("MCP server tools and prompts", () => {
   let server: ReturnType<typeof createMcpServer>;
 
   beforeEach(async () => {
-    loggerMocks.recordEffectiveness.mockClear();
+    resetProcessEffectivenessMetrics();
     loggerMocks.resetMetrics.mockClear();
     fs.mkdirSync(`${testMainRepo}/.opencode/index`, { recursive: true });
     indexerMockState.constructorArgs.length = 0;
     indexerMockState.instances.length = 0;
+    indexerMockState.constructorError = undefined;
     mergerMocks.loadProjectConfigLayer.mockReset();
     mergerMocks.loadProjectConfigLayer.mockReturnValue({});
     mockIndexResult = {
@@ -359,7 +384,7 @@ describe("MCP server tools and prompts", () => {
       filePaths: [],
     };
 
-    const config = parseConfig({});
+    const config = parseConfig({ effectivenessMetrics: { enabled: true } });
     server = createMcpServer("/tmp/test-project", config);
     client = new Client({ name: "test-client", version: "1.0.0" });
 
@@ -371,6 +396,7 @@ describe("MCP server tools and prompts", () => {
   });
 
   afterEach(async () => {
+    resetProcessEffectivenessMetrics();
     await client.close();
     fs.rmSync(testMainRepo, { recursive: true, force: true });
   });
@@ -445,12 +471,13 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("Found 1 results");
     expect(content[0].text).toContain("validateToken");
-    expect(loggerMocks.recordEffectiveness).toHaveBeenCalledWith(expect.objectContaining({
-      route: "search",
-      host: "opencode",
-      outcome: "success",
-      resultCount: 1,
-    }));
+    const snapshot = getProcessEffectivenessMetrics();
+    expect(snapshot.totalCalls).toBe(1);
+    expect(snapshot.toolRoute.search).toBe(1);
+    expect(snapshot.hostMode.opencode).toBe(1);
+    expect(snapshot.outcome.success).toBe(1);
+    expect(snapshot.resultCount["1"]).toBe(1);
+    expect(snapshot.returnedTokenEstimate[returnedTokenBucket(countContextTokens(content[0].text ?? ""))]).toBe(1);
   });
 
   it("should execute codebase_search with null optional fields", async () => {
@@ -489,13 +516,13 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("Found 1 locations");
     expect(content[0].text).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
-    expect(loggerMocks.recordEffectiveness).toHaveBeenCalledWith(expect.objectContaining({
-      route: "peek",
-      host: "opencode",
-      outcome: "success",
-      resultCount: 1,
-      exactHandoffEmitted: true,
-    }));
+    const snapshot = getProcessEffectivenessMetrics();
+    expect(snapshot.totalCalls).toBe(1);
+    expect(snapshot.toolRoute.peek).toBe(1);
+    expect(snapshot.hostMode.opencode).toBe(1);
+    expect(snapshot.outcome.success).toBe(1);
+    expect(snapshot.exactHandoffEmitted.yes).toBe(1);
+    expect(snapshot.returnedTokenEstimate[returnedTokenBucket(countContextTokens(content[0].text ?? ""))]).toBe(1);
   });
 
   it("should record no-result and error outcomes without retaining error content", async () => {
@@ -505,11 +532,12 @@ describe("MCP server tools and prompts", () => {
       name: "codebase_peek",
       arguments: { query: "no result query" },
     });
-    expect(loggerMocks.recordEffectiveness).toHaveBeenLastCalledWith(expect.objectContaining({
-      route: "peek",
-      outcome: "no-result",
-      resultCount: 0,
-    }));
+    expect(getProcessEffectivenessMetrics()).toMatchObject({
+      totalCalls: 1,
+      toolRoute: { peek: 1 },
+      outcome: { "no-result": 1 },
+      resultCount: { "0": 1 },
+    });
 
     const secretError = "sk-private-error-content-must-not-persist";
     search.mockRejectedValueOnce(new Error(secretError));
@@ -517,12 +545,136 @@ describe("MCP server tools and prompts", () => {
       name: "codebase_search",
       arguments: { query: "failing query" },
     });
-    expect(loggerMocks.recordEffectiveness).toHaveBeenLastCalledWith(expect.objectContaining({
-      route: "search",
-      outcome: "error",
-      resultCount: 0,
-    }));
-    expect(JSON.stringify(loggerMocks.recordEffectiveness.mock.calls)).not.toContain(secretError);
+    const snapshot = getProcessEffectivenessMetrics();
+    expect(snapshot.totalCalls).toBe(2);
+    expect(snapshot.toolRoute.search).toBe(1);
+    expect(snapshot.outcome.error).toBe(1);
+    expect(snapshot.returnedTokenEstimate["0"]).toBe(1);
+    expect(JSON.stringify(snapshot)).not.toContain(secretError);
+  });
+
+  it("should count an MCP formatter failure as one error instead of success", async () => {
+    indexerMockState.instances[0].search.mockResolvedValueOnce([{
+      startLine: 1,
+      endLine: 2,
+      name: "broken",
+      chunkType: "function",
+      content: "source",
+      score: 0.9,
+      get filePath(): string {
+        throw new Error("MCP formatter failed");
+      },
+    }]);
+    await client.callTool({
+      name: "codebase_search",
+      arguments: { query: "broken formatter" },
+    });
+    const snapshot = getProcessEffectivenessMetrics();
+    expect(snapshot.totalCalls).toBe(1);
+    expect(snapshot.toolRoute.search).toBe(1);
+    expect(snapshot.hostMode.opencode).toBe(1);
+    expect(snapshot.outcome.error).toBe(1);
+    expect(snapshot.returnedTokenEstimate["0"]).toBe(1);
+  });
+
+  it("should safely count constructor and invalid-config failures exactly once per attempted call", async () => {
+    const constructorRoot = `/tmp/effectiveness-constructor-error-${process.pid}`;
+    const enabledConfig = parseConfig({ effectivenessMetrics: { enabled: true } });
+    indexerMockState.constructorError = new Error("secret constructor detail");
+    expect(() => initializeTools(constructorRoot, enabledConfig, "opencode")).toThrow();
+    await expect(searchCodebaseWithEffectiveness(
+      constructorRoot,
+      "opencode",
+      "search",
+      "secret query",
+      {},
+      (results) => ({ output: results, text: "unreachable" }),
+    )).rejects.toThrow("secret constructor detail");
+    indexerMockState.constructorError = undefined;
+
+    const configRoot = `/tmp/effectiveness-config-error-${process.pid}`;
+    mergerMocks.loadProjectConfigLayer.mockReturnValue({
+      effectivenessMetrics: { enabled: true },
+      reranker: { enabled: true, provider: "custom" },
+    });
+    await expect(searchCodebaseWithEffectiveness(
+      configRoot,
+      "opencode",
+      "peek",
+      "another secret query",
+      { metadataOnly: true },
+      (results) => ({ output: results, text: "unreachable" }),
+    )).rejects.toThrow();
+
+    const snapshot = getProcessEffectivenessMetrics();
+    expect(snapshot.totalCalls).toBe(2);
+    expect(snapshot.toolRoute.search).toBe(1);
+    expect(snapshot.toolRoute.peek).toBe(1);
+    expect(snapshot.outcome.error).toBe(2);
+    expect(snapshot.returnedTokenEstimate["0"]).toBe(2);
+    expect(JSON.stringify(snapshot)).not.toContain("secret");
+  });
+
+  it("should not allocate or record effectiveness state for a disabled host call", async () => {
+    const disabledServer = createMcpServer(
+      `/tmp/effectiveness-disabled-host-${process.pid}`,
+      parseConfig(undefined),
+    );
+    const disabledClient = new Client({ name: "disabled-test-client", version: "1.0.0" });
+    const [disabledClientTransport, disabledServerTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      disabledServer.connect(disabledServerTransport),
+      disabledClient.connect(disabledClientTransport),
+    ]);
+    resetProcessEffectivenessMetrics();
+
+    try {
+      await disabledClient.callTool({
+        name: "codebase_search",
+        arguments: { query: "disabled metrics query" },
+      });
+      expect(isProcessEffectivenessCollectorAllocated()).toBe(false);
+      expect(getProcessEffectivenessMetrics().totalCalls).toBe(0);
+    } finally {
+      await disabledClient.close();
+    }
+  });
+
+  it("should preserve Jcode host token, outcome, single-count, and reset parity", async () => {
+    const jcodeServer = createMcpServer(
+      "/tmp/jcode-test-project",
+      parseConfig({ effectivenessMetrics: { enabled: true } }),
+      "jcode",
+    );
+    const jcodeClient = new Client({ name: "jcode-test-client", version: "1.0.0" });
+    const [jcodeClientTransport, jcodeServerTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      jcodeServer.connect(jcodeServerTransport),
+      jcodeClient.connect(jcodeClientTransport),
+    ]);
+    resetProcessEffectivenessMetrics();
+    loggerMocks.resetMetrics.mockClear();
+
+    const result = await jcodeClient.callTool({
+      name: "codebase_search",
+      arguments: { query: "jcode search" },
+    });
+    const text = (result.content as Array<{ text?: string }>)[0]?.text ?? "";
+    const snapshot = getProcessEffectivenessMetrics();
+    expect(snapshot.totalCalls).toBe(1);
+    expect(snapshot.toolRoute.search).toBe(1);
+    expect(snapshot.hostMode.jcode).toBe(1);
+    expect(snapshot.outcome.success).toBe(1);
+    expect(snapshot.resultCount["1"]).toBe(1);
+    expect(snapshot.returnedTokenEstimate[returnedTokenBucket(countContextTokens(text))]).toBe(1);
+
+    loggerMocks.resetMetrics.mockImplementationOnce(() => {
+      throw new Error("operational reset failed");
+    });
+    const reset = await jcodeClient.callTool({ name: "index_metrics", arguments: { reset: true } });
+    expect(getProcessEffectivenessMetrics().totalCalls).toBe(0);
+    expect((reset.content as Array<{ text?: string }>)[0]?.text).toContain("Metrics reset.");
+    await jcodeClient.close();
   });
 
   it("should execute codebase_peek with null optional fields", async () => {
@@ -1198,12 +1350,17 @@ describe("MCP server tools and prompts", () => {
   });
 
   it("should reset in-memory metrics through index_metrics", async () => {
+    await client.callTool({
+      name: "codebase_search",
+      arguments: { query: "seed metrics before reset" },
+    });
+    expect(getProcessEffectivenessMetrics().totalCalls).toBe(1);
     const result = await client.callTool({
       name: "index_metrics",
       arguments: { reset: true },
     });
 
-    expect(loggerMocks.resetMetrics).toHaveBeenCalledOnce();
+    expect(getProcessEffectivenessMetrics().totalCalls).toBe(0);
     expect((result.content as Array<{ text?: string }>)[0]?.text).toContain("Metrics reset.");
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -47,6 +47,11 @@ const indexerMockState = vi.hoisted(() => ({
   }>,
 }));
 
+const loggerMocks = vi.hoisted(() => ({
+  recordEffectiveness: vi.fn(),
+  resetMetrics: vi.fn(),
+}));
+
 function graphSymbol(id: string, name: string, filePath: string, startLine = 1) {
   return {
     id,
@@ -268,6 +273,8 @@ vi.mock("../src/indexer/index.js", () => {
     getLogger = vi.fn().mockReturnValue({
       isEnabled: vi.fn().mockReturnValue(false),
       isMetricsEnabled: vi.fn().mockReturnValue(false),
+      recordEffectiveness: loggerMocks.recordEffectiveness,
+      resetMetrics: loggerMocks.resetMetrics,
       getLogs: vi.fn().mockReturnValue([]),
       getLogsByCategory: vi.fn().mockReturnValue([]),
       getLogsByLevel: vi.fn().mockReturnValue([]),
@@ -311,6 +318,8 @@ describe("MCP server tools and prompts", () => {
   let server: ReturnType<typeof createMcpServer>;
 
   beforeEach(async () => {
+    loggerMocks.recordEffectiveness.mockClear();
+    loggerMocks.resetMetrics.mockClear();
     fs.mkdirSync(`${testMainRepo}/.opencode/index`, { recursive: true });
     indexerMockState.constructorArgs.length = 0;
     indexerMockState.instances.length = 0;
@@ -436,6 +445,12 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("Found 1 results");
     expect(content[0].text).toContain("validateToken");
+    expect(loggerMocks.recordEffectiveness).toHaveBeenCalledWith(expect.objectContaining({
+      route: "search",
+      host: "opencode",
+      outcome: "success",
+      resultCount: 1,
+    }));
   });
 
   it("should execute codebase_search with null optional fields", async () => {
@@ -474,6 +489,40 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("Found 1 locations");
     expect(content[0].text).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
+    expect(loggerMocks.recordEffectiveness).toHaveBeenCalledWith(expect.objectContaining({
+      route: "peek",
+      host: "opencode",
+      outcome: "success",
+      resultCount: 1,
+      exactHandoffEmitted: true,
+    }));
+  });
+
+  it("should record no-result and error outcomes without retaining error content", async () => {
+    const search = indexerMockState.instances[0].search;
+    search.mockResolvedValueOnce([]);
+    await client.callTool({
+      name: "codebase_peek",
+      arguments: { query: "no result query" },
+    });
+    expect(loggerMocks.recordEffectiveness).toHaveBeenLastCalledWith(expect.objectContaining({
+      route: "peek",
+      outcome: "no-result",
+      resultCount: 0,
+    }));
+
+    const secretError = "sk-private-error-content-must-not-persist";
+    search.mockRejectedValueOnce(new Error(secretError));
+    await client.callTool({
+      name: "codebase_search",
+      arguments: { query: "failing query" },
+    });
+    expect(loggerMocks.recordEffectiveness).toHaveBeenLastCalledWith(expect.objectContaining({
+      route: "search",
+      outcome: "error",
+      resultCount: 0,
+    }));
+    expect(JSON.stringify(loggerMocks.recordEffectiveness.mock.calls)).not.toContain(secretError);
   });
 
   it("should execute codebase_peek with null optional fields", async () => {
@@ -1146,6 +1195,16 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content).toHaveLength(1);
     expect(content[0].type).toBe("text");
+  });
+
+  it("should reset in-memory metrics through index_metrics", async () => {
+    const result = await client.callTool({
+      name: "index_metrics",
+      arguments: { reset: true },
+    });
+
+    expect(loggerMocks.resetMetrics).toHaveBeenCalledOnce();
+    expect((result.content as Array<{ text?: string }>)[0]?.text).toContain("Metrics reset.");
   });
 
   it("should execute index_logs tool", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -10,6 +10,7 @@ const operationMocks = vi.hoisted(() => ({
   runIndexHealthCheck: vi.fn(),
   searchCodebase: vi.fn(),
   implementationLookup: vi.fn(),
+  recordToolEffectiveness: vi.fn(),
 }));
 
 vi.mock("../src/tools/operations.js", () => ({
@@ -27,6 +28,7 @@ vi.mock("../src/tools/operations.js", () => ({
   runIndexCodebase: vi.fn(),
   runIndexHealthCheck: operationMocks.runIndexHealthCheck,
   searchCodebase: operationMocks.searchCodebase,
+  recordToolEffectiveness: operationMocks.recordToolEffectiveness,
   getIndexLogs: vi.fn(() => ({ text: "" })),
 }));
 
@@ -82,6 +84,7 @@ describe("Pi adapter conformance", () => {
     operationMocks.runIndexHealthCheck.mockReset();
     operationMocks.searchCodebase.mockReset();
     operationMocks.implementationLookup.mockReset();
+    operationMocks.recordToolEffectiveness.mockReset();
   });
 
   it("registers codebase_context first as the preferred gateway route", async () => {
@@ -131,6 +134,27 @@ describe("Pi adapter conformance", () => {
     expect(result?.content[0]?.text).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
     expect(result?.content[0]?.text).not.toContain("```");
     expect(result?.details).toEqual(expect.arrayContaining([expect.objectContaining({ name: "validateToken" })]));
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "authentication validation", expect.objectContaining({
+      metadataOnly: true,
+      effectivenessRoute: "peek",
+    }));
+  });
+
+  it("marks full-content search for effectiveness aggregation", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([]);
+    const { tools } = await registerPiTools();
+
+    await tools.get("codebase_search")?.execute(
+      "tool-call",
+      { query: "request routing" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "request routing", expect.objectContaining({
+      effectivenessRoute: "search",
+    }));
   });
 
   it("formats caller results like other host adapters", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -9,8 +9,11 @@ const operationMocks = vi.hoisted(() => ({
   getIndexHealthCheck: vi.fn(),
   runIndexHealthCheck: vi.fn(),
   searchCodebase: vi.fn(),
+  searchCodebaseWithEffectiveness: vi.fn(),
   implementationLookup: vi.fn(),
   recordToolEffectiveness: vi.fn(),
+  getIndexMetrics: vi.fn(() => ({ text: "" })),
+  isToolEffectivenessEnabled: vi.fn(() => true),
 }));
 
 vi.mock("../src/tools/operations.js", () => ({
@@ -19,7 +22,7 @@ vi.mock("../src/tools/operations.js", () => ({
   getCallGraphData: operationMocks.getCallGraphData,
   getCallGraphPath: operationMocks.getCallGraphPath,
   getIndexHealthCheck: operationMocks.getIndexHealthCheck,
-  getIndexMetrics: vi.fn(() => ({ text: "" })),
+  getIndexMetrics: operationMocks.getIndexMetrics,
   getIndexStatus: vi.fn(),
   getPrImpact: vi.fn(),
   implementationLookup: operationMocks.implementationLookup,
@@ -28,8 +31,10 @@ vi.mock("../src/tools/operations.js", () => ({
   runIndexCodebase: vi.fn(),
   runIndexHealthCheck: operationMocks.runIndexHealthCheck,
   searchCodebase: operationMocks.searchCodebase,
+  searchCodebaseWithEffectiveness: operationMocks.searchCodebaseWithEffectiveness,
   recordToolEffectiveness: operationMocks.recordToolEffectiveness,
   getIndexLogs: vi.fn(() => ({ text: "" })),
+  isToolEffectivenessEnabled: operationMocks.isToolEffectivenessEnabled,
 }));
 
 interface RegisteredTool {
@@ -83,8 +88,38 @@ describe("Pi adapter conformance", () => {
     operationMocks.getIndexHealthCheck.mockReset();
     operationMocks.runIndexHealthCheck.mockReset();
     operationMocks.searchCodebase.mockReset();
+    operationMocks.searchCodebaseWithEffectiveness.mockReset();
+    operationMocks.searchCodebaseWithEffectiveness.mockImplementation(
+      async (projectRoot, host, route, query, options, render) => {
+        try {
+          const results = await operationMocks.searchCodebase(projectRoot, host, query, options);
+          const rendered = render(results);
+          operationMocks.recordToolEffectiveness(projectRoot, host, {
+            route,
+            host,
+            outcome: results.length > 0 ? "success" : "no-result",
+            resultCount: results.length,
+            returnedTokenEstimate: countContextTokens(rendered.text),
+            exactHandoffEmitted: rendered.text.includes("Exact-search handoff:"),
+          });
+          return rendered.output;
+        } catch (error) {
+          operationMocks.recordToolEffectiveness(projectRoot, host, {
+            route,
+            host,
+            outcome: "error",
+            resultCount: 0,
+            returnedTokenEstimate: 0,
+          });
+          throw error;
+        }
+      },
+    );
     operationMocks.implementationLookup.mockReset();
     operationMocks.recordToolEffectiveness.mockReset();
+    operationMocks.isToolEffectivenessEnabled.mockReset();
+    operationMocks.isToolEffectivenessEnabled.mockReturnValue(true);
+    operationMocks.getIndexMetrics.mockClear();
   });
 
   it("registers codebase_context first as the preferred gateway route", async () => {
@@ -134,17 +169,16 @@ describe("Pi adapter conformance", () => {
     expect(result?.content[0]?.text).toContain('Exact-search handoff: use exact grep/search for "validateToken"');
     expect(result?.content[0]?.text).not.toContain("```");
     expect(result?.details).toEqual(expect.arrayContaining([expect.objectContaining({ name: "validateToken" })]));
-    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "authentication validation", expect.objectContaining({
+    expect(operationMocks.searchCodebaseWithEffectiveness).toHaveBeenCalledWith("/repo", "pi", "peek", "authentication validation", expect.objectContaining({
       metadataOnly: true,
-      effectivenessRoute: "peek",
-    }));
+    }), expect.any(Function));
   });
 
   it("marks full-content search for effectiveness aggregation", async () => {
     operationMocks.searchCodebase.mockResolvedValue([]);
     const { tools } = await registerPiTools();
 
-    await tools.get("codebase_search")?.execute(
+    const result = await tools.get("codebase_search")?.execute(
       "tool-call",
       { query: "request routing" },
       new AbortController().signal,
@@ -152,9 +186,59 @@ describe("Pi adapter conformance", () => {
       { cwd: "/repo" },
     );
 
-    expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "pi", "request routing", expect.objectContaining({
-      effectivenessRoute: "search",
+    expect(operationMocks.searchCodebaseWithEffectiveness).toHaveBeenCalledWith(
+      "/repo",
+      "pi",
+      "search",
+      "request routing",
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(result?.content[0]?.text).toBe("No matching code found. Try a different query or run index_codebase first.");
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenCalledTimes(1);
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenLastCalledWith("/repo", "pi", expect.objectContaining({
+      outcome: "no-result",
+      returnedTokenEstimate: countContextTokens(result?.content[0]?.text ?? ""),
     }));
+  });
+
+  it("records Pi formatter failures as one error and forwards metrics reset", async () => {
+    const broken = {
+      startLine: 1,
+      endLine: 2,
+      name: "broken",
+      chunkType: "function",
+      content: "source",
+      score: 0.9,
+      get filePath(): string {
+        throw new Error("Pi formatter failed");
+      },
+    };
+    operationMocks.searchCodebase.mockResolvedValueOnce([broken]);
+    const { tools } = await registerPiTools();
+
+    await expect(tools.get("codebase_search")?.execute(
+      "tool-call",
+      { query: "broken formatter" },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    )).rejects.toThrow("Pi formatter failed");
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenCalledTimes(1);
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenLastCalledWith("/repo", "pi", expect.objectContaining({
+      route: "search",
+      outcome: "error",
+      returnedTokenEstimate: 0,
+    }));
+
+    await tools.get("index_metrics")?.execute(
+      "tool-call",
+      { reset: true },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+    expect(operationMocks.getIndexMetrics).toHaveBeenCalledWith("/repo", "pi", { reset: true });
   });
 
   it("formats caller results like other host adapters", async () => {

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -8,6 +8,7 @@ const operationMocks = vi.hoisted(() => ({
   implementationLookup: vi.fn(),
   getCallGraphPath: vi.fn(),
   getCallGraphData: vi.fn(),
+  recordToolEffectiveness: vi.fn(),
 }));
 
 vi.mock("../src/tools/operations.js", async () => {
@@ -18,10 +19,11 @@ vi.mock("../src/tools/operations.js", async () => {
     implementationLookup: operationMocks.implementationLookup,
     getCallGraphPath: operationMocks.getCallGraphPath,
     getCallGraphData: operationMocks.getCallGraphData,
+    recordToolEffectiveness: operationMocks.recordToolEffectiveness,
   };
 });
 
-import { codebase_context } from "../src/tools/index.js";
+import { codebase_context, codebase_peek, codebase_search } from "../src/tools/index.js";
 
 const context = { worktree: "/repo" };
 const commonArgs = {
@@ -53,6 +55,74 @@ describe("native OpenCode codebase_context", () => {
       callers: [],
       callees: [],
     });
+  });
+
+  it("marks OpenCode peek and search routes for effectiveness aggregation", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([]);
+
+    await codebase_peek.execute({
+      query: "request routing",
+      limit: 10,
+      fileType: undefined,
+      directory: undefined,
+      chunkType: undefined,
+      blameAuthor: undefined,
+      blameSha: undefined,
+      blameSince: undefined,
+    }, context);
+    expect(operationMocks.searchCodebase).toHaveBeenLastCalledWith("/repo", "opencode", "request routing", expect.objectContaining({
+      metadataOnly: true,
+      effectivenessRoute: "peek",
+    }));
+
+    await codebase_search.execute({
+      query: "request routing",
+      limit: 5,
+      fileType: undefined,
+      directory: undefined,
+      chunkType: undefined,
+      contextLines: undefined,
+      blameAuthor: undefined,
+      blameSha: undefined,
+      blameSince: undefined,
+    }, context);
+    expect(operationMocks.searchCodebase).toHaveBeenLastCalledWith("/repo", "opencode", "request routing", expect.objectContaining({
+      effectivenessRoute: "search",
+    }));
+  });
+
+  it("records bounded context recovery and scope-relaxation categories", async () => {
+    operationMocks.searchCodebase
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        filePath: "src/auth.ts",
+        startLine: 1,
+        endLine: 5,
+        name: "authHandler",
+        chunkType: "function",
+        content: "sensitive source",
+        score: 0.9,
+      }]);
+
+    await codebase_context.execute({
+      ...commonArgs,
+      query: "find request helpers",
+      fileType: "ts",
+      directory: "src",
+    }, context);
+
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenCalledWith("/repo", "opencode", expect.objectContaining({
+      route: "context-conceptual",
+      host: "opencode",
+      outcome: "success",
+      recoveryUsed: true,
+      resultCount: 1,
+      scopeRelaxation: "both",
+      exactHandoffEmitted: true,
+    }));
+    expect(JSON.stringify(operationMocks.recordToolEffectiveness.mock.calls)).not.toContain("sensitive source");
+    expect(JSON.stringify(operationMocks.recordToolEffectiveness.mock.calls)).not.toContain("src/auth.ts");
+    expect(JSON.stringify(operationMocks.recordToolEffectiveness.mock.calls)).not.toContain("authHandler");
   });
 
   it("returns a bounded conceptual evidence pack without source content", async () => {

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -5,10 +5,13 @@ import { resolveSearchContext } from "../src/tools/context.js";
 
 const operationMocks = vi.hoisted(() => ({
   searchCodebase: vi.fn(),
+  searchCodebaseWithEffectiveness: vi.fn(),
   implementationLookup: vi.fn(),
   getCallGraphPath: vi.fn(),
   getCallGraphData: vi.fn(),
   recordToolEffectiveness: vi.fn(),
+  isToolEffectivenessEnabled: vi.fn(() => true),
+  getIndexMetrics: vi.fn(() => ({ text: "metrics" })),
 }));
 
 vi.mock("../src/tools/operations.js", async () => {
@@ -16,14 +19,17 @@ vi.mock("../src/tools/operations.js", async () => {
   return {
     ...actual,
     searchCodebase: operationMocks.searchCodebase,
+    searchCodebaseWithEffectiveness: operationMocks.searchCodebaseWithEffectiveness,
     implementationLookup: operationMocks.implementationLookup,
     getCallGraphPath: operationMocks.getCallGraphPath,
     getCallGraphData: operationMocks.getCallGraphData,
     recordToolEffectiveness: operationMocks.recordToolEffectiveness,
+    isToolEffectivenessEnabled: operationMocks.isToolEffectivenessEnabled,
+    getIndexMetrics: operationMocks.getIndexMetrics,
   };
 });
 
-import { codebase_context, codebase_peek, codebase_search } from "../src/tools/index.js";
+import { codebase_context, codebase_peek, codebase_search, index_metrics } from "../src/tools/index.js";
 
 const context = { worktree: "/repo" };
 const commonArgs = {
@@ -42,7 +48,34 @@ const commonArgs = {
 describe("native OpenCode codebase_context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    operationMocks.isToolEffectivenessEnabled.mockReturnValue(true);
     operationMocks.searchCodebase.mockResolvedValue([]);
+    operationMocks.searchCodebaseWithEffectiveness.mockImplementation(
+      async (projectRoot, host, route, query, options, render) => {
+        try {
+          const results = await operationMocks.searchCodebase(projectRoot, host, query, options);
+          const rendered = render(results);
+          operationMocks.recordToolEffectiveness(projectRoot, host, {
+            route,
+            host,
+            outcome: results.length > 0 ? "success" : "no-result",
+            resultCount: results.length,
+            returnedTokenEstimate: countContextTokens(rendered.text),
+            exactHandoffEmitted: rendered.text.includes("Exact-search handoff:"),
+          });
+          return rendered.output;
+        } catch (error) {
+          operationMocks.recordToolEffectiveness(projectRoot, host, {
+            route,
+            host,
+            outcome: "error",
+            resultCount: 0,
+            returnedTokenEstimate: 0,
+          });
+          throw error;
+        }
+      },
+    );
     operationMocks.implementationLookup.mockResolvedValue([]);
     operationMocks.getCallGraphPath.mockResolvedValue({
       from: { status: "not_found", name: "", candidates: [], totalCandidates: 0 },
@@ -70,10 +103,9 @@ describe("native OpenCode codebase_context", () => {
       blameSha: undefined,
       blameSince: undefined,
     }, context);
-    expect(operationMocks.searchCodebase).toHaveBeenLastCalledWith("/repo", "opencode", "request routing", expect.objectContaining({
+    expect(operationMocks.searchCodebaseWithEffectiveness).toHaveBeenLastCalledWith("/repo", "opencode", "peek", "request routing", expect.objectContaining({
       metadataOnly: true,
-      effectivenessRoute: "peek",
-    }));
+    }), expect.any(Function));
 
     await codebase_search.execute({
       query: "request routing",
@@ -86,9 +118,76 @@ describe("native OpenCode codebase_context", () => {
       blameSha: undefined,
       blameSince: undefined,
     }, context);
-    expect(operationMocks.searchCodebase).toHaveBeenLastCalledWith("/repo", "opencode", "request routing", expect.objectContaining({
-      effectivenessRoute: "search",
+    expect(operationMocks.searchCodebaseWithEffectiveness).toHaveBeenLastCalledWith(
+      "/repo",
+      "opencode",
+      "search",
+      "request routing",
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("records OpenCode tokens from final text once and treats formatter failures as errors", async () => {
+    operationMocks.searchCodebase.mockResolvedValueOnce([]);
+    const output = await codebase_search.execute({
+      query: "no matches",
+      limit: 5,
+      fileType: undefined,
+      directory: undefined,
+      chunkType: undefined,
+      contextLines: undefined,
+      blameAuthor: undefined,
+      blameSha: undefined,
+      blameSince: undefined,
+    }, context);
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenCalledTimes(1);
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenLastCalledWith("/repo", "opencode", expect.objectContaining({
+      route: "search",
+      outcome: "no-result",
+      returnedTokenEstimate: countContextTokens(output),
     }));
+
+    operationMocks.recordToolEffectiveness.mockClear();
+    const broken = {
+      startLine: 1,
+      endLine: 2,
+      name: "broken",
+      chunkType: "function",
+      content: "source",
+      score: 0.9,
+      get filePath(): string {
+        throw new Error("OpenCode formatter failed");
+      },
+    };
+    operationMocks.searchCodebase.mockResolvedValueOnce([broken]);
+    await expect(codebase_search.execute({
+      query: "broken formatter",
+      limit: 5,
+      fileType: undefined,
+      directory: undefined,
+      chunkType: undefined,
+      contextLines: undefined,
+      blameAuthor: undefined,
+      blameSha: undefined,
+      blameSince: undefined,
+    }, context)).rejects.toThrow("OpenCode formatter failed");
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenCalledTimes(1);
+    expect(operationMocks.recordToolEffectiveness).toHaveBeenLastCalledWith("/repo", "opencode", expect.objectContaining({
+      route: "search",
+      outcome: "error",
+      returnedTokenEstimate: 0,
+    }));
+  });
+
+  it("forwards OpenCode metrics reset without recording another tool event", async () => {
+    operationMocks.getIndexMetrics.mockClear();
+    operationMocks.recordToolEffectiveness.mockClear();
+
+    await index_metrics.execute({ reset: true }, context);
+
+    expect(operationMocks.getIndexMetrics).toHaveBeenCalledWith("/repo", "opencode", { reset: true });
+    expect(operationMocks.recordToolEffectiveness).not.toHaveBeenCalled();
   });
 
   it("records bounded context recovery and scope-relaxation categories", async () => {


### PR DESCRIPTION
## Summary

Add opt-in, privacy-safe effectiveness metrics and a deterministic offline evaluation for repository-tool token usage and visible evidence coverage.

## Changes

- Add process-lifetime, memory-only bounded counters for tool route, host, outcome, recovery, latency, token buckets, and handoff behavior without retaining queries, paths, source, symbols, repository identity, or user identity.
- Expose view/reset behavior through `index_metrics` consistently across OpenCode, MCP, and Pi while keeping effectiveness metrics independent from debug query logging.
- Add a deterministic synthetic evaluation with like-for-like result and token limits, visible-evidence recall, an exact-search snippet baseline, checked-in output, privacy regressions, and explicit methodology limitations.

## Testing

Validated locally on macOS arm64 with independent privacy and methodology review approval.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

The deterministic report was regenerated successfully. Focused privacy, process-lifetime, host-parity, reset, and benchmark suites also passed. `git diff --check` passed.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

No linked issue.