### PR TITLE
feat: add intent-aware retrieval ranking

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,7 +97,7 @@ Source Files → Parse → Chunk → Embed → Store
 ### Search Flow
 
 ```
-Query → Embed → Search → Rank → Return
+Query → Embed → Search → Scope → Rank → Return
 
 1. EMBED QUERY
    └─ Same embedding model as indexing
@@ -109,16 +109,23 @@ Query → Embed → Search → Rank → Return
    └─ KEYWORD: BM25 inverted index
       └─ Returns top-K keyword matches
 
-3. HYBRID FUSION
+3. SCOPE CANDIDATES
+   └─ Restricts candidates to the current branch
+   └─ Applies directory, file-type, chunk-type, and blame filters before reranking
+   └─ Prevents out-of-scope source from reaching an external reranker
+
+4. HYBRID FUSION
    └─ Combines semantic + keyword candidates
    └─ Fusion controlled by fusionStrategy (rrf default, weighted fallback)
-   └─ Deterministic rerank applies to top-N candidates
 
-4. BRANCH FILTER
-   └─ Only returns chunks existing on current branch
-   └─ Prevents stale results from other branches
+5. LOCAL EVIDENCE RANKING
+   └─ NFKC/case-normalized exact symbol matching
+   └─ Definition, implementation, test, docs, config, and call-flow intent signals
+   └─ Authoritative-definition preference, nested duplicate removal, and file diversity
+   └─ Stable ordering for equal scores
+   └─ Optional external reranking stays within local evidence classes and scoped candidates
 
-5. RETURN RESULTS
+6. RETURN RESULTS
    └─ File path, line numbers, code snippet
    └─ Sorted by combined score
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Privacy-safe effectiveness metrics**: Added independent top-level opt-in, process-lifetime memory-only, schema-versioned fixed counters and histograms for repository tool routes, hosts, outcomes, recovery, result counts, latency, token budgets, returned-token estimates, exact-search handoffs, and scope relaxation across OpenCode, MCP, and Pi. The process-wide collector survives Indexer and config-watcher refreshes without repository or user identity dimensions, supports explicit reset, and has adversarial privacy, saturation, disabled-overhead, final-response, and error-path coverage.
 - **Offline effectiveness evaluation**: Added deterministic synthetic fixtures and a no-network formatting report with equal `maxResults` and final-response token budgets across routes. Evidence is credited only when visible in returned text, and the oracle exact-search baseline emits only matching lines without arbitrary complete reads. The report states that fixed rankings and markers do not measure retrieval quality, latency, end-to-end agent success, causal impact, or production performance.
+- **Intent-aware ranking evaluation**: Added a transparent fixed-candidate baseline comparison for evidence recall@3 and MRR across exact and Unicode-normalized definitions, test/docs/config/call-flow queries, duplicate evidence, file diversity, and a conceptual-search guardrail.
 
 ### Changed
 
@@ -18,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Automatic branch and PR index preparation**: `pr_impact` now safely materializes and indexes missing branch or pull-request commits in isolated hook-disabled worktrees, verifies commit-aware fork-specific catalogs, and reuses or replaces indexes without changing the caller's worktree.
 - **Name-based call graph routing**: Callers, callees, and dependency paths now resolve unique symbol names automatically across native OpenCode, MCP, Pi, and `codebase_context`. Duplicate names return bounded candidate locations with optional file-path disambiguators, while `symbolId` remains an optional compatibility escape hatch.
 - **Self-recovering context lookup**: `codebase_context` now retries empty scoped searches without file filters, retries inferred symbol text after definition-style misses, reports bounded recovery metadata, and keeps all fallback responses within the requested token budget across MCP, native OpenCode, Pi, and evaluation.
+- **Intent-aware local ranking**: Semantic and hybrid search now strongly promote exact NFKC/case-normalized authoritative definitions, interpret definition/implementation/test/docs/config/call-flow wording, demote imports, wrappers, fixtures, generated/vendor copies unless requested, remove nested duplicate chunks, diversify useful files, preserve conceptual retrieval strength, and keep stable ties.
+- **Scoped external reranking**: Directory, file-type, chunk-type, and blame filters now run before external reranking. Only already-scoped candidates and their exact indexed line ranges can be sent, while intent classification and evidence-class ordering remain deterministic and local.
 
 ## [0.18.1] - 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Use `include` to replace defaults, or `additionalInclude` to extend (e.g. `"**/*
 2. **Chunking**: Large blocks are split with overlapping windows to preserve context across chunk boundaries.
 3. **Embedding**: These blocks are converted into vector representations using your configured AI provider.
 4. **Storage**: Embeddings are stored in SQLite (deduplicated by content hash) and vectors in `usearch` with F16 quantization for 50% memory savings. A branch catalog tracks which chunks exist on each branch.
-5. **Hybrid Search**: Combines semantic similarity (vectors) with BM25 keyword matching, fuses (`rrf` default, `weighted` fallback), applies deterministic rerank, then filters by current branch/metadata.
+5. **Hybrid Search**: Combines semantic similarity (vectors) with BM25 keyword matching, applies branch and hard metadata scopes before reranking, fuses candidates (`rrf` default, `weighted` fallback), then applies deterministic local intent ranking and optional external reranking.
 
 **Performance characteristics:**
 - **Incremental indexing**: ~50ms check time — only re-embeds changed files
@@ -479,8 +479,12 @@ The plugin exposes these tools to the OpenCode agent:
 **Behavioral semantic retrieval with full content.** Searches code by describing behavior.
 - **Use for**: Discovery when you already want full matching snippets and are ready to inspect implementation text.
 - **Example**: `"find the middleware that sanitizes input"`
-- **Ranking path**: hybrid retrieval → fusion (`search.fusionStrategy`) → deterministic rerank (`search.rerankTopN`) → filters
+- **Ranking path**: hybrid retrieval → branch/directory/file-type/chunk/blame scope → fusion (`search.fusionStrategy`) → deterministic local intent rerank (`search.rerankTopN`) → optional external rerank within local evidence classes → minimum-score filter
 - **Blame filters**: when `indexing.gitBlame.enabled` is `true`, filter with `blameAuthor`, `blameSha`, or `blameSince`.
+
+The local ranker is deterministic and does not call another model. Exact symbol names receive a strong NFKC and case-normalized match signal. Definition and implementation questions prefer authoritative declarations over imports, export wrappers, tests, fixtures, docs, and generated or vendor files. Explicit test, docs, config, and call-flow wording instead promotes the requested evidence class. Natural-language conceptual queries keep retrieval score as the dominant signal, while nested duplicate chunks are removed and remaining evidence is spread across relevant files. True score ties retain input order, then candidate id as a final deterministic fallback.
+
+When an external reranker is enabled, hard directory, file-type, chunk-type, and blame scopes are enforced before any request. The external service receives only candidates already inside that scope and only the candidate's exact indexed line range, without extra surrounding source. Local intent classification, exact-name promotion, duplicate suppression, and evidence-class ordering remain local.
 
 **Writing good queries:**
 

--- a/benchmarks/baselines/intent-aware-ranking.json
+++ b/benchmarks/baselines/intent-aware-ranking.json
@@ -1,0 +1,71 @@
+{
+  "fixtureVersion": "1.0.0",
+  "queryCount": 8,
+  "topK": 3,
+  "baseline": {
+    "evidenceRecallAt3": 0.8125,
+    "mrr": 0.483333
+  },
+  "intentAware": {
+    "evidenceRecallAt3": 1,
+    "mrr": 1
+  },
+  "perQuery": [
+    {
+      "id": "exact-definition",
+      "baselineRecallAt3": 0,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 0.2,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "unicode-definition",
+      "baselineRecallAt3": 1,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 0.333333,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "test-intent",
+      "baselineRecallAt3": 1,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 0.333333,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "docs-intent",
+      "baselineRecallAt3": 1,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 0.333333,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "config-intent",
+      "baselineRecallAt3": 1,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 0.333333,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "call-flow-intent",
+      "baselineRecallAt3": 1,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 0.333333,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "diverse-evidence",
+      "baselineRecallAt3": 0.5,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 1,
+      "intentAwareReciprocalRank": 1
+    },
+    {
+      "id": "conceptual-guardrail",
+      "baselineRecallAt3": 1,
+      "intentAwareRecallAt3": 1,
+      "baselineReciprocalRank": 1,
+      "intentAwareReciprocalRank": 1
+    }
+  ]
+}

--- a/benchmarks/fixtures/intent-aware-ranking.json
+++ b/benchmarks/fixtures/intent-aware-ranking.json
@@ -1,0 +1,98 @@
+{
+  "version": "1.0.0",
+  "name": "intent-aware-local-ranking",
+  "description": "Synthetic fixed-candidate evaluation for deterministic local post-retrieval ranking on representative coding-agent queries.",
+  "methodology": {
+    "baseline": "Sort the supplied candidate pool by retrieval score descending, then candidate id. This isolates the local post-retrieval ranker from embeddings and candidate generation.",
+    "candidatePools": "Each query uses a hand-labeled, fixed candidate pool containing plausible high-scoring distractors. Candidate pools are not exhaustive repository judgments.",
+    "metrics": "Evidence recall@3 is the fraction of labeled relevant candidate ids present in the first three results. Reciprocal rank uses the first labeled relevant candidate.",
+    "limitations": "This fixture measures deterministic reranking only. It does not measure embedding recall, indexing quality, latency, external rerankers, or end-to-end agent task success."
+  },
+  "topK": 3,
+  "queries": [
+    {
+      "id": "exact-definition",
+      "query": "where is normalizeSession defined",
+      "relevantIds": ["definition"],
+      "candidates": [
+        { "id": "import", "score": 0.99, "filePath": "/repo/src/index.ts", "startLine": 1, "endLine": 1, "chunkType": "import_statement", "name": "normalizeSession" },
+        { "id": "container", "score": 0.98, "filePath": "/repo/src/session.ts", "startLine": 10, "endLine": 24, "chunkType": "export_statement", "name": "normalizeSession" },
+        { "id": "test", "score": 0.97, "filePath": "/repo/tests/session.test.ts", "startLine": 1, "endLine": 20, "chunkType": "function", "name": "normalizeSession" },
+        { "id": "docs", "score": 0.96, "filePath": "/repo/docs/session.md", "startLine": 1, "endLine": 20, "chunkType": "other", "name": "normalizeSession" },
+        { "id": "definition", "score": 0.72, "filePath": "/repo/src/session.ts", "startLine": 11, "endLine": 24, "chunkType": "function_declaration", "name": "normalizeSession" }
+      ]
+    },
+    {
+      "id": "unicode-definition",
+      "query": "where is CAFÉSERVICE implemented",
+      "relevantIds": ["unicode-definition"],
+      "candidates": [
+        { "id": "factory", "score": 0.98, "filePath": "/repo/src/cafe-factory.ts", "startLine": 1, "endLine": 20, "chunkType": "function", "name": "CafeServiceFactory" },
+        { "id": "unicode-docs", "score": 0.96, "filePath": "/repo/docs/cafe.md", "startLine": 1, "endLine": 20, "chunkType": "other", "name": "CaféService" },
+        { "id": "unicode-definition", "score": 0.63, "filePath": "/repo/src/cafe.ts", "startLine": 5, "endLine": 30, "chunkType": "class_declaration", "name": "CaféService" }
+      ]
+    },
+    {
+      "id": "test-intent",
+      "query": "tests for resolveSession",
+      "relevantIds": ["session-test"],
+      "candidates": [
+        { "id": "session-definition", "score": 0.98, "filePath": "/repo/src/session.ts", "startLine": 10, "endLine": 30, "chunkType": "function", "name": "resolveSession" },
+        { "id": "session-docs", "score": 0.94, "filePath": "/repo/docs/session.md", "startLine": 1, "endLine": 20, "chunkType": "other", "name": "resolveSession guide" },
+        { "id": "session-test", "score": 0.86, "filePath": "/repo/tests/session.test.ts", "startLine": 5, "endLine": 35, "chunkType": "test_declaration", "name": "resolveSession test" }
+      ]
+    },
+    {
+      "id": "docs-intent",
+      "query": "documentation for query routing",
+      "relevantIds": ["routing-docs"],
+      "candidates": [
+        { "id": "routing-code", "score": 0.97, "filePath": "/repo/src/routing.ts", "startLine": 1, "endLine": 40, "chunkType": "function", "name": "routeQuery" },
+        { "id": "routing-test", "score": 0.95, "filePath": "/repo/tests/routing.test.ts", "startLine": 1, "endLine": 30, "chunkType": "test_declaration", "name": "routing test" },
+        { "id": "routing-docs", "score": 0.84, "filePath": "/repo/README.md", "startLine": 20, "endLine": 45, "chunkType": "other", "name": "query routing documentation" }
+      ]
+    },
+    {
+      "id": "config-intent",
+      "query": "embedding provider configuration settings",
+      "relevantIds": ["provider-config"],
+      "candidates": [
+        { "id": "provider-code", "score": 0.97, "filePath": "/repo/src/embeddings/provider.ts", "startLine": 1, "endLine": 40, "chunkType": "class_declaration", "name": "EmbeddingProvider" },
+        { "id": "provider-docs", "score": 0.94, "filePath": "/repo/docs/embeddings.md", "startLine": 1, "endLine": 30, "chunkType": "other", "name": "embedding provider guide" },
+        { "id": "provider-config", "score": 0.82, "filePath": "/repo/config/embeddings.yaml", "startLine": 1, "endLine": 20, "chunkType": "other", "name": "embedding provider settings" }
+      ]
+    },
+    {
+      "id": "call-flow-intent",
+      "query": "who calls resolveSession",
+      "relevantIds": ["caller-evidence"],
+      "candidates": [
+        { "id": "resolve-definition", "score": 0.98, "filePath": "/repo/src/session.ts", "startLine": 10, "endLine": 30, "chunkType": "function", "name": "resolveSession" },
+        { "id": "call-docs", "score": 0.93, "filePath": "/repo/docs/call-graph.md", "startLine": 1, "endLine": 20, "chunkType": "other", "name": "call graph guide" },
+        { "id": "caller-evidence", "score": 0.81, "filePath": "/repo/src/call-graph/session-callers.ts", "startLine": 1, "endLine": 35, "chunkType": "function", "name": "findSessionCallers" }
+      ]
+    },
+    {
+      "id": "diverse-evidence",
+      "query": "authenticate requests and refresh session state",
+      "relevantIds": ["auth", "session"],
+      "candidates": [
+        { "id": "auth", "score": 0.97, "filePath": "/repo/src/auth.ts", "startLine": 10, "endLine": 30, "chunkType": "function", "name": "authenticateRequest" },
+        { "id": "auth-container", "score": 0.96, "filePath": "/repo/src/auth.ts", "startLine": 9, "endLine": 30, "chunkType": "export_statement", "name": "authenticateRequest" },
+        { "id": "auth-helper", "score": 0.95, "filePath": "/repo/src/auth.ts", "startLine": 32, "endLine": 45, "chunkType": "function", "name": "parseAuthHeader" },
+        { "id": "session", "score": 0.90, "filePath": "/repo/src/session.ts", "startLine": 1, "endLine": 25, "chunkType": "function", "name": "refreshSession" }
+      ]
+    },
+    {
+      "id": "conceptual-guardrail",
+      "query": "recover corrupted sqlite index safely",
+      "conceptualGuardrail": true,
+      "relevantIds": ["recovery"],
+      "candidates": [
+        { "id": "recovery", "score": 0.96, "filePath": "/repo/src/indexer/recovery.ts", "startLine": 1, "endLine": 45, "chunkType": "function", "name": "recoverCorruptedIndex" },
+        { "id": "generated-recovery", "score": 0.94, "filePath": "/repo/generated/recovery.ts", "startLine": 1, "endLine": 45, "chunkType": "function", "name": "recoverCorruptedIndex" },
+        { "id": "recovery-docs", "score": 0.92, "filePath": "/repo/docs/recovery.md", "startLine": 1, "endLine": 25, "chunkType": "other", "name": "recovery guide" }
+      ]
+    }
+  ]
+}

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -33,6 +33,14 @@ This command evaluates five versioned synthetic scenarios only. Each scenario su
 
 The checked-in report at `benchmarks/baselines/privacy-safe-effectiveness.json` contains aggregate methodology and route statistics only. It contains no fixture source, symbols, paths, repository names, queries, scenario IDs, or evidence identifiers. This is a synthetic formatting comparison with fixed rankings and oracle markers. It excludes discovery cost and does not measure retrieval quality, latency, end-to-end agent success, causal impact, or production-repository performance.
 
+The deterministic local ranker also has a focused fixed-candidate comparison:
+
+```bash
+npx vitest run tests/intent-aware-ranking-eval.test.ts
+```
+
+`benchmarks/fixtures/intent-aware-ranking.json` contains eight representative coding-agent queries for exact and Unicode-normalized definitions, test/docs/config/call-flow intent, evidence diversity, and a conceptual-search guardrail. The baseline sorts the supplied candidates by retrieval score and id, while the candidate run applies only the local intent-aware ranker. `benchmarks/baselines/intent-aware-ranking.json` records evidence recall@3 and MRR plus per-query values. The candidate pools and relevance ids are hand-labeled and fixed, so this comparison isolates post-retrieval ordering. It does not measure embedding recall, candidate generation, indexing quality, latency, external rerankers, production repositories, or end-to-end agent success.
+
 Evaluation comparisons require the same dataset name, version, and query count. Use the
 agent-context budget rather than the default search baseline when evaluating `agent-context.json`.
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -43,6 +43,17 @@ import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
 import { getChunkGitBlame, type GitBlameMetadata } from "./git-blame.js";
 import {
+  analyzeQueryIntent,
+  extractIntentIdentifierHints,
+  isConfigPath,
+  isDocumentationPath as isIntentDocumentationPath,
+  isFixturePath,
+  isLikelyImplementationPath as isIntentImplementationPath,
+  isTestPath,
+  normalizeRankingText,
+  rankIntentAwareCandidates,
+} from "./intent-aware-ranking.js";
+import {
   acquireIndexLock,
   completeLeaseRecovery,
   createLeaseTemporaryPath,
@@ -453,7 +464,7 @@ interface RerankDocumentPayload {
   text: string;
 }
 
-type ExternalRerankBand = "implementation" | "documentation" | "test" | "other";
+type ExternalRerankBand = "implementation" | "documentation" | "test" | "config" | "other";
 
 interface HybridRankOptions {
   fusionStrategy: "weighted" | "rrf";
@@ -711,7 +722,6 @@ function isPathWithinRoot(filePath: string, rootPath: string): boolean {
 }
 
 const rankingQueryTokenCache = new Map<string, Set<string>>();
-const rankingNameTokenCache = new Map<string, Set<string>>();
 const rankingPathTokenCache = new Map<string, Set<string>>();
 const rankingTextTokenCache = new Map<string, Set<string>>();
 const rankHybridResultsCache = new WeakMap<RankedCandidate[], WeakMap<RankedCandidate[], Map<string, RankedCandidate[]>>>();
@@ -722,66 +732,6 @@ const STOPWORDS = new Set([
   "find", "show", "get", "run", "use", "code", "function", "implementation",
   "retrieve", "results", "result", "search", "pipeline", "top", "in", "on", "of",
   "to", "by", "as", "or", "an", "a",
-]);
-
-const TEST_PATH_SEGMENTS = [
-  "tests/",
-  "__tests__/",
-  "/test/",
-  "fixtures/",
-  "benchmark",
-  "README",
-  "ARCHITECTURE",
-  "docs/",
-];
-
-const IMPLEMENTATION_EXCLUDE_PATH_SEGMENTS = [
-  "tests/",
-  "__tests__/",
-  "/test/",
-  "fixtures/",
-  "benchmark",
-  "readme",
-  "architecture",
-  "docs/",
-  "examples/",
-  "example/",
-  ".github/",
-  "/scripts/",
-  "/migrations/",
-  "/generated/",
-];
-
-const SOURCE_INTENT_HINTS = new Set([
-  "implement",
-  "implementation",
-  "function",
-  "method",
-  "class",
-  "logic",
-  "algorithm",
-  "pipeline",
-  "indexer",
-  "where",
-]);
-
-const DOC_TEST_INTENT_HINTS = new Set([
-  "test",
-  "tests",
-  "fixture",
-  "fixtures",
-  "benchmark",
-  "readme",
-  "docs",
-  "documentation",
-]);
-
-const DOC_INTENT_HINTS = new Set([
-  "readme",
-  "docs",
-  "documentation",
-  "guide",
-  "usage",
 ]);
 
 function setBoundedCache(
@@ -803,7 +753,7 @@ function tokenizeTextForRanking(text: string): Set<string> {
     return new Set<string>();
   }
 
-  const lowered = text.toLowerCase();
+  const lowered = normalizeRankingText(text);
   const cache = rankingQueryTokenCache.get(lowered) ?? rankingTextTokenCache.get(lowered);
   if (cache) {
     return cache;
@@ -811,7 +761,7 @@ function tokenizeTextForRanking(text: string): Set<string> {
 
   const tokens = new Set(
     lowered
-      .replace(/[^\w\s]/g, " ")
+      .replace(/[^\p{L}\p{N}_$\s]/gu, " ")
       .split(/\s+/)
       .filter((token) => token.length > 1 && !STOPWORDS.has(token))
   );
@@ -822,14 +772,14 @@ function tokenizeTextForRanking(text: string): Set<string> {
 }
 
 function splitPathTokens(filePath: string): Set<string> {
-  const lowered = filePath.toLowerCase();
+  const lowered = normalizeRankingText(filePath);
   const cache = rankingPathTokenCache.get(lowered);
   if (cache) {
     return cache;
   }
 
   const normalized = lowered
-    .replace(/[^a-z0-9/._-]/g, " ")
+    .replace(/[^\p{L}\p{N}/._-]/gu, " ")
     .split(/[/._-]+/)
     .filter((token) => token.length > 1);
   const tokens = new Set(normalized);
@@ -837,176 +787,73 @@ function splitPathTokens(filePath: string): Set<string> {
   return tokens;
 }
 
-function splitNameTokens(name: string): Set<string> {
-  if (!name) {
-    return new Set<string>();
-  }
-
-  const lowered = name.toLowerCase();
-  const cache = rankingNameTokenCache.get(lowered);
-  if (cache) {
-    return cache;
-  }
-
-  const tokens = new Set(
-    lowered
-      .replace(/[^\w\s]/g, " ")
-      .split(/\s+/)
-      .filter((token) => token.length > 1)
-  );
-  setBoundedCache(rankingNameTokenCache, lowered, tokens);
-  return tokens;
-}
-
-function chunkTypeBoost(chunkType: string): number {
-  switch (chunkType) {
-    case "function":
-    case "function_declaration":
-    case "method":
-    case "method_definition":
-    case "method_declaration":
-    case "protocol_function_declaration":
-    case "init_declaration":
-    case "deinit_declaration":
-    case "subscript_declaration":
-    case "class":
-    case "class_declaration":
-    case "actor_declaration":
-    case "extension_declaration":
-      return 0.2;
-    case "interface":
-    case "type":
-    case "enum":
-    case "enum_declaration":
-    case "struct":
-    case "struct_declaration":
-    case "impl":
-    case "trait":
-    case "protocol_declaration":
-    case "module":
-      return 0.1;
-    default:
-      return 0;
-  }
-}
-
 function isTestOrDocPath(filePath: string): boolean {
-  return TEST_PATH_SEGMENTS.some((segment) => filePath.includes(segment));
+  return isTestPath(filePath) || isFixturePath(filePath) || isIntentDocumentationPath(filePath);
 }
 
 function isLikelyImplementationPath(filePath: string): boolean {
-  const lowered = filePath.toLowerCase();
-  if (IMPLEMENTATION_EXCLUDE_PATH_SEGMENTS.some((segment) => lowered.includes(segment))) {
-    return false;
-  }
-
-  const ext = lowered.split(".").pop() ?? "";
-  if (["md", "mdx", "txt", "rst", "adoc", "snap", "json", "yaml", "yml", "lock"].includes(ext)) {
-    return false;
-  }
-
-  return true;
+  return isIntentImplementationPath(filePath);
 }
 
 function isDocumentationPath(filePath: string): boolean {
-  const lowered = filePath.toLowerCase();
-  const ext = lowered.split(".").pop() ?? "";
-  return lowered.includes("readme") || ["md", "mdx", "rst", "adoc", "txt"].includes(ext);
+  return isIntentDocumentationPath(filePath);
 }
 
 function classifyExternalRerankBand(
   candidate: RankedCandidate,
-  preferSourcePaths: boolean,
-  docIntent: boolean
+  intent: ReturnType<typeof analyzeQueryIntent>
 ): ExternalRerankBand {
   const isDocOrTest = isTestOrDocPath(candidate.metadata.filePath);
   const isDocumentation = isDocumentationPath(candidate.metadata.filePath);
+  const isTest = isTestPath(candidate.metadata.filePath) || isFixturePath(candidate.metadata.filePath);
+  const isConfig = isConfigPath(candidate.metadata.filePath);
   const isImplementation = isLikelyImplementationPath(candidate.metadata.filePath) &&
     isImplementationChunkType(candidate.metadata.chunkType);
 
-  if (preferSourcePaths) {
+  if (intent.preferSourcePaths) {
     if (isImplementation) return "implementation";
+    if (isConfig) return "config";
     if (isDocumentation) return "documentation";
-    if (isDocOrTest) return "test";
+    if (isTest || isDocOrTest) return "test";
     return "other";
   }
 
-  if (docIntent) {
+  if (intent.primary === "docs") {
     if (isDocumentation) return "documentation";
+    if (isConfig) return "config";
     if (isImplementation) return "implementation";
-    if (isDocOrTest) return "test";
+    if (isTest || isDocOrTest) return "test";
+    return "other";
+  }
+
+  if (intent.primary === "test") {
+    if (isTest || isDocOrTest) return "test";
+    if (isDocumentation) return "documentation";
+    if (isConfig) return "config";
+    if (isImplementation) return "implementation";
+    return "other";
+  }
+
+  if (intent.primary === "config") {
+    if (isConfig) return "config";
+    if (isImplementation) return "implementation";
+    if (isDocumentation) return "documentation";
+    if (isTest || isDocOrTest) return "test";
     return "other";
   }
 
   if (isImplementation) return "implementation";
+  if (isConfig) return "config";
   if (isDocumentation) return "documentation";
-  if (isDocOrTest) return "test";
+  if (isTest || isDocOrTest) return "test";
   return "other";
 }
 
-function classifyQueryIntent(tokens: string[]): "source" | "doc_test" | "neutral" {
-  const sourceIntentHits = tokens.filter((t) => SOURCE_INTENT_HINTS.has(t)).length;
-  const docTestIntentHits = tokens.filter((t) => DOC_TEST_INTENT_HINTS.has(t)).length;
-
-  if (sourceIntentHits === 0 && docTestIntentHits === 0) {
-    return "neutral";
-  }
-
-  if (sourceIntentHits > docTestIntentHits) {
-    return "source";
-  }
-
-  if (docTestIntentHits > sourceIntentHits) {
-    return "doc_test";
-  }
-
-  return "neutral";
-}
-
 function classifyQueryIntentRaw(query: string): "source" | "doc_test" | "neutral" {
-  const lowerQuery = query.toLowerCase();
-  const docTestRawHits = Array.from(DOC_TEST_INTENT_HINTS).filter((hint) =>
-    new RegExp(`\\b${hint}\\b`).test(lowerQuery)
-  ).length;
-  const sourceRawHits = [
-    "implement",
-    "implementation",
-    "implements",
-    "function",
-    "method",
-    "class",
-    "logic",
-    "algorithm",
-    "pipeline",
-    "indexer",
-  ].filter((hint) => new RegExp(`\\b${hint}\\b`).test(lowerQuery)).length;
-
-  if (docTestRawHits > sourceRawHits) {
-    return "doc_test";
-  }
-
-  if (sourceRawHits > docTestRawHits && sourceRawHits > 0) {
-    return "source";
-  }
-
-  const hasWhereIsPattern = /\bwhere\s+is\b/.test(lowerQuery);
-  const hasIdentifierHints = extractIdentifierHints(query).length > 0;
-  if (hasWhereIsPattern && hasIdentifierHints && docTestRawHits === 0) {
-    return "source";
-  }
-
-  const queryTokens = Array.from(tokenizeTextForRanking(query));
-  return classifyQueryIntent(queryTokens);
-}
-
-function classifyDocIntent(tokens: string[]): "docs" | "test" | "mixed" | "none" {
-  const docHits = tokens.filter((t) => DOC_INTENT_HINTS.has(t)).length;
-  const testHits = tokens.filter((t) => ["test", "tests", "fixture", "fixtures", "benchmark"].includes(t)).length;
-
-  if (docHits > 0 && testHits === 0) return "docs";
-  if (testHits > 0 && docHits === 0) return "test";
-  if (testHits > 0 || docHits > 0) return "mixed";
-  return "none";
+  const intent = analyzeQueryIntent(query);
+  if (intent.primary === "test" || intent.primary === "docs") return "doc_test";
+  if (intent.preferSourcePaths) return "source";
+  return "neutral";
 }
 
 function isImplementationChunkType(chunkType: string): boolean {
@@ -1036,15 +883,7 @@ function isImplementationChunkType(chunkType: string): boolean {
 }
 
 function extractIdentifierHints(query: string): string[] {
-  const identifiers = query.match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? [];
-  return identifiers
-    .filter((id) => id.length >= 3)
-    .filter((id) => {
-      const lower = id.toLowerCase();
-      if (STOPWORDS.has(lower)) return false;
-      return /[A-Z]/.test(id) || id.includes("_") || id.endsWith("Results") || id.endsWith("Result");
-    })
-    .map((id) => id.toLowerCase());
+  return extractIntentIdentifierHints(query);
 }
 
 function extractCodeTermHints(query: string): string[] {
@@ -1056,9 +895,12 @@ function extractCodeTermHints(query: string): string[] {
 }
 
 function normalizeIdentifierVariants(identifier: string): string[] {
-  const lower = identifier.toLowerCase();
-  const compact = lower.replace(/[^a-z0-9]/g, "");
-  const snake = compact.replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
+  const lower = normalizeRankingText(identifier);
+  const compact = lower.replace(/[^\p{L}\p{N}]/gu, "");
+  const snake = identifier
+    .normalize("NFKC")
+    .replace(/([\p{Ll}\p{N}])([\p{Lu}])/gu, "$1_$2")
+    .toLowerCase();
   const kebab = snake.replace(/_/g, "-");
   const variants = [lower, compact, snake, kebab].filter((value) => value.length > 0);
   return Array.from(new Set(variants));
@@ -1309,129 +1151,7 @@ export function rerankResults(
   rerankTopN: number,
   options?: { prioritizeSourcePaths?: boolean }
 ): RankedCandidate[] {
-  if (rerankTopN <= 0 || candidates.length <= 1) {
-    return candidates;
-  }
-
-  const topN = Math.min(rerankTopN, candidates.length);
-  const queryTokens = tokenizeTextForRanking(query);
-  if (queryTokens.size === 0) {
-    return candidates;
-  }
-
-  const queryTokenList = Array.from(queryTokens);
-  const docIntent = classifyDocIntent(queryTokenList);
-  const preferSourcePaths = options?.prioritizeSourcePaths ?? classifyQueryIntentRaw(query) === "source";
-  const identifierHints = extractIdentifierHints(query);
-
-  const head = candidates.slice(0, topN).map((candidate, idx) => {
-    const pathTokens = splitPathTokens(candidate.metadata.filePath);
-    const nameTokens = splitNameTokens(candidate.metadata.name ?? "");
-    const chunkTypeTokens = tokenizeTextForRanking(candidate.metadata.chunkType);
-    let exactOrPrefixNameHits = 0;
-    let pathOverlap = 0;
-    let chunkTypeHits = 0;
-
-    for (const token of queryTokenList) {
-      if (nameTokens.has(token)) {
-        exactOrPrefixNameHits += 1;
-      } else {
-        for (const nameToken of nameTokens) {
-          if (nameToken.startsWith(token) || token.startsWith(nameToken)) {
-            exactOrPrefixNameHits += 1;
-            break;
-          }
-        }
-      }
-
-      if (pathTokens.has(token)) {
-        pathOverlap += 1;
-      }
-
-      if (chunkTypeTokens.has(token)) {
-        chunkTypeHits += 1;
-      }
-    }
-
-    const likelyTestOrDoc = isTestOrDocPath(candidate.metadata.filePath);
-    const lowerPath = candidate.metadata.filePath.toLowerCase();
-    const lowerName = (candidate.metadata.name ?? "").toLowerCase();
-    const hasIdentifierMatch = identifierHints.some((id) => lowerPath.includes(id) || lowerName.includes(id));
-
-    const implementationPathBoost = preferSourcePaths && isLikelyImplementationPath(candidate.metadata.filePath) ? 0.08 : 0;
-    const isReadmePath = candidate.metadata.filePath.toLowerCase().includes("readme");
-    const testDocPenalty = preferSourcePaths && likelyTestOrDoc ? 0.12 : 0;
-    const readmeDocBoost = !preferSourcePaths && isReadmePath ? 0.08 : 0;
-    const identifierBoost = hasIdentifierMatch ? 0.12 : 0;
-    const tokenCoverage = queryTokenList.length > 0
-      ? (exactOrPrefixNameHits + pathOverlap + chunkTypeHits) / queryTokenList.length
-      : 0;
-    const coverageBoost = Math.min(0.12, tokenCoverage * 0.06);
-
-    const deterministicBoost =
-      exactOrPrefixNameHits * 0.08 +
-      pathOverlap * 0.03 +
-      chunkTypeHits * 0.02 +
-      coverageBoost +
-      identifierBoost +
-      implementationPathBoost -
-      testDocPenalty +
-      readmeDocBoost +
-      chunkTypeBoost(candidate.metadata.chunkType);
-
-    return {
-      candidate,
-      boostedScore: candidate.score + deterministicBoost,
-      originalIndex: idx,
-      hasIdentifierMatch,
-      implementationChunk: isImplementationChunkType(candidate.metadata.chunkType),
-      isLikelyImplementationPath: isLikelyImplementationPath(candidate.metadata.filePath),
-      isTestOrDocPath: likelyTestOrDoc,
-      isReadmePath,
-    };
-  });
-
-  head.sort((a, b) => {
-    if (b.boostedScore !== a.boostedScore) return b.boostedScore - a.boostedScore;
-    if (b.candidate.score !== a.candidate.score) return b.candidate.score - a.candidate.score;
-    if (a.originalIndex !== b.originalIndex) return a.originalIndex - b.originalIndex;
-    return a.candidate.id.localeCompare(b.candidate.id);
-  });
-
-  if (preferSourcePaths) {
-    head.sort((a, b) => {
-      const aId = a.hasIdentifierMatch ? 1 : 0;
-      const bId = b.hasIdentifierMatch ? 1 : 0;
-      if (aId !== bId) return bId - aId;
-
-      const aImpl = a.implementationChunk ? 1 : 0;
-      const bImpl = b.implementationChunk ? 1 : 0;
-      if (aImpl !== bImpl) return bImpl - aImpl;
-
-      const aImplementationPath = a.isLikelyImplementationPath ? 1 : 0;
-      const bImplementationPath = b.isLikelyImplementationPath ? 1 : 0;
-      if (aImplementationPath !== bImplementationPath) return bImplementationPath - aImplementationPath;
-
-      const aTestDoc = a.isTestOrDocPath ? 1 : 0;
-      const bTestDoc = b.isTestOrDocPath ? 1 : 0;
-      if (aTestDoc !== bTestDoc) return aTestDoc - bTestDoc;
-
-      return 0;
-    });
-  } else if (docIntent === "docs") {
-    head.sort((a, b) => {
-      const aReadme = a.isReadmePath ? 1 : 0;
-      const bReadme = b.isReadmePath ? 1 : 0;
-      if (aReadme !== bReadme) return bReadme - aReadme;
-      return 0;
-    });
-  }
-
-  const shouldDiversify = !(preferSourcePaths && identifierHints.length > 0);
-  const diversifiedHead = diversifyEntriesByFileAndSymbol(head, (entry) => entry.candidate, shouldDiversify);
-
-  const tail = candidates.slice(topN);
-  return [...diversifiedHead.map((entry) => entry.candidate), ...tail];
+  return rankIntentAwareCandidates(query, candidates, rerankTopN, options);
 }
 
 function diversifyEntriesByFileAndSymbol<T>(
@@ -2001,22 +1721,25 @@ export function selectIndexableChunks<T extends { chunkType: string }>(
   return selectChunksWithFileCoverage(indexableChunks, limit);
 }
 
-function matchesSearchFilters(
+function matchesHardSearchFilters(
   candidate: RankedCandidate,
-  options: SearchFilterOptions | undefined,
-  minScore: number
+  options: SearchFilterOptions | undefined
 ): boolean {
-  if (candidate.score < minScore) return false;
-
   if (options?.fileType) {
     const ext = candidate.metadata.filePath.split(".").pop()?.toLowerCase();
-    if (ext !== options.fileType.toLowerCase().replace(/^\./, "")) return false;
+    const requestedExtension = options.fileType.trim().toLowerCase().replace(/^\./, "");
+    if (ext !== requestedExtension) return false;
   }
 
   if (options?.directory) {
-    const normalizedDir = options.directory.replace(/^\/|\/$/g, "");
-    if (!candidate.metadata.filePath.includes(`/${normalizedDir}/`) &&
-      !candidate.metadata.filePath.includes(`${normalizedDir}/`)) return false;
+    const normalizedPath = candidate.metadata.filePath.replace(/\\/g, "/");
+    const normalizedDir = options.directory.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
+    const isAbsoluteDirectory = normalizedDir.startsWith("/");
+    const matchesDirectory = isAbsoluteDirectory
+      ? normalizedPath === normalizedDir || normalizedPath.startsWith(`${normalizedDir}/`)
+      : normalizedPath === normalizedDir || normalizedPath.startsWith(`${normalizedDir}/`) ||
+        normalizedPath.includes(`/${normalizedDir}/`) || normalizedPath.endsWith(`/${normalizedDir}`);
+    if (!matchesDirectory) return false;
   }
 
   if (options?.chunkType && candidate.metadata.chunkType !== options.chunkType) {
@@ -2042,6 +1765,14 @@ function matchesSearchFilters(
   }
 
   return true;
+}
+
+function matchesSearchFilters(
+  candidate: RankedCandidate,
+  options: SearchFilterOptions | undefined,
+  minScore: number
+): boolean {
+  return candidate.score >= minScore && matchesHardSearchFilters(candidate, options);
 }
 
 function unionCandidates(
@@ -3032,9 +2763,9 @@ export class Indexer {
       return candidates;
     }
 
-    const queryTokens = Array.from(tokenizeTextForRanking(query));
-    const preferSourcePaths = classifyQueryIntentRaw(query) === "source";
-    const docIntent = classifyDocIntent(queryTokens) === "docs";
+    const queryIntent = analyzeQueryIntent(query);
+    const preferSourcePaths = queryIntent.preferSourcePaths;
+    const docIntent = queryIntent.primary === "docs";
 
     if (options?.definitionIntent === true) {
       return candidates;
@@ -3051,19 +2782,24 @@ export class Indexer {
       ["implementation", []],
       ["documentation", []],
       ["test", []],
+      ["config", []],
       ["other", []],
     ]);
 
     for (const candidate of head) {
-      const band = classifyExternalRerankBand(candidate, preferSourcePaths, docIntent);
+      const band = classifyExternalRerankBand(candidate, queryIntent);
       grouped.get(band)?.push(candidate);
     }
 
     const orderedBands: ExternalRerankBand[] = preferSourcePaths
-      ? ["implementation", "other", "documentation", "test"]
-      : docIntent
-        ? ["documentation", "implementation", "other", "test"]
-        : ["implementation", "other", "documentation", "test"];
+      ? ["implementation", "other", "config", "documentation", "test"]
+      : queryIntent.primary === "docs"
+        ? ["documentation", "implementation", "config", "other", "test"]
+        : queryIntent.primary === "test"
+          ? ["test", "implementation", "other", "documentation", "config"]
+          : queryIntent.primary === "config"
+            ? ["config", "implementation", "other", "documentation", "test"]
+            : ["implementation", "other", "config", "documentation", "test"];
 
     try {
       const rerankedHead: RankedCandidate[] = [];
@@ -3193,8 +2929,8 @@ export class Indexer {
     try {
       const fileContent = await fsPromises.readFile(candidate.metadata.filePath, "utf-8");
       const lines = fileContent.split("\n");
-      const snippetStartLine = Math.max(1, candidate.metadata.startLine - 2);
-      const snippetEndLine = Math.min(lines.length, candidate.metadata.endLine + 2);
+      const snippetStartLine = Math.max(1, candidate.metadata.startLine);
+      const snippetEndLine = Math.min(lines.length, candidate.metadata.endLine);
       const snippet = lines.slice(snippetStartLine - 1, snippetEndLine).join("\n").trim();
       parts.push("snippet:");
       parts.push(snippet.length > 0 ? snippet : "[empty]");
@@ -5366,6 +5102,12 @@ export class Indexer {
     const keywordCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0)
       ? keywordResults
       : prefilteredKeyword;
+    const scopedSemanticCandidates = semanticCandidates.filter((candidate) =>
+      matchesHardSearchFilters(candidate, options)
+    );
+    const scopedKeywordCandidates = keywordCandidates.filter((candidate) =>
+      matchesHardSearchFilters(candidate, options)
+    );
     const prefilterMs = performance.now() - prefilterStartTime;
 
     if (this.config.scope !== "global" && branchChunkIds && branchChunkIds.size === 0) {
@@ -5390,7 +5132,7 @@ export class Indexer {
     const rankingHybridWeight = embedding === undefined && fusionStrategy === "weighted"
       ? 1
       : effectiveHybridWeight;
-    const combined = rankHybridResults(query, semanticCandidates, keywordCandidates, {
+    const combined = rankHybridResults(query, scopedSemanticCandidates, scopedKeywordCandidates, {
       fusionStrategy,
       rrfK,
       rerankTopN,
@@ -5407,14 +5149,14 @@ export class Indexer {
     const rescued = promoteIdentifierMatches(
       query,
       rerankedCombined,
-      semanticCandidates,
-      keywordCandidates,
+      scopedSemanticCandidates,
+      scopedKeywordCandidates,
       database,
       branchChunkIds,
       sourceIntent
     );
 
-    const union = unionCandidates(semanticCandidates, keywordCandidates);
+    const union = unionCandidates(scopedSemanticCandidates, scopedKeywordCandidates);
 
     const deterministicIdentifierLane = buildDeterministicIdentifierPass(
       query,

--- a/src/indexer/intent-aware-ranking.ts
+++ b/src/indexer/intent-aware-ranking.ts
@@ -1,0 +1,501 @@
+import type { ChunkMetadata } from "../native/index.js";
+
+export type RankedCandidate = { id: string; score: number; metadata: ChunkMetadata };
+
+export type PrimaryQueryIntent =
+  | "definition"
+  | "implementation"
+  | "test"
+  | "docs"
+  | "config"
+  | "call-flow"
+  | "conceptual"
+  | "neutral";
+
+export interface QueryIntentProfile {
+  primary: PrimaryQueryIntent;
+  identifierHints: string[];
+  primaryIdentifier?: string;
+  preferSourcePaths: boolean;
+  explicitArtifactIntent: boolean;
+}
+
+const STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "been", "being", "by", "code",
+  "find", "for", "from", "get", "how", "in", "into", "is", "of", "on", "or",
+  "result", "results", "retrieve", "run", "search", "show", "that", "the", "this",
+  "to", "top", "use", "using", "was", "were", "what", "when", "where", "which",
+  "who", "why", "with",
+]);
+
+const INTENT_WORDS = new Set([
+  "benchmark", "benchmarks", "body", "call", "called", "callee", "callees", "caller",
+  "callers", "calls", "class", "config", "configuration", "declaration", "defined",
+  "definition", "dependency", "docs", "documentation", "example", "examples", "fixture",
+  "fixtures", "function", "guide", "implement", "implementation", "implemented", "implements",
+  "invoked", "logic", "manifest", "method", "readme", "reference", "references", "settings",
+  "source", "spec", "specs", "symbol", "test", "tests", "usage",
+]);
+
+const AUTHORITATIVE_CHUNK_TYPES = new Set([
+  "actor_declaration",
+  "arrow_function",
+  "class",
+  "class_declaration",
+  "class_definition",
+  "class_name_statement",
+  "class_specifier",
+  "constructor_definition",
+  "deinit_declaration",
+  "enum",
+  "enum_declaration",
+  "enum_definition",
+  "enum_item",
+  "extension_declaration",
+  "function",
+  "function_declaration",
+  "function_definition",
+  "function_item",
+  "impl",
+  "impl_item",
+  "init_declaration",
+  "interface",
+  "interface_declaration",
+  "method",
+  "method_declaration",
+  "method_definition",
+  "mod_item",
+  "module",
+  "namespace_definition",
+  "protocol_declaration",
+  "protocol_function_declaration",
+  "signal_statement",
+  "struct",
+  "struct_declaration",
+  "struct_item",
+  "struct_specifier",
+  "subscript_declaration",
+  "trait",
+  "trait_declaration",
+  "trait_item",
+  "trigger_declaration",
+  "type",
+  "type_alias_declaration",
+  "type_declaration",
+  "type_spec",
+  "union_declaration",
+]);
+
+const IMPORT_CHUNK_TYPES = new Set([
+  "import",
+  "import_declaration",
+  "import_statement",
+  "include_directive",
+  "use_declaration",
+  "use_statement",
+]);
+
+const WEAK_CONTAINER_CHUNK_TYPES = new Set([
+  "block",
+  "export_statement",
+  "lexical_declaration",
+  "other",
+  "program",
+  "source_file",
+  "statement_block",
+]);
+
+const TEST_CHUNK_TYPES = new Set(["test", "test_declaration"]);
+
+const IMPLEMENTATION_FILE_EXTENSIONS = new Set([
+  "apex", "bash", "c", "cc", "cls", "cpp", "cs", "cts", "cxx", "gd", "go", "h",
+  "hpp", "hxx", "inc", "java", "js", "jsx", "kt", "kts", "lua", "m", "metal",
+  "mjs", "mts", "php", "py", "rb", "rs", "scala", "sh", "swift", "trigger", "ts",
+  "tsx", "zig", "zsh",
+]);
+
+function normalizePath(filePath: string): string {
+  return normalizeRankingText(filePath).replace(/\\/g, "/");
+}
+
+export function normalizeRankingText(value: string): string {
+  return value.normalize("NFKC").toLowerCase();
+}
+
+function compactIdentifier(value: string): string {
+  return normalizeRankingText(value).replace(/[^\p{L}\p{N}$]+/gu, "");
+}
+
+function identifierTokens(value: string): string[] {
+  const normalized = value
+    .normalize("NFKC")
+    .replace(/([\p{Ll}\p{N}])([\p{Lu}])/gu, "$1 $2")
+    .replace(/[^\p{L}\p{N}$]+/gu, " ")
+    .toLowerCase();
+  return normalized.split(/\s+/).filter((token) => token.length > 1);
+}
+
+function queryWords(query: string): string[] {
+  return query.normalize("NFKC").match(/[\p{L}_$][\p{L}\p{N}_$-]*/gu) ?? [];
+}
+
+function hasCodeShape(value: string): boolean {
+  return /[_$]/u.test(value) || /[\p{Ll}\p{N}][\p{Lu}]/u.test(value);
+}
+
+export function extractIntentIdentifierHints(query: string): string[] {
+  const quoted = Array.from(query.matchAll(/[`'"]([\p{L}_$][\p{L}\p{N}_$-]*)[`'"]/gu))
+    .map((match) => match[1]);
+  const words = queryWords(query);
+  const normalizedWords = words.map((word) => normalizeRankingText(word));
+  const contentWords = words.filter((_word, index) => {
+    const normalized = normalizedWords[index] ?? "";
+    return normalized.length >= 2 && !STOPWORDS.has(normalized) && !INTENT_WORDS.has(normalized);
+  });
+
+  const explicitlyCodeShaped = contentWords.filter(hasCodeShape);
+  const hasDefinitionWording = /\b(?:defined|definition|declaration|implemented|implementation|symbol)\b/iu.test(query) ||
+    /\bwhere\s+is\b/iu.test(query);
+  const singleContentHint = contentWords.length === 1 ? contentWords : [];
+  const intentAnchoredHints = hasDefinitionWording ? contentWords.slice(0, 3) : [];
+  const candidates = [...quoted, ...explicitlyCodeShaped, ...singleContentHint, ...intentAnchoredHints];
+
+  const seen = new Set<string>();
+  const hints: string[] = [];
+  for (const candidate of candidates) {
+    const normalized = normalizeRankingText(candidate);
+    if (normalized.length < 2 || seen.has(normalized)) continue;
+    seen.add(normalized);
+    hints.push(normalized);
+  }
+  return hints.slice(0, 8);
+}
+
+export function analyzeQueryIntent(query: string): QueryIntentProfile {
+  const normalized = normalizeRankingText(query);
+  const identifierHints = extractIntentIdentifierHints(query);
+  const primaryIdentifier = identifierHints[0];
+  const testIntent = /\b(?:tests?|specs?|fixtures?|benchmarks?|coverage)\b/u.test(normalized);
+  const docsIntent = /\b(?:docs?|documentation|readme|guides?|usage|examples?)\b/u.test(normalized);
+  const configIntent = /\b(?:config|configuration|settings|manifest|tsconfig|package\.json|ya?ml|toml)\b/u.test(normalized);
+  const callFlowIntent = /\b(?:callers?|callees?|call\s+(?:flow|graph|path|chain)|called\s+by|invoked\s+by|references?\s+to|dependency\s+path)\b/u.test(normalized) ||
+    /\bwho\s+calls\b/u.test(normalized);
+  const definitionIntent = /\b(?:defined|definition|declaration|symbol)\b/u.test(normalized) ||
+    /\bwhere\s+is\b/u.test(normalized);
+  const implementationIntent = /\b(?:implement|implementation|implemented|implements|source|logic|body)\b/u.test(normalized);
+  const conceptual = identifierHints.length === 0 && queryWords(query).filter((word) => {
+    const wordNormalized = normalizeRankingText(word);
+    return !STOPWORDS.has(wordNormalized) && !INTENT_WORDS.has(wordNormalized);
+  }).length >= 3;
+
+  let primary: PrimaryQueryIntent;
+  if (testIntent) primary = "test";
+  else if (docsIntent) primary = "docs";
+  else if (configIntent) primary = "config";
+  else if (callFlowIntent) primary = "call-flow";
+  else if (definitionIntent) primary = "definition";
+  else if (implementationIntent) primary = "implementation";
+  else if (conceptual) primary = "conceptual";
+  else primary = "neutral";
+
+  const explicitArtifactIntent = primary === "test" || primary === "docs" || primary === "config" || primary === "call-flow";
+  const preferSourcePaths = primary === "definition" || primary === "implementation" || primary === "call-flow" ||
+    (primary === "neutral" && identifierHints.length > 0);
+
+  return {
+    primary,
+    identifierHints,
+    primaryIdentifier,
+    preferSourcePaths,
+    explicitArtifactIntent,
+  };
+}
+
+export function isTestPath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  return /(?:^|\/)(?:test|tests|__tests__|spec|specs)(?:\/|$)/u.test(normalized) ||
+    /\.(?:test|spec)\.[^/]+$/u.test(normalized);
+}
+
+export function isFixturePath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  return /(?:^|\/)(?:fixture|fixtures|testdata|snapshots?)(?:\/|$)/u.test(normalized) || normalized.endsWith(".snap");
+}
+
+export function isDocumentationPath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  return /(?:^|\/)docs?(?:\/|$)/u.test(normalized) || /(?:^|\/)readme(?:\.|$)/u.test(normalized) ||
+    /\.(?:md|mdx|rst|adoc|txt)$/u.test(normalized);
+}
+
+export function isGeneratedOrVendorPath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  return /(?:^|\/)(?:node_modules|vendor|vendors|generated|dist|build|coverage|\.next|target)(?:\/|$)/u.test(normalized) ||
+    /(?:\.min\.[^/]+|\.generated\.[^/]+|(?:^|\/)package-lock\.json|(?:^|\/)yarn\.lock|(?:^|\/)pnpm-lock\.yaml)$/u.test(normalized);
+}
+
+export function isConfigPath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  const baseName = normalized.split("/").pop() ?? normalized;
+  return /(?:^|\/)(?:config|configs|\.github)(?:\/|$)/u.test(normalized) ||
+    /^(?:package\.json|tsconfig(?:\.[^.]+)?\.json|pyproject\.toml|cargo\.toml|go\.mod)$/u.test(baseName) ||
+    /(?:^|\.)(?:config|settings|rc)\.[^/]+$/u.test(baseName) ||
+    /\.(?:yaml|yml|toml|ini)$/u.test(baseName);
+}
+
+export function isAuthoritativeChunkType(chunkType: string): boolean {
+  return AUTHORITATIVE_CHUNK_TYPES.has(normalizeRankingText(chunkType));
+}
+
+export function isImportChunkType(chunkType: string): boolean {
+  return IMPORT_CHUNK_TYPES.has(normalizeRankingText(chunkType));
+}
+
+function isWeakContainer(metadata: ChunkMetadata): boolean {
+  const chunkType = normalizeRankingText(metadata.chunkType);
+  const lineSpan = Math.max(1, metadata.endLine - metadata.startLine + 1);
+  if (chunkType === "export_statement") return true;
+  return WEAK_CONTAINER_CHUNK_TYPES.has(chunkType) && (lineSpan <= 2 || !metadata.name);
+}
+
+export function isLikelyImplementationPath(filePath: string): boolean {
+  if (isTestPath(filePath) || isFixturePath(filePath) || isDocumentationPath(filePath) || isGeneratedOrVendorPath(filePath)) {
+    return false;
+  }
+  if (!isConfigPath(filePath)) return true;
+  const extension = normalizePath(filePath).split(".").pop() ?? "";
+  return IMPLEMENTATION_FILE_EXTENSIONS.has(extension);
+}
+
+function nameMatchStrength(name: string | undefined, hints: string[]): number {
+  if (!name || hints.length === 0) return 0;
+  const normalizedName = normalizeRankingText(name);
+  const compactName = compactIdentifier(name);
+  const nameTokens = new Set(identifierTokens(name));
+  let best = 0;
+
+  for (const hint of hints) {
+    const normalizedHint = normalizeRankingText(hint);
+    const compactHint = compactIdentifier(hint);
+    if (normalizedName === normalizedHint) {
+      best = Math.max(best, 4);
+    } else if (compactName.length > 0 && compactName === compactHint) {
+      best = Math.max(best, 3.6);
+    } else if (normalizedName.startsWith(normalizedHint) || normalizedHint.startsWith(normalizedName)) {
+      best = Math.max(best, 1.6);
+    } else if (normalizedName.includes(normalizedHint)) {
+      best = Math.max(best, 1.2);
+    } else {
+      const hintTokens = identifierTokens(hint);
+      if (hintTokens.length > 0 && hintTokens.every((token) => nameTokens.has(token))) {
+        best = Math.max(best, 1);
+      }
+    }
+  }
+
+  return best;
+}
+
+function tokenOverlap(query: string, metadata: ChunkMetadata): number {
+  const queryTokens = new Set(queryWords(query).flatMap(identifierTokens).filter((token) => !STOPWORDS.has(token)));
+  if (queryTokens.size === 0) return 0;
+  const candidateTokens = new Set([
+    ...identifierTokens(metadata.name ?? ""),
+    ...identifierTokens(metadata.chunkType),
+    ...identifierTokens(normalizePath(metadata.filePath).split("/").slice(-3).join(" ")),
+  ]);
+  let hits = 0;
+  for (const token of queryTokens) {
+    if (candidateTokens.has(token)) hits += 1;
+  }
+  return hits / queryTokens.size;
+}
+
+function callFlowAffinity(metadata: ChunkMetadata): number {
+  const tokens = new Set([
+    ...identifierTokens(metadata.name ?? ""),
+    ...identifierTokens(normalizePath(metadata.filePath)),
+  ]);
+  return ["call", "caller", "callee", "graph", "reference", "dependency", "edge", "path"]
+    .filter((token) => tokens.has(token)).length;
+}
+
+interface ScoredCandidate {
+  candidate: RankedCandidate;
+  adjustedScore: number;
+  originalIndex: number;
+  nameMatch: number;
+}
+
+function scoreCandidate(query: string, intent: QueryIntentProfile, candidate: RankedCandidate, originalIndex: number): ScoredCandidate {
+  const metadata = candidate.metadata;
+  const nameMatch = nameMatchStrength(metadata.name, intent.identifierHints);
+  const authoritative = isAuthoritativeChunkType(metadata.chunkType);
+  const importChunk = isImportChunkType(metadata.chunkType);
+  const weakContainer = isWeakContainer(metadata);
+  const testPath = isTestPath(metadata.filePath) || TEST_CHUNK_TYPES.has(normalizeRankingText(metadata.chunkType));
+  const fixturePath = isFixturePath(metadata.filePath);
+  const docsPath = isDocumentationPath(metadata.filePath);
+  const generatedOrVendor = isGeneratedOrVendorPath(metadata.filePath);
+  const configPath = isConfigPath(metadata.filePath);
+  const implementationPath = isLikelyImplementationPath(metadata.filePath);
+  const overlap = tokenOverlap(query, metadata);
+  let boost = 0;
+
+  if (intent.primary === "conceptual") {
+    boost += Math.min(0.14, overlap * 0.14);
+    if (generatedOrVendor) boost -= 0.18;
+    if (importChunk || weakContainer) boost -= 0.04;
+  } else if (intent.primary === "test") {
+    boost += testPath ? 1.25 : 0;
+    boost += fixturePath ? 0.7 : 0;
+    boost += /\b(?:test|spec|fixture)\b/u.test(normalizeRankingText(metadata.name ?? "")) ? 0.35 : 0;
+    boost += nameMatch * 0.28;
+    if (docsPath) boost -= 0.2;
+    if (generatedOrVendor) boost -= 0.7;
+  } else if (intent.primary === "docs") {
+    boost += docsPath ? 1.25 : 0;
+    boost += normalizePath(metadata.filePath).includes("readme") ? 0.25 : 0;
+    boost += nameMatch * 0.25;
+    if (testPath || fixturePath) boost -= 0.25;
+    if (generatedOrVendor) boost -= 0.7;
+  } else if (intent.primary === "config") {
+    boost += configPath ? 1.3 : 0;
+    boost += nameMatch * 0.35;
+    boost += Math.min(0.3, overlap * 0.3);
+    if (testPath || fixturePath || docsPath) boost -= 0.35;
+    if (generatedOrVendor) boost -= 0.7;
+  } else if (intent.primary === "call-flow") {
+    boost += Math.min(1.2, callFlowAffinity(metadata) * 0.35);
+    boost += authoritative && implementationPath ? 0.3 : 0;
+    boost += nameMatch * 0.12;
+    if (testPath || fixturePath || docsPath) boost -= 0.55;
+    if (importChunk || weakContainer) boost -= 0.25;
+    if (generatedOrVendor) boost -= 0.8;
+  } else {
+    const identifierDriven = intent.identifierHints.length > 0;
+    boost += nameMatch;
+    boost += authoritative ? (identifierDriven ? 0.65 : 0.18) : 0;
+    boost += implementationPath && intent.preferSourcePaths ? 0.22 : 0;
+    boost += Math.min(identifierDriven ? 0.25 : 0.12, overlap * (identifierDriven ? 0.25 : 0.12));
+    if (importChunk) boost -= identifierDriven ? 1.05 : 0.08;
+    if (weakContainer) boost -= identifierDriven ? 0.9 : 0.06;
+    if (testPath) boost -= intent.preferSourcePaths ? 0.85 : 0;
+    if (fixturePath) boost -= intent.preferSourcePaths ? 1 : 0;
+    if (docsPath) boost -= intent.preferSourcePaths ? 0.8 : 0;
+    if (generatedOrVendor) boost -= intent.preferSourcePaths ? 1.1 : 0.2;
+  }
+
+  return {
+    candidate,
+    adjustedScore: candidate.score + boost,
+    originalIndex,
+    nameMatch,
+  };
+}
+
+function rangesOverlap(a: ChunkMetadata, b: ChunkMetadata): boolean {
+  return a.startLine <= b.endLine && b.startLine <= a.endLine;
+}
+
+function containsRange(outer: ChunkMetadata, inner: ChunkMetadata): boolean {
+  return outer.startLine <= inner.startLine && outer.endLine >= inner.endLine;
+}
+
+function areDuplicateEvidence(a: RankedCandidate, b: RankedCandidate): boolean {
+  if (normalizePath(a.metadata.filePath) !== normalizePath(b.metadata.filePath)) return false;
+  const aName = normalizeRankingText(a.metadata.name ?? "");
+  const bName = normalizeRankingText(b.metadata.name ?? "");
+  const sameNamedSymbol = aName.length > 0 && aName === bName;
+  const eitherUnnamed = aName.length === 0 || bName.length === 0;
+  const eitherWeakContainer = isWeakContainer(a.metadata) || isWeakContainer(b.metadata);
+  const sameRange = a.metadata.startLine === b.metadata.startLine && a.metadata.endLine === b.metadata.endLine;
+  if (sameRange) return sameNamedSymbol || eitherUnnamed || eitherWeakContainer;
+  if (a.metadata.hash && b.metadata.hash && a.metadata.hash === b.metadata.hash) {
+    return sameNamedSymbol || eitherUnnamed || eitherWeakContainer;
+  }
+  if (!rangesOverlap(a.metadata, b.metadata)) return false;
+
+  const nested = containsRange(a.metadata, b.metadata) || containsRange(b.metadata, a.metadata);
+  return nested && (sameNamedSymbol || eitherWeakContainer);
+}
+
+function deduplicateEvidence(entries: ScoredCandidate[]): ScoredCandidate[] {
+  const selected: ScoredCandidate[] = [];
+  for (const entry of entries) {
+    if (selected.some((existing) => areDuplicateEvidence(existing.candidate, entry.candidate))) continue;
+    selected.push(entry);
+  }
+  return selected;
+}
+
+function diversify(entries: ScoredCandidate[], preserveExactMatches: boolean): ScoredCandidate[] {
+  if (entries.length <= 2) return entries;
+  const exact = preserveExactMatches ? entries.filter((entry) => entry.nameMatch >= 3.6) : [];
+  const exactIds = new Set(exact.map((entry) => entry.candidate.id));
+  const remainder = entries.filter((entry) => !exactIds.has(entry.candidate.id));
+  const groups = new Map<string, ScoredCandidate[]>();
+  const order: string[] = [];
+
+  for (const entry of remainder) {
+    const filePath = normalizePath(entry.candidate.metadata.filePath);
+    if (!groups.has(filePath)) {
+      groups.set(filePath, []);
+      order.push(filePath);
+    }
+    groups.get(filePath)?.push(entry);
+  }
+
+  const diversified: ScoredCandidate[] = [];
+  let round = 0;
+  let added = true;
+  while (added) {
+    added = false;
+    for (const filePath of order) {
+      const entry = groups.get(filePath)?.[round];
+      if (!entry) continue;
+      diversified.push(entry);
+      added = true;
+    }
+    round += 1;
+  }
+
+  return [...exact, ...diversified];
+}
+
+export function rankIntentAwareCandidates(
+  query: string,
+  candidates: RankedCandidate[],
+  rerankTopN: number,
+  options?: { prioritizeSourcePaths?: boolean },
+): RankedCandidate[] {
+  if (rerankTopN <= 0 || candidates.length <= 1) return candidates;
+  const intent = analyzeQueryIntent(query);
+  if (options?.prioritizeSourcePaths !== undefined && options.prioritizeSourcePaths !== intent.preferSourcePaths) {
+    intent.preferSourcePaths = options.prioritizeSourcePaths;
+  }
+
+  const topN = Math.min(rerankTopN, candidates.length);
+  const scoredHead = candidates.slice(0, topN).map((candidate, index) => scoreCandidate(query, intent, candidate, index));
+  scoredHead.sort((a, b) => {
+    if (b.adjustedScore !== a.adjustedScore) return b.adjustedScore - a.adjustedScore;
+    if (b.candidate.score !== a.candidate.score) return b.candidate.score - a.candidate.score;
+    if (a.originalIndex !== b.originalIndex) return a.originalIndex - b.originalIndex;
+    return a.candidate.id.localeCompare(b.candidate.id);
+  });
+
+  const scoredTail = candidates.slice(topN).map((candidate, index) => ({
+    candidate,
+    adjustedScore: candidate.score,
+    originalIndex: topN + index,
+    nameMatch: nameMatchStrength(candidate.metadata.name, intent.identifierHints),
+  }));
+  const deduplicated = deduplicateEvidence([...scoredHead, ...scoredTail]);
+  const shouldDiversify = intent.primary !== "definition" && intent.primary !== "implementation" || intent.identifierHints.length === 0;
+  const preserveExactMatches = intent.identifierHints.length > 0 &&
+    (intent.primary === "definition" || intent.primary === "implementation" || intent.primary === "neutral");
+  const ordered = shouldDiversify
+    ? diversify(deduplicated, preserveExactMatches)
+    : deduplicated;
+  return ordered.map((entry) => entry.candidate);
+}

--- a/src/tools/symbol-inference.ts
+++ b/src/tools/symbol-inference.ts
@@ -1,3 +1,5 @@
+import { analyzeQueryIntent } from "../indexer/intent-aware-ranking.js";
+
 const IDENTIFIER_RE = /[A-Za-z_$][A-Za-z0-9_$]*/g;
 const QUOTED_BACKTICK_RE = /`([^`]+)`/g;
 const QUOTED_SINGLE_RE = /'([^'\\]+)'/g;
@@ -109,6 +111,10 @@ function isSingleMeaningfulToken(query: string, symbol: string): boolean {
 }
 
 export function inferExactSymbolFromQuery(query: string): string | undefined {
+  if (analyzeQueryIntent(query).explicitArtifactIntent) {
+    return undefined;
+  }
+
   const quoted = extractQuotedIdentifiers(query);
   if (quoted.length === 1) {
     return quoted[0];

--- a/tests/intent-aware-ranking-eval.test.ts
+++ b/tests/intent-aware-ranking-eval.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "fs";
+import * as path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import type { RankedCandidate } from "../src/indexer/intent-aware-ranking.js";
+import { rankIntentAwareCandidates } from "../src/indexer/intent-aware-ranking.js";
+
+interface FixtureCandidate {
+  id: string;
+  score: number;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  chunkType: string;
+  name?: string;
+}
+
+interface FixtureQuery {
+  id: string;
+  query: string;
+  relevantIds: string[];
+  conceptualGuardrail?: boolean;
+  candidates: FixtureCandidate[];
+}
+
+interface RankingFixture {
+  version: string;
+  name: string;
+  methodology: {
+    baseline: string;
+    candidatePools: string;
+    metrics: string;
+    limitations: string;
+  };
+  topK: number;
+  queries: FixtureQuery[];
+}
+
+interface QueryMetrics {
+  id: string;
+  baselineRecallAt3: number;
+  intentAwareRecallAt3: number;
+  baselineReciprocalRank: number;
+  intentAwareReciprocalRank: number;
+}
+
+interface GoldenComparison {
+  fixtureVersion: string;
+  queryCount: number;
+  topK: number;
+  baseline: { evidenceRecallAt3: number; mrr: number };
+  intentAware: { evidenceRecallAt3: number; mrr: number };
+  perQuery: QueryMetrics[];
+}
+
+const fixturePath = path.join(process.cwd(), "benchmarks", "fixtures", "intent-aware-ranking.json");
+const goldenPath = path.join(process.cwd(), "benchmarks", "baselines", "intent-aware-ranking.json");
+
+function toCandidate(candidate: FixtureCandidate): RankedCandidate {
+  return {
+    id: candidate.id,
+    score: candidate.score,
+    metadata: {
+      filePath: candidate.filePath,
+      startLine: candidate.startLine,
+      endLine: candidate.endLine,
+      chunkType: candidate.chunkType,
+      name: candidate.name,
+      language: "typescript",
+      hash: candidate.id,
+    },
+  };
+}
+
+function evidenceRecallAtK(ids: string[], relevantIds: string[], k: number): number {
+  const relevant = new Set(relevantIds);
+  const found = new Set(ids.slice(0, k).filter((id) => relevant.has(id)));
+  return relevant.size === 0 ? 0 : found.size / relevant.size;
+}
+
+function reciprocalRank(ids: string[], relevantIds: string[]): number {
+  const relevant = new Set(relevantIds);
+  const rank = ids.findIndex((id) => relevant.has(id));
+  return rank < 0 ? 0 : 1 / (rank + 1);
+}
+
+function rounded(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function evaluate(fixture: RankingFixture): GoldenComparison {
+  const perQuery = fixture.queries.map((query): QueryMetrics => {
+    const candidates = query.candidates.map(toCandidate);
+    const baselineIds = [...candidates]
+      .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+      .map((candidate) => candidate.id);
+    const intentAwareIds = rankIntentAwareCandidates(query.query, candidates, candidates.length)
+      .map((candidate) => candidate.id);
+
+    if (query.conceptualGuardrail) {
+      expect(reciprocalRank(intentAwareIds, query.relevantIds)).toBeGreaterThanOrEqual(
+        reciprocalRank(baselineIds, query.relevantIds),
+      );
+    }
+
+    return {
+      id: query.id,
+      baselineRecallAt3: rounded(evidenceRecallAtK(baselineIds, query.relevantIds, fixture.topK)),
+      intentAwareRecallAt3: rounded(evidenceRecallAtK(intentAwareIds, query.relevantIds, fixture.topK)),
+      baselineReciprocalRank: rounded(reciprocalRank(baselineIds, query.relevantIds)),
+      intentAwareReciprocalRank: rounded(reciprocalRank(intentAwareIds, query.relevantIds)),
+    };
+  });
+
+  const average = (values: number[]): number => rounded(values.reduce((sum, value) => sum + value, 0) / values.length);
+  return {
+    fixtureVersion: fixture.version,
+    queryCount: fixture.queries.length,
+    topK: fixture.topK,
+    baseline: {
+      evidenceRecallAt3: average(perQuery.map((query) => query.baselineRecallAt3)),
+      mrr: average(perQuery.map((query) => query.baselineReciprocalRank)),
+    },
+    intentAware: {
+      evidenceRecallAt3: average(perQuery.map((query) => query.intentAwareRecallAt3)),
+      mrr: average(perQuery.map((query) => query.intentAwareReciprocalRank)),
+    },
+    perQuery,
+  };
+}
+
+describe("intent-aware local ranking evaluation", () => {
+  it("matches the transparent golden comparison and improves aggregate evidence recall and MRR", () => {
+    const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as RankingFixture;
+    const golden = JSON.parse(readFileSync(goldenPath, "utf-8")) as GoldenComparison;
+    const actual = evaluate(fixture);
+
+    expect(fixture.methodology.baseline).toContain("supplied candidate pool");
+    expect(fixture.methodology.limitations).toContain("does not measure embedding recall");
+    expect(actual).toEqual(golden);
+    expect(actual.intentAware.evidenceRecallAt3).toBeGreaterThan(actual.baseline.evidenceRecallAt3);
+    expect(actual.intentAware.mrr).toBeGreaterThan(actual.baseline.mrr);
+  });
+});

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -411,6 +411,80 @@ describe("retrieval ranking", () => {
     expect(reranked[0]?.id).toBe("docs");
   });
 
+  it("strongly prefers an exact authoritative symbol over imports, containers, tests, docs, and vendor copies", () => {
+    const candidates: Candidate[] = [
+      { id: "import", score: 0.99, metadata: meta({ filePath: "/repo/src/index.ts", name: "normalizeSession", chunkType: "import_statement", startLine: 1, endLine: 1, hash: "import" }) },
+      { id: "container", score: 0.98, metadata: meta({ filePath: "/repo/src/session.ts", name: "normalizeSession", chunkType: "export_statement", startLine: 10, endLine: 24, hash: "container" }) },
+      { id: "test", score: 0.97, metadata: meta({ filePath: "/repo/tests/session.test.ts", name: "normalizeSession", chunkType: "function", hash: "test" }) },
+      { id: "docs", score: 0.96, metadata: meta({ filePath: "/repo/docs/session.md", name: "normalizeSession", chunkType: "other", hash: "docs" }) },
+      { id: "vendor", score: 0.95, metadata: meta({ filePath: "/repo/vendor/session.ts", name: "normalizeSession", chunkType: "function", hash: "vendor" }) },
+      { id: "definition", score: 0.72, metadata: meta({ filePath: "/repo/src/session.ts", name: "normalizeSession", chunkType: "function_declaration", startLine: 11, endLine: 24, hash: "definition" }) },
+    ];
+
+    const ranked = rerankResults("where is normalizeSession defined", candidates, candidates.length);
+    expect(ranked[0]?.id).toBe("definition");
+    expect(ranked.map((candidate) => candidate.id)).not.toContain("container");
+  });
+
+  it("matches identifiers with deterministic NFKC and case normalization", () => {
+    const candidates: Candidate[] = [
+      { id: "noise", score: 0.99, metadata: meta({ filePath: "/repo/src/noise.ts", name: "CafeServiceFactory", chunkType: "function", hash: "noise" }) },
+      { id: "target", score: 0.6, metadata: meta({ filePath: "/repo/src/cafe.ts", name: "Cafe\u0301Service", chunkType: "class_declaration", hash: "target" }) },
+    ];
+
+    const ranked = rerankResults("where is CAFÉSERVICE implemented", candidates, candidates.length);
+    expect(ranked[0]?.id).toBe("target");
+  });
+
+  it("uses explicit test, docs, config, and call-flow intent instead of always preferring source definitions", () => {
+    const candidates: Candidate[] = [
+      { id: "definition", score: 0.98, metadata: meta({ filePath: "/repo/src/session.ts", name: "resolveSession", chunkType: "function", hash: "definition" }) },
+      { id: "test", score: 0.88, metadata: meta({ filePath: "/repo/tests/session.test.ts", name: "resolveSession test", chunkType: "test_declaration", hash: "test" }) },
+      { id: "docs", score: 0.87, metadata: meta({ filePath: "/repo/docs/session.md", name: "session guide", chunkType: "other", hash: "docs" }) },
+      { id: "config", score: 0.86, metadata: meta({ filePath: "/repo/config/session.yaml", name: "session settings", chunkType: "other", hash: "config" }) },
+      { id: "call-flow", score: 0.85, metadata: meta({ filePath: "/repo/src/call-graph/session-callers.ts", name: "findSessionCallers", chunkType: "function", hash: "call-flow" }) },
+    ];
+
+    expect(rerankResults("tests for resolveSession", candidates, candidates.length)[0]?.id).toBe("test");
+    expect(rerankResults("documentation for resolveSession", candidates, candidates.length)[0]?.id).toBe("docs");
+    expect(rerankResults("session configuration settings", candidates, candidates.length)[0]?.id).toBe("config");
+    expect(rerankResults("who calls resolveSession", candidates, candidates.length)[0]?.id).toBe("call-flow");
+  });
+
+  it("removes nested same-symbol containers without collapsing distinct nested symbols", () => {
+    const candidates: Candidate[] = [
+      { id: "target", score: 0.9, metadata: meta({ filePath: "/repo/src/session.ts", name: "resolveSession", chunkType: "function", startLine: 10, endLine: 20, hash: "target" }) },
+      { id: "container", score: 0.89, metadata: meta({ filePath: "/repo/src/session.ts", name: "resolveSession", chunkType: "export_statement", startLine: 9, endLine: 20, hash: "container" }) },
+      { id: "distinct", score: 0.88, metadata: meta({ filePath: "/repo/src/session.ts", name: "refreshSession", chunkType: "function", startLine: 22, endLine: 30, hash: "distinct" }) },
+    ];
+
+    const ranked = rerankResults("session lifecycle", candidates, candidates.length);
+    expect(ranked.map((candidate) => candidate.id)).toEqual(["target", "distinct"]);
+  });
+
+  it("keeps stable input order for true ties and preserves strong conceptual relevance", () => {
+    const tied: Candidate[] = [
+      { id: "z", score: 0.9, metadata: meta({ filePath: "/repo/src/a.ts", name: "alpha", chunkType: "function", hash: "z" }) },
+      { id: "a", score: 0.9, metadata: meta({ filePath: "/repo/src/b.ts", name: "beta", chunkType: "function", hash: "a" }) },
+    ];
+    const conceptual: Candidate[] = [
+      { id: "relevant", score: 0.96, metadata: meta({ filePath: "/repo/src/recovery.ts", name: "recoverCorruptedIndex", chunkType: "function", hash: "relevant" }) },
+      { id: "generated", score: 0.94, metadata: meta({ filePath: "/repo/generated/recovery.ts", name: "recoverCorruptedIndex", chunkType: "function", hash: "generated" }) },
+      { id: "docs", score: 0.93, metadata: meta({ filePath: "/repo/docs/recovery.md", name: "recovery guide", chunkType: "other", hash: "docs" }) },
+    ];
+
+    expect(rerankResults("unrelated", tied, tied.length).map((candidate) => candidate.id)).toEqual(["z", "a"]);
+    expect(rerankResults("unrelated", tied, tied.length).map((candidate) => candidate.id)).toEqual(["z", "a"]);
+    expect(rerankResults("recover corrupted sqlite index safely", conceptual, conceptual.length)[0]?.id).toBe("relevant");
+
+    const acronymConcept: Candidate[] = [
+      { id: "metrics", score: 0.96, metadata: meta({ filePath: "/repo/src/eval/metrics.ts", name: "computeEvalMetrics", chunkType: "function", hash: "metrics" }) },
+      { id: "acronym", score: 0.9, metadata: meta({ filePath: "/repo/src/constants.ts", name: "MRR", chunkType: "other", hash: "acronym" }) },
+    ];
+    expect(rerankResults("calculate retrieval recall MRR and discounted gain", acronymConcept, acronymConcept.length)[0]?.id)
+      .toBe("metrics");
+  });
+
   it("extracts file path hint from path-constrained implementation query", () => {
     const query = "where is createSystem implementation in packages/react/src/styled-system/system.ts";
     expect(extractFilePathHint(query)).toBe("packages/react/src/styled-system/system.ts");
@@ -444,7 +518,7 @@ describe("retrieval ranking", () => {
     });
     const indexer = new Indexer("/repo", config);
 
-    const firstPath = createTempFile("src/first.ts", "export function firstThing() {\n  return 'first';\n}\n");
+    const firstPath = createTempFile("src/first.ts", "const SECRET_BEFORE = 'private';\nexport function firstThing() {\n  return 'first';\n}\nconst SECRET_AFTER = 'private';\n");
     const secondPath = createTempFile("src/second.ts", "export function secondThing() {\n  return 'second';\n}\n");
     const thirdPath = createTempFile("src/third.ts", "export function thirdThing() {\n  return 'third';\n}\n");
 
@@ -465,7 +539,7 @@ describe("retrieval ranking", () => {
     }) as typeof fetch;
 
     const candidates: Candidate[] = [
-      { id: "first", score: 0.9, metadata: meta({ filePath: firstPath, name: "firstThing", chunkType: "function", startLine: 1, endLine: 3 }) },
+      { id: "first", score: 0.9, metadata: meta({ filePath: firstPath, name: "firstThing", chunkType: "function", startLine: 2, endLine: 4 }) },
       { id: "second", score: 0.89, metadata: meta({ filePath: secondPath, name: "secondThing", chunkType: "function", startLine: 1, endLine: 3 }) },
       { id: "third", score: 0.88, metadata: meta({ filePath: thirdPath, name: "thirdThing", chunkType: "function", startLine: 1, endLine: 3 }) },
     ];
@@ -478,6 +552,8 @@ describe("retrieval ranking", () => {
     expect(rerankBody?.documents?.[0]).toContain("snippet:");
     expect(rerankBody?.documents?.[0]).toContain("export function firstThing()");
     expect(rerankBody?.documents?.[0]).toContain("intent_hint: implementation");
+    expect(rerankBody?.documents?.[0]).not.toContain("SECRET_BEFORE");
+    expect(rerankBody?.documents?.[0]).not.toContain("SECRET_AFTER");
     globalThis.fetch = fetchSpy;
   });
 

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -506,6 +506,120 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(results[0]?.filePath).not.toContain(path.join("app", "indexer", "index.ts"));
   });
 
+  it("applies directory, file type, and blame scopes before sending candidates to an external reranker", async () => {
+    const scopedDir = fs.mkdtempSync(path.join(os.tmpdir(), "search-reranker-scope-"));
+    let scopedIndexer: Indexer | undefined;
+    try {
+      execFileSync("git", ["init"], { cwd: scopedDir });
+      execFileSync("git", ["config", "user.name", "Default User"], { cwd: scopedDir });
+      execFileSync("git", ["config", "user.email", "default@example.com"], { cwd: scopedDir });
+      fs.mkdirSync(path.join(scopedDir, "private", "scope"), { recursive: true });
+      fs.mkdirSync(path.join(scopedDir, "public"), { recursive: true });
+
+      fs.writeFileSync(path.join(scopedDir, "private", "scope", "allowed-a.ts"),
+        "export function authorizeRequest() { return 'active session request'; }\n", "utf-8");
+      fs.writeFileSync(path.join(scopedDir, "private", "scope", "allowed-b.ts"),
+        "export function refreshAuthorization() { return 'active session request'; }\n", "utf-8");
+      execFileSync("git", ["add", "."], { cwd: scopedDir });
+      execFileSync("git", ["commit", "-m", "add allowed scoped sources"], {
+        cwd: scopedDir,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Jane Doe",
+          GIT_AUTHOR_EMAIL: "jane@example.com",
+          GIT_COMMITTER_NAME: "Jane Doe",
+          GIT_COMMITTER_EMAIL: "jane@example.com",
+        },
+      });
+
+      fs.writeFileSync(path.join(scopedDir, "private", "scope", "excluded.md"),
+        "# active session request FILE_TYPE_SECRET\n", "utf-8");
+      fs.writeFileSync(path.join(scopedDir, "private", "scope", "excluded-blame.ts"),
+        "export function leakedByBlame() { return 'active session request BLAME_SECRET'; }\n", "utf-8");
+      fs.writeFileSync(path.join(scopedDir, "public", "excluded-directory.ts"),
+        "export function leakedByDirectory() { return 'active session request DIRECTORY_SECRET'; }\n", "utf-8");
+      execFileSync("git", ["add", "."], { cwd: scopedDir });
+      execFileSync("git", ["commit", "-m", "add excluded sources"], {
+        cwd: scopedDir,
+        env: {
+          ...process.env,
+          GIT_AUTHOR_NAME: "Alex Roe",
+          GIT_AUTHOR_EMAIL: "alex@example.com",
+          GIT_COMMITTER_NAME: "Alex Roe",
+          GIT_COMMITTER_EMAIL: "alex@example.com",
+        },
+      });
+
+      const rerankerRequests: string[][] = [];
+      fetchSpy.mockImplementation(async (url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        if (String(url).includes("/rerank")) {
+          const documents = (JSON.parse(String(init?.body ?? "{}")) as { documents?: string[] }).documents ?? [];
+          rerankerRequests.push(documents);
+          return new Response(JSON.stringify({
+            results: documents.map((_, index) => ({ index, relevance_score: 1 - index / 100 })),
+          }), { status: 200 });
+        }
+
+        const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+        const texts = Array.isArray(body.input) ? body.input : [];
+        return new Response(JSON.stringify({
+          data: texts.map((text) => ({
+            embedding: Array.from({ length: 8 }, (_, index) => ((text.length + index * 13) % 97) / 97),
+          })),
+          usage: { total_tokens: Math.max(1, texts.length * 8) },
+        }), { status: 200 });
+      });
+
+      const config = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-embedding-model",
+          dimensions: 8,
+        },
+        reranker: {
+          enabled: true,
+          provider: "custom",
+          model: "mock-reranker",
+          baseUrl: "https://rerank.example/v1",
+          topN: 10,
+        },
+        indexing: {
+          watchFiles: false,
+          gitBlame: { enabled: true },
+        },
+        search: {
+          maxResults: 10,
+          minScore: 0,
+          rerankTopN: 20,
+        },
+      });
+
+      scopedIndexer = new Indexer(scopedDir, config);
+      await scopedIndexer.index();
+      const results = await scopedIndexer.search("authorize incoming requests with active sessions", 10, {
+        metadataOnly: true,
+        filterByBranch: false,
+        directory: "private/scope",
+        fileType: "ts",
+        blameAuthor: "jane@example.com",
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results.every((result) => result.filePath.includes(path.join("private", "scope", "allowed-")))).toBe(true);
+      expect(rerankerRequests.length).toBeGreaterThan(0);
+      const sentDocuments = rerankerRequests.flat();
+      expect(sentDocuments).toHaveLength(2);
+      expect(sentDocuments.every((document) => document.includes(path.join("private", "scope", "allowed-")))).toBe(true);
+      expect(sentDocuments.join("\n")).not.toContain("FILE_TYPE_SECRET");
+      expect(sentDocuments.join("\n")).not.toContain("BLAME_SECRET");
+      expect(sentDocuments.join("\n")).not.toContain("DIRECTORY_SECRET");
+    } finally {
+      await scopedIndexer?.close();
+      fs.rmSync(scopedDir, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to weighted keyword search when query embedding generation fails", async () => {
     const config = parseConfig({
       embeddingProvider: "custom",

--- a/tests/symbol-inference.test.ts
+++ b/tests/symbol-inference.test.ts
@@ -35,4 +35,15 @@ describe("inferExactSymbolFromQuery", () => {
     expect(inferExactSymbolFromQuery("compare getStatus and forceIndex definitions"))
       .toBeUndefined();
   });
+
+  it("does not route explicit test, docs, config, or call-flow queries to definition lookup", () => {
+    expect(inferExactSymbolFromQuery("tests for `getStatus`"))
+      .toBeUndefined();
+    expect(inferExactSymbolFromQuery("where is getStatus documentation"))
+      .toBeUndefined();
+    expect(inferExactSymbolFromQuery("getStatus configuration settings"))
+      .toBeUndefined();
+    expect(inferExactSymbolFromQuery("who calls getStatus"))
+      .toBeUndefined();
+  });
 });

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -348,6 +348,44 @@ describe("native OpenCode codebase_context", () => {
     });
   });
 
+  it("keeps explicit artifact-intent queries on host-aware scoped search instead of definition lookup", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([{
+      filePath: "tests/status.test.ts",
+      startLine: 1,
+      endLine: 5,
+      name: "getStatus test",
+      chunkType: "test_declaration",
+      content: "hidden",
+      score: 0.9,
+    }]);
+
+    const queries = [
+      "tests for `getStatus`",
+      "where is getStatus documentation",
+      "getStatus configuration settings",
+      "who calls getStatus",
+    ];
+
+    for (const query of queries) {
+      operationMocks.searchCodebase.mockClear();
+      operationMocks.implementationLookup.mockClear();
+      await codebase_context.execute({
+        ...commonArgs,
+        query,
+        fileType: "ts",
+        directory: "src",
+      }, context);
+
+      expect(operationMocks.implementationLookup).not.toHaveBeenCalled();
+      expect(operationMocks.searchCodebase).toHaveBeenCalledWith("/repo", "opencode", query, {
+        limit: 100,
+        fileType: "ts",
+        directory: "src",
+        metadataOnly: true,
+      });
+    }
+  });
+
   it("falls back from an inferred definition miss to conceptual search", async () => {
     operationMocks.searchCodebase.mockResolvedValue([{
       filePath: "src/fallback.ts",


### PR DESCRIPTION
## Summary

Add deterministic intent-aware ranking so repository search prioritizes authoritative, diverse evidence for common agent queries.

## Changes

- Detect definition, implementation, test, docs, config, call-flow, conceptual, and identifier-driven intent using local deterministic signals.
- Boost exact symbol and authoritative implementation matches, suppress duplicate nested evidence, diversify files, and de-emphasize imports, containers, generated/vendor paths, tests, fixtures, or docs unless requested.
- Apply strict scope filters before external reranking, preserve deterministic ties, and add a synthetic golden evaluation for top-k recall and MRR with explicit limitations.

## Testing

Validated locally on macOS arm64 with independent retrieval/privacy review approval.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`): 1,119 tests
- [x] Lint passes (`npm run lint`)

Focused ranking, integration, symbol-inference, context, privacy, Unicode, and deterministic-order tests passed. `git diff --check` passed.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

No linked issue.