### PR TITLE
fix: silence routine branch change logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Broader agent routing hints** (#158): Common repository tasks such as fixing bugs, adding support, investigating failures, refactoring, and reviewing code now receive lightweight `codebase_context`-first guidance. Each matching user message emits the hint at most once, preventing repeated token overhead during tool-call loops. Exact identifier, direct-path, external, and unrelated operational requests remain unnudged.
 
+### Fixed
+
+- **Silent branch switching by default** (#189): Branch changes no longer print directly to stdout. Opt-in branch diagnostics are recorded through the configured debug logger and remain available through `index_logs` when both `debug.enabled` and `debug.logBranch` are enabled.
+
 ## [0.19.1] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -843,7 +843,7 @@ Zero-config by default (uses `auto` mode). Customize in `.opencode/codebase-inde
     "logEmbedding": true,                     // Log embedding API calls
     "logCache": true,                         // Log cache hits/misses
     "logGc": true,                            // Log garbage collection
-    "logBranch": true,                        // Log branch detection
+    "logBranch": true,                        // Log branch detection and switches to index_logs (no stdout output)
     "metrics": false                          // Enable operational metrics collection
   },
   "effectivenessMetrics": {
@@ -923,7 +923,7 @@ String values in `codebase-index.json` can reference environment variables with 
 | `logEmbedding` | `true` | Log embedding API calls (success, error, rate-limit) |
 | `logCache` | `true` | Log cache hits and misses |
 | `logGc` | `true` | Log garbage collection operations |
-| `logBranch` | `true` | Log branch detection and switches |
+| `debug.logBranch` | `true` | Record branch detection and switches in `index_logs` when `debug.enabled` is also `true`; never prints routine branch changes to stdout |
 | `metrics` | `false` | Enable metrics collection (indexing stats, search timing, cache performance) |
 | **effectivenessMetrics** | | |
 | `enabled` | `false` | Independently opt in to memory-only, fixed-cardinality repository-tool effectiveness counters. Does not enable debug logs; stores no queries, response text, code, symbols, paths, repo names, user identity, or stable identifiers. |

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -69,7 +69,10 @@ export function createWatcherWithIndexer(
   if (isGitRepo(projectRoot)) {
     gitWatcher = new GitHeadWatcher(projectRoot);
     gitWatcher.start(async (oldBranch, newBranch) => {
-      console.log(`Branch changed: ${oldBranch ?? "(none)"} -> ${newBranch}`);
+      getIndexer().getLogger().branch("info", "Branch changed", {
+        oldBranch,
+        newBranch,
+      });
       requestReindex();
     });
   }

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -192,6 +192,43 @@ describe("FileWatcher", () => {
   });
 
   describe("createWatcherWithIndexer", () => {
+    it("records branch changes without writing to stdout and still reindexes", async () => {
+      fs.mkdirSync(path.join(tempDir, ".git", "refs", "heads"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+
+      const branch = vi.fn();
+      const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+      const indexer = {
+        index: vi.fn().mockResolvedValue(undefined),
+        getLogger: vi.fn().mockReturnValue({ branch }),
+      };
+      const combinedWatcher = createWatcherWithIndexer(
+        () => indexer,
+        tempDir,
+        createTestConfig({
+          debug: {
+            ...createTestConfig().debug,
+            enabled: false,
+            logBranch: false,
+          },
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      fs.writeFileSync(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/feature\n");
+
+      await vi.waitFor(() => {
+        expect(branch).toHaveBeenCalledWith("info", "Branch changed", {
+          oldBranch: "main",
+          newBranch: "feature",
+        });
+      }, { timeout: 2500 });
+      await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce(), { timeout: 2500 });
+      expect(consoleLog).not.toHaveBeenCalled();
+
+      await combinedWatcher.stop();
+    });
+
     it("handles file-triggered reindexing in the background", async () => {
       vi.setConfig({ testTimeout: 4000 });
       let resolveIndex: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- stop printing routine Git branch changes directly to stdout
- retain opt-in branch diagnostics in `index_logs` through the existing configured Logger
- preserve branch-triggered background reindexing
- clarify that the setting is nested at `debug.logBranch`

## Reproduction and result
Before this change, switching `main -> feature` printed `Branch changed: main -> feature` even with both `debug.enabled: false` and `debug.logBranch: false`.

After the change:
- disabled logging: stdout `[]`, branch logs `[]`
- enabled `debug.enabled` + `debug.logBranch`: stdout `[]`, one structured branch log in `index_logs`

The issue sample places `logBranch` at the configuration root. The supported setting is `debug.logBranch`; no undocumented top-level compatibility was added.

## Validation
- `npm run build:ts`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run` (full suite)
- `npx vitest run tests/watcher.test.ts tests/logger.test.ts tests/config.test.ts`

Closes #189