### PR TITLE
chore: prepare v0.19.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.18.1"
+      "version": "0.19.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-27
+
 ### Added
 
 - **Reliable opt-in MCP auto-indexing**: Added a process-scoped coordinator shared by Jcode, Codex, Claude, OpenCode, Pi, manual indexing, and file watchers. It tracks sanitized lifecycle/progress timestamps, skips healthy current indexes, coalesces concurrent work, bounds exponential lock retries and first-retrieval waits, refreshes stale indexes with the latest Indexer, and cancels retry work during shutdown while preserving multiprocess locks and home/project-marker safety. `autoIndex` remains `false` by default so retrieval never triggers paid embedding work without explicit opt-in.
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Exact-search handoffs**: Metadata-only semantic discovery and conceptual context packs now return bounded, result-derived symbol suggestions for exact usage or exhaustive-match searches, with handoffs included in context token-budget accounting across OpenCode, MCP, and Pi.
 - **Automatic branch and PR index preparation**: `pr_impact` now safely materializes and indexes missing branch or pull-request commits in isolated hook-disabled worktrees, verifies commit-aware fork-specific catalogs, and reuses or replaces indexes without changing the caller's worktree.
+- **Global knowledge-base reuse**: Global indexes now reuse identical knowledge-base chunks across projects instead of re-embedding them for each project catalog, while keeping project-owned source chunks isolated.
 - **Name-based call graph routing**: Callers, callees, and dependency paths now resolve unique symbol names automatically across native OpenCode, MCP, Pi, and `codebase_context`. Duplicate names return bounded candidate locations with optional file-path disambiguators, while `symbolId` remains an optional compatibility escape hatch.
 - **Self-recovering context lookup**: `codebase_context` now retries empty scoped searches without file filters, retries inferred symbol text after definition-style misses, reports bounded recovery metadata, and keeps all fallback responses within the requested token budget across MCP, native OpenCode, Pi, and evaluation.
 - **Intent-aware local ranking**: Semantic and hybrid search now strongly promote exact NFKC/case-normalized authoritative definitions, interpret definition/implementation/test/docs/config/call-flow wording, demote imports, wrappers, fixtures, generated/vendor copies unless requested, remove nested duplicate chunks, diversify useful files, preserve conceptual retrieval strength, and keep stable ties.
@@ -495,7 +498,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.1...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...v0.17.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -13,7 +13,7 @@ describe("Claude Code plugin", () => {
     };
 
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.18.1");
+    expect(pluginManifest.version).toBe("0.19.0");
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -42,7 +42,7 @@ describe("Claude Code plugin", () => {
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.18.1",
+      version: "0.19.0",
     }));
   });
 });


### PR DESCRIPTION
## Summary

Prepares the v0.19.0 minor release from the published v0.18.1 baseline.

## Changes

- Reconcile every shipped change in `v0.18.1..HEAD` into the dated v0.19.0 changelog, including coordinated MCP auto-indexing, retrieval/routing improvements, automatic branch preparation, privacy-safe metrics, and global knowledge-base reuse.
- Bump npm package, lockfile, Claude marketplace, Claude plugin, and Codex plugin versions to 0.19.0.
- Update marketplace version tests and changelog comparison links.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Additional release validation:
- Packed and installed `opencode-codebase-index-0.19.0.tgz` in a clean project.
- Verified ESM and CommonJS imports, package version, 13 MCP tools, Jcode first-use automatic indexing, `codebase_context`, `call_graph`, and `index_status` readiness.
- Production dependency audit reports 0 vulnerabilities.
- One concurrency cleanup test failed once during the first full run, then passed three consecutive isolated runs and the complete 1,138-test rerun.
- Independent release review approved commit `4b3e191` after full-delta reconciliation.

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, `semver:patch`) when needed

## Related Issues

No linked issue.
