### PR TITLE
fix: avoid filesystem-root indexing outside git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Plugin startup smoke coverage**: Added a bounded subprocess harness for empty, runtime-state-only, and package-marked non-git projects. It runs within the existing CI test job without additional native builds.
+
+### Changed
+
+- **Safer project marker detection**: Runtime-generated `.opencode` and `.codebase-index` directories no longer qualify as project markers, so they cannot enable background watching or indexing in otherwise empty directories.
+
+### Fixed
+
+- **OpenCode startup root handling** (#184): When selecting the OpenCode plugin root, prefer `worktree` only if it is a real Git repository. Non-git worktree values now correctly fall back to `directory` to avoid accidental indexing and watching from filesystem roots.
+
 ## [0.19.0] - 2026-07-27
 
 ### Added

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -70,7 +70,8 @@ The plugin looks for any of these files/directories:
 - `build.gradle`
 - `CMakeLists.txt`
 - `Makefile`
-- `.opencode`
+
+Runtime state directories such as `.opencode` and `.codebase-index` are intentionally not project markers because the host or plugin can create them in otherwise empty directories.
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { loadCommandsFromDirectory } from "./commands/loader.js";
 import { RoutingHintController } from "./routing-hints.js";
 import { isHomeDirectory, startAutoIndex } from "./utils/auto-index.js";
 import { hasProjectMarker } from "./utils/files.js";
+import { isGitRepo } from "./git/index.js";
 import type { CombinedWatcher } from "./watcher/index.js";
 
 const activeWatchers = new Map<string, CombinedWatcher>();
@@ -72,6 +73,14 @@ function appendRoutingHints(
   }
 }
 
+function resolveProjectRoot(directory: string, worktree?: string): string {
+  if (worktree && isGitRepo(worktree)) {
+    return worktree;
+  }
+
+  return directory;
+}
+
 interface ChatTransformInput {
   sessionID?: string;
 }
@@ -83,7 +92,7 @@ interface ChatTransformOutput {
 
 const plugin: Plugin = async ({ directory, worktree }) => {
   try {
-    const projectRoot = worktree || directory;
+    const projectRoot = resolveProjectRoot(directory, worktree);
     const rawConfig = loadMergedConfig(projectRoot);
     const config = parseConfig(rawConfig);
 

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -18,8 +18,6 @@ const PROJECT_MARKERS = [
   "build.gradle",
   "CMakeLists.txt",
   "Makefile",
-  ".opencode",
-  ".codebase-index",
 ];
 
 export function hasProjectMarker(projectRoot: string): boolean {

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -285,9 +285,19 @@ describe("files utilities", () => {
       expect(hasProjectMarker(tempDir)).toBe(true);
     });
 
-    it("should return true when .opencode exists", () => {
-      fs.mkdirSync(path.join(tempDir, ".opencode"), { recursive: true });
+    it("should return true when Makefile exists", () => {
+      fs.writeFileSync(path.join(tempDir, "Makefile"), "all:\n");
       expect(hasProjectMarker(tempDir)).toBe(true);
+    });
+
+    it("should return false when only .opencode exists", () => {
+      fs.mkdirSync(path.join(tempDir, ".opencode"), { recursive: true });
+      expect(hasProjectMarker(tempDir)).toBe(false);
+    });
+
+    it("should return false when only .codebase-index exists", () => {
+      fs.mkdirSync(path.join(tempDir, ".codebase-index"), { recursive: true });
+      expect(hasProjectMarker(tempDir)).toBe(false);
     });
 
     it("should return false for empty directory", () => {

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, symlinkSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     },
   },
   createWatcherWithIndexer: vi.fn(() => ({ stop: vi.fn() })),
+  initializeTools: vi.fn(),
   hints: ["runtime-routing-hint"],
   routingControllers: [] as Array<{
     getSystemHints: ReturnType<typeof vi.fn>;
@@ -71,7 +72,7 @@ vi.mock("../src/tools/index.js", () => {
     remove_knowledge_base: toolStub,
     pr_impact: toolStub,
     index_visualize: toolStub,
-    initializeTools: vi.fn(),
+    initializeTools: mockState.initializeTools,
     getSharedIndexer: vi.fn(() => indexerStub),
   };
 });
@@ -115,6 +116,7 @@ describe("plugin routing hint hook selection", () => {
     mockState.hints = ["runtime-routing-hint"];
     mockState.routingControllers.length = 0;
     mockState.createWatcherWithIndexer.mockClear();
+    mockState.initializeTools.mockClear();
   });
 
   it("does not watch a project symlink that resolves to the home directory", async () => {
@@ -130,6 +132,40 @@ describe("plugin routing hint hook selection", () => {
       expect(mockState.createWatcherWithIndexer).not.toHaveBeenCalled();
     } finally {
       warn.mockRestore();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to directory when worktree is not a git repository", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "plugin-non-git-worktree-"));
+    const nonGitWorktree = path.parse(tempDir).root;
+    mockState.initializeTools.mockClear();
+
+    try {
+      await plugin({ directory: tempDir, worktree: nonGitWorktree } as Parameters<typeof plugin>[0]);
+
+      expect(mockState.initializeTools).toHaveBeenCalledWith(tempDir, expect.any(Object));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a git worktree when it is a real git repository", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "plugin-git-worktree-"));
+    const directory = path.join(tempDir, "selected-dir");
+    const worktree = path.join(tempDir, "worktree");
+
+    mkdirSync(directory, { recursive: true });
+    mkdirSync(path.join(worktree, ".git"), { recursive: true });
+    writeFileSync(path.join(worktree, ".git", "HEAD"), "ref: refs/heads/main\n", "utf-8");
+
+    mockState.initializeTools.mockClear();
+
+    try {
+      await plugin({ directory, worktree } as Parameters<typeof plugin>[0]);
+
+      expect(mockState.initializeTools).toHaveBeenCalledWith(worktree, expect.any(Object));
+    } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });

--- a/tests/startup-regression-harness.mjs
+++ b/tests/startup-regression-harness.mjs
@@ -1,0 +1,31 @@
+/* global process, console */
+import * as path from "node:path";
+
+import plugin from "../dist/index.js";
+
+const projectRoot = process.argv[2];
+const scenario = process.argv[3];
+
+if (!projectRoot) {
+  console.error("Missing projectRoot argument for startup regression harness.");
+  process.exit(1);
+}
+
+if (scenario !== "empty" && scenario !== "runtime-state-only" && scenario !== "package-marked") {
+  console.error(`Invalid scenario argument: ${scenario}`);
+  process.exit(2);
+}
+
+try {
+  const worktree = path.parse(projectRoot).root;
+  const runtime = await plugin({ directory: projectRoot, worktree });
+  if (!runtime || typeof runtime !== "object") {
+    throw new Error("Plugin returned an invalid runtime object");
+  }
+
+  process.stdout.write("PLUGIN_STARTUP_READY\n");
+  process.exit(0);
+} catch {
+  console.error("Failed to initialize plugin.");
+  process.exit(1);
+}

--- a/tests/startup-regression.test.ts
+++ b/tests/startup-regression.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, it } from "vitest";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+import * as os from "node:os";
+import * as path from "node:path";
+
+const STARTUP_TIMEOUT_MS = 4_000;
+const STARTUP_SENTINEL = "PLUGIN_STARTUP_READY";
+const HARNESS_PATH = path.resolve(process.cwd(), "tests", "startup-regression-harness.mjs");
+
+function makeIsolatedEnv(): { root: string; home: string } {
+  const home = mkdtempSync(path.join(os.tmpdir(), "codebase-index-startup-home-"));
+  const nestedHome = path.join(home, "home");
+  mkdirSync(nestedHome, { recursive: true });
+  return { root: home, home: nestedHome };
+}
+
+function verifyReadyOutput(output: string): void {
+  if (!output.includes(STARTUP_SENTINEL)) {
+    throw new Error(
+      `Expected startup sentinel ${STARTUP_SENTINEL} but got output:\n${output}`,
+    );
+  }
+}
+
+function runStartupHarness(
+  projectRoot: string,
+  scenario: "empty" | "runtime-state-only" | "package-marked",
+): void {
+  const harnessDir = path.dirname(HARNESS_PATH);
+  if (!existsSync(harnessDir)) {
+    throw new Error(`Missing harness script directory: ${harnessDir}`);
+  }
+
+  const isolatedHome = makeIsolatedEnv();
+  const result = spawnSync(
+    process.execPath,
+    [HARNESS_PATH, projectRoot, scenario],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: isolatedHome.home,
+        USERPROFILE: isolatedHome.home,
+      },
+      timeout: STARTUP_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
+      killSignal: "SIGKILL",
+    },
+  );
+
+  rmSync(isolatedHome.root, { recursive: true, force: true });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.signal) {
+    throw new Error(`Startup subprocess timed out or was killed by signal ${result.signal}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Startup subprocess exited with ${result.status}: ${result.stderr?.trim() || "no stderr"}`,
+    );
+  }
+
+  verifyReadyOutput(result.stdout ?? "");
+}
+
+function createEmptyScenarioDir(): string {
+  const projectDir = mkdtempSync(path.join(os.tmpdir(), "startup-regression-empty-"));
+
+  return projectDir;
+}
+
+function createRuntimeStateScenarioDir(): string {
+  const projectDir = mkdtempSync(path.join(os.tmpdir(), "startup-regression-runtime-state-"));
+
+  mkdirSync(path.join(projectDir, ".opencode"), { recursive: true });
+  mkdirSync(path.join(projectDir, ".codebase-index"), { recursive: true });
+
+  return projectDir;
+}
+
+describe("plugin startup regression", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("starts in an empty non-git directory", () => {
+    const projectDir = createEmptyScenarioDir();
+    tempDirs.push(projectDir);
+
+    runStartupHarness(projectDir, "empty");
+  });
+
+  it("starts in a package-marked non-git directory", () => {
+    const projectDir = mkdtempSync(path.join(os.tmpdir(), "startup-regression-package-"));
+    tempDirs.push(projectDir);
+
+    writeFileSync(path.join(projectDir, "package.json"), "{}", "utf-8");
+    runStartupHarness(projectDir, "package-marked");
+  });
+
+  it("starts with only runtime state in a non-git directory", () => {
+    const projectDir = createRuntimeStateScenarioDir();
+    tempDirs.push(projectDir);
+
+    runStartupHarness(projectDir, "runtime-state-only");
+  });
+});


### PR DESCRIPTION
## Root cause
OpenCode 1.18.7 supplies the selected folder as `directory`, but supplies the filesystem root (`/`, or a Windows drive root) as `worktree` outside Git repositories. The plugin used `worktree || directory`, so non-git startup could watch and index the entire filesystem. After `git init`, OpenCode supplies the repository root as `worktree`, explaining the reported behavior.

## Summary
- use `worktree` only when it resolves to an actual Git repository; otherwise use `directory`
- add focused regression tests for broad non-git worktrees and real Git worktrees
- add a bounded bundled-plugin smoke harness using OpenCode's broad non-git worktree semantics
- cover empty, runtime-state-only, and package-marked non-git directories
- run the sub-second smoke tests inside the existing CI job without additional native builds
- stop treating runtime-generated `.opencode` and `.codebase-index` directories as project markers

## Validation
- actual OpenCode 1.18.7 diagnostic plugin confirmed `directory=<selected dir>, worktree=/` before `git init`, and matching directory/worktree after `git init`
- one-time validation passed on Linux, macOS, and Windows before removing the expensive duplicate OS matrix
- `npm run build:ts`
- `npx vitest run tests/plugin-hooks.test.ts tests/startup-regression.test.ts tests/files.test.ts` (36 tests, under one second)
- `npm run typecheck`
- `npm run lint`
- CodeQL passed

Fixes #184.
