### PR TITLE
fix: broaden agent routing hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Broader agent routing hints** (#158): Common repository tasks such as fixing bugs, adding support, investigating failures, refactoring, and reviewing code now receive lightweight `codebase_context`-first guidance. Each matching user message emits the hint at most once, preventing repeated token overhead during tool-call loops. Exact identifier, direct-path, external, and unrelated operational requests remain unnudged.
+
 ## [0.19.1] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `rrfK` | `60` | RRF smoothing constant. Higher values flatten rank impact, lower values prioritize top-ranked candidates more strongly |
 | `rerankTopN` | `20` | Deterministic rerank depth cap. Applies lightweight name/path/chunk-type rerank to top-N only |
 | `contextLines` | `0` | Extra lines to include before/after each match |
-| `routingHints` | `true` | Inject lightweight runtime hints for local conceptual discovery and definition lookups. Set to `false` to disable plugin-side routing nudges. |
+| `routingHints` | `true` | Inject lightweight runtime hints for local conceptual discovery, broad repository coding tasks, and definition lookups. Set to `false` to disable plugin-side routing nudges. |
 | `routingGraphHandoffHints` | `false` | When `true`, conceptual discovery hints also say to use graph tools (including OMO CodeGraph) after semantic discovery identifies relevant symbols. |
 | `routingHintRole` | `"system"` | Message role used when injecting routing hints: `"system"` (default) or `"developer"`. |
 | **reranker** | | Optional second-stage model reranker for the top candidate pool |
@@ -940,7 +940,7 @@ These warnings improve observability but do **not** change the recovery behavior
 ### Retrieval ranking behavior
 
 - `codebase_search` and `codebase_peek` use the hybrid path: semantic + keyword retrieval → fusion (`fusionStrategy`) → deterministic rerank (`rerankTopN`) → optional external reranker (`reranker`) → filtering.
-- When `search.routingHints` is enabled (default), the plugin adds tiny per-turn runtime hints for local conceptual discovery and definition queries. Conceptual discovery is nudged toward `codebase_peek` / `codebase_search`, while definition questions are nudged toward `implementation_lookup`. Exact identifier and unrelated operational tasks are left alone. Set `search.routingGraphHandoffHints` to `true` to add opt-in graph/OMO CodeGraph handoff wording, and set `search.routingHintRole` to `"developer"` if your client/runtime expects developer-role guidance instead of system-role guidance.
+- When `search.routingHints` is enabled (default), the plugin adds a tiny, one-shot runtime hint for matching local conceptual discovery, broad repository coding tasks such as fixing or investigating code, and definition queries. A hint is emitted at most once per user message, so tool-call loops do not repeatedly add it. Conceptual and broad-task prompts are nudged toward `codebase_context` first, with `codebase_peek` / `codebase_search` for targeted follow-up, while definition questions are nudged toward `implementation_lookup`. Exact identifier and unrelated operational tasks are left alone. Set `search.routingGraphHandoffHints` to `true` to add opt-in graph/OMO CodeGraph handoff wording, and set `search.routingHintRole` to `"developer"` if your client/runtime expects developer-role guidance instead of system-role guidance.
 - `find_similar` stays semantic-only: semantic retrieval + deterministic rerank only (no keyword retrieval, no RRF).
 - For compatibility rollbacks, set `search.fusionStrategy` to `"weighted"` to use the legacy weighted fusion path.
 - When enabled, the external reranker sees path metadata plus a bounded on-disk code snippet for each candidate so it can distinguish real implementations from docs/tests more reliably.

--- a/src/routing-hints-patterns.ts
+++ b/src/routing-hints-patterns.ts
@@ -65,6 +65,22 @@ const CONCEPTUAL_DISCOVERY_HINTS = [
   "code that",
 ];
 
+const BROAD_LOCAL_TASK_HINTS = [
+  "fix the bug",
+  "fix this",
+  "fix issue",
+  "implement ",
+  "add support",
+  "investigate ",
+  "debug ",
+  "refactor ",
+  "review this",
+  "review codebase",
+  "review the codebase",
+  "audit this",
+  "audit the codebase",
+];
+
 const DEFINITION_HINTS = [
   "defined",
   "definition",
@@ -118,6 +134,10 @@ export function isExternalLookup(text: string): boolean {
 
 export function hasConceptualDiscoveryHint(text: string): boolean {
   return includesHint(text, CONCEPTUAL_DISCOVERY_HINTS);
+}
+
+export function hasBroadLocalTaskHint(text: string): boolean {
+  return includesHint(text, BROAD_LOCAL_TASK_HINTS);
 }
 
 export function hasDefinitionHint(text: string): boolean {

--- a/src/routing-hints.ts
+++ b/src/routing-hints.ts
@@ -3,6 +3,7 @@ import {
   containsQuotedIdentifier,
   countWords,
   hasConceptualDiscoveryHint,
+  hasBroadLocalTaskHint,
   hasDefinitionHint,
   hasExactMatchHint,
   hasIdentifierShape,
@@ -14,6 +15,7 @@ import {
 
 export type RoutingIntent =
   | "local_conceptual"
+  | "local_broad_task"
   | "definition_lookup"
   | "exact_identifier"
   | "external"
@@ -70,11 +72,12 @@ export function assessRoutingIntent(text: string): RoutingAssessment {
   const matchedDefinitionHint = hasDefinitionHint(lowered);
   const matchedExactMatchHint = hasExactMatchHint(lowered);
   const matchedNonDiscoveryHint = hasNonDiscoveryHint(lowered);
+  const matchedBroadLocalTask = hasBroadLocalTaskHint(lowered);
   const hasIdentifier = hasIdentifierShape(normalizedText);
   const hasQuotedIdentifier = containsQuotedIdentifier(normalizedText);
   const shortQuery = countWords(lowered) <= 10;
 
-  if (matchedNonDiscoveryHint && !matchedConceptualHint) {
+  if (matchedNonDiscoveryHint && !matchedConceptualHint && !matchedBroadLocalTask) {
     return {
       intent: "other",
       text: normalizedText,
@@ -95,6 +98,14 @@ export function assessRoutingIntent(text: string): RoutingAssessment {
       intent: "definition_lookup",
       text: normalizedText,
       reason: "definition_lookup_request",
+    };
+  }
+
+  if (matchedBroadLocalTask) {
+    return {
+      intent: "local_broad_task",
+      text: normalizedText,
+      reason: "broad_local_code_task",
     };
   }
 
@@ -134,19 +145,19 @@ export function buildRoutingHint(
     return "For this turn, prefer `implementation_lookup` to find the authoritative definition site. Use `codebase_search` only if no definition is found, and use `grep` for exhaustive literal matches.";
   }
 
-  if (assessment.intent !== "local_conceptual") {
+  if (assessment.intent !== "local_conceptual" && assessment.intent !== "local_broad_task") {
     return null;
   }
 
   if (!status || !status.indexed || status.compatibility?.compatible === false) {
-      const graphHandoff = includeGraphHandoff ? " Use graph tools after semantic discovery identifies relevant symbols." : "";
-      return `For this turn, if local code discovery by behavior is needed, check \`index_status\` first and run \`index_codebase\` if the index is missing or incompatible.${graphHandoff} Use \`grep\` for exact identifiers or exhaustive matches.`;
+    const graphHandoff = includeGraphHandoff ? " Use graph tools after semantic discovery identifies relevant symbols." : "";
+    return `For this turn, if local code discovery by behavior is needed, check \`index_status\` first and run \`index_codebase\` if the index is missing or incompatible.${graphHandoff} Then use \`codebase_context\` as the first local repository lookup. Use \`grep\` for exact identifiers or exhaustive matches.`;
   }
 
   const graphHandoff = includeGraphHandoff
     ? " before graph tools such as `call_graph`, `call_graph_path`, `pr_impact`, or OMO CodeGraph"
     : "";
-  return `For this turn, prefer \`codebase_peek\` for local code discovery by behavior or likely location${graphHandoff}. Then use \`codebase_search\` when you need implementation content. Use \`grep\` for exact identifiers or exhaustive matches.`;
+  return `For this turn, prefer \`codebase_context\` for local code discovery, then use \`codebase_peek\` for metadata and \`codebase_search\` when you need implementation content${graphHandoff}. Use \`grep\` for exact identifiers or exhaustive matches.`;
 }
 
 export class RoutingHintController {
@@ -164,7 +175,10 @@ export class RoutingHintController {
     this.compactSessions();
     this.sessionState.set(sessionID, {
       assessment,
-      pendingHint: assessment.intent === "local_conceptual" || assessment.intent === "definition_lookup",
+      pendingHint:
+        assessment.intent === "local_conceptual"
+        || assessment.intent === "local_broad_task"
+        || assessment.intent === "definition_lookup",
       updatedAt: Date.now(),
     });
 
@@ -184,6 +198,10 @@ export class RoutingHintController {
     const status = await this.safeGetStatus();
     const hint = buildRoutingHint(state.assessment, status, this.includeGraphHandoff);
 
+    state.pendingHint = false;
+    state.updatedAt = Date.now();
+    this.sessionState.set(sessionID, state);
+
     return hint ? [hint] : [];
   }
 
@@ -194,7 +212,8 @@ export class RoutingHintController {
     }
 
     if (
-      toolName === "codebase_peek"
+      toolName === "codebase_context"
+      || toolName === "codebase_peek"
       || toolName === "codebase_search"
       || toolName === "implementation_lookup"
       || toolName === "index_status"

--- a/tests/routing-hints.test.ts
+++ b/tests/routing-hints.test.ts
@@ -21,17 +21,39 @@ describe("routing hints", () => {
   });
 
   describe("assessRoutingIntent", () => {
-    it("detects conceptual local discovery", () => {
-      const assessment = assessRoutingIntent("Where is the auth flow implemented?");
+    it.each([
+      "Where is authentication implemented?",
+      "How does the retry queue work?",
+      "Fix the bug where expired sessions remain active",
+      "Add support for cancelling in-flight indexing",
+      "Refactor the cache invalidation to avoid duplicate work",
+      "Investigate why startup hangs on Windows",
+      "Review this codebase for security issues",
+      "Implement issue 158.",
+    ])("emits a local-code routing hint for %s", (query) => {
+      const assessment = assessRoutingIntent(query);
 
-      expect(assessment.intent).toBe("local_conceptual");
-      expect(assessment.reason).toBe("conceptual_local_discovery");
+      expect(buildRoutingHint(assessment, { indexed: true, compatibility: { compatible: true } }, true)).toContain("codebase_context");
     });
 
-    it("detects exact identifier lookups", () => {
-      const assessment = assessRoutingIntent("Find all references to `validateToken`");
+    it.each([
+      ["Fix the bug where expired sessions remain active", "local_broad_task"],
+      ["Add support for cancelling in-flight indexing", "local_broad_task"],
+      ["Implement issue 158.", "local_broad_task"],
+      ["Fix the bug and add tests", "local_broad_task"],
+    ])("classifies %s as %s", (query, intent) => {
+      const assessment = assessRoutingIntent(query);
 
-      expect(assessment.intent).toBe("exact_identifier");
+      expect(assessment.intent).toBe(intent);
+    });
+
+    it.each([
+      ["Find all references to `validateToken`", "exact_identifier"],
+      ["Run the tests and fix the failing build", "other"],
+      ["Update CHANGELOG.md for the release", "other"],
+      ["Read src/index.ts", "direct_path"],
+    ])("classifies %s as %s", (query, intent) => {
+      expect(assessRoutingIntent(query).intent).toBe(intent);
     });
 
     it("does not alternate exact-identifier detection for repeated backticked queries", () => {
@@ -51,22 +73,10 @@ describe("routing hints", () => {
       expect(assessment.reason).toBe("definition_lookup_request");
     });
 
-    it("detects direct path requests", () => {
-      const assessment = assessRoutingIntent("Inspect src/indexer/index.ts for ranking logic");
-
-      expect(assessment.intent).toBe("direct_path");
-    });
-
     it("detects external lookups", () => {
       const assessment = assessRoutingIntent("Check the official docs for Next.js app router");
 
       expect(assessment.intent).toBe("external");
-    });
-
-    it("leaves unrelated coding tasks alone", () => {
-      const assessment = assessRoutingIntent("Run the tests and fix the failing build");
-
-      expect(assessment.intent).toBe("other");
     });
   });
 
@@ -78,9 +88,22 @@ describe("routing hints", () => {
         true,
       );
 
-      expect(hint).toContain("prefer `codebase_peek`");
+      expect(hint).toContain("prefer `codebase_context`");
+      expect(hint).toContain("`codebase_peek`");
       expect(hint).toContain("`codebase_search`");
+      expect(hint).toContain("`grep`");
       expect(hint).toContain("before graph tools such as `call_graph`, `call_graph_path`, `pr_impact`, or OMO CodeGraph");
+    });
+
+    it("returns a semantic routing hint for broad local task prompts", () => {
+      const hint = buildRoutingHint(
+        assessRoutingIntent("Fix the bug where expired sessions remain active"),
+        { indexed: true, compatibility: { compatible: true } },
+        true,
+      );
+
+      expect(hint).toContain("prefer `codebase_context`");
+      expect(hint).toContain("`codebase_search`");
       expect(hint).toContain("`grep`");
     });
 
@@ -105,13 +128,27 @@ describe("routing hints", () => {
       expect(hint).toBeNull();
     });
 
+    it.each([
+      "Run the tests and fix the failing build",
+      "Update CHANGELOG.md for the release",
+      "Find all references to `validateToken`",
+      "Read src/index.ts",
+    ])("returns no hint for %s", (query) => {
+      const hint = buildRoutingHint(
+        assessRoutingIntent(query),
+        { indexed: true, compatibility: { compatible: true } },
+      );
+
+      expect(hint).toBeNull();
+    });
+
     it("omits graph handoff wording by default", () => {
       const hint = buildRoutingHint(
         assessRoutingIntent("Where is the webhook validation logic?"),
         { indexed: true, compatibility: { compatible: true } },
       );
 
-      expect(hint).toContain("prefer `codebase_peek`");
+      expect(hint).toContain("prefer `codebase_context`");
       expect(hint).not.toContain("OMO CodeGraph");
       expect(hint).not.toContain("Use graph tools after semantic discovery");
     });
@@ -152,8 +189,37 @@ describe("routing hints", () => {
 
       const hints = await controller.getSystemHints("session-1");
       expect(hints).toHaveLength(1);
-      expect(hints[0]).toContain("prefer `codebase_peek`");
+      expect(hints[0]).toContain("prefer `codebase_context`");
       expect(hints[0]).toContain("OMO CodeGraph");
+    });
+
+    it("stores broad local task state and emits codebase_context-first hint", async () => {
+      const controller = new RoutingHintController(async () => ({
+        indexed: true,
+        compatibility: { compatible: true },
+      }), 200, true);
+
+      controller.observeUserMessage("session-1b", [{ type: "text", text: "Fix the bug where expired sessions remain active" }]);
+
+      const hints = await controller.getSystemHints("session-1b");
+      expect(hints).toHaveLength(1);
+      expect(hints[0]).toContain("prefer `codebase_context`");
+      expect(hints[0]).toContain("`codebase_search`");
+    });
+
+    it("emits at most one hint for each user message", async () => {
+      const controller = new RoutingHintController(async () => ({
+        indexed: true,
+        compatibility: { compatible: true },
+      }));
+
+      controller.observeUserMessage("session-once", [{ type: "text", text: "Investigate why startup hangs" }]);
+
+      expect(await controller.getSystemHints("session-once")).toHaveLength(1);
+      expect(await controller.getSystemHints("session-once")).toEqual([]);
+
+      controller.observeUserMessage("session-once", [{ type: "text", text: "Fix the bug in startup recovery" }]);
+      expect(await controller.getSystemHints("session-once")).toHaveLength(1);
     });
 
     it("stops nudging after a codebase tool is used", async () => {
@@ -181,6 +247,19 @@ describe("routing hints", () => {
       controller.observeUserMessage("session-3", [{ type: "text", text: "Find all references to `validateToken`" }]);
 
       const hints = await controller.getSystemHints("session-3");
+      expect(hints).toEqual([]);
+    });
+
+    it("stops nudging after codebase_context is used", async () => {
+      const controller = new RoutingHintController(async () => ({
+        indexed: true,
+        compatibility: { compatible: true },
+      }), 200, true);
+
+      controller.observeUserMessage("session-3b", [{ type: "text", text: "Review this codebase for security issues" }]);
+      controller.markToolUsed("session-3b", "codebase_context");
+
+      const hints = await controller.getSystemHints("session-3b");
       expect(hints).toEqual([]);
     });
 


### PR DESCRIPTION
## Summary
- recognize common repository coding tasks such as fixing, implementing, investigating, refactoring, reviewing, and auditing
- route conceptual and broad-task prompts to `codebase_context` first
- emit at most one hint per matching user message, preventing repeated token overhead during tool-call loops
- preserve exact identifier, direct path, external lookup, and unrelated operational behavior
- align routing documentation and add behavior-level regression fixtures

## Measured result
A deterministic 12-prompt routing benchmark improved from **7/12** correct decisions before the change to **12/12** after it. The positive local-code subset improved from **3/8** hints to **8/8**, while all four negative controls remained unnudged.

## Token safeguard
Routing guidance is one-shot per matching user message. Repeated model calls after tools do not receive the same hint again, even if the agent ignores the recommendation.

## Validation
- `npm run build:ts`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run` (full suite before the one-shot amendment)
- `npx vitest run tests/routing-hints.test.ts tests/plugin-hooks.test.ts` (after amendment)

Closes #158