### PR TITLE
fix: rescue exact definitions omitted by chunk caps

### DIFF
--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Run eval quality gate (real provider config required)
         run: |
-          ARGS=(eval run --config .github/eval-quality-config.json --output .eval-results --reindex --ci --budget "${{ steps.eval-provider.outputs.budget_path }}")
+          ARGS=(eval run --config .github/eval-quality-config.json --output eval-results --reindex --ci --budget "${{ steps.eval-provider.outputs.budget_path }}")
           if [ -n "${{ steps.eval-provider.outputs.against_path }}" ]; then
             ARGS+=(--against "${{ steps.eval-provider.outputs.against_path }}")
           fi
@@ -152,7 +152,7 @@ jobs:
       - name: Add evaluation summary
         if: always()
         run: |
-          SUMMARY=$(find .eval-results -name summary.md -type f -print 2>/dev/null | sort | tail -n 1)
+          SUMMARY=$(find eval-results -name summary.md -type f -print 2>/dev/null | sort | tail -n 1)
           if [ -n "$SUMMARY" ]; then
             cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
           else
@@ -164,7 +164,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: eval-quality-${{ github.run_id }}
-          path: .eval-results
+          path: eval-results
           if-no-files-found: warn
           retention-days: 14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Exact definitions in large files**: Definition and implementation searches now rescue branch-scoped symbols from the uncapped symbol catalog when per-file embedding limits omit their semantic chunks, restoring exact lookup without increasing embedding volume.
+- **Evaluation artifact uploads**: Scheduled quality diagnostics now use a visible output directory so GitHub Actions uploads the generated summaries and per-query evidence on both successful and failed runs.
 - **Silent branch switching by default** (#189): Branch changes no longer print directly to stdout. Opt-in branch diagnostics are recorded through the configured debug logger and remain available through `index_logs` when both `debug.enabled` and `debug.logBranch` are enabled.
 
 ## [0.19.1] - 2026-07-27

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -873,7 +873,7 @@ function classifyQueryIntentRaw(query: string): "source" | "doc_test" | "neutral
 }
 
 function isImplementationChunkType(chunkType: string): boolean {
-  return [
+  return CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunkType) || [
     "export_statement",
     "function",
     "function_declaration",
@@ -1435,10 +1435,11 @@ function promoteIdentifierMatches(
   return [...promoted, ...remainder];
 }
 
-function buildSymbolDefinitionLane(
+export function buildSymbolDefinitionLane(
   query: string,
   database: Database,
   branchChunkIds: Set<string> | null,
+  branchSymbolIds: Set<string> | null,
   limit: number,
   fallbackCandidates: RankedCandidate[],
   prioritizeSourcePaths: boolean = classifyQueryIntentRaw(query) === "source"
@@ -1462,18 +1463,18 @@ function buildSymbolDefinitionLane(
     identifier: string,
     normalizedIdentifier: string,
     baseScore?: number
-  ) => {
+  ): boolean => {
     if (branchChunkIds && !branchChunkIds.has(chunk.chunkId)) {
-      return;
+      return false;
     }
 
     const chunkType = (chunk.nodeType ?? "other") as ChunkMetadata["chunkType"];
     if (!isImplementationChunkType(chunkType)) {
-      return;
+      return false;
     }
 
     if (!isLikelyImplementationPath(chunk.filePath)) {
-      return;
+      return false;
     }
 
     const nameLower = (chunk.name ?? "").toLowerCase();
@@ -1499,6 +1500,7 @@ function buildSymbolDefinitionLane(
         },
       });
     }
+    return true;
   };
 
   const normalizedHints = identifierHints
@@ -1529,13 +1531,47 @@ function buildSymbolDefinitionLane(
     }
 
     for (const symbol of dedupSymbols.values()) {
+      if (branchSymbolIds && !branchSymbolIds.has(symbol.id)) {
+        continue;
+      }
+      if (filePathHint && !pathMatchesHint(symbol.filePath, filePathHint)) {
+        continue;
+      }
+
       const chunks = database.getChunksByFile(symbol.filePath);
+      let foundCoveringChunk = false;
       for (const chunk of chunks) {
         if (chunk.startLine > symbol.startLine || chunk.endLine < symbol.endLine) {
           continue;
         }
 
-        upsertChunkCandidate(chunk, identifier, normalizedIdentifier);
+        foundCoveringChunk = upsertChunkCandidate(chunk, identifier, normalizedIdentifier) || foundCoveringChunk;
+      }
+
+      if (foundCoveringChunk || !isLikelyImplementationPath(symbol.filePath)) {
+        continue;
+      }
+
+      const symbolName = symbol.name.toLowerCase();
+      const exactName =
+        symbolName === identifier ||
+        symbolName.replace(/_/g, "") === normalizedIdentifier;
+      const score = exactName ? 0.99 : 0.88;
+      const existing = symbolCandidates.get(symbol.id);
+      if (!existing || score > existing.score) {
+        symbolCandidates.set(symbol.id, {
+          id: symbol.id,
+          score,
+          metadata: {
+            filePath: symbol.filePath,
+            startLine: symbol.startLine,
+            endLine: symbol.endLine,
+            chunkType: symbol.kind as ChunkMetadata["chunkType"],
+            name: symbol.name,
+            language: symbol.language,
+            hash: symbol.id,
+          },
+        });
       }
     }
 
@@ -1545,6 +1581,9 @@ function buildSymbolDefinitionLane(
     }
 
     for (const chunk of dedupChunksByName.values()) {
+      if (filePathHint && !pathMatchesHint(chunk.filePath, filePathHint)) {
+        continue;
+      }
       upsertChunkCandidate(chunk, identifier, normalizedIdentifier);
     }
   }
@@ -5096,10 +5135,11 @@ export class Indexer {
     const keywordMs = performance.now() - keywordStartTime;
 
     let branchChunkIds: Set<string> | null = null;
+    let branchSymbolIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
-      branchChunkIds = new Set(
-        this.getBranchCatalogKeys().flatMap((branchKey) => database.getBranchChunkIds(branchKey))
-      );
+      const branchCatalogKeys = this.getBranchCatalogKeys();
+      branchChunkIds = new Set(branchCatalogKeys.flatMap((branchKey) => database.getBranchChunkIds(branchKey)));
+      branchSymbolIds = new Set(branchCatalogKeys.flatMap((branchKey) => database.getBranchSymbolIds(branchKey)));
     }
 
     const prefilterStartTime = performance.now();
@@ -5192,6 +5232,7 @@ export class Indexer {
       query,
       database,
       branchChunkIds,
+      branchSymbolIds,
       maxResults,
       union,
       sourceIntent
@@ -5215,7 +5256,7 @@ export class Indexer {
     ).slice(0, maxResults);
 
     const identifierFallback = (!options?.definitionIntent && filtered.length === 0 && identifierHints.length > 0)
-      ? buildSymbolDefinitionLane(query, database, branchChunkIds, maxResults, union, true)
+      ? buildSymbolDefinitionLane(query, database, branchChunkIds, branchSymbolIds, maxResults, union, true)
         .filter((r) => matchesSearchFilters(r, options, this.config.search.minScore))
         .slice(0, maxResults)
       : [];

--- a/tests/effectiveness-ci.test.ts
+++ b/tests/effectiveness-ci.test.ts
@@ -71,8 +71,9 @@ describe("effectiveness quality CI", () => {
 
     expect(workflow).toContain("- name: Add evaluation summary\n        if: always()");
     expect(workflow).toContain("- name: Upload evaluation diagnostics\n        if: always()");
-    expect(workflow).toContain("--output .eval-results");
-    expect(workflow).toContain("path: .eval-results");
+    expect(workflow).toContain("--output eval-results");
+    expect(workflow).toContain("path: eval-results");
+    expect(workflow).not.toContain(".eval-results");
     expect(workflow).toContain("if-no-files-found: warn");
     expect(workflow).toContain("retention-days: 14");
     expect(workflow).not.toContain(".codebase-index");

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -6,7 +6,8 @@ import { execFileSync } from "child_process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { parseConfig } from "../src/config/schema.js";
-import { Indexer } from "../src/indexer/index.js";
+import { buildSymbolDefinitionLane, Indexer } from "../src/indexer/index.js";
+import { Database } from "../src/native/index.js";
 
 describe("search integration", () => {
   let tempDir: string;
@@ -112,6 +113,211 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(topPaths[0]).toContain(path.join("app", "indexer", "index.ts"));
     expect(topPaths).not.toContain(path.join("tests", "fixtures", "call-graph", "same-file-refs.ts"));
     expect(topPaths).not.toContain(path.join("benchmarks", "run.ts"));
+  });
+
+  it("returns exact symbols whose semantic chunks were omitted by the per-file cap", async () => {
+    const largeFile = path.join(tempDir, "app", "indexer", "large.ts");
+    const declarations = Array.from({ length: 30 }, (_, index) =>
+      index === 15
+        ? `export function cappedExactDefinition() {
+  const values = [
+    "target",
+    "semantic",
+    "definition",
+    "omitted",
+    "from",
+    "embedding",
+    "chunks",
+  ];
+  return values.join("-");
+}`
+        : `export function filler${index}() {
+  const value = ${index};
+  return value;
+}`
+    );
+    fs.writeFileSync(largeFile, `${declarations.join("\n\n")}\n`, "utf-8");
+
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+        maxChunksPerFile: 2,
+        fallbackToTextOnMaxChunks: true,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+      },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const status = await indexer.getStatus();
+    const database = new Database(path.join(status.indexPath, "codebase.db"));
+    try {
+      expect(database.getSymbolsByName("cappedExactDefinition")).toHaveLength(1);
+      expect(database.getChunksByName("cappedExactDefinition")).toHaveLength(0);
+    } finally {
+      database.close();
+    }
+
+    const results = await indexer.search("where is cappedExactDefinition implementation", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]).toMatchObject({
+      filePath: largeFile,
+      name: "cappedExactDefinition",
+    });
+    expect(results[0]?.startLine).toBeGreaterThan(1);
+    expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
+  });
+
+  it("does not rescue capped symbols from another branch", () => {
+    const database = new Database(path.join(tempDir, "branch-symbols.db"));
+    try {
+      const symbol = {
+        id: "sym_feature_only",
+        filePath: path.join(tempDir, "app", "feature.ts"),
+        name: "featureOnlyCappedDefinition",
+        kind: "export_statement",
+        startLine: 31,
+        startCol: 0,
+        endLine: 31,
+        endCol: 64,
+        language: "typescript",
+      };
+      database.upsertSymbol(symbol);
+      database.addSymbolsToBranch("feature", [symbol.id]);
+
+      const featureResults = buildSymbolDefinitionLane(
+        "where is featureOnlyCappedDefinition implementation",
+        database,
+        new Set(),
+        new Set(database.getBranchSymbolIds("feature")),
+        5,
+        [],
+        true,
+      );
+      const mainResults = buildSymbolDefinitionLane(
+        "where is featureOnlyCappedDefinition implementation",
+        database,
+        new Set(),
+        new Set(database.getBranchSymbolIds("main")),
+        5,
+        [],
+        true,
+      );
+
+      expect(featureResults[0]).toMatchObject({
+        id: symbol.id,
+        metadata: { name: symbol.name, filePath: symbol.filePath },
+      });
+      expect(mainResults).toEqual([]);
+    } finally {
+      database.close();
+    }
+  });
+
+  it("keeps language-specific symbol kinds eligible after rescue", async () => {
+    const pythonFile = path.join(tempDir, "app", "indexer", "large.py");
+    const declarations = Array.from({ length: 30 }, (_, index) =>
+      index === 15
+        ? `def capped_python_definition():
+    values = [
+        "python",
+        "semantic",
+        "definition",
+        "omitted",
+        "from",
+        "embedding",
+        "chunks",
+    ]
+    return "-".join(values)`
+        : `def python_filler_${index}():
+    value = ${index}
+    return value`
+    );
+    fs.writeFileSync(pythonFile, `${declarations.join("\n\n")}\n`, "utf-8");
+
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+        maxChunksPerFile: 2,
+        fallbackToTextOnMaxChunks: true,
+      },
+      search: { maxResults: 10, minScore: 0 },
+    });
+
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+    const results = await indexer.search("where is capped_python_definition implementation", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+
+    expect(results[0]).toMatchObject({
+      filePath: pythonFile,
+      name: "capped_python_definition",
+      chunkType: "function_definition",
+    });
+  });
+
+  it("honors explicit file hints when duplicate rescued symbols exist", () => {
+    const database = new Database(path.join(tempDir, "path-symbols.db"));
+    try {
+      const symbols = ["first", "second"].map((directory, index) => ({
+        id: `sym_duplicate_${directory}`,
+        filePath: path.join(tempDir, "app", directory, "target.ts"),
+        name: "duplicateCappedDefinition",
+        kind: "export_statement",
+        startLine: index + 10,
+        startCol: 0,
+        endLine: index + 12,
+        endCol: 1,
+        language: "typescript",
+      }));
+      database.upsertSymbolsBatch(symbols);
+      database.upsertChunksBatch(["first", "third", "fourth"].map((directory, index) => ({
+        chunkId: `chunk_duplicate_${index}`,
+        contentHash: `hash_duplicate_${index}`,
+        filePath: path.join(tempDir, "app", directory, "target.ts"),
+        startLine: index + 20,
+        endLine: index + 22,
+        nodeType: "export_statement",
+        name: "duplicateCappedDefinition",
+        language: "typescript",
+      })));
+
+      const results = buildSymbolDefinitionLane(
+        "where is duplicateCappedDefinition implementation in app/second/target.ts",
+        database,
+        null,
+        null,
+        1,
+        [],
+        true,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.metadata.filePath).toBe(symbols[1]?.filePath);
+    } finally {
+      database.close();
+    }
   });
 
   it("annotates indexed chunks with git blame and filters by blame author", async () => {


### PR DESCRIPTION
## Summary
- rescue exact definition and implementation results from the uncapped symbol catalog when per-file embedding limits omit their semantic chunks
- keep rescue branch-scoped, language-aware, and constrained by explicit file-path hints, including stored named chunks
- use a visible eval output directory so failed and successful quality runs upload diagnostics

## Root cause
Large files can exceed `indexing.maxChunksPerFile`. The database still records all parsed symbols, but search previously required an indexed chunk covering each symbol. Definitions omitted by the chunk cap therefore became undiscoverable even though their symbol metadata was available.

## Measured retrieval impact
Using the same existing local index without reindexing or adding embeddings:

| Dataset | Before Hit@5 | After Hit@5 | Before MRR@10 | After MRR@10 |
|---|---:|---:|---:|---:|
| small (4 queries) | 50.0% | 75.0% | 0.5417 | 0.7917 |
| medium (8 queries) | 62.5% | 87.5% | 0.4792 | 0.7292 |
| agent-context (12 queries) | 33.3% | 50.0% | 0.1938 | 0.3604 |

The remaining small-dataset miss is the multi-identifier configuration query. Its relevance labels and query wording need separate evaluation work rather than being tuned in this fix.

## Validation
- regression confirmed to fail on pre-fix `origin/main`
- `npm run build`
- `npm run build:ts` after final review fixes
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (63 files, 1,186 tests)
- `git diff --check`
- independent strong-model review approved the refreshed diff

## Cost and compatibility
- no embedding-cap increase and no reindex required
- no public tool schema changes
- no privacy or effectiveness-metric collection changes
