### PR TITLE
Avoid draining laptop batteries with automatic indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Battery-aware background indexing**: Added the opt-in `indexing.pauseBackgroundIndexingOnBattery` setting. On macOS, automatic startup and watcher-triggered indexing now waits for AC power, coalesces pending work into one update, and keeps manual `index_codebase` requests available. Power detection uses a five-second `pmset` timeout and fails open if the source cannot be determined.
+
 ## [0.19.1] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "autoIndexMaxRetries": 5,                 // Transient interprocess lock retries (0-10)
     "autoIndexRetryDelayMs": 100,             // Initial exponential lock retry delay
     "watchFiles": true,                       // Re-index on file changes
+    "pauseBackgroundIndexingOnBattery": false, // Defer background indexing on macOS battery power
     "maxFileSize": 1048576,                   // Max file size in bytes (default: 1MB)
     "maxChunksPerFile": 100,                  // Max chunks per file
     "semanticOnly": false,                    // Only index functions/classes (skip blocks)
@@ -884,6 +885,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `autoIndexMaxRetries` | `5` | Maximum transient interprocess lock retries (0-10) for background automatic indexing. |
 | `autoIndexRetryDelayMs` | `100` | Initial exponential lock retry delay in milliseconds (10-10000). |
 | `watchFiles` | `true` | Re-index when files change |
+| `pauseBackgroundIndexingOnBattery` | `false` | On macOS, defer automatic startup and watcher-triggered indexing while using battery power, then run one pending incremental update after AC power returns. Manual `index_codebase` requests remain available. This option has no effect on other platforms. |
 | `maxFileSize` | `1048576` | Skip files larger than this (bytes). Default: 1MB |
 | `maxChunksPerFile` | `100` | Maximum chunks to index per file (controls token costs for large files) |
 | `semanticOnly` | `false` | When `true`, only index semantic nodes (functions, classes) and skip generic blocks |

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -12,6 +12,7 @@ export function getDefaultIndexingConfig(): IndexingConfig {
     autoIndexMaxRetries: 5,
     autoIndexRetryDelayMs: 100,
     watchFiles: true,
+    pauseBackgroundIndexingOnBattery: false,
     maxFileSize: 1048576,
     maxChunksPerFile: 100,
     semanticOnly: false,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,11 @@ export interface IndexingConfig {
   /** Initial exponential retry delay after transient lock contention. */
   autoIndexRetryDelayMs: number;
   watchFiles: boolean;
+  /**
+   * On macOS, defer automatic indexing while the computer is using battery power.
+   * Manual index requests are never blocked. Default: false
+   */
+  pauseBackgroundIndexingOnBattery: boolean;
   maxFileSize: number;
   maxChunksPerFile: number;
   semanticOnly: boolean;
@@ -196,6 +201,9 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
       ? Math.min(10_000, Math.max(10, Math.floor(rawIndexing.autoIndexRetryDelayMs)))
       : defaultIndexing.autoIndexRetryDelayMs,
     watchFiles: typeof rawIndexing.watchFiles === "boolean" ? rawIndexing.watchFiles : defaultIndexing.watchFiles,
+    pauseBackgroundIndexingOnBattery: typeof rawIndexing.pauseBackgroundIndexingOnBattery === "boolean"
+      ? rawIndexing.pauseBackgroundIndexingOnBattery
+      : defaultIndexing.pauseBackgroundIndexingOnBattery,
     maxFileSize: typeof rawIndexing.maxFileSize === "number" ? rawIndexing.maxFileSize : defaultIndexing.maxFileSize,
     maxChunksPerFile: typeof rawIndexing.maxChunksPerFile === "number" ? Math.max(1, rawIndexing.maxChunksPerFile) : defaultIndexing.maxChunksPerFile,
     semanticOnly: typeof rawIndexing.semanticOnly === "boolean" ? rawIndexing.semanticOnly : defaultIndexing.semanticOnly,

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -302,16 +302,8 @@ class AutoIndexCoordinator {
     const batteryCheck = this.waitForACPower();
     this.batteryCheck = batteryCheck;
     void batteryCheck.then(
-      () => {
-        if (this.batteryCheck === batteryCheck) {
-          this.batteryCheck = null;
-        }
-      },
-      () => {
-        if (this.batteryCheck === batteryCheck) {
-          this.batteryCheck = null;
-        }
-      },
+      () => this.finishBatteryCheck(batteryCheck),
+      () => this.finishBatteryCheck(batteryCheck),
     );
     return batteryCheck;
   }
@@ -621,6 +613,16 @@ class AutoIndexCoordinator {
     const resolve = this.resolveBatteryRetry;
     this.resolveBatteryRetry = null;
     resolve?.();
+  }
+
+  private finishBatteryCheck(batteryCheck: Promise<CoordinatedIndexResult>): void {
+    if (this.batteryCheck !== batteryCheck) return;
+    this.batteryCheck = null;
+    const deferredRequest = this.batteryDeferredRequest;
+    this.batteryDeferredRequest = null;
+    if (deferredRequest && !this.stopped) {
+      void this.request(deferredRequest);
+    }
   }
 }
 

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -223,10 +223,12 @@ class AutoIndexCoordinator {
   private inFlight: Promise<CoordinatedIndexResult> | null = null;
   private activeRequest: IndexRequest | null = null;
   private batteryCheck: Promise<CoordinatedIndexResult> | null = null;
+  private batteryIndexJob: Promise<CoordinatedIndexResult> | null = null;
   private batteryDeferredRequest: IndexRequest | null = null;
   private batteryRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private resolveBatteryRetry: (() => void) | null = null;
   private pendingRequest: IndexRequest | null = null;
+  private pendingFollowUp: Promise<CoordinatedIndexResult> | null = null;
   private abortController: AbortController | null = null;
   private stopped = false;
 
@@ -294,6 +296,10 @@ class AutoIndexCoordinator {
       return this.enqueueRequest(request);
     }
 
+    if (this.batteryCheck && this.batteryIndexJob !== null && this.batteryIndexJob === this.inFlight) {
+      return this.enqueueRequest(request);
+    }
+
     this.batteryDeferredRequest = mergeRequests(this.batteryDeferredRequest, request);
     if (this.batteryCheck) {
       return this.batteryCheck;
@@ -324,6 +330,11 @@ class AutoIndexCoordinator {
       }
       if (request.source === "watcher") {
         this.pendingRequest = mergeRequests(this.pendingRequest, request);
+        const active = this.inFlight;
+        return active.then(() => {
+          if (this.stopped) return { outcome: "stopped" };
+          return this.pendingFollowUp ?? { outcome: "stopped" };
+        });
       }
       return this.inFlight;
     }
@@ -376,10 +387,20 @@ class AutoIndexCoordinator {
       this.inFlight = null;
       this.activeRequest = null;
       this.abortController = null;
+      if (this.batteryIndexJob === job) {
+        this.batteryIndexJob = null;
+        this.batteryCheck = null;
+      }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
       if (pending && !this.stopped) {
-        void this.request(pending);
+        const followUp = this.request(pending);
+        this.pendingFollowUp = followUp;
+        void followUp.then(() => {
+          if (this.pendingFollowUp === followUp) {
+            this.pendingFollowUp = null;
+          }
+        });
       }
     });
     return job;
@@ -572,7 +593,12 @@ class AutoIndexCoordinator {
       if (!policy || !await this.isBatteryPauseActive(policy)) {
         const request = this.batteryDeferredRequest;
         this.batteryDeferredRequest = null;
-        return request ? this.enqueueRequest(request) : { outcome: "stopped" };
+        if (!request) return { outcome: "stopped" };
+        const job = this.enqueueRequest(request);
+        if (this.inFlight === job) {
+          this.batteryIndexJob = job;
+        }
+        return job;
       }
       await this.waitForBatteryRetry(policy.recheckDelayMs);
     }

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -1,6 +1,7 @@
 import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
 import type { HostMode } from "../config/host.js";
 import type { Indexer, IndexProgress, IndexStats } from "../indexer/index.js";
+import type { BackgroundIndexingPolicy } from "./power-source.js";
 import { existsSync, realpathSync } from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -8,6 +9,7 @@ import * as path from "path";
 import { resolveProjectIndexPath } from "../config/paths.js";
 import { isTransientIndexLockContention } from "../indexer/index-lock.js";
 import { hasProjectMarker } from "./files.js";
+import { createBackgroundIndexingPolicy } from "./power-source.js";
 
 export type AutoIndexCoordinatorState =
   | "idle"
@@ -63,6 +65,7 @@ type CoordinatedIndexer = Pick<
 > & Partial<Pick<Indexer, "getIndexFreshness">>;
 
 interface AutoIndexRegistration {
+  backgroundIndexingPolicy: BackgroundIndexingPolicy | null;
   config: ParsedCodebaseIndexConfig;
   getIndexer: () => CoordinatedIndexer;
   projectRoot: string;
@@ -219,6 +222,10 @@ class AutoIndexCoordinator {
   private activation: Promise<void> = Promise.resolve();
   private inFlight: Promise<CoordinatedIndexResult> | null = null;
   private activeRequest: IndexRequest | null = null;
+  private batteryCheck: Promise<CoordinatedIndexResult> | null = null;
+  private batteryDeferredRequest: IndexRequest | null = null;
+  private batteryRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private resolveBatteryRetry: (() => void) | null = null;
   private pendingRequest: IndexRequest | null = null;
   private abortController: AbortController | null = null;
   private stopped = false;
@@ -234,6 +241,8 @@ class AutoIndexCoordinator {
   }
 
   update(registration: AutoIndexRegistration): void {
+    const pauseOnBatteryChanged = registration.config.indexing.pauseBackgroundIndexingOnBattery
+      !== this.registration.config.indexing.pauseBackgroundIndexingOnBattery;
     this.registration = registration;
     this.status.enabled = registration.config.indexing.autoIndex;
     this.status.blockedReason = registration.blockedReason;
@@ -248,6 +257,9 @@ class AutoIndexCoordinator {
       if (!this.inFlight) {
         this.setState("idle", { source: undefined });
       }
+    }
+    if (pauseOnBatteryChanged) {
+      this.cancelBatteryRetry();
     }
   }
 
@@ -274,7 +286,34 @@ class AutoIndexCoordinator {
     if (this.stopped) {
       return Promise.resolve({ outcome: "stopped" });
     }
-    return this.activation.then(() => this.enqueueRequest(request));
+    return this.activation.then(() => this.enqueueBatteryAwareRequest(request));
+  }
+
+  private enqueueBatteryAwareRequest(request: IndexRequest): Promise<CoordinatedIndexResult> {
+    if (!this.shouldDeferForBattery(request)) {
+      return this.enqueueRequest(request);
+    }
+
+    this.batteryDeferredRequest = mergeRequests(this.batteryDeferredRequest, request);
+    if (this.batteryCheck) {
+      return this.batteryCheck;
+    }
+
+    const batteryCheck = this.waitForACPower();
+    this.batteryCheck = batteryCheck;
+    void batteryCheck.then(
+      () => {
+        if (this.batteryCheck === batteryCheck) {
+          this.batteryCheck = null;
+        }
+      },
+      () => {
+        if (this.batteryCheck === batteryCheck) {
+          this.batteryCheck = null;
+        }
+      },
+    );
+    return batteryCheck;
   }
 
   private enqueueRequest(request: IndexRequest): Promise<CoordinatedIndexResult> {
@@ -313,6 +352,8 @@ class AutoIndexCoordinator {
 
   async stop(waitForCompletion = false): Promise<void> {
     this.stopped = true;
+    this.batteryDeferredRequest = null;
+    this.cancelBatteryRetry();
     this.pendingRequest = null;
     this.abortController?.abort();
     this.setState("stopped", {
@@ -346,7 +387,7 @@ class AutoIndexCoordinator {
       const pending = this.pendingRequest;
       this.pendingRequest = null;
       if (pending && !this.stopped) {
-        this.startRequest(pending);
+        void this.request(pending);
       }
     });
     return job;
@@ -527,6 +568,60 @@ class AutoIndexCoordinator {
 
     return this.registration.safeToRun && this.registration.config.indexing.autoIndex;
   }
+
+  private shouldDeferForBattery(request: IndexRequest): boolean {
+    return this.registration.backgroundIndexingPolicy !== null
+      && (request.source === "startup" || request.source === "watcher");
+  }
+
+  private async waitForACPower(): Promise<CoordinatedIndexResult> {
+    while (!this.stopped) {
+      const policy = this.registration.backgroundIndexingPolicy;
+      if (!policy || !await this.isBatteryPauseActive(policy)) {
+        const request = this.batteryDeferredRequest;
+        this.batteryDeferredRequest = null;
+        return request ? this.enqueueRequest(request) : { outcome: "stopped" };
+      }
+      await this.waitForBatteryRetry(policy.recheckDelayMs);
+    }
+    return { outcome: "stopped" };
+  }
+
+  private async isBatteryPauseActive(policy: BackgroundIndexingPolicy): Promise<boolean> {
+    try {
+      return await policy.isPaused();
+    } catch (error) {
+      console.error(
+        `[codebase-index] Failed to apply the background indexing power policy; background indexing will continue: ${safeFailureMessage(error)}`,
+      );
+      return false;
+    }
+  }
+
+  private waitForBatteryRetry(delayMs: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.batteryRetryTimer === timer) {
+          this.batteryRetryTimer = null;
+          this.resolveBatteryRetry = null;
+        }
+        resolve();
+      }, delayMs);
+      timer.unref?.();
+      this.batteryRetryTimer = timer;
+      this.resolveBatteryRetry = resolve;
+    });
+  }
+
+  private cancelBatteryRetry(): void {
+    if (this.batteryRetryTimer) {
+      clearTimeout(this.batteryRetryTimer);
+      this.batteryRetryTimer = null;
+    }
+    const resolve = this.resolveBatteryRetry;
+    this.resolveBatteryRetry = null;
+    resolve?.();
+  }
 }
 
 function getCoordinator(projectRoot: string, host: HostMode): AutoIndexCoordinator | null {
@@ -543,6 +638,9 @@ export function configureAutoIndex(
   const projectKey = projectLookupKey(projectRoot, host);
   const safety = getProjectSafety(projectRoot, config);
   const registration: AutoIndexRegistration = {
+    backgroundIndexingPolicy: createBackgroundIndexingPolicy(
+      config.indexing.pauseBackgroundIndexingOnBattery,
+    ),
     config,
     getIndexer,
     projectRoot,

--- a/src/utils/power-source.ts
+++ b/src/utils/power-source.ts
@@ -1,0 +1,133 @@
+import * as childProcess from "child_process";
+
+export type MacOsPowerSource = "ac" | "battery" | "unknown";
+
+export interface BackgroundIndexingPolicy {
+  readonly recheckDelayMs: number;
+  isPaused(): Promise<boolean>;
+}
+
+type PowerSourceReader = () => Promise<MacOsPowerSource>;
+type CommandRunner = (
+  file: string,
+  args: string[],
+  options: { timeoutMs: number },
+) => Promise<string>;
+
+interface BackgroundIndexingPolicyOptions {
+  platform?: NodeJS.Platform;
+  readPowerSource?: PowerSourceReader;
+  recheckDelayMs?: number;
+}
+
+const POWER_SOURCE_RECHECK_DELAY_MS = 60_000;
+const PMSET_TIMEOUT_MS = 5_000;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function runCommand(
+  file: string,
+  args: string[],
+  options: { timeoutMs: number },
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(
+      file,
+      args,
+      { encoding: "utf8", timeout: options.timeoutMs },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+export function parseMacOsPowerSource(output: string): MacOsPowerSource {
+  const match = output.match(/Now drawing from '([^']+)'/i);
+  if (!match) {
+    return "unknown";
+  }
+
+  const source = match[1].toLowerCase();
+  if (source === "battery power") {
+    return "battery";
+  }
+  if (source === "ac power") {
+    return "ac";
+  }
+  return "unknown";
+}
+
+export async function readMacOsPowerSource(
+  commandRunner: CommandRunner = runCommand,
+): Promise<MacOsPowerSource> {
+  const output = await commandRunner(
+    "/usr/bin/pmset",
+    ["-g", "batt"],
+    { timeoutMs: PMSET_TIMEOUT_MS },
+  );
+  return parseMacOsPowerSource(output);
+}
+
+class MacOsBackgroundIndexingPolicy implements BackgroundIndexingPolicy {
+  private lastPaused: boolean | null = null;
+  private reportedFailure = false;
+
+  constructor(
+    private readonly readPowerSource: PowerSourceReader,
+    readonly recheckDelayMs: number,
+  ) {}
+
+  isPaused(): Promise<boolean> {
+    return this.checkPowerSource();
+  }
+
+  private async checkPowerSource(): Promise<boolean> {
+    try {
+      const source = await this.readPowerSource();
+      if (source === "unknown") {
+        throw new Error("pmset returned an unrecognized power source");
+      }
+
+      this.reportedFailure = false;
+      const paused = source === "battery";
+      if (paused && this.lastPaused !== true) {
+        console.warn("[codebase-index] Background indexing paused while macOS is using battery power.");
+      } else if (!paused && this.lastPaused === true) {
+        console.warn("[codebase-index] AC power detected; resuming pending background indexing.");
+      }
+      this.lastPaused = paused;
+      return paused;
+    } catch (error) {
+      if (!this.reportedFailure) {
+        console.error(
+          `[codebase-index] Failed to determine the macOS power source; background indexing will continue: ${getErrorMessage(error)}`,
+        );
+        this.reportedFailure = true;
+      }
+      this.lastPaused = false;
+      return false;
+    }
+  }
+}
+
+export function createBackgroundIndexingPolicy(
+  pauseOnBattery: boolean,
+  options: BackgroundIndexingPolicyOptions = {},
+): BackgroundIndexingPolicy | null {
+  const platform = options.platform ?? process.platform;
+  if (!pauseOnBattery || platform !== "darwin") {
+    return null;
+  }
+
+  return new MacOsBackgroundIndexingPolicy(
+    options.readPowerSource ?? readMacOsPowerSource,
+    options.recheckDelayMs ?? POWER_SOURCE_RECHECK_DELAY_MS,
+  );
+}

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -1,9 +1,10 @@
 import type { CodebaseIndexConfig } from "../config/schema.js";
-import { parseConfig } from "../config/schema.js";
 import type { HostMode } from "../config/host.js";
+import type { Indexer } from "../indexer/index.js";
+
+import { parseConfig } from "../config/schema.js";
 import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
 import { loadConfigFile } from "../config/merger.js";
-import type { Indexer } from "../indexer/index.js";
 import { isGitRepo } from "../git/index.js";
 import { refreshIndexerForDirectory } from "../tools/operations.js";
 import { configureAutoIndex, requestBackgroundIndex } from "../utils/auto-index.js";

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -6,6 +6,17 @@ import * as path from "path";
 import { parseConfig } from "../src/config/schema.js";
 import { IndexLockContentionError } from "../src/indexer/index-lock.js";
 import type { IndexFreshnessResult, IndexProgress, IndexStats, StatusResult } from "../src/indexer/index.js";
+import type { BackgroundIndexingPolicy } from "../src/utils/power-source.js";
+
+const powerSource = vi.hoisted(() => ({
+  createBackgroundIndexingPolicy: vi.fn(),
+  policy: null as BackgroundIndexingPolicy | null,
+}));
+
+vi.mock("../src/utils/power-source.js", () => ({
+  createBackgroundIndexingPolicy: powerSource.createBackgroundIndexingPolicy,
+}));
+
 import {
   configureAutoIndex,
   getAutoIndexStatus,
@@ -108,6 +119,8 @@ describe("auto-index coordinator", () => {
   let projectRoot: string;
 
   beforeEach(() => {
+    powerSource.policy = null;
+    powerSource.createBackgroundIndexingPolicy.mockImplementation(() => powerSource.policy);
     projectRoot = mkdtempSync(path.join(os.tmpdir(), "auto-index-coordinator-"));
     mkdirSync(path.join(projectRoot, "src"));
     writeFileSync(path.join(projectRoot, "package.json"), "{}");
@@ -115,6 +128,7 @@ describe("auto-index coordinator", () => {
 
   afterEach(async () => {
     await resetAutoIndexCoordinatorsForTests();
+    vi.useRealTimers();
     rmSync(projectRoot, { recursive: true, force: true });
   });
 
@@ -293,6 +307,98 @@ describe("auto-index coordinator", () => {
     await firstRequest;
     await vi.waitFor(() => expect(secondIndexer.index).toHaveBeenCalledOnce());
     expect(firstIndexer.index).toHaveBeenCalledOnce();
+  });
+
+  it("defers startup indexing on battery power and resumes once on AC power", async () => {
+    vi.useFakeTimers();
+    let onBattery = true;
+    const policy: BackgroundIndexingPolicy = {
+      isPaused: vi.fn(async () => onBattery),
+      recheckDelayMs: 100,
+    };
+    powerSource.policy = policy;
+    const indexer = new MockIndexer();
+    configureAutoIndex(projectRoot, "jcode", config({ pauseBackgroundIndexingOnBattery: true }), () => indexer);
+
+    const startup = startAutoIndex(projectRoot, "jcode");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(policy.isPaused).toHaveBeenCalledOnce();
+    expect(indexer.index).not.toHaveBeenCalled();
+
+    onBattery = false;
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(startup).resolves.toMatchObject({ outcome: "ready" });
+    expect(indexer.index).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces battery-deferred watcher requests into one AC reindex", async () => {
+    vi.useFakeTimers();
+    let onBattery = true;
+    const policy: BackgroundIndexingPolicy = {
+      isPaused: vi.fn(async () => onBattery),
+      recheckDelayMs: 100,
+    };
+    powerSource.policy = policy;
+    const indexer = new MockIndexer();
+    configureAutoIndex(projectRoot, "jcode", config({ pauseBackgroundIndexingOnBattery: true }), () => indexer);
+
+    const requests = [
+      requestBackgroundIndex(projectRoot, "jcode"),
+      requestBackgroundIndex(projectRoot, "jcode"),
+      requestBackgroundIndex(projectRoot, "jcode"),
+    ];
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(policy.isPaused).toHaveBeenCalledOnce();
+    expect(indexer.index).not.toHaveBeenCalled();
+
+    onBattery = false;
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(Promise.all(requests)).resolves.toEqual([
+      expect.objectContaining({ outcome: "ready" }),
+      expect.objectContaining({ outcome: "ready" }),
+      expect.objectContaining({ outcome: "ready" }),
+    ]);
+    expect(indexer.index).toHaveBeenCalledOnce();
+  });
+
+  it("stops a battery-deferred background request without indexing", async () => {
+    vi.useFakeTimers();
+    const policy: BackgroundIndexingPolicy = {
+      isPaused: vi.fn().mockResolvedValue(true),
+      recheckDelayMs: 100,
+    };
+    powerSource.policy = policy;
+    const indexer = new MockIndexer();
+    configureAutoIndex(projectRoot, "jcode", config({ pauseBackgroundIndexingOnBattery: true }), () => indexer);
+
+    const request = requestBackgroundIndex(projectRoot, "jcode");
+    await vi.advanceTimersByTimeAsync(0);
+    await stopAutoIndex(projectRoot, "jcode");
+
+    await expect(request).resolves.toEqual({ outcome: "stopped" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(indexer.index).not.toHaveBeenCalled();
+  });
+
+  it("keeps manual indexing available while background work is paused on battery", async () => {
+    const policy: BackgroundIndexingPolicy = {
+      isPaused: vi.fn().mockResolvedValue(true),
+      recheckDelayMs: 100,
+    };
+    powerSource.policy = policy;
+    const indexer = new MockIndexer();
+    configureAutoIndex(projectRoot, "jcode", config({ pauseBackgroundIndexingOnBattery: true }), () => indexer);
+
+    await expect(runCoordinatedIndex(projectRoot, "jcode", false)).resolves.toMatchObject({
+      outcome: "ready",
+    });
+
+    expect(indexer.index).toHaveBeenCalledOnce();
+    expect(policy.isPaused).not.toHaveBeenCalled();
   });
 
   it("drains the old coordinator before starting an index-key replacement", async () => {

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -373,16 +373,25 @@ describe("auto-index coordinator", () => {
     powerSource.policy = policy;
     const indexer = new MockIndexer();
     const firstRun = deferred<IndexStats>();
-    indexer.index.mockImplementationOnce(() => firstRun.promise);
+    const secondRun = deferred<IndexStats>();
+    indexer.index
+      .mockImplementationOnce(() => firstRun.promise)
+      .mockImplementationOnce(() => secondRun.promise);
     configureAutoIndex(projectRoot, "jcode", config({ pauseBackgroundIndexingOnBattery: true }), () => indexer);
 
     const firstRequest = requestBackgroundIndex(projectRoot, "jcode");
     await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
     const queuedChange = requestBackgroundIndex(projectRoot, "jcode");
+    let queuedChangeSettled = false;
+    void queuedChange?.then(() => {
+      queuedChangeSettled = true;
+    });
     firstRun.resolve(stats());
 
     await expect(firstRequest).resolves.toMatchObject({ outcome: "ready" });
     await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2));
+    expect(queuedChangeSettled).toBe(false);
+    secondRun.resolve(stats());
     await expect(queuedChange).resolves.toMatchObject({ outcome: "ready" });
   });
 

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -365,6 +365,27 @@ describe("auto-index coordinator", () => {
     expect(indexer.index).toHaveBeenCalledOnce();
   });
 
+  it("drains watcher changes queued while a battery-aware index is running", async () => {
+    const policy: BackgroundIndexingPolicy = {
+      isPaused: vi.fn().mockResolvedValue(false),
+      recheckDelayMs: 100,
+    };
+    powerSource.policy = policy;
+    const indexer = new MockIndexer();
+    const firstRun = deferred<IndexStats>();
+    indexer.index.mockImplementationOnce(() => firstRun.promise);
+    configureAutoIndex(projectRoot, "jcode", config({ pauseBackgroundIndexingOnBattery: true }), () => indexer);
+
+    const firstRequest = requestBackgroundIndex(projectRoot, "jcode");
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const queuedChange = requestBackgroundIndex(projectRoot, "jcode");
+    firstRun.resolve(stats());
+
+    await expect(firstRequest).resolves.toMatchObject({ outcome: "ready" });
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2));
+    await expect(queuedChange).resolves.toMatchObject({ outcome: "ready" });
+  });
+
   it("stops a battery-deferred background request without indexing", async () => {
     vi.useFakeTimers();
     const policy: BackgroundIndexingPolicy = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -87,6 +87,7 @@ describe("config schema", () => {
       expect(config.scope).toBe("project");
       expect(config.include).toHaveLength(DEFAULT_INCLUDE.length);
       expect(config.exclude).toHaveLength(DEFAULT_EXCLUDE.length);
+      expect(config.indexing.pauseBackgroundIndexingOnBattery).toBe(false);
     });
 
     it("should return defaults for null input", () => {
@@ -199,6 +200,7 @@ describe("config schema", () => {
           indexing: {
             autoIndex: true,
             watchFiles: false,
+            pauseBackgroundIndexingOnBattery: true,
             semanticOnly: true,
             autoGc: false,
           },
@@ -206,6 +208,7 @@ describe("config schema", () => {
 
         expect(config.indexing.autoIndex).toBe(true);
         expect(config.indexing.watchFiles).toBe(false);
+        expect(config.indexing.pauseBackgroundIndexingOnBattery).toBe(true);
         expect(config.indexing.semanticOnly).toBe(true);
         expect(config.indexing.autoGc).toBe(false);
       });
@@ -215,11 +218,13 @@ describe("config schema", () => {
           indexing: {
             autoIndex: "true",
             watchFiles: 1,
+            pauseBackgroundIndexingOnBattery: "yes",
           },
         });
 
         expect(config.indexing.autoIndex).toBe(false);
         expect(config.indexing.watchFiles).toBe(true);
+        expect(config.indexing.pauseBackgroundIndexingOnBattery).toBe(false);
       });
 
       it("should parse numeric indexing options", () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -948,6 +948,32 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("failed-batches.json");
   });
 
+  it("keeps manual MCP indexing available when battery pausing is enabled", async () => {
+    await client.close();
+    const config = parseConfig({
+      indexing: {
+        pauseBackgroundIndexingOnBattery: true,
+      },
+    });
+    server = createMcpServer("/tmp/test-project", config);
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    const indexer = (await import("../src/tools/operations.js"))
+      .getIndexerForProject("/tmp/test-project", "opencode");
+
+    const result = await client.callTool({
+      name: "index_codebase",
+      arguments: {},
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(indexer.index).toHaveBeenCalledOnce();
+  });
+
   it("should return an explicit INDEX_BUSY MCP result", async () => {
     const owner = {
       pid: 4242,

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
 const mockState = vi.hoisted(() => ({
   config: {
+    scope: "project" as "project" | "global",
     search: {
       routingHints: true,
       routingGraphHandoffHints: false,
@@ -12,11 +13,20 @@ const mockState = vi.hoisted(() => ({
     },
     indexing: {
       autoIndex: false,
+      autoIndexWaitMs: 50,
+      autoIndexMaxRetries: 0,
+      autoIndexRetryDelayMs: 10,
       watchFiles: false,
+      pauseBackgroundIndexingOnBattery: false,
       requireProjectMarker: true,
     },
   },
   createWatcherWithIndexer: vi.fn(() => ({ stop: vi.fn() })),
+  indexer: {
+    forceIndex: vi.fn().mockResolvedValue({}),
+    getStatus: vi.fn().mockResolvedValue({ indexed: true }),
+    index: vi.fn().mockResolvedValue({}),
+  },
   initializeTools: vi.fn(),
   hints: ["runtime-routing-hint"],
   routingControllers: [] as Array<{
@@ -48,12 +58,6 @@ vi.mock("../src/commands/loader.js", () => ({
 
 vi.mock("../src/tools/index.js", () => {
   const toolStub = {};
-  const indexerStub = {
-    initialize: vi.fn().mockResolvedValue(undefined),
-    index: vi.fn().mockResolvedValue(undefined),
-    getStatus: vi.fn().mockResolvedValue({ indexed: true, compatibility: { compatible: true } }),
-  };
-
   return {
     codebase_context: toolStub,
     codebase_search: toolStub,
@@ -73,7 +77,8 @@ vi.mock("../src/tools/index.js", () => {
     pr_impact: toolStub,
     index_visualize: toolStub,
     initializeTools: mockState.initializeTools,
-    getSharedIndexer: vi.fn(() => indexerStub),
+    getIndexerForProject: vi.fn(() => mockState.indexer),
+    getSharedIndexer: vi.fn(() => mockState.indexer),
   };
 });
 
@@ -98,10 +103,13 @@ vi.mock("../src/routing-hints.js", () => {
 });
 
 import plugin from "../src/index.js";
+import { configureAutoIndex, resetAutoIndexCoordinatorsForTests } from "../src/utils/auto-index.js";
+import type { ParsedCodebaseIndexConfig } from "../src/config/schema.js";
 
 describe("plugin routing hint hook selection", () => {
   beforeEach(() => {
     mockState.config = {
+      scope: "project",
       search: {
         routingHints: true,
         routingGraphHandoffHints: false,
@@ -109,14 +117,35 @@ describe("plugin routing hint hook selection", () => {
       },
       indexing: {
         autoIndex: false,
+        autoIndexWaitMs: 50,
+        autoIndexMaxRetries: 0,
+        autoIndexRetryDelayMs: 10,
         watchFiles: false,
+        pauseBackgroundIndexingOnBattery: false,
         requireProjectMarker: true,
       },
     };
     mockState.hints = ["runtime-routing-hint"];
     mockState.routingControllers.length = 0;
     mockState.createWatcherWithIndexer.mockClear();
-    mockState.initializeTools.mockClear();
+    mockState.indexer.forceIndex.mockReset().mockResolvedValue({});
+    mockState.indexer.getStatus.mockReset().mockResolvedValue({ indexed: true });
+    mockState.indexer.index.mockReset().mockResolvedValue({});
+    mockState.initializeTools.mockReset().mockImplementation((
+      projectRoot: string,
+      config: ParsedCodebaseIndexConfig,
+    ) => {
+      configureAutoIndex(
+        projectRoot,
+        "opencode",
+        config,
+        () => mockState.indexer,
+      );
+    });
+  });
+
+  afterEach(async () => {
+    await resetAutoIndexCoordinatorsForTests();
   });
 
   it("does not watch a project symlink that resolves to the home directory", async () => {
@@ -176,6 +205,32 @@ describe("plugin routing hint hook selection", () => {
     expect(runtime.tool).toEqual(expect.objectContaining({
       codebase_context: expect.any(Object),
     }));
+  });
+
+  it("reloads without waiting for a stuck watcher or starting a redundant index", async () => {
+    mockState.config.indexing.autoIndex = true;
+    mockState.config.indexing.watchFiles = true;
+    let resolveIndex: (() => void) | undefined;
+    mockState.indexer.index.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveIndex = () => resolve({});
+    }));
+    const firstWatcher = {
+      stop: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const secondWatcher = { stop: vi.fn().mockResolvedValue(undefined) };
+    mockState.createWatcherWithIndexer
+      .mockReturnValueOnce(firstWatcher)
+      .mockReturnValueOnce(secondWatcher);
+
+    await plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0]);
+    await vi.waitFor(() => expect(mockState.indexer.index).toHaveBeenCalledOnce());
+
+    await expect(plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0])).resolves.toBeDefined();
+
+    expect(firstWatcher.stop).toHaveBeenCalledOnce();
+    expect(mockState.indexer.index).toHaveBeenCalledOnce();
+    resolveIndex?.();
+    await vi.waitFor(() => expect(mockState.indexer.getStatus).toHaveBeenCalled());
   });
 
   it("injects hints through system transform when role is system", async () => {

--- a/tests/power-source.test.ts
+++ b/tests/power-source.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createBackgroundIndexingPolicy,
+  parseMacOsPowerSource,
+  readMacOsPowerSource,
+} from "../src/utils/power-source.js";
+
+describe("macOS power source", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses AC and battery power from pmset output", () => {
+    expect(parseMacOsPowerSource("Now drawing from 'AC Power'\n")).toBe("ac");
+    expect(parseMacOsPowerSource("Now drawing from 'Battery Power'\n")).toBe("battery");
+    expect(parseMacOsPowerSource("No power source available\n")).toBe("unknown");
+  });
+
+  it("runs pmset with a five-second timeout", async () => {
+    const runCommand = vi.fn().mockResolvedValue("Now drawing from 'Battery Power'\n");
+
+    await expect(readMacOsPowerSource(runCommand)).resolves.toBe("battery");
+    expect(runCommand).toHaveBeenCalledWith(
+      "/usr/bin/pmset",
+      ["-g", "batt"],
+      { timeoutMs: 5_000 },
+    );
+  });
+
+  it("does not create a policy when disabled or outside macOS", () => {
+    const readPowerSource = vi.fn().mockResolvedValue("battery");
+
+    expect(createBackgroundIndexingPolicy(false, {
+      platform: "darwin",
+      readPowerSource,
+    })).toBeNull();
+    expect(createBackgroundIndexingPolicy(true, {
+      platform: "linux",
+      readPowerSource,
+    })).toBeNull();
+    expect(readPowerSource).not.toHaveBeenCalled();
+  });
+
+  it("pauses on battery and resumes on AC power", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const readPowerSource = vi.fn()
+      .mockResolvedValueOnce("battery")
+      .mockResolvedValueOnce("ac");
+    const policy = createBackgroundIndexingPolicy(true, {
+      platform: "darwin",
+      readPowerSource,
+      recheckDelayMs: 10,
+    });
+
+    await expect(policy?.isPaused()).resolves.toBe(true);
+    await expect(policy?.isPaused()).resolves.toBe(false);
+
+    expect(consoleWarn).toHaveBeenNthCalledWith(
+      1,
+      "[codebase-index] Background indexing paused while macOS is using battery power.",
+    );
+    expect(consoleWarn).toHaveBeenNthCalledWith(
+      2,
+      "[codebase-index] AC power detected; resuming pending background indexing.",
+    );
+  });
+
+  it("logs once and allows indexing when power detection fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const readPowerSource = vi.fn().mockRejectedValue(new Error("pmset timed out"));
+    const policy = createBackgroundIndexingPolicy(true, {
+      platform: "darwin",
+      readPowerSource,
+    });
+
+    await expect(policy?.isPaused()).resolves.toBe(false);
+    await expect(policy?.isPaused()).resolves.toBe(false);
+
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[codebase-index] Failed to determine the macOS power source; background indexing will continue: pmset timed out",
+    );
+  });
+
+  it("fails open for unrecognized pmset output", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const policy = createBackgroundIndexingPolicy(true, {
+      platform: "darwin",
+      readPowerSource: vi.fn().mockResolvedValue("unknown"),
+    });
+
+    await expect(policy?.isPaused()).resolves.toBe(false);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("background indexing will continue"),
+    );
+  });
+});

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -14,7 +14,11 @@ const createTestConfig = (overrides: Partial<ParsedCodebaseIndexConfig> = {}): P
   exclude: [],
   indexing: {
     autoIndex: false,
+    autoIndexWaitMs: 10_000,
+    autoIndexMaxRetries: 5,
+    autoIndexRetryDelayMs: 100,
     watchFiles: true,
+    pauseBackgroundIndexingOnBattery: false,
     maxFileSize: 1048576,
     maxChunksPerFile: 100,
     semanticOnly: false,


### PR DESCRIPTION
## Why

When working away from power, simply opening a project can start codebase indexing. Further indexing can then be triggered by file changes and branch switches. That work may use CPU, network, and embedding APIs when a laptop is relying on its battery.

This keeps the current behavior unchanged by default, while giving macOS users who want it a way to defer that background work until AC power is available.

## What changed

This adds an opt-in setting:

`indexing.pauseBackgroundIndexingOnBattery: false`

When enabled on macOS:

- automatic indexing at startup and after file or branch changes is deferred while the computer is on battery power;
- multiple triggers are coalesced into one pending update;
- the pending update resumes when AC power returns;
- manual MCP `index_codebase` calls remain available immediately;
- other platforms keep their current behavior.

Power detection uses `pmset` with a five-second timeout. Errors and unrecognized output fail open, so power detection never blocks indexing.

The change extends the existing process-scoped automatic indexing coordinator shared by startup and watchers. This avoids redundant work and keeps plugin reloads from waiting for a previous watcher or index run.

## Validation

- `npm run typecheck`
- `npm run lint`
- `CHOKIDAR_USEPOLLING=1 npm run build:ts`
- `CHOKIDAR_USEPOLLING=1 npm run build`
- Targeted polling tests: 210 passed.
- Full polling suite: 1,136 passed. It still reports 21 known upstream baseline failures in `indexer-clear-index`, `indexer-failed-batches`, `branch-materialization`, `branch-materialization-multiprocess`, and `automatic-branch-index`.
