### PR TITLE
feat: strengthen representative retrieval quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Battery-aware background indexing**: Added the opt-in `indexing.pauseBackgroundIndexingOnBattery` setting. On macOS, automatic startup and watcher-triggered indexing now waits for AC power, coalesces pending work into one update, and keeps manual `index_codebase` requests available. Power detection uses a five-second `pmset` timeout and fails open if the source cannot be determined.
 - **Actionable effectiveness diagnostics**: Privacy-safe runtime metrics now include bounded per-route outcome, result-count, latency, and returned-token histograms. Scheduled quality evaluations retain public synthetic summary and per-query artifacts for 14 days, including failed runs.
+- **Representative retrieval evaluation**: Added a versioned hand-labeled benchmark spanning TypeScript, Rust, Swift, and PHP with difficulty and intent axes, scoped filters, recovery expectations, strict negative cases, symbol-aware graded evidence, and per-query route, outcome, and recovery diagnostics.
 
 ### Changed
 
 - **Broader agent routing hints** (#158): Common repository tasks such as fixing bugs, adding support, investigating failures, refactoring, and reviewing code now receive lightweight `codebase_context`-first guidance. Each matching user message emits the hint at most once, preventing repeated token overhead during tool-call loops. Exact identifier, direct-path, external, and unrelated operational requests remain unnudged.
 - **Stronger retrieval quality gate**: The GitHub Models scheduled evaluation now requires at least 75% Hit@5 and 0.65 MRR@10, so the gate catches material retrieval regressions that the previous permissive floor allowed.
+- **Source-aware context packs**: Conceptual agent context now prioritizes implementation files over documentation, tests, and fixtures unless the query explicitly asks for those paths, while preserving the underlying retrieval order within each evidence class.
 
 ### Fixed
 
 - **Exact definitions in large files**: Definition and implementation searches now rescue branch-scoped symbols from the uncapped symbol catalog when per-file embedding limits omit their semantic chunks, restoring exact lookup without increasing embedding volume.
+- **Nested method definitions**: Symbol catalogs now recursively extract nested declarations independently of capped semantic chunks, migrate unchanged indexes without re-embedding content, and restore exact method lookup in large classes.
 - **Evaluation artifact uploads**: Scheduled quality diagnostics now use a visible output directory so GitHub Actions uploads the generated summaries and per-query evidence on both successful and failed runs.
 - **Silent branch switching by default** (#189): Branch changes no longer print directly to stdout. Opt-in branch diagnostics are recorded through the configured debug logger and remain available through `index_logs` when both `debug.enabled` and `debug.logBranch` are enabled.
 

--- a/benchmarks/baselines/eval-baseline-summary.json
+++ b/benchmarks/baselines/eval-baseline-summary.json
@@ -4,6 +4,7 @@
   "datasetPath": "benchmarks/golden/small.json",
   "datasetName": "small",
   "datasetVersion": "1.0.0",
+  "datasetFingerprint": "054eccab2ca1480b532cbe5a87ad078a88597d8f832237719b3e07c65aeaf6e5",
   "queryCount": 4,
   "topK": 10,
   "searchConfig": {

--- a/benchmarks/golden/representative.json
+++ b/benchmarks/golden/representative.json
@@ -1,0 +1,258 @@
+{
+  "version": "2.0.0",
+  "name": "representative-retrieval",
+  "description": "Hand-labeled retrieval kernel covering exact and nested definitions, conceptual source discovery, language and path filters, scoped recovery, graded multi-file evidence, similarity, keywords, and a negative filtered search.",
+  "queries": [
+    {
+      "id": "ts-definition-top-level",
+      "query": "where is fuseResultsRrf implemented?",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "easy",
+      "tags": ["definition", "top-level", "routing"],
+      "expected": {
+        "expectedRoute": "definition",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/indexer/index.ts", "symbol": "fuseResultsRrf", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "ts-definition-nested-method",
+      "query": "find the getStatus method definition",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["definition", "nested-symbol", "large-file"],
+      "expected": {
+        "expectedRoute": "definition",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/indexer/index.ts", "symbol": "getStatus", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "rust-call-extraction-concept",
+      "query": "extract function calls from syntax trees for the repository graph",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "medium",
+      "tags": ["conceptual", "rust", "call-graph", "file-filter"],
+      "args": { "fileType": "rs" },
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "native/src/call_extractor.rs", "symbol": "extract_calls", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "eval-metrics-concept",
+      "query": "calculate retrieval hit rate reciprocal rank and discounted cumulative gain",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["conceptual", "ranking-metrics", "source-vs-docs"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/eval/metrics.ts", "symbol": "computeEvalMetrics", "relevance": 3 },
+          { "path": "src/eval/metrics.ts", "symbol": "reciprocalRankAtK", "relevance": 3 },
+          { "path": "src/eval/metrics.ts", "symbol": "ndcgAtK", "relevance": 3 },
+          { "path": "src/eval/metrics.ts", "symbol": "buildPerQueryResult", "relevance": 2 }
+        ]
+      }
+    },
+    {
+      "id": "index-lock-concept",
+      "query": "prevent two processes from mutating the same code index concurrently",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "medium",
+      "tags": ["conceptual", "concurrency", "implementation"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/indexer/index-lock.ts", "symbol": "acquireIndexLock", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "mcp-registration-concept",
+      "query": "register and route the MCP tools exposed to coding agents",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "medium",
+      "tags": ["conceptual", "mcp", "implementation"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/mcp-server/register-tools.ts", "symbol": "registerMcpTools", "relevance": 3 },
+          { "path": "src/mcp-server.ts", "symbol": "createMcpServer", "relevance": 2 }
+        ]
+      }
+    },
+    {
+      "id": "config-loading-graded-evidence",
+      "query": "load project and user configuration then validate defaults",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "medium",
+      "tags": ["conceptual", "configuration", "multi-evidence"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/config/merger.ts", "relevance": 3 },
+          { "path": "src/config/schema.ts", "relevance": 2 },
+          { "path": "src/config/index.ts", "relevance": 1 }
+        ]
+      }
+    },
+    {
+      "id": "file-watcher-implementation",
+      "query": "implementation that watches source files and refreshes the index after code changes",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "medium",
+      "tags": ["implementation", "watcher", "multi-evidence"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/watcher/file-watcher.ts", "symbol": "FileWatcher", "relevance": 3 },
+          { "path": "src/watcher/index.ts", "symbol": "createWatcherWithIndexer", "relevance": 2 }
+        ]
+      }
+    },
+    {
+      "id": "swift-nested-method-filtered",
+      "query": "show the UserRepository load method definition",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "language": "swift",
+      "difficulty": "hard",
+      "tags": ["definition", "swift", "nested-symbol", "filters"],
+      "args": {
+        "symbol": "load",
+        "fileType": "swift",
+        "directory": "tests/fixtures/swift"
+      },
+      "expected": {
+        "expectedRoute": "definition",
+        "expectedOutcome": "results",
+        "recoveryExpectation": "none",
+        "gradedEvidence": [
+          { "path": "tests/fixtures/swift/ModernService.swift", "symbol": "load", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "php-path-and-type-filter",
+      "query": "find the helper function used by the PHP caller fixture",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "language": "php",
+      "difficulty": "medium",
+      "tags": ["definition", "php", "filters", "ambiguity"],
+      "args": {
+        "symbol": "helper",
+        "fileType": "php",
+        "directory": "tests/fixtures/call-graph"
+      },
+      "expected": {
+        "expectedRoute": "definition",
+        "expectedOutcome": "results",
+        "recoveryExpectation": "none",
+        "gradedEvidence": [
+          { "path": "tests/fixtures/call-graph/php-simple-calls.php", "symbol": "helper", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "scoped-recovery-definition",
+      "query": "find the getStatus method definition",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["definition", "recovery", "directory-filter"],
+      "args": {
+        "symbol": "getStatus",
+        "directory": "does/not/exist"
+      },
+      "expected": {
+        "expectedRoute": "definition",
+        "expectedOutcome": "results",
+        "recoveryExpectation": "filter-relaxed",
+        "gradedEvidence": [
+          { "path": "src/indexer/index.ts", "symbol": "getStatus", "relevance": 3 }
+        ]
+      }
+    },
+    {
+      "id": "similarity-rrf-fusion",
+      "query": "find code similar to combining semantic and keyword rankings with reciprocal rank fusion",
+      "queryType": "similarity",
+      "retrievalMode": "search",
+      "language": "typescript",
+      "difficulty": "medium",
+      "tags": ["similarity", "ranking", "fusion"],
+      "expected": {
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/indexer/index.ts", "symbol": "fuseResultsRrf", "relevance": 3 },
+          { "path": "src/indexer/index.ts", "symbol": "rankHybridResults", "relevance": 2 }
+        ]
+      }
+    },
+    {
+      "id": "keyword-search-knobs",
+      "query": "fusionStrategy hybridWeight rrfK rerankTopN",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "typescript",
+      "difficulty": "easy",
+      "tags": ["keyword", "configuration", "multi-evidence"],
+      "expected": {
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          { "path": "src/config/schema.ts", "relevance": 3 },
+          { "path": "src/indexer/index.ts", "relevance": 2 },
+          { "path": "src/eval/runner-config.ts", "symbol": "resolveSearchConfig", "relevance": 2 },
+          { "path": "src/eval/runner.ts", "symbol": "runSweep", "relevance": 1 },
+          { "path": "src/eval/cli-parser.ts", "symbol": "hasSweepOptions", "relevance": 1 }
+        ]
+      }
+    },
+    {
+      "id": "negative-strict-directory-filter",
+      "query": "symbolThatCannotExistInThisRepository",
+      "queryType": "definition",
+      "retrievalMode": "search",
+      "language": "typescript",
+      "difficulty": "easy",
+      "tags": ["negative", "no-result", "directory-filter"],
+      "args": {
+        "directory": "does/not/exist"
+      },
+      "expected": {
+        "expectedOutcome": "no-results"
+      }
+    }
+  ]
+}

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -23,6 +23,41 @@ Run the agent-facing dataset with its matching quality and context-efficiency ga
 npm run eval:agent:ci
 ```
 
+Run the hand-labeled representative retrieval kernel:
+
+```bash
+npm run eval:representative
+```
+
+`benchmarks/golden/representative.json` is a compact, versioned quality set for
+exact and nested definitions, conceptual source discovery, TypeScript, Rust,
+Swift, and PHP, scoped file and directory filters, filter-relaxation recovery,
+graded multi-file evidence, similarity, keyword-heavy retrieval, and a strict
+negative filtered search. It complements the larger existing datasets rather
+than replacing them.
+
+Version 2 golden queries can declare:
+
+- `language`, `difficulty`, and bounded `tags` for per-query diagnostics
+- `args.symbol`, `args.fileType`, and `args.directory`, which the runner passes
+  through the same search/context paths used by production tools
+- `expected.expectedRoute`, `expected.expectedOutcome`, and
+  `expected.recoveryExpectation`
+- `expected.gradedEvidence`, whose entries identify a repository-relative path,
+  optional exact symbol, and relevance grade from 1 to 3
+
+Hit and reciprocal-rank metrics require both the labeled path and symbol when a
+symbol is present. nDCG uses the relevance grades. Legacy `filePath` and
+`acceptableFiles` labels remain supported as binary alternatives. Expected
+paths are matched as exact repository-relative paths or as suffixes of absolute
+result paths, never in the reverse direction. The per-query artifact retains
+the declared axes plus route, outcome, and recovery matches for diagnosis.
+
+This kernel measures retrieval and context packing on this repository. It does
+not prove end-to-end agent success or universal state-of-the-art quality. Keep
+cross-repository, provider-specific, latency, and production telemetry evidence
+separate when making broader claims.
+
 Generate the deterministic privacy-safe effectiveness report without embeddings, network access, or repository indexing:
 
 ```bash
@@ -43,8 +78,12 @@ npx vitest run tests/intent-aware-ranking-eval.test.ts
 
 Opt-in runtime effectiveness counters complement these synthetic reports. `index_metrics` exposes fixed aggregate counters plus bounded per-route outcome, result-count, latency, and returned-token histograms. These route-specific views can reveal that one route has a higher no-result rate or larger response buckets, but they remain process-memory-only and contain no queries, paths, symbols, source, repository identity, or raw measurements. They cannot establish causal end-to-end agent success or compare trends across process restarts.
 
-Evaluation comparisons require the same dataset name, version, and query count. Use the
-agent-context budget rather than the default search baseline when evaluating `agent-context.json`.
+Evaluation comparisons require the same dataset name, version, query count, and dataset
+fingerprint. Summaries created before fingerprints were added are intentionally rejected,
+because matching metadata alone cannot prove that labels and query text are identical. Re-run
+the trusted evaluation and follow the baseline blessing workflow below to regenerate a legacy
+summary. Use the agent-context budget rather than the default search baseline when evaluating
+`agent-context.json`.
 
 Context-mode evaluation applies the production evidence packer with its default
 1200-token response budget. The pack contains location evidence only, removes

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -195,7 +195,19 @@ pub struct FileInput {
 pub struct ParsedFile {
     pub path: String,
     pub chunks: Vec<CodeChunk>,
+    pub symbols: Vec<ParsedSymbol>,
     pub hash: String,
+}
+
+#[napi(object)]
+pub struct ParsedSymbol {
+    pub name: String,
+    pub kind: String,
+    pub start_line: u32,
+    pub start_col: u32,
+    pub end_line: u32,
+    pub end_col: u32,
+    pub language: String,
 }
 
 #[napi(object)]

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::types::Language;
-use crate::{CodeChunk, FileInput, ParsedFile};
+use crate::{CodeChunk, FileInput, ParsedFile, ParsedSymbol};
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;
 use rayon::prelude::*;
@@ -78,17 +78,113 @@ pub fn parse_files_parallel(files: Vec<FileInput>) -> Result<Vec<ParsedFile>> {
     let results: Vec<ParsedFile> = files
         .par_iter()
         .filter_map(|file| {
-            let chunks = parse_file_internal(&file.path, &file.content).ok()?;
+            let (chunks, symbols) =
+                parse_file_with_symbols_internal(&file.path, &file.content).ok()?;
             let hash = crate::hasher::xxhash_content(&file.content);
             Some(ParsedFile {
                 path: file.path.clone(),
                 chunks,
+                symbols,
                 hash,
             })
         })
         .collect();
 
     Ok(results)
+}
+
+fn parse_file_with_symbols_internal(
+    file_path: &str,
+    content: &str,
+) -> Result<(Vec<CodeChunk>, Vec<ParsedSymbol>)> {
+    let ext = Path::new(file_path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or("");
+    let language = Language::from_extension(ext);
+
+    if language == Language::Text {
+        return Ok((chunk_by_lines(content, &language), Vec::new()));
+    }
+
+    let mut parser = Parser::new();
+    let ts_language = match language {
+        Language::TypeScript | Language::TypeScriptTsx => {
+            tree_sitter_typescript::LANGUAGE_TSX.into()
+        }
+        Language::JavaScript | Language::JavaScriptJsx => tree_sitter_javascript::LANGUAGE.into(),
+        Language::Python => tree_sitter_python::LANGUAGE.into(),
+        Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+        Language::Swift => tree_sitter_swift::LANGUAGE.into(),
+        Language::Go => tree_sitter_go::LANGUAGE.into(),
+        Language::Json => tree_sitter_json::LANGUAGE.into(),
+        Language::Java => tree_sitter_java::LANGUAGE.into(),
+        Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
+        Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
+        Language::Bash => tree_sitter_bash::LANGUAGE.into(),
+        Language::C => tree_sitter_c::LANGUAGE.into(),
+        Language::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+        Language::Metal => tree_sitter_cpp::LANGUAGE.into(),
+        Language::Toml => tree_sitter_toml_ng::LANGUAGE.into(),
+        Language::Yaml => tree_sitter_yaml::LANGUAGE.into(),
+        Language::Php => tree_sitter_php::LANGUAGE_PHP.into(),
+        Language::Zig => tree_sitter_zig::LANGUAGE.into(),
+        Language::Gdscript => tree_sitter_gdscript::LANGUAGE.into(),
+        Language::Matlab => tree_sitter_matlab::LANGUAGE.into(),
+        Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
+        _ => return Ok((chunk_by_lines(content, &language), Vec::new())),
+    };
+
+    parser.set_language(&ts_language)?;
+    let tree = parser
+        .parse(content, None)
+        .ok_or_else(|| anyhow!("Failed to parse file: {}", file_path))?;
+    let chunks = extract_chunks(&tree, content, &language)?;
+    let symbols = extract_symbols(&tree, content, &language);
+    Ok((chunks, symbols))
+}
+
+fn extract_symbols(tree: &Tree, source: &str, language: &Language) -> Vec<ParsedSymbol> {
+    let mut symbols = Vec::new();
+    let mut cursor = tree.root_node().walk();
+    extract_symbol_nodes(&mut cursor, source, language, &mut symbols, 0);
+    symbols
+}
+
+fn extract_symbol_nodes(
+    cursor: &mut tree_sitter::TreeCursor,
+    source: &str,
+    language: &Language,
+    symbols: &mut Vec<ParsedSymbol>,
+    depth: usize,
+) {
+    const MAX_RECURSION_DEPTH: usize = 1024;
+
+    loop {
+        let node = cursor.node();
+        if is_semantic_node(node.kind(), language) && node.kind() != "export_statement" {
+            if let Some(name) = extract_name(cursor, source, language) {
+                symbols.push(ParsedSymbol {
+                    name,
+                    kind: semantic_chunk_type(&node, source, language),
+                    start_line: node.start_position().row as u32 + 1,
+                    start_col: node.start_position().column as u32,
+                    end_line: node.end_position().row as u32 + 1,
+                    end_col: node.end_position().column as u32,
+                    language: language.as_str().to_string(),
+                });
+            }
+        }
+
+        if depth <= MAX_RECURSION_DEPTH && cursor.goto_first_child() {
+            extract_symbol_nodes(cursor, source, language, symbols, depth + 1);
+            cursor.goto_parent();
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
 }
 
 fn extract_chunks(tree: &Tree, source: &str, language: &Language) -> Result<Vec<CodeChunk>> {
@@ -204,8 +300,13 @@ fn extract_semantic_nodes(
                 node_type,
                 "class_specifier" | "struct_specifier" | "union_specifier"
             );
-        let should_descend =
-            !is_semantic || *language == Language::Swift || descend_into_metal_type;
+        let descend_into_ts_abstract_class =
+            matches!(language, Language::TypeScript | Language::TypeScriptTsx)
+                && node_type == "abstract_class_declaration";
+        let should_descend = !is_semantic
+            || *language == Language::Swift
+            || descend_into_metal_type
+            || descend_into_ts_abstract_class;
         if should_descend && !skip_children && cursor.goto_first_child() {
             extract_semantic_nodes(cursor, source, language, chunks, depth + 1);
             cursor.goto_parent();
@@ -425,6 +526,7 @@ lazy_static! {
         set.insert("enum_declaration");
         set.insert("export_statement");
         set.insert("lexical_declaration");
+        set.insert("abstract_class_declaration");
         // Added 5 most common statement types
         set.insert("expression_statement");
         set.insert("if_statement");
@@ -651,6 +753,12 @@ fn is_semantic_node(node_type: &str, language: &Language) -> bool {
 }
 
 fn semantic_chunk_type(node: &tree_sitter::Node, source: &str, language: &Language) -> String {
+    if matches!(language, Language::TypeScript | Language::TypeScriptTsx)
+        && node.kind() == "abstract_class_declaration"
+    {
+        return "class_declaration".to_string();
+    }
+
     if *language != Language::Swift {
         return node.kind().to_string();
     }
@@ -708,6 +816,16 @@ fn extract_name(
             PERF_STATS.lock().unwrap().extract_name_time += elapsed;
         }
         return Some(name.to_string());
+    }
+
+    if node.kind() == "arrow_function" {
+        let name = extract_arrow_binding_name(node, source);
+        #[cfg(debug_assertions)]
+        {
+            let elapsed = start.elapsed().as_micros();
+            PERF_STATS.lock().unwrap().extract_name_time += elapsed;
+        }
+        return name;
     }
 
     if *language == Language::Metal {
@@ -917,6 +1035,21 @@ fn extract_declarator_name(node: tree_sitter::Node<'_>, source: &str) -> Option<
     }
 
     None
+}
+
+fn extract_arrow_binding_name(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    let parent = node.parent()?;
+    if parent.kind() != "variable_declarator" {
+        return None;
+    }
+
+    if let Some(name_node) = parent.child_by_field_name("name") {
+        if let Some(name) = extract_declarator_name(name_node, source) {
+            return Some(name);
+        }
+    }
+
+    extract_declarator_name(parent, source)
 }
 
 fn split_large_chunk(chunk: CodeChunk, chunks: &mut Vec<CodeChunk>) {
@@ -1233,8 +1366,8 @@ class Child: Base, Runnable {
     #[test]
     fn test_parse_typescript() {
         let content = r#"
-function greet(name: string): string {
-    return `Hello, ${name}!`;
+	function greet(name: string): string {
+	    return `Hello, ${name}!`;
 }
 
 class Greeter {
@@ -1255,9 +1388,67 @@ class Greeter {
     }
 
     #[test]
+    fn test_extract_arrow_function_name_uses_variable_binding() {
+        let content = r#"
+	const handle = (event: string) => {
+	  return event.toLowerCase();
+	};
+
+	const normalize = (value: number) => value * 2;
+	const values = [1, 2].map(item => item * 2);
+	"#;
+
+        let (_chunks, symbols) = parse_file_with_symbols_internal("arrows.ts", content)
+            .expect("should parse TypeScript arrow functions");
+
+        let arrow_names: Vec<String> = symbols
+            .iter()
+            .filter(|symbol| symbol.kind == "arrow_function")
+            .map(|symbol| symbol.name.clone())
+            .collect();
+
+        assert!(arrow_names.iter().any(|name| name == "handle"));
+        assert!(arrow_names.iter().any(|name| name == "normalize"));
+        assert!(!arrow_names.iter().any(|name| name == "event"));
+        assert!(!arrow_names.iter().any(|name| name == "value"));
+        assert!(!arrow_names.iter().any(|name| name == "item"));
+    }
+
+    #[test]
+    fn test_extracts_exported_abstract_class_declaration_and_methods() {
+        let content = r#"
+	export abstract class AbstractAnimal {
+	  identify(): string {
+	    return "animal";
+	  }
+
+	  describe(): string {
+	    return this.identify();
+	  }
+	}
+	"#;
+
+        let (_chunks, symbols) = parse_file_with_symbols_internal("animal.ts", content)
+            .expect("should parse exported abstract class");
+
+        assert!(symbols.iter().any(|symbol| {
+            symbol.kind == "class_declaration" && symbol.name == "AbstractAnimal"
+        }));
+
+        let method_names: Vec<String> = symbols
+            .iter()
+            .filter(|symbol| symbol.kind == "method_definition")
+            .map(|symbol| symbol.name.clone())
+            .collect();
+
+        assert!(method_names.iter().any(|name| name == "identify"));
+        assert!(method_names.iter().any(|name| name == "describe"));
+    }
+
+    #[test]
     fn test_parse_python() {
         let content = r#"
-def greet(name: str) -> str:
+	def greet(name: str) -> str:
     return f"Hello, {name}!"
 
 class Greeter:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dev": "tsup --watch",
     "eval": "npx tsx src/cli.ts eval run",
     "eval:agent": "npx tsx src/cli.ts eval run --dataset benchmarks/golden/agent-context.json",
+    "eval:representative": "npx tsx src/cli.ts eval run --dataset benchmarks/golden/representative.json",
     "eval:agent:ci": "npx tsx src/cli.ts eval run --dataset benchmarks/golden/agent-context.json --reindex --ci --budget benchmarks/budgets/agent-context.json",
     "eval:smoke": "npx tsx src/cli.ts eval run --config .github/eval-config.json --reindex --dataset benchmarks/golden/small.json",
     "eval:ci": "npx tsx src/cli.ts eval run --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",

--- a/src/eval/compare.ts
+++ b/src/eval/compare.ts
@@ -12,6 +12,28 @@ function metricDelta(current: number, baseline: number): MetricDelta {
 }
 
 export function compareSummaries(current: EvalSummary, baseline: EvalSummary, againstPath: string): EvalComparison {
+  const hasCurrentFingerprint = current.datasetFingerprint !== undefined;
+  const hasBaselineFingerprint = baseline.datasetFingerprint !== undefined;
+
+  if (hasCurrentFingerprint !== hasBaselineFingerprint) {
+    throw new Error(
+      `Cannot compare evaluation summaries with mismatched dataset fingerprint presence: current=${
+        hasCurrentFingerprint ? "present" : "missing"
+      }, baseline=${hasBaselineFingerprint ? "present" : "missing"} at ${againstPath}`
+    );
+  }
+
+  if (
+    hasCurrentFingerprint &&
+    hasBaselineFingerprint &&
+    current.datasetFingerprint !== baseline.datasetFingerprint
+  ) {
+    throw new Error(
+      `Cannot compare incompatible evaluation datasets by fingerprint: current=${current.datasetFingerprint}, ` +
+      `baseline=${baseline.datasetFingerprint} at ${againstPath}`
+    );
+  }
+
   if (
     current.datasetName !== baseline.datasetName ||
     current.datasetVersion !== baseline.datasetVersion ||

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -108,7 +108,13 @@ function getRelevantEvidence(query: GoldenQuery): GoldenGradedEvidence[] {
 }
 
 function hasSymbolRequirement(query: GoldenQuery): boolean {
-  return getRelevantEvidence(query).some((entry) => entry.symbol !== undefined);
+  return isSymbolIntended(query);
+}
+
+function isSymbolIntended(query: GoldenQuery): boolean {
+  return query.expected.symbol !== undefined
+    || query.args?.symbol !== undefined
+    || query.expected.gradedEvidence?.some((entry) => entry.symbol !== undefined) === true;
 }
 
 function isExpectedFile(filePath: string, relevant: GoldenGradedEvidence[]): boolean {
@@ -119,10 +125,19 @@ function resultRelevance(
   filePath: string,
   symbol: string | undefined,
   relevant: GoldenGradedEvidence[],
+  isSymbolIntendedQuery: boolean,
 ): number {
   let relevance = 0;
   for (const entry of relevant) {
     if (!pathMatchesExpected(filePath, entry.path)) {
+      continue;
+    }
+
+    if (isSymbolIntendedQuery) {
+      if (symbol === undefined || entry.symbol === undefined || symbol !== entry.symbol) {
+        continue;
+      }
+    } else if (entry.symbol !== undefined && symbol !== undefined && symbol !== entry.symbol) {
       continue;
     }
 
@@ -131,7 +146,12 @@ function resultRelevance(
       continue;
     }
 
-    if (symbol !== undefined && symbol === entry.symbol) {
+    if (isSymbolIntendedQuery && entry.symbol !== undefined && symbol === entry.symbol) {
+      relevance = Math.max(relevance, entry.relevance);
+      continue;
+    }
+
+    if (!isSymbolIntendedQuery && symbol !== undefined && symbol === entry.symbol) {
       relevance = Math.max(relevance, entry.relevance);
     }
   }
@@ -142,8 +162,26 @@ function isRelevantResult(
   filePath: string,
   symbol: string | undefined,
   relevant: GoldenGradedEvidence[],
+  isSymbolIntendedQuery: boolean,
 ): boolean {
-  return resultRelevance(filePath, symbol, relevant) > 0;
+  return resultRelevance(filePath, symbol, relevant, isSymbolIntendedQuery) > 0;
+}
+
+function evidenceMatchesResult(
+  entry: GoldenGradedEvidence,
+  filePath: string,
+  symbol: string | undefined,
+  isSymbolIntendedQuery: boolean,
+): boolean {
+  if (!pathMatchesExpected(filePath, entry.path)) {
+    return false;
+  }
+
+  if (isSymbolIntendedQuery) {
+    return entry.symbol !== undefined && symbol === entry.symbol;
+  }
+
+  return entry.symbol === undefined || symbol === entry.symbol;
 }
 
 function hasGradeBasedEvidence(query: GoldenQuery): boolean {
@@ -166,11 +204,12 @@ function dedupeRelevantEvidence(relevant: GoldenGradedEvidence[]): GoldenGradedE
 function reciprocalRankAtK(
   results: PerQueryEvalResult["results"],
   relevant: GoldenGradedEvidence[],
+  isSymbolIntendedQuery: boolean,
   k: number,
 ): number {
   const top = uniqueResultsByEvidence(results).slice(0, k);
   for (let i = 0; i < top.length; i += 1) {
-    if (isRelevantResult(top[i].filePath, top[i].name, relevant)) {
+    if (isRelevantResult(top[i].filePath, top[i].name, relevant, isSymbolIntendedQuery)) {
       return 1 / (i + 1);
     }
   }
@@ -181,15 +220,38 @@ function ndcgAtK(
   query: GoldenQuery,
   results: PerQueryEvalResult["results"],
   relevant: GoldenGradedEvidence[],
+  isSymbolIntendedQuery: boolean,
   k: number,
 ): number {
   const top = uniqueResultsByEvidence(results).slice(0, k);
+  const availableEvidence = dedupeRelevantEvidence(relevant).filter(
+    (entry) => !isSymbolIntendedQuery || entry.symbol !== undefined,
+  );
   const dcg = top.reduce((sum, result, i) => {
-    const rel = resultRelevance(result.filePath, result.name, relevant);
+    let bestEvidenceIndex = -1;
+    let rel = 0;
+    for (let evidenceIndex = 0; evidenceIndex < availableEvidence.length; evidenceIndex += 1) {
+      const entry = availableEvidence[evidenceIndex];
+      if (
+        entry.relevance > rel
+        && evidenceMatchesResult(entry, result.filePath, result.name, isSymbolIntendedQuery)
+      ) {
+        bestEvidenceIndex = evidenceIndex;
+        rel = entry.relevance;
+      }
+    }
+
+    if (bestEvidenceIndex < 0) {
+      return sum;
+    }
+
+    availableEvidence.splice(bestEvidenceIndex, 1);
     return sum + (2 ** rel - 1) / Math.log2(i + 2);
   }, 0);
 
-  const dedupedRelevant = dedupeRelevantEvidence(relevant);
+  const dedupedRelevant = dedupeRelevantEvidence(relevant).filter(
+    (entry) => !isSymbolIntendedQuery || entry.symbol !== undefined,
+  );
   const idealRelevances = hasGradeBasedEvidence(query)
     ? dedupedRelevant
         .map((entry) => entry.relevance)
@@ -203,7 +265,16 @@ function ndcgAtK(
     0,
   );
 
-  return idcg === 0 ? 0 : dcg / idcg;
+  if (idcg === 0) {
+    return 0;
+  }
+
+  const ndcg = dcg / idcg;
+  if (ndcg <= 0) {
+    return 0;
+  }
+
+  return ndcg > 1 ? 1 : ndcg;
 }
 
 function isDocsOrTestsPath(filePath: string): boolean {
@@ -223,10 +294,11 @@ export function classifyFailureBucket(
   k: number
 ): FailureBucket | undefined {
   const relevant = getRelevantEvidence(query);
+  const isSymbolIntendedQuery = isSymbolIntended(query);
   if (query.expected.expectedOutcome === "no-results") return undefined;
   const top = uniqueResultsByEvidence(results).slice(0, k);
   const hasRelevantTopK = top.some((result) =>
-    isRelevantResult(result.filePath, result.name, relevant)
+    isRelevantResult(result.filePath, result.name, relevant, isSymbolIntendedQuery)
   );
 
   if (!hasRelevantTopK) {
@@ -269,10 +341,13 @@ export function buildPerQueryResult(
   },
 ): PerQueryEvalResult {
   const relevant = getRelevantEvidence(query);
+  const isSymbolIntendedQuery = isSymbolIntended(query);
   const deduped = uniqueResultsByEvidence(results);
 
   const hitAt = (cutoff: number): boolean =>
-    deduped.slice(0, cutoff).some((result) => isRelevantResult(result.filePath, result.name, relevant));
+    deduped.slice(0, cutoff).some((result) =>
+      isRelevantResult(result.filePath, result.name, relevant, isSymbolIntendedQuery)
+    );
 
   const perQuery: PerQueryEvalResult = {
     id: query.id,
@@ -302,8 +377,8 @@ export function buildPerQueryResult(
     hitAt3: hitAt(3),
     hitAt5: hitAt(5),
     hitAt10: hitAt(10),
-    reciprocalRankAt10: reciprocalRankAtK(deduped, relevant, 10),
-    ndcgAt10: ndcgAtK(query, deduped, relevant, 10),
+    reciprocalRankAt10: reciprocalRankAtK(deduped, relevant, isSymbolIntendedQuery, 10),
+    ndcgAt10: ndcgAtK(query, deduped, relevant, isSymbolIntendedQuery, 10),
     failureBucket: classifyFailureBucket(query, results, k),
     rawTop3DistinctRatio: distinctTopKRatio(results, 3),
     tokenBudget: context?.tokenBudget,

--- a/src/eval/metrics.ts
+++ b/src/eval/metrics.ts
@@ -5,6 +5,7 @@ import type {
   EvalResolvedRoute,
   EvalMetrics,
   FailureBucket,
+  GoldenGradedEvidence,
   GoldenQuery,
   PerQueryEvalResult,
 } from "./types.js";
@@ -27,18 +28,28 @@ function normalizePath(input: string): string {
   return normalizePathSeparators(input);
 }
 
-function uniqueResultsByPath(results: PerQueryEvalResult["results"]): PerQueryEvalResult["results"] {
+function uniqueResultsByEvidence(results: PerQueryEvalResult["results"]): PerQueryEvalResult["results"] {
   const seen = new Set<string>();
   const unique: PerQueryEvalResult["results"] = [];
 
   for (const result of results) {
-    const normalized = normalizePath(result.filePath);
-    if (seen.has(normalized)) continue;
-    seen.add(normalized);
+    const key = `${normalizePath(result.filePath)}::${result.name ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
     unique.push(result);
   }
 
   return unique;
+}
+
+function uniqueResultsByPath(results: PerQueryEvalResult["results"]): PerQueryEvalResult["results"] {
+  const seen = new Set<string>();
+  return results.filter((result) => {
+    const key = normalizePath(result.filePath);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 function distinctTopKRatio(results: PerQueryEvalResult["results"], k: number): number {
@@ -52,40 +63,144 @@ export function pathMatchesExpected(actualPath: string, expectedPath: string): b
   const actual = normalizePath(actualPath);
   const expected = normalizePath(expectedPath);
   if (actual === expected) return true;
-  return actual.endsWith(`/${expected}`) || expected.endsWith(`/${actual}`);
+  return actual.endsWith(`/${expected}`);
 }
 
 export function getRelevantPaths(query: GoldenQuery): string[] {
-  const fromExact = query.expected.filePath ? [query.expected.filePath] : [];
-  const fromAcceptable = query.expected.acceptableFiles ?? [];
-  return Array.from(new Set([...fromExact, ...fromAcceptable]));
+  const evidence = getRelevantEvidence(query);
+  return Array.from(new Set(evidence.map((entry) => entry.path)));
 }
 
-function isRelevantResult(filePath: string, relevantPaths: string[]): boolean {
-  return relevantPaths.some((expected) => pathMatchesExpected(filePath, expected));
+function getRelevantEvidence(query: GoldenQuery): GoldenGradedEvidence[] {
+  const legacyEvidence: GoldenGradedEvidence[] = [];
+
+  if (query.expected.filePath !== undefined) {
+    legacyEvidence.push({
+      path: query.expected.filePath,
+      ...(query.expected.symbol !== undefined ? { symbol: query.expected.symbol } : {}),
+      relevance: 1,
+    });
+  }
+
+  if (query.expected.acceptableFiles) {
+    for (const path of query.expected.acceptableFiles) {
+      legacyEvidence.push({
+        path,
+        ...(query.expected.symbol !== undefined ? { symbol: query.expected.symbol } : {}),
+        relevance: 1,
+      });
+    }
+  }
+
+  const gradedEvidence = query.expected.gradedEvidence ?? [];
+  const allEvidence = [...legacyEvidence, ...gradedEvidence];
+
+  const dedupeKey = (entry: GoldenGradedEvidence): string => {
+    return `${normalizePath(entry.path)}::${entry.symbol ?? ""}`;
+  };
+
+  const unique = new Map<string, GoldenGradedEvidence>();
+  for (const entry of allEvidence) {
+    unique.set(dedupeKey(entry), entry);
+  }
+
+  return Array.from(unique.values());
 }
 
-function reciprocalRankAtK(results: PerQueryEvalResult["results"], relevantPaths: string[], k: number): number {
-  const top = uniqueResultsByPath(results).slice(0, k);
+function hasSymbolRequirement(query: GoldenQuery): boolean {
+  return getRelevantEvidence(query).some((entry) => entry.symbol !== undefined);
+}
+
+function isExpectedFile(filePath: string, relevant: GoldenGradedEvidence[]): boolean {
+  return relevant.some((entry) => pathMatchesExpected(filePath, entry.path));
+}
+
+function resultRelevance(
+  filePath: string,
+  symbol: string | undefined,
+  relevant: GoldenGradedEvidence[],
+): number {
+  let relevance = 0;
+  for (const entry of relevant) {
+    if (!pathMatchesExpected(filePath, entry.path)) {
+      continue;
+    }
+
+    if (entry.symbol === undefined) {
+      relevance = Math.max(relevance, entry.relevance);
+      continue;
+    }
+
+    if (symbol !== undefined && symbol === entry.symbol) {
+      relevance = Math.max(relevance, entry.relevance);
+    }
+  }
+  return relevance;
+}
+
+function isRelevantResult(
+  filePath: string,
+  symbol: string | undefined,
+  relevant: GoldenGradedEvidence[],
+): boolean {
+  return resultRelevance(filePath, symbol, relevant) > 0;
+}
+
+function hasGradeBasedEvidence(query: GoldenQuery): boolean {
+  return (query.expected.gradedEvidence?.length ?? 0) > 0;
+}
+
+function dedupeRelevantEvidence(relevant: GoldenGradedEvidence[]): GoldenGradedEvidence[] {
+  const deduped = new Map<string, GoldenGradedEvidence>();
+
+  for (const entry of relevant) {
+    const key = `${normalizePath(entry.path)}::${entry.symbol ?? ""}`;
+    if (!deduped.has(key)) {
+      deduped.set(key, entry);
+    }
+  }
+
+  return [...deduped.values()];
+}
+
+function reciprocalRankAtK(
+  results: PerQueryEvalResult["results"],
+  relevant: GoldenGradedEvidence[],
+  k: number,
+): number {
+  const top = uniqueResultsByEvidence(results).slice(0, k);
   for (let i = 0; i < top.length; i += 1) {
-    if (isRelevantResult(top[i].filePath, relevantPaths)) {
+    if (isRelevantResult(top[i].filePath, top[i].name, relevant)) {
       return 1 / (i + 1);
     }
   }
   return 0;
 }
 
-function ndcgAtK(results: PerQueryEvalResult["results"], relevantPaths: string[], k: number): number {
-  const top = uniqueResultsByPath(results).slice(0, k);
+function ndcgAtK(
+  query: GoldenQuery,
+  results: PerQueryEvalResult["results"],
+  relevant: GoldenGradedEvidence[],
+  k: number,
+): number {
+  const top = uniqueResultsByEvidence(results).slice(0, k);
   const dcg = top.reduce((sum, result, i) => {
-    const rel = isRelevantResult(result.filePath, relevantPaths) ? 1 : 0;
-    return sum + rel / Math.log2(i + 2);
+    const rel = resultRelevance(result.filePath, result.name, relevant);
+    return sum + (2 ** rel - 1) / Math.log2(i + 2);
   }, 0);
 
-  const idealLen = Math.min(k, relevantPaths.length);
-  const idcg = Array.from({ length: idealLen }, (_, i) => 1 / Math.log2(i + 2)).reduce(
-    (sum, value) => sum + value,
-    0
+  const dedupedRelevant = dedupeRelevantEvidence(relevant);
+  const idealRelevances = hasGradeBasedEvidence(query)
+    ? dedupedRelevant
+        .map((entry) => entry.relevance)
+        .sort((a, b) => b - a)
+        .slice(0, k)
+    : relevant.length > 0
+      ? [1]
+      : [];
+  const idcg = idealRelevances.reduce(
+    (sum, rel, index) => sum + (2 ** rel - 1) / Math.log2(index + 2),
+    0,
   );
 
   return idcg === 0 ? 0 : dcg / idcg;
@@ -107,28 +222,27 @@ export function classifyFailureBucket(
   results: PerQueryEvalResult["results"],
   k: number
 ): FailureBucket | undefined {
-  const relevantPaths = getRelevantPaths(query);
-  const top = uniqueResultsByPath(results).slice(0, k);
-  const hasRelevantTopK = top.some((result) => isRelevantResult(result.filePath, relevantPaths));
+  const relevant = getRelevantEvidence(query);
+  if (query.expected.expectedOutcome === "no-results") return undefined;
+  const top = uniqueResultsByEvidence(results).slice(0, k);
+  const hasRelevantTopK = top.some((result) =>
+    isRelevantResult(result.filePath, result.name, relevant)
+  );
 
   if (!hasRelevantTopK) {
+    const hasExpectedFileTopK = top.some((result) => isExpectedFile(result.filePath, relevant));
+    if (hasExpectedFileTopK && hasSymbolRequirement(query)) {
+      return "wrong-symbol";
+    }
     return "no-relevant-hit-top-k";
   }
 
-  if (query.expected.symbol) {
-    const hasSymbol = top.some(
-      (result) =>
-        isRelevantResult(result.filePath, relevantPaths) && result.name === query.expected.symbol
-    );
-    if (!hasSymbol) return "wrong-symbol";
-  }
-
   const top1 = top[0];
-  if (top1 && !isRelevantResult(top1.filePath, relevantPaths) && isDocsOrTestsPath(top1.filePath)) {
+  if (top1 && !isExpectedFile(top1.filePath, relevant) && isDocsOrTestsPath(top1.filePath)) {
     return "docs-tests-outranking-source";
   }
 
-  if (top1 && !isRelevantResult(top1.filePath, relevantPaths)) {
+  if (top1 && !isExpectedFile(top1.filePath, relevant)) {
     return "wrong-file";
   }
 
@@ -150,12 +264,15 @@ export function buildPerQueryResult(
     candidateCount: number;
     deduplicatedCount: number;
     omittedCount: number;
+    recoveryRelaxed?: boolean;
+    recoveryUsed?: boolean;
   },
 ): PerQueryEvalResult {
-  const relevantPaths = getRelevantPaths(query);
-  const deduped = uniqueResultsByPath(results);
+  const relevant = getRelevantEvidence(query);
+  const deduped = uniqueResultsByEvidence(results);
+
   const hitAt = (cutoff: number): boolean =>
-    deduped.slice(0, cutoff).some((result) => isRelevantResult(result.filePath, relevantPaths));
+    deduped.slice(0, cutoff).some((result) => isRelevantResult(result.filePath, result.name, relevant));
 
   const perQuery: PerQueryEvalResult = {
     id: query.id,
@@ -164,13 +281,29 @@ export function buildPerQueryResult(
     retrievalMode: query.retrievalMode ?? "search",
     resolvedRoute: route.resolvedRoute,
     routedQuery: route.routedQuery,
+    routeMatched: query.expected.expectedRoute
+      ? query.expected.expectedRoute === route.resolvedRoute
+      : undefined,
+    outcomeMatched: query.expected.expectedOutcome === undefined
+      ? undefined
+      : query.expected.expectedOutcome === "results"
+        ? deduped.length > 0
+        : deduped.length === 0,
+    recoveryMatched: query.expected.recoveryExpectation === undefined
+      ? undefined
+      : query.expected.recoveryExpectation === "filter-relaxed"
+        ? context?.recoveryRelaxed === true
+        : context?.recoveryUsed !== true,
+    language: query.language,
+    difficulty: query.difficulty,
+    tags: query.tags,
     latencyMs,
     hitAt1: hitAt(1),
     hitAt3: hitAt(3),
     hitAt5: hitAt(5),
     hitAt10: hitAt(10),
-    reciprocalRankAt10: reciprocalRankAtK(deduped, relevantPaths, 10),
-    ndcgAt10: ndcgAtK(deduped, relevantPaths, 10),
+    reciprocalRankAt10: reciprocalRankAtK(deduped, relevant, 10),
+    ndcgAt10: ndcgAtK(query, deduped, relevant, 10),
     failureBucket: classifyFailureBucket(query, results, k),
     rawTop3DistinctRatio: distinctTopKRatio(results, 3),
     tokenBudget: context?.tokenBudget,
@@ -200,6 +333,13 @@ export function computeEvalMetrics(
 ): EvalMetrics {
   const count = perQuery.length;
   const safeDiv = (value: number): number => (count === 0 ? 0 : value / count);
+  const positiveQueryIds = new Set(
+    queries
+      .filter((query) => query.expected.expectedOutcome !== "no-results")
+      .map((query) => query.id),
+  );
+  const positiveCount = perQuery.filter((query) => positiveQueryIds.has(query.id)).length;
+  const safePositiveDiv = (value: number): number => positiveCount === 0 ? 0 : value / positiveCount;
 
   const sum = {
     hitAt1: 0,
@@ -225,29 +365,56 @@ export function computeEvalMetrics(
   const totalContextResponseTokens = contextResponseTokens.reduce((sum, value) => sum + value, 0);
   const contextTokenUnits = totalContextResponseTokens / 1000;
 
+  let routeMatchedCount = 0;
+  let routeExpectedCount = 0;
+  let outcomeMatchedCount = 0;
+  let outcomeExpectedCount = 0;
+  let recoveryMatchedCount = 0;
+  let recoveryExpectedCount = 0;
+
   for (const query of perQuery) {
-    if (query.hitAt1) sum.hitAt1 += 1;
-    if (query.hitAt3) sum.hitAt3 += 1;
-    if (query.hitAt5) sum.hitAt5 += 1;
-    if (query.hitAt10) sum.hitAt10 += 1;
-    sum.mrrAt10 += query.reciprocalRankAt10;
-    sum.ndcgAt10 += query.ndcgAt10;
-    sum.distinctTop3Ratio += distinctTopKRatio(query.results, 3);
+    if (positiveQueryIds.has(query.id)) {
+      if (query.hitAt1) sum.hitAt1 += 1;
+      if (query.hitAt3) sum.hitAt3 += 1;
+      if (query.hitAt5) sum.hitAt5 += 1;
+      if (query.hitAt10) sum.hitAt10 += 1;
+      sum.mrrAt10 += query.reciprocalRankAt10;
+      sum.ndcgAt10 += query.ndcgAt10;
+    }
+    sum.distinctTop3Ratio += distinctTopKRatio(uniqueResultsByPath(query.results), 3);
     sum.rawDistinctTop3Ratio += query.rawTop3DistinctRatio;
     if (query.failureBucket) {
       failureBuckets[query.failureBucket] += 1;
+    }
+
+    if (query.routeMatched !== undefined) {
+      routeExpectedCount += 1;
+      if (query.routeMatched) {
+        routeMatchedCount += 1;
+      }
+    }
+    if (query.outcomeMatched !== undefined) {
+      outcomeExpectedCount += 1;
+      if (query.outcomeMatched) outcomeMatchedCount += 1;
+    }
+    if (query.recoveryMatched !== undefined) {
+      recoveryExpectedCount += 1;
+      if (query.recoveryMatched) recoveryMatchedCount += 1;
     }
   }
 
   const queryTokens = queries.reduce((acc, q) => acc + estimateTokens(q.query), 0);
 
   return {
-    hitAt1: safeDiv(sum.hitAt1),
-    hitAt3: safeDiv(sum.hitAt3),
-    hitAt5: safeDiv(sum.hitAt5),
-    hitAt10: safeDiv(sum.hitAt10),
-    mrrAt10: safeDiv(sum.mrrAt10),
-    ndcgAt10: safeDiv(sum.ndcgAt10),
+    hitAt1: safePositiveDiv(sum.hitAt1),
+    hitAt3: safePositiveDiv(sum.hitAt3),
+    hitAt5: safePositiveDiv(sum.hitAt5),
+    hitAt10: safePositiveDiv(sum.hitAt10),
+    mrrAt10: safePositiveDiv(sum.mrrAt10),
+    ndcgAt10: safePositiveDiv(sum.ndcgAt10),
+    routeAccuracy: routeExpectedCount === 0 ? 0 : routeMatchedCount / routeExpectedCount,
+    outcomeAccuracy: outcomeExpectedCount === 0 ? 0 : outcomeMatchedCount / outcomeExpectedCount,
+    recoveryAccuracy: recoveryExpectedCount === 0 ? 0 : recoveryMatchedCount / recoveryExpectedCount,
     distinctTop3Ratio: safeDiv(sum.distinctTop3Ratio),
     rawDistinctTop3Ratio: safeDiv(sum.rawDistinctTop3Ratio),
     latencyMs: {
@@ -274,16 +441,19 @@ export function computeEvalMetrics(
       },
       duplicateCandidateRatio: contextQueries.length === 0
         ? 0
-        : contextQueries.reduce((sum, item) => sum + item.duplicateCandidateRatio, 0) / contextQueries.length,
+        : contextQueries.reduce((sum, item) => sum + item.duplicateCandidateRatio, 0) /
+          contextQueries.length,
       selectedFileRatio: contextQueries.length === 0
         ? 0
-        : contextQueries.reduce((sum, item) => sum + item.selectedFileRatio, 0) / contextQueries.length,
+        : contextQueries.reduce((sum, item) => sum + item.selectedFileRatio, 0) /
+          contextQueries.length,
       hitAt5Per1kResponseTokens: contextTokenUnits === 0
         ? 0
         : contextQueries.filter((item) => item.hitAt5).length / contextTokenUnits,
       mrrAt10Per1kResponseTokens: contextTokenUnits === 0
         ? 0
-        : contextQueries.reduce((sum, item) => sum + item.reciprocalRankAt10, 0) / contextTokenUnits,
+        : contextQueries.reduce((sum, item) => sum + item.reciprocalRankAt10, 0) /
+          contextTokenUnits,
     },
     failureBuckets,
   };

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import { existsSync } from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
@@ -30,12 +31,38 @@ import type {
   EvalComparison,
   EvalGateResult,
   EvalRunOptions,
+  GoldenDataset,
   EvalSummary,
   PerQueryEvalResult,
   SweepAggregateReport,
   SweepDefinition,
   SweepRunSummary,
 } from "./types.js";
+
+function normalizeForFingerprint(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeForFingerprint(entry));
+  }
+
+  if (value && typeof value === "object") {
+    const normalized: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      const normalizedValue = normalizeForFingerprint((value as Record<string, unknown>)[key]);
+      if (normalizedValue !== undefined) {
+        normalized[key] = normalizedValue;
+      }
+    }
+
+    return normalized;
+  }
+
+  return value;
+}
+
+function buildDatasetFingerprint(dataset: GoldenDataset): string {
+  const canonical = JSON.stringify(normalizeForFingerprint(dataset));
+  return crypto.createHash("sha256").update(canonical).digest("hex");
+}
 
 export interface EvalRunResult {
   outputDir: string;
@@ -81,28 +108,44 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
       const contextResult = query.retrievalMode === "context"
         ? await resolveSearchContext({
           query: query.query,
+          symbol: query.args?.symbol,
+          fileType: query.args?.fileType,
+          directory: query.args?.directory,
           limit: 10,
           tokenBudget: DEFAULT_CONTEXT_PACK_TOKEN_BUDGET,
         }, {
-          lookup: (symbol, limit, _scope) => indexer.search(symbol, limit, {
+          lookup: (symbol, limit, scope) => indexer.search(symbol, limit, {
             metadataOnly: true,
             filterByBranch: !!query.expected.branch,
             definitionIntent: true,
+            fileType: scope.fileType,
+            directory: scope.directory,
           }),
-          search: (searchQuery, limit, _scope) => indexer.search(searchQuery, limit, {
+          search: (searchQuery, limit, scope) => indexer.search(searchQuery, limit, {
             metadataOnly: true,
             filterByBranch: !!query.expected.branch,
             definitionIntent: false,
+            fileType: scope.fileType,
+            directory: scope.directory,
           }),
         })
         : undefined;
       const result = contextResult?.details?.results ?? await indexer.search(query.query, 10, {
         metadataOnly: true,
         filterByBranch: !!query.expected.branch,
+        fileType: query.args?.fileType,
+        directory: query.args?.directory,
       });
       const elapsed = performance.now() - start;
       const resolvedRoute = contextResult?.details?.route === "definition" ? "definition" : "search";
       const routedQuery = contextResult?.details?.routedQuery ?? query.query;
+      const successfulRecoveryAttempt = contextResult?.details?.recovery?.successfulAttemptIndex;
+      const recoveryAttempts = contextResult?.details?.recovery?.attempts ?? [];
+      const recoveryRelaxed = successfulRecoveryAttempt === undefined
+        ? false
+        : (recoveryAttempts[successfulRecoveryAttempt]?.relaxedFields.length ?? 0) > 0;
+      const recoveryUsed = recoveryAttempts.length > 1
+        || recoveryAttempts.some((attempt) => attempt.relaxedFields.length > 0);
 
       const materialized = result.map((item) => ({
         filePath: item.filePath,
@@ -122,6 +165,8 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
         candidateCount: contextResult.details.candidateCount ?? 0,
         deduplicatedCount: contextResult.details.deduplicatedCount ?? 0,
         omittedCount: contextResult.details.omittedCount ?? 0,
+        recoveryUsed,
+        recoveryRelaxed,
       } : undefined));
     }
 
@@ -136,6 +181,7 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
       datasetPath,
       datasetName: dataset.name,
       datasetVersion: dataset.version,
+      datasetFingerprint: buildDatasetFingerprint(dataset),
       queryCount: dataset.queries.length,
       topK: 10,
       searchConfig: {

--- a/src/eval/schema.ts
+++ b/src/eval/schema.ts
@@ -4,7 +4,12 @@ import type {
   EvalBudget,
   GoldenDataset,
   GoldenExpected,
+  GoldenGradedEvidence,
   GoldenQuery,
+  GoldenQueryArgs,
+  GoldenQueryDifficulty,
+  GoldenQueryExpectedOutcome,
+  GoldenQueryRecoveryExpectation,
   GoldenRetrievalMode,
   GoldenQueryType,
 } from "./types.js";
@@ -26,6 +31,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function asPositiveNumber(value: unknown, path: string): number {
@@ -50,10 +59,144 @@ function parseQueryType(value: unknown, path: string): GoldenQueryType {
   );
 }
 
+function parseExpectedRoute(
+  value: unknown,
+  path: string,
+): "search" | "definition" | undefined {
+  if (value === undefined) return undefined;
+  if (value === "search" || value === "definition") return value;
+  throw new Error(`${path} must be one of: search, definition`);
+}
+
+function parseExpectedOutcome(
+  value: unknown,
+  path: string,
+): GoldenQueryExpectedOutcome | undefined {
+  if (value === undefined) return undefined;
+  if (value === "results" || value === "no-results") {
+    return value;
+  }
+  throw new Error(`${path} must be one of: results, no-results`);
+}
+
+function parseRecoveryExpectation(
+  value: unknown,
+  path: string,
+): GoldenQueryRecoveryExpectation | undefined {
+  if (value === undefined) return undefined;
+  if (value === "none" || value === "filter-relaxed") {
+    return value;
+  }
+  throw new Error(`${path} must be one of: none, filter-relaxed`);
+}
+
+function parseQueryDifficulty(
+  value: unknown,
+  path: string,
+): GoldenQueryDifficulty | undefined {
+  if (value === undefined) return undefined;
+  if (value === "easy" || value === "medium" || value === "hard") {
+    return value;
+  }
+  throw new Error(`${path} must be one of: easy, medium, hard`);
+}
+
+function parseQueryTags(value: unknown, path: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!isStringArray(value) || value.some((tag) => tag.trim().length === 0)) {
+    throw new Error(`${path} must be an array of non-empty strings`);
+  }
+  if (value.length > 16) {
+    throw new Error(`${path} must contain at most 16 tags`);
+  }
+
+  return value;
+}
+
+function parseQueryArgs(value: unknown, path: string): GoldenQueryArgs | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+
+  const symbol = parseStringOrUndefined(value.symbol, `${path}.symbol`);
+  const fileType = parseStringOrUndefined(value.fileType, `${path}.fileType`);
+  const directory = parseStringOrUndefined(value.directory, `${path}.directory`);
+  return {
+    ...(symbol !== undefined ? { symbol } : {}),
+    ...(fileType !== undefined ? { fileType } : {}),
+    ...(directory !== undefined ? { directory } : {}),
+  };
+}
+
+const SEMVER_VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+function parseSemanticVersion(value: unknown, path: string): string {
+  if (!isNonEmptyString(value)) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+  if (!SEMVER_VERSION_PATTERN.test(value)) {
+    throw new Error(`${path} must be a valid semantic version (MAJOR.MINOR.PATCH)`);
+  }
+
+  return value;
+}
+
 function parseRetrievalMode(value: unknown, path: string): GoldenRetrievalMode {
   if (value === undefined || value === "search") return "search";
   if (value === "context") return value;
   throw new Error(`${path} must be one of: search, context`);
+}
+
+function parseStringOrUndefined(value: unknown, path: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isNonEmptyString(value)) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+
+  return value;
+}
+
+function parseGradedEvidence(value: unknown, path: string): GoldenGradedEvidence[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} must be an array`);
+  }
+
+  return value.map((entry, index) => {
+    if (!isRecord(entry)) {
+      throw new Error(`${path}[${index}] must be an object`);
+    }
+
+    const evidencePath = parseStringOrUndefined(entry.path, `${path}[${index}].path`);
+    if (evidencePath === undefined) {
+      throw new Error(`${path}[${index}].path is required`);
+    }
+
+    const symbol = parseStringOrUndefined(entry.symbol, `${path}[${index}].symbol`);
+    const relevance = parseEvidenceRelevance(entry.relevance, `${path}[${index}].relevance`);
+
+    return {
+      path: evidencePath,
+      ...(symbol !== undefined ? { symbol } : {}),
+      relevance,
+    };
+  });
+}
+
+function parseEvidenceRelevance(
+  value: unknown,
+  path: string,
+): 1 | 2 | 3 {
+  if (value === undefined) {
+    throw new Error(`${path} is required`);
+  }
+  if (value !== 1 && value !== 2 && value !== 3) {
+    throw new Error(`${path} must be 1, 2, or 3`);
+  }
+
+  return value;
 }
 
 function parseExpected(input: unknown, path: string): GoldenExpected {
@@ -65,12 +208,25 @@ function parseExpected(input: unknown, path: string): GoldenExpected {
   const acceptableFilesRaw = input.acceptableFiles;
   const symbolRaw = input.symbol;
   const branchRaw = input.branch;
+  const expectedRouteRaw = input.expectedRoute;
+  const expectedOutcomeRaw = input.expectedOutcome;
+  const recoveryExpectationRaw = input.recoveryExpectation;
+  const gradedEvidenceRaw = input.gradedEvidence;
 
-  const filePath = typeof filePathRaw === "string" ? filePathRaw : undefined;
+  const filePath = parseStringOrUndefined(filePathRaw, `${path}.filePath`);
   const acceptableFiles = isStringArray(acceptableFilesRaw) ? acceptableFilesRaw : undefined;
+  const gradedEvidence = parseGradedEvidence(gradedEvidenceRaw, `${path}.gradedEvidence`);
 
-  if (!filePath && (!acceptableFiles || acceptableFiles.length === 0)) {
-    throw new Error(`${path} must include either expected.filePath or expected.acceptableFiles`);
+  const expectedOutcome = parseExpectedOutcome(expectedOutcomeRaw, `${path}.expectedOutcome`);
+  if (
+    expectedOutcome !== "no-results" &&
+    !filePath &&
+    (!acceptableFiles || acceptableFiles.length === 0) &&
+    gradedEvidence.length === 0
+  ) {
+    throw new Error(
+      `${path} must include expected.filePath, expected.acceptableFiles, or expected.gradedEvidence`
+    );
   }
 
   if (acceptableFilesRaw !== undefined && !isStringArray(acceptableFilesRaw)) {
@@ -85,12 +241,26 @@ function parseExpected(input: unknown, path: string): GoldenExpected {
     throw new Error(`${path}.branch must be a string when provided`);
   }
 
+  const expectedRoute = parseExpectedRoute(expectedRouteRaw, `${path}.expectedRoute`);
+  const recoveryExpectation = parseRecoveryExpectation(
+    recoveryExpectationRaw,
+    `${path}.recoveryExpectation`
+  );
+
   return {
     filePath,
     acceptableFiles,
     symbol: typeof symbolRaw === "string" ? symbolRaw : undefined,
     branch: typeof branchRaw === "string" ? branchRaw : undefined,
+    expectedRoute,
+    expectedOutcome,
+    recoveryExpectation,
+    ...(gradedEvidence.length > 0 ? { gradedEvidence } : {}),
   };
+}
+
+function parseQueryLanguage(value: unknown, path: string): string | undefined {
+  return parseStringOrUndefined(value, path);
 }
 
 function parseQuery(input: unknown, index: number): GoldenQuery {
@@ -104,6 +274,10 @@ function parseQuery(input: unknown, index: number): GoldenQuery {
   const queryType = input.queryType;
   const retrievalMode = input.retrievalMode;
   const expected = input.expected;
+  const language = input.language;
+  const difficulty = input.difficulty;
+  const tags = input.tags;
+  const args = input.args;
 
   if (typeof id !== "string" || id.trim().length === 0) {
     throw new Error(`${path}.id must be a non-empty string`);
@@ -116,11 +290,15 @@ function parseQuery(input: unknown, index: number): GoldenQuery {
   return {
     id,
     query,
-    queryType: parseQueryType(queryType, `${path}.queryType`),
-    retrievalMode: parseRetrievalMode(retrievalMode, `${path}.retrievalMode`),
-    expected: parseExpected(expected, `${path}.expected`),
-  };
-}
+      queryType: parseQueryType(queryType, `${path}.queryType`),
+      retrievalMode: parseRetrievalMode(retrievalMode, `${path}.retrievalMode`),
+      language: parseQueryLanguage(language, `${path}.language`),
+      difficulty: parseQueryDifficulty(difficulty, `${path}.difficulty`),
+      args: parseQueryArgs(args, `${path}.args`),
+      tags: parseQueryTags(tags, `${path}.tags`),
+      expected: parseExpected(expected, `${path}.expected`),
+    };
+  }
 
 export function parseGoldenDataset(raw: unknown, sourceLabel: string): GoldenDataset {
   if (!isRecord(raw)) {
@@ -132,9 +310,7 @@ export function parseGoldenDataset(raw: unknown, sourceLabel: string): GoldenDat
   const description = raw.description;
   const queriesRaw = raw.queries;
 
-  if (typeof version !== "string" || version.trim().length === 0) {
-    throw new Error(`${sourceLabel}.version must be a non-empty string`);
-  }
+  const validatedVersion = parseSemanticVersion(version, `${sourceLabel}.version`);
 
   if (typeof name !== "string" || name.trim().length === 0) {
     throw new Error(`${sourceLabel}.name must be a non-empty string`);
@@ -163,7 +339,7 @@ export function parseGoldenDataset(raw: unknown, sourceLabel: string): GoldenDat
   }
 
   return {
-    version,
+    version: validatedVersion,
     name,
     description: typeof description === "string" ? description : undefined,
     queries,
@@ -238,16 +414,8 @@ export function parseBudget(raw: unknown, sourceLabel: string): EvalBudget {
         "p95LatencyMaxAbsoluteMs",
         sourceLabel
       ),
-      minHitAt5: parseThresholdValue(
-        thresholds.minHitAt5,
-        "minHitAt5",
-        sourceLabel
-      ),
-      minMrrAt10: parseThresholdValue(
-        thresholds.minMrrAt10,
-        "minMrrAt10",
-        sourceLabel
-      ),
+      minHitAt5: parseThresholdValue(thresholds.minHitAt5, "minHitAt5", sourceLabel),
+      minMrrAt10: parseThresholdValue(thresholds.minMrrAt10, "minMrrAt10", sourceLabel),
       minRawDistinctTop3Ratio: parseThresholdValue(
         thresholds.minRawDistinctTop3Ratio,
         "minRawDistinctTop3Ratio",

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -7,14 +7,34 @@ export type GoldenQueryType =
   | "keyword-heavy"
   | "conceptual";
 
+export type GoldenQueryDifficulty = "easy" | "medium" | "hard";
+export type GoldenQueryExpectedOutcome = "results" | "no-results";
+export type GoldenQueryRecoveryExpectation = "none" | "filter-relaxed";
 export type GoldenRetrievalMode = "search" | "context";
 export type EvalResolvedRoute = "search" | "definition";
+export type GoldenExpectedRoute = "search" | "definition";
+
+export interface GoldenGradedEvidence {
+  path: string;
+  symbol?: string;
+  relevance: 1 | 2 | 3;
+}
+
+export interface GoldenQueryArgs {
+  symbol?: string;
+  fileType?: string;
+  directory?: string;
+}
 
 export interface GoldenExpected {
   filePath?: string;
   acceptableFiles?: string[];
   symbol?: string;
   branch?: string;
+  expectedRoute?: GoldenExpectedRoute;
+  expectedOutcome?: GoldenQueryExpectedOutcome;
+  recoveryExpectation?: GoldenQueryRecoveryExpectation;
+  gradedEvidence?: GoldenGradedEvidence[];
 }
 
 export interface GoldenQuery {
@@ -22,6 +42,10 @@ export interface GoldenQuery {
   query: string;
   queryType: GoldenQueryType;
   retrievalMode?: GoldenRetrievalMode;
+  language?: string;
+  difficulty?: GoldenQueryDifficulty;
+  args?: GoldenQueryArgs;
+  tags?: string[];
   expected: GoldenExpected;
 }
 
@@ -77,6 +101,12 @@ export interface PerQueryEvalResult {
   retrievalMode: GoldenRetrievalMode;
   resolvedRoute: EvalResolvedRoute;
   routedQuery: string;
+  routeMatched?: boolean;
+  outcomeMatched?: boolean;
+  recoveryMatched?: boolean;
+  language?: string;
+  difficulty?: GoldenQueryDifficulty;
+  tags?: string[];
   latencyMs: number;
   hitAt1: boolean;
   hitAt3: boolean;
@@ -118,6 +148,9 @@ export interface EvalMetrics {
   hitAt10: number;
   mrrAt10: number;
   ndcgAt10: number;
+  routeAccuracy: number;
+  outcomeAccuracy: number;
+  recoveryAccuracy: number;
   distinctTop3Ratio: number;
   rawDistinctTop3Ratio: number;
   latencyMs: {
@@ -144,6 +177,7 @@ export interface EvalSummary {
   datasetPath: string;
   datasetName: string;
   datasetVersion: string;
+  datasetFingerprint?: string;
   queryCount: number;
   topK: number;
   searchConfig: Pick<SearchConfig, "fusionStrategy" | "hybridWeight" | "rrfK" | "rerankTopN">;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -523,6 +523,7 @@ const INDEX_METADATA_VERSION = "1";
 const EMBEDDING_STRATEGY_VERSION = "2";
 const SWIFT_PARSER_VERSION = "1";
 const METAL_PARSER_VERSION = "1";
+const SYMBOL_EXTRACTOR_VERSION = "1";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
 const RANK_HYBRID_CACHE_LIMIT = 256;
 
@@ -1545,6 +1546,12 @@ export function buildSymbolDefinitionLane(
           continue;
         }
 
+        const chunkName = (chunk.name ?? "").toLowerCase();
+        const symbolName = symbol.name.toLowerCase();
+        if (chunkName !== symbolName && chunkName.replace(/_/g, "") !== symbolName.replace(/_/g, "")) {
+          continue;
+        }
+
         foundCoveringChunk = upsertChunkCandidate(chunk, identifier, normalizedIdentifier) || foundCoveringChunk;
       }
 
@@ -2274,6 +2281,13 @@ export class Indexer {
 
     const projectHash = hashContent(path.resolve(this.projectRoot)).slice(0, 16);
     return `${key}.${projectHash}`;
+  }
+
+  private getSymbolExtractorVersionMetadataKey(
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): string {
+    const branchKey = this.getBranchCatalogKeyFor(catalogIdentity);
+    return `index.symbolExtractorVersion.${hashContent(branchKey).slice(0, 24)}`;
   }
 
   private hasProjectForceReembedPending(): boolean {
@@ -3995,7 +4009,9 @@ export class Indexer {
       const branchKey = this.getBranchCatalogKey();
       const alreadyIndexed = database.getBranchChunkIds(branchKey).length > 0
         && database.getBranchSymbolIds(branchKey).length > 0;
-      if (alreadyIndexed && this.getStoredBranchCommit(database) === normalizedCommit) {
+      const symbolsCurrent = database.getMetadata(this.getSymbolExtractorVersionMetadataKey())
+        === SYMBOL_EXTRACTOR_VERSION;
+      if (alreadyIndexed && symbolsCurrent && this.getStoredBranchCommit(database) === normalizedCommit) {
         return { prepared: false };
       }
 
@@ -4075,6 +4091,9 @@ export class Indexer {
     const metalParserMetadataKey = this.getMetalParserVersionMetadataKey();
     const reparseCachedMetalFiles =
       database.getMetadata(metalParserMetadataKey) !== METAL_PARSER_VERSION;
+    const symbolExtractorMetadataKey = this.getSymbolExtractorVersionMetadataKey();
+    const refreshCachedSymbols =
+      database.getMetadata(symbolExtractorMetadataKey) !== SYMBOL_EXTRACTOR_VERSION;
     if (
       reparseCachedSwiftFiles &&
       Array.from(this.fileHashCache.keys()).some(
@@ -4142,7 +4161,8 @@ export class Indexer {
         cachedHashMatches &&
         !needsCallGraphRefresh &&
         !requiresSwiftParserUpgrade &&
-        !requiresMetalParserUpgrade
+        !requiresMetalParserUpgrade &&
+        !refreshCachedSymbols
       ) {
         unchangedFilePaths.add(canonicalPath);
         this.logger.recordCacheHit();
@@ -4392,44 +4412,25 @@ export class Indexer {
 
       const fileSymbols: SymbolData[] = [];
 
-      for (const chunk of parsed.chunks) {
-        if (!chunk.name || !CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(chunk.chunkType)) continue;
-
-        // Large Metal functions are split into overlapping chunks. Keep one symbol
-        // spanning the full declaration so same-file resolution does not treat the
-        // fragments as ambiguous overloads.
-        const existingMetalSymbol = chunk.language === "metal"
-          ? fileSymbols.find((symbol) =>
-              symbol.name === chunk.name
-              && symbol.kind === chunk.chunkType
-              && symbol.startLine <= chunk.endLine
-              && chunk.startLine <= symbol.endLine
-            )
-          : undefined;
-        if (existingMetalSymbol) {
-          existingMetalSymbol.startLine = Math.min(existingMetalSymbol.startLine, chunk.startLine);
-          existingMetalSymbol.endLine = Math.max(existingMetalSymbol.endLine, chunk.endLine);
-          existingMetalSymbol.startCol = Math.min(existingMetalSymbol.startCol, chunk.startCol ?? 0);
-          existingMetalSymbol.endCol = Math.max(existingMetalSymbol.endCol, chunk.endCol ?? 0);
-          continue;
-        }
+      for (const parsedSymbol of parsed.symbols) {
+        if (!CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(parsedSymbol.kind)) continue;
 
         const preparedNamespace = this.getPreparedBranchNamespace();
         const symbolId = `sym_${hashContent(
           (preparedNamespace ? `${preparedNamespace}:` : "") +
-          parsed.path + ":" + chunk.name + ":" + chunk.chunkType + ":" +
-          chunk.startLine + ":" + (chunk.startCol ?? 0) + ":" + changedFile.hash,
+          parsed.path + ":" + parsedSymbol.name + ":" + parsedSymbol.kind + ":" +
+          parsedSymbol.startLine + ":" + parsedSymbol.startCol + ":" + changedFile.hash,
         ).slice(0, 16)}`;
         const symbol: SymbolData = {
           id: symbolId,
           filePath: parsed.path,
-          name: chunk.name,
-          kind: chunk.chunkType,
-          startLine: chunk.startLine,
-          startCol: chunk.startCol ?? 0,
-          endLine: chunk.endLine,
-          endCol: chunk.endCol ?? 0,
-          language: chunk.language,
+          name: parsedSymbol.name,
+          kind: parsedSymbol.kind,
+          startLine: parsedSymbol.startLine,
+          startCol: parsedSymbol.startCol,
+          endLine: parsedSymbol.endLine,
+          endCol: parsedSymbol.endCol,
+          language: parsedSymbol.language,
         };
         fileSymbols.push(symbol);
         allSymbolIds.add(symbolId);
@@ -4440,7 +4441,7 @@ export class Indexer {
       // must lowercase the symbol-map keys here too. Otherwise a declaration
       // like `MyMethod` would not match a lowercased call edge target like
       // `mymethod`, leaving same-file calls unresolved (toSymbolId = NULL).
-      const fileLanguage = parsed.chunks[0]?.language;
+      const fileLanguage = parsed.symbols[0]?.language ?? parsed.chunks[0]?.language;
       const isCaseInsensitiveLanguage =
         !!fileLanguage && CASE_INSENSITIVE_LANGUAGES.has(fileLanguage);
       const normalizeSymbolKey = (name: string): string =>
@@ -4578,6 +4579,7 @@ export class Indexer {
       }
       database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
       database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
+      database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
       this.saveBranchCommit(database, indexedCommit);
       this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
@@ -4615,6 +4617,7 @@ export class Indexer {
       }
       database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
       database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
+      database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
       this.saveBranchCommit(database, indexedCommit);
       this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
@@ -4940,6 +4943,7 @@ export class Indexer {
     }
     database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
     database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
+    database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
     this.saveBranchCommit(database, indexedCommit);
     this.saveIndexMetadata(configuredProviderInfo);
     this.indexCompatibility = { compatible: true };
@@ -5449,6 +5453,7 @@ export class Indexer {
     if (
       (hasSwiftFiles && database.getMetadata(this.getSwiftParserVersionMetadataKey()) !== SWIFT_PARSER_VERSION)
       || (hasMetalFiles && database.getMetadata(this.getMetalParserVersionMetadataKey()) !== METAL_PARSER_VERSION)
+      || database.getMetadata(this.getSymbolExtractorVersionMetadataKey()) !== SYMBOL_EXTRACTOR_VERSION
       || (hasCallGraphMigrationFiles
         && database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION)
     ) {
@@ -6354,7 +6359,11 @@ export class Indexer {
     const storedCommit = this.getStoredBranchCommit(database, catalogIdentity);
     const catalogIdentityMatches = storedCommit === expectedCommit;
 
-    if (branchSymbols.length === 0 || !catalogIdentityMatches) {
+    const symbolsCurrent = database.getMetadata(
+      this.getSymbolExtractorVersionMetadataKey(catalogIdentity),
+    ) === SYMBOL_EXTRACTOR_VERSION;
+
+    if (branchSymbols.length === 0 || !catalogIdentityMatches || !symbolsCurrent) {
       if (!resolvedBranch || resolvedBranch === "default") {
         throw new Error("Run index_codebase first to build the call graph and symbol index for this project.");
       }

--- a/src/native/index.ts
+++ b/src/native/index.ts
@@ -130,7 +130,18 @@ export type ChunkType =
 export interface ParsedFile {
   path: string;
   chunks: CodeChunk[];
+  symbols: ParsedSymbol[];
   hash: string;
+}
+
+export interface ParsedSymbol {
+  name: string;
+  kind: string;
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+  language: string;
 }
 
 
@@ -240,8 +251,21 @@ export function parseFiles(files: FileInput[]): ParsedFile[] {
   return result.map((f: any) => ({
     path: f.path,
     chunks: f.chunks.map(mapChunk),
+    symbols: (f.symbols ?? []).map(mapParsedSymbol),
     hash: f.hash,
   }));
+}
+
+function mapParsedSymbol(symbol: any): ParsedSymbol {
+  return {
+    name: symbol.name,
+    kind: symbol.kind,
+    startLine: symbol.startLine ?? symbol.start_line,
+    startCol: symbol.startCol ?? symbol.start_col,
+    endLine: symbol.endLine ?? symbol.end_line,
+    endCol: symbol.endCol ?? symbol.end_col,
+    language: symbol.language,
+  };
 }
 
 function mapChunk(c: any): CodeChunk {

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -1,5 +1,6 @@
 import type { HostMode } from "../config/host.js";
 import type { SearchResult } from "../indexer/index.js";
+import { analyzeQueryIntent } from "../indexer/intent-aware-ranking.js";
 import {
   getCallGraphData,
   getCallGraphPath,
@@ -464,6 +465,7 @@ export async function resolveSearchContext(
     const results = await tryConceptualSearch(attempt.queryText, attempt.scope, attempt.relaxed);
     if (results.length > 0) {
       const heading = buildPackHeading("conceptual", decisions);
+      const intent = analyzeQueryIntent(attempt.queryText);
       return toResult(
         "conceptual",
         attempt.queryText,
@@ -472,6 +474,8 @@ export async function resolveSearchContext(
           maxResults: limit,
           heading,
           includeExactSearchHandoff: true,
+          preferImplementationPaths:
+            intent.preferSourcePaths || (intent.primary !== "docs" && intent.primary !== "test"),
         }),
       );
     }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -3,6 +3,8 @@ import type { CallGraphDataResult, CallGraphPathResult, CallGraphSymbolResolutio
 import type { LogEntry } from "../utils/logger.js";
 import { get_encoding } from "tiktoken";
 
+import { isLikelyImplementationPath } from "../indexer/intent-aware-ranking.js";
+
 export const MIN_CONTEXT_PACK_TOKEN_BUDGET = 128;
 export const MAX_CONTEXT_PACK_TOKEN_BUDGET = 4000;
 export const DEFAULT_CONTEXT_PACK_TOKEN_BUDGET = 1200;
@@ -18,6 +20,7 @@ export interface ContextPackOptions {
   heading?: string;
   maxResults?: number;
   includeExactSearchHandoff?: boolean;
+  preferImplementationPaths?: boolean;
 }
 
 export interface ContextPackResult {
@@ -93,10 +96,22 @@ function normalizedLineRange(result: SearchResult): { start: number; end: number
     : { start: result.endLine, end: result.startLine };
 }
 
-function rankContextCandidates(results: SearchResult[]): RankedSearchResult[] {
+function rankContextCandidates(
+  results: SearchResult[],
+  preferImplementationPaths: boolean,
+): RankedSearchResult[] {
   return results
     .map((result, originalIndex) => ({ result, originalIndex }))
-    .sort((left, right) => right.result.score - left.result.score || left.originalIndex - right.originalIndex);
+    .sort((left, right) => {
+      if (preferImplementationPaths) {
+        const leftIsImplementation = isLikelyImplementationPath(left.result.filePath);
+        const rightIsImplementation = isLikelyImplementationPath(right.result.filePath);
+        if (leftIsImplementation !== rightIsImplementation) {
+          return leftIsImplementation ? -1 : 1;
+        }
+      }
+      return right.result.score - left.result.score || left.originalIndex - right.originalIndex;
+    });
 }
 
 function deduplicateContextCandidates(candidates: RankedSearchResult[]): SearchResult[] {
@@ -213,7 +228,12 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const maxResults = Math.max(0, Math.floor(options.maxResults ?? results.length));
   const includeExactSearchHandoff = options.includeExactSearchHandoff ?? false;
   const candidateCount = results.length;
-  const deduplicated = deduplicateContextCandidates(rankContextCandidates(results));
+  const deduplicated = deduplicateContextCandidates(
+    rankContextCandidates(
+      results,
+      options.preferImplementationPaths ?? false,
+    ),
+  );
   const diversified = diversifyContextCandidates(deduplicated);
   const duplicateCount = candidateCount - deduplicated.length;
   const selectable = diversified.slice(0, maxResults);

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -32,6 +32,10 @@ function branchCommitMetadataKey(catalogIdentity: string): string {
   return `index.branchCommit.${hashContent(catalogIdentity).slice(0, 24)}`;
 }
 
+function symbolExtractorMetadataKey(catalogIdentity: string): string {
+  return `index.symbolExtractorVersion.${hashContent(catalogIdentity).slice(0, 24)}`;
+}
+
 describe("automatic branch index preparation", () => {
   let tempDir: string;
   let repo: string;
@@ -175,6 +179,33 @@ function changed(): number {
     const second = await indexer.getPrImpact({ branch: "feature" });
     expect(second.indexPreparation).toEqual({ prepared: false, branch: "feature" });
     expect(fetchSpy.mock.calls.length).toBe(fetchesAfterPreparation);
+  });
+
+  it("reparses a cached alternate branch when its symbol extractor metadata is stale", async () => {
+    await indexer.getPrImpact({ branch: "feature" });
+    const db = await database();
+    expect(db.getMetadata(symbolExtractorMetadataKey("main"))).toBe("1");
+    expect(db.getMetadata(symbolExtractorMetadataKey("feature"))).toBe("1");
+
+    const status = await indexer.getStatus();
+    await indexer.close();
+    const directDatabase = new Database(path.join(status.indexPath, "codebase.db"));
+    directDatabase.setMetadata(symbolExtractorMetadataKey("feature"), "stale");
+    directDatabase.close();
+    indexer = new Indexer(repo, config);
+    const fetchesBeforeMigration = fetchSpy.mock.calls.length;
+
+    const migrated = await indexer.getPrImpact({ branch: "feature" });
+
+    expect(migrated.indexPreparation).toMatchObject({
+      prepared: true,
+      branch: "feature",
+      commit: featureCommit,
+    });
+    expect(fetchSpy.mock.calls.length).toBe(fetchesBeforeMigration);
+    const migratedDb = await database();
+    expect(migratedDb.getMetadata(symbolExtractorMetadataKey("feature"))).toBe("1");
+    expect(migratedDb.getMetadata(symbolExtractorMetadataKey("main"))).toBe("1");
   });
 
   it("reindexes a moved branch OID, replaces stale catalog data, and preserves primary data", async () => {

--- a/tests/eval-compare.test.ts
+++ b/tests/eval-compare.test.ts
@@ -3,13 +3,18 @@ import { describe, expect, it } from "vitest";
 import { compareSummaries } from "../src/eval/compare.js";
 import type { EvalSummary } from "../src/eval/types.js";
 
-function summary(overrides: Partial<Pick<EvalSummary, "datasetName" | "datasetVersion" | "queryCount">> = {}): EvalSummary {
+function summary(
+  overrides: Partial<
+    Pick<EvalSummary, "datasetName" | "datasetVersion" | "queryCount" | "datasetFingerprint">
+  > = {},
+): EvalSummary {
   return {
     generatedAt: "2026-07-25T00:00:00.000Z",
     projectRoot: "/repo",
     datasetPath: "dataset.json",
     datasetName: overrides.datasetName ?? "agent-context",
     datasetVersion: overrides.datasetVersion ?? "1.0.0",
+    datasetFingerprint: overrides.datasetFingerprint,
     queryCount: overrides.queryCount ?? 12,
     topK: 10,
     searchConfig: { fusionStrategy: "rrf", hybridWeight: 0.4, rrfK: 60, rerankTopN: 20 },
@@ -46,6 +51,31 @@ function summary(overrides: Partial<Pick<EvalSummary, "datasetName" | "datasetVe
 describe("evaluation comparison", () => {
   it("compares matching datasets", () => {
     expect(compareSummaries(summary(), summary(), "baseline.json").deltas.hitAt5.absolute).toBe(0);
+  });
+
+  it("compares matching datasets when fingerprints match", () => {
+    const comparison = compareSummaries(
+      summary({ datasetFingerprint: "abc123" }),
+      summary({ datasetFingerprint: "abc123" }),
+      "baseline.json"
+    );
+
+    expect(comparison.deltas.hitAt5.absolute).toBe(0);
+  });
+
+  it("rejects when dataset fingerprints do not match", () => {
+    expect(() =>
+      compareSummaries(
+        summary({ datasetFingerprint: "abc123" }),
+        summary({ datasetFingerprint: "def456" }),
+        "baseline.json"
+      )
+    ).toThrow(/incompatible evaluation datasets by fingerprint/);
+  });
+
+  it("rejects comparison when one summary has a fingerprint and the other does not", () => {
+    expect(() => compareSummaries(summary(), summary({ datasetFingerprint: "abc123" }), "baseline.json")).toThrow(/mismatched dataset fingerprint presence/);
+    expect(() => compareSummaries(summary({ datasetFingerprint: "abc123" }), summary(), "baseline.json")).toThrow(/mismatched dataset fingerprint presence/);
   });
 
   it.each([

--- a/tests/eval-metrics.test.ts
+++ b/tests/eval-metrics.test.ts
@@ -19,7 +19,7 @@ function query(overrides: Partial<GoldenQuery> = {}): GoldenQuery {
 describe("eval metrics", () => {
   it("matches expected paths with suffix support", () => {
     expect(pathMatchesExpected("/repo/src/indexer/index.ts", "src/indexer/index.ts")).toBe(true);
-    expect(pathMatchesExpected("src/indexer/index.ts", "/repo/src/indexer/index.ts")).toBe(true);
+    expect(pathMatchesExpected("src/indexer/index.ts", "/repo/src/indexer/index.ts")).toBe(false);
     expect(pathMatchesExpected("/repo/src/tools/index.ts", "src/indexer/index.ts")).toBe(false);
   });
 
@@ -28,6 +28,19 @@ describe("eval metrics", () => {
       expected: {
         filePath: "src/indexer/index.ts",
         acceptableFiles: ["src/tools/index.ts", "src/indexer/index.ts"],
+      },
+    });
+
+    expect(getRelevantPaths(q)).toEqual(["src/indexer/index.ts", "src/tools/index.ts"]);
+  });
+
+  it("builds relevant path set from graded evidence", () => {
+    const q = query({
+      expected: {
+        gradedEvidence: [
+          { path: "src/indexer/index.ts", symbol: "rankHybridResults", relevance: 3 },
+          { path: "src/tools/index.ts", symbol: "toolSymbol", relevance: 2 },
+        ],
       },
     });
 
@@ -104,6 +117,92 @@ describe("eval metrics", () => {
     expect(wrongSymbol.failureBucket).toBe("wrong-symbol");
   });
 
+  it("classifies wrong symbol using graded evidence even when path matches", () => {
+    const q = query({
+      expected: {
+        gradedEvidence: [{ path: "src/indexer/index.ts", symbol: "rankHybridResults", relevance: 3 }],
+      },
+    });
+
+    const wrongSymbol = buildPerQueryResult(
+      q,
+      [
+        {
+          filePath: "/repo/src/indexer/index.ts",
+          startLine: 1,
+          endLine: 2,
+          score: 0.9,
+          chunkType: "function",
+          name: "someOtherFunction",
+        },
+      ],
+      10,
+      10
+    );
+
+    expect(wrongSymbol.failureBucket).toBe("wrong-symbol");
+    expect(wrongSymbol.hitAt1).toBe(false);
+  });
+
+  it("keeps distinct symbols in one file and rewards higher graded evidence", () => {
+    const q = query({
+      expected: {
+        gradedEvidence: [
+          { path: "src/indexer/index.ts", symbol: "rankHybridResults", relevance: 3 },
+          { path: "src/indexer/index.ts", symbol: "rerankResults", relevance: 1 },
+        ],
+      },
+    });
+    const highFirst = buildPerQueryResult(q, [
+      {
+        filePath: "/repo/src/indexer/index.ts",
+        startLine: 1,
+        endLine: 2,
+        score: 1,
+        chunkType: "function",
+        name: "rankHybridResults",
+      },
+      {
+        filePath: "/repo/src/indexer/index.ts",
+        startLine: 3,
+        endLine: 4,
+        score: 0.9,
+        chunkType: "function",
+        name: "rerankResults",
+      },
+    ], 10, 10);
+    const lowFirst = buildPerQueryResult(q, [...highFirst.results].reverse(), 10, 10);
+
+    expect(highFirst.results).toHaveLength(2);
+    expect(highFirst.ndcgAt10).toBeGreaterThan(lowFirst.ndcgAt10);
+    expect(highFirst.ndcgAt10).toBeCloseTo(1, 8);
+  });
+
+  it("does not inflate nDCG ideal with multiple legacy acceptable files", () => {
+    const q = query({
+      expected: {
+        filePath: "src/indexer/index.ts",
+        acceptableFiles: ["src/tools/index.ts", "src/indexer/index.ts", "src/tools/index.ts"],
+      },
+    });
+
+    const per = buildPerQueryResult(
+      q,
+      [{
+        filePath: "/repo/src/tools/index.ts",
+        startLine: 1,
+        endLine: 2,
+        score: 0.95,
+        chunkType: "function",
+        name: "codebase_search",
+      }],
+      20,
+      10
+    );
+
+    expect(per.ndcgAt10).toBeCloseTo(1, 8);
+  });
+
   it("aggregates eval metrics including latency percentiles and costs", () => {
     const queries: GoldenQuery[] = [
       query({ id: "q1" }),
@@ -159,12 +258,118 @@ describe("eval metrics", () => {
 
     expect(metrics.hitAt1).toBe(0.5);
     expect(metrics.hitAt3).toBe(1);
+    expect(metrics.routeAccuracy).toBe(0);
     expect(metrics.mrrAt10).toBeCloseTo(0.75, 5);
     expect(metrics.distinctTop3Ratio).toBe(1);
     expect(metrics.rawDistinctTop3Ratio).toBe(1);
     expect(metrics.latencyMs.p50).toBeGreaterThan(0);
     expect(metrics.embedding.callCount).toBe(20);
     expect(metrics.embedding.estimatedCostUsd).toBeCloseTo(0.00002, 8);
+  });
+
+  it("tracks route accuracy only for queries with expected routes", () => {
+    const routeQueries: GoldenQuery[] = [
+      query({
+        id: "route-matched",
+        expected: {
+          filePath: "src/indexer/index.ts",
+          expectedRoute: "search",
+        },
+      }),
+      query({
+        id: "route-mismatch",
+        expected: {
+          filePath: "src/indexer/index.ts",
+          expectedRoute: "search",
+        },
+      }),
+    ];
+
+    const routeResults = [
+      buildPerQueryResult(
+        routeQueries[0],
+        [
+          {
+            filePath: "/repo/src/indexer/index.ts",
+            startLine: 1,
+            endLine: 2,
+            score: 1,
+            chunkType: "function",
+            name: "rankHybridResults",
+          },
+        ],
+        10,
+        10,
+        { resolvedRoute: "search", routedQuery: "rankHybridResults" }
+      ),
+      buildPerQueryResult(
+        routeQueries[1],
+        [
+          {
+            filePath: "/repo/src/indexer/index.ts",
+            startLine: 1,
+            endLine: 2,
+            score: 1,
+            chunkType: "function",
+            name: "rankHybridResults",
+          },
+        ],
+        10,
+        10,
+        { resolvedRoute: "definition", routedQuery: "rankHybridResults" }
+      ),
+    ];
+
+    const routeMetrics = computeEvalMetrics(routeQueries, routeResults, 0, 0, 0);
+
+    expect(routeMetrics.routeAccuracy).toBe(0.5);
+    expect(routeResults[0]?.routeMatched).toBe(true);
+    expect(routeResults[1]?.routeMatched).toBe(false);
+  });
+
+  it("tracks result outcomes and filter-relaxation recovery without penalizing positive hit denominators", () => {
+    const positive = query({
+      id: "positive",
+      expected: {
+        filePath: "src/indexer/index.ts",
+        symbol: "rankHybridResults",
+        expectedOutcome: "results",
+        recoveryExpectation: "filter-relaxed",
+      },
+    });
+    const negative = query({
+      id: "negative",
+      expected: { expectedOutcome: "no-results" },
+    });
+    const positiveResult = buildPerQueryResult(
+      positive,
+      [{
+        filePath: "/repo/src/indexer/index.ts",
+        startLine: 1,
+        endLine: 2,
+        score: 1,
+        chunkType: "function",
+        name: "rankHybridResults",
+      }],
+      10,
+      10,
+      undefined,
+      {
+        tokenBudget: 1200,
+        responseTokens: 50,
+        candidateCount: 1,
+        deduplicatedCount: 1,
+        omittedCount: 0,
+        recoveryRelaxed: true,
+      },
+    );
+    const negativeResult = buildPerQueryResult(negative, [], 10, 10);
+    const metrics = computeEvalMetrics([positive, negative], [positiveResult, negativeResult], 0, 0, 0);
+
+    expect(metrics.hitAt5).toBe(1);
+    expect(metrics.outcomeAccuracy).toBe(1);
+    expect(metrics.recoveryAccuracy).toBe(1);
+    expect(negativeResult.failureBucket).toBeUndefined();
   });
 
   it("tracks deduped and raw distinctTop3 ratios separately", () => {

--- a/tests/eval-metrics.test.ts
+++ b/tests/eval-metrics.test.ts
@@ -203,6 +203,77 @@ describe("eval metrics", () => {
     expect(per.ndcgAt10).toBeCloseTo(1, 8);
   });
 
+  it("keeps nDCG bounded when duplicate same-path results match a single path label", () => {
+    const q = query({
+      expected: {
+        filePath: "src/indexer/index.ts",
+      },
+    });
+
+    const per = buildPerQueryResult(q, [
+      {
+        filePath: "/repo/src/indexer/index.ts",
+        startLine: 1,
+        endLine: 2,
+        score: 0.99,
+        chunkType: "function",
+        name: "rankHybridResults",
+      },
+      {
+        filePath: "/repo/src/indexer/index.ts",
+        startLine: 3,
+        endLine: 4,
+        score: 0.98,
+        chunkType: "function",
+        name: "otherFunction",
+      },
+      {
+        filePath: "/repo/src/indexer/index.ts",
+        startLine: 5,
+        endLine: 6,
+        score: 0.97,
+        chunkType: "function",
+        name: "thirdFunction",
+      },
+    ], 20, 10);
+
+    expect(per.hitAt1).toBe(true);
+    expect(per.ndcgAt10).toBe(1);
+    expect(per.results).toHaveLength(3);
+  });
+
+  it("does not let wrong-symbol-only hits pass symbol-intended mixed evidence", () => {
+    const q = {
+      id: "q-symbol-intended-path-label",
+      query: "where is rankHybridResults implementation",
+      queryType: "definition" as const,
+      expected: {
+        symbol: "rankHybridResults",
+        gradedEvidence: [{ path: "src/indexer/index.ts", relevance: 3 }],
+      },
+    };
+
+    const per = buildPerQueryResult(
+      q,
+      [
+        {
+          filePath: "/repo/src/indexer/index.ts",
+          startLine: 1,
+          endLine: 2,
+          score: 0.99,
+          chunkType: "function",
+          name: "wrongSymbol",
+        },
+      ],
+      20,
+      10,
+    );
+
+    expect(per.hitAt1).toBe(false);
+    expect(per.ndcgAt10).toBe(0);
+    expect(per.failureBucket).toBe("wrong-symbol");
+  });
+
   it("aggregates eval metrics including latency percentiles and costs", () => {
     const queries: GoldenQuery[] = [
       query({ id: "q1" }),

--- a/tests/eval-runner.test.ts
+++ b/tests/eval-runner.test.ts
@@ -122,6 +122,7 @@ describe("eval runner", () => {
     });
 
     expect(result.summary.queryCount).toBe(1);
+    expect(result.summary.datasetFingerprint).toMatch(/^[0-9a-f]{64}$/);
     expect(result.perQuery[0]?.resolvedRoute).toBe("definition");
     expect(result.perQuery[0]?.routedQuery).toBe("rankHybridResults");
     expect(typeof result.summary.metrics.distinctTop3Ratio).toBe("number");
@@ -136,6 +137,117 @@ describe("eval runner", () => {
     expect(readFileSync(path.join(result.outputDir, "summary.md"), "utf-8")).toContain("Context response tokens max");
     expect(readFileSync(path.join(result.outputDir, "summary.md"), "utf-8")).toContain("# Evaluation Summary");
     expect(readFileSync(path.join(result.outputDir, "per-query.json"), "utf-8")).toContain("\"queries\"");
+
+    const repeatRun = await runEvaluation({
+      projectRoot: tempDir,
+      datasetPath: "benchmarks/golden/small.json",
+      outputRoot: "benchmarks/results",
+      ciMode: false,
+      reindex: false,
+    });
+
+    expect(repeatRun.summary.datasetFingerprint).toBe(result.summary.datasetFingerprint);
+  });
+
+  it("applies query args as search filters in search mode", async () => {
+    const datasetPath = path.join(tempDir, "benchmarks", "golden", "args-search.json");
+    writeFileSync(
+      datasetPath,
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          name: "args-search",
+          queries: [
+            {
+              id: "q-search",
+              query: "codebase_search",
+              queryType: "keyword-heavy",
+              retrievalMode: "search",
+              language: "typescript",
+              difficulty: "easy",
+              tags: ["filters", "search"],
+              args: {
+                fileType: "ts",
+                directory: "src/tools",
+              },
+              expected: {
+                filePath: "src/tools/index.ts",
+                expectedOutcome: "results",
+              },
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    const result = await runEvaluation({
+      projectRoot: tempDir,
+      datasetPath: "benchmarks/golden/args-search.json",
+      outputRoot: "benchmarks/results",
+      ciMode: false,
+      reindex: false,
+    });
+
+    expect(result.perQuery).toHaveLength(1);
+    expect(result.perQuery[0]?.results[0]?.filePath).toContain("src/tools/index.ts");
+    expect(result.perQuery[0]?.failureBucket).toBeUndefined();
+  });
+
+  it("records metadata and recovery outcome for context queries", async () => {
+    const datasetPath = path.join(tempDir, "benchmarks", "golden", "args-context.json");
+    writeFileSync(
+      datasetPath,
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          name: "args-context",
+          queries: [
+            {
+              id: "q-context",
+              query: "where is rankHybridResults implementation",
+              queryType: "definition",
+              retrievalMode: "context",
+              language: "typescript",
+              difficulty: "medium",
+              tags: ["context", "filters"],
+              args: {
+                symbol: "rankHybridResults",
+                fileType: "ts",
+                directory: "src/indexer",
+              },
+              expected: {
+                filePath: "src/indexer/index.ts",
+                symbol: "rankHybridResults",
+                expectedRoute: "definition",
+                expectedOutcome: "results",
+                recoveryExpectation: "none",
+              },
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    const result = await runEvaluation({
+      projectRoot: tempDir,
+      datasetPath: "benchmarks/golden/args-context.json",
+      outputRoot: "benchmarks/results",
+      ciMode: false,
+      reindex: false,
+    });
+
+    expect(result.perQuery).toHaveLength(1);
+    expect(result.perQuery[0]?.language).toBe("typescript");
+    expect(result.perQuery[0]?.difficulty).toBe("medium");
+    expect(result.perQuery[0]?.tags).toEqual(["context", "filters"]);
+    expect(result.perQuery[0]?.routeMatched).toBe(true);
+    expect(result.perQuery[0]?.recoveryMatched).toBe(true);
   });
 
   it("does not delete an inherited main-repo project index when reindexing from a fresh worktree", async () => {
@@ -783,6 +895,32 @@ describe("eval runner", () => {
     expect(readFileSync(path.join(compareRun.outputDir, "compare.json"), "utf-8")).toContain("\"distinctTop3Ratio\"");
     expect(readFileSync(path.join(compareRun.outputDir, "compare.json"), "utf-8")).toContain("\"rawDistinctTop3Ratio\"");
     expect(readFileSync(path.join(compareRun.outputDir, "compare.json"), "utf-8")).toContain("\"deltas\"");
+  });
+
+  it("rejects comparisons when one summary lacks dataset fingerprint", async () => {
+    const baselineRun = await runEvaluation({
+      projectRoot: tempDir,
+      datasetPath: "benchmarks/golden/small.json",
+      outputRoot: "benchmarks/results",
+      ciMode: false,
+      reindex: false,
+    });
+
+    const baselineSummary = { ...baselineRun.summary } as Record<string, unknown>;
+    delete baselineSummary.datasetFingerprint;
+    const baselinePath = path.join(tempDir, "benchmarks", "baselines", "legacy-fingerprint-summary.json");
+    writeFileSync(baselinePath, JSON.stringify(baselineSummary, null, 2), "utf-8");
+
+    await expect(
+      runEvaluation({
+        projectRoot: tempDir,
+        datasetPath: "benchmarks/golden/small.json",
+        outputRoot: "benchmarks/results",
+        againstPath: "benchmarks/baselines/legacy-fingerprint-summary.json",
+        ciMode: false,
+        reindex: false,
+      }),
+    ).rejects.toThrow(/mismatched dataset fingerprint presence/);
   });
 
   it("fails fast when baseline summary is missing required diversity metrics", async () => {

--- a/tests/eval-schema.test.ts
+++ b/tests/eval-schema.test.ts
@@ -26,6 +26,14 @@ describe("eval schema", () => {
             id: "q1",
             query: "where is rankHybridResults implementation",
             queryType: "definition",
+            language: "typescript",
+            difficulty: "easy",
+            tags: ["definition", "typescript"],
+            args: {
+              symbol: "rankHybridResults",
+              fileType: "ts",
+              directory: "src/indexer",
+            },
             expected: {
               filePath: "src/indexer/index.ts",
               symbol: "rankHybridResults",
@@ -39,6 +47,11 @@ describe("eval schema", () => {
     expect(dataset.name).toBe("small");
     expect(dataset.queries).toHaveLength(1);
     expect(dataset.queries[0]?.retrievalMode).toBe("search");
+    expect(dataset.queries[0]?.difficulty).toBe("easy");
+    expect(dataset.queries[0]?.tags).toEqual(["definition", "typescript"]);
+    expect(dataset.queries[0]?.args?.symbol).toBe("rankHybridResults");
+    expect(dataset.queries[0]?.args?.fileType).toBe("ts");
+    expect(dataset.queries[0]?.args?.directory).toBe("src/indexer");
   });
 
   it("parses agent-facing context retrieval queries", () => {
@@ -99,7 +112,172 @@ describe("eval schema", () => {
         },
         "dataset.json"
       )
-    ).toThrow(/expected.filePath or expected.acceptableFiles/);
+    ).toThrow(/expected.filePath, expected.acceptableFiles, or expected.gradedEvidence/);
+  });
+
+  it("parses no-results expected outcomes without explicit evidence", () => {
+    const dataset = parseGoldenDataset(
+      {
+        version: "1.0.0",
+        name: "negative",
+        queries: [
+          {
+            id: "q1",
+            query: "no such symbol exists",
+            queryType: "definition",
+            expected: {
+              expectedOutcome: "no-results",
+            },
+          },
+        ],
+      },
+      "dataset.json"
+    );
+
+    expect(dataset.queries[0]?.expected.expectedOutcome).toBe("no-results");
+  });
+
+  it("rejects invalid difficulty values", () => {
+    expect(() =>
+      parseGoldenDataset(
+        {
+          version: "1.0.0",
+          name: "invalid",
+          queries: [
+            {
+              id: "q1",
+              query: "where",
+              queryType: "conceptual",
+              difficulty: "extreme",
+              expected: {
+                filePath: "src/index.ts",
+              },
+            },
+          ],
+        },
+        "dataset.json"
+      )
+    ).toThrow(/must be one of: easy, medium, hard/);
+  });
+
+  it("rejects invalid recovery expectations", () => {
+    expect(() =>
+      parseGoldenDataset(
+        {
+          version: "1.0.0",
+          name: "invalid",
+          queries: [
+            {
+              id: "q1",
+              query: "where",
+              queryType: "conceptual",
+              expected: {
+                filePath: "src/index.ts",
+                recoveryExpectation: "unknown",
+              },
+            },
+          ],
+        },
+        "dataset.json"
+      )
+    ).toThrow(/must be one of: none, filter-relaxed/);
+  });
+
+  it("accepts graded evidence-only expected entries", () => {
+    const dataset = parseGoldenDataset(
+      {
+        version: "1.0.0",
+        name: "graded-evidence",
+        queries: [
+          {
+            id: "q1",
+            query: "where is rankHybridResults implementation",
+            queryType: "definition",
+            expected: {
+              gradedEvidence: [
+                {
+                  path: "src/indexer/index.ts",
+                  symbol: "rankHybridResults",
+                  relevance: 3,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      "dataset.json"
+    );
+
+    expect(dataset.queries[0]?.expected.gradedEvidence?.[0]).toEqual({
+      path: "src/indexer/index.ts",
+      symbol: "rankHybridResults",
+      relevance: 3,
+    });
+  });
+
+  it("parses nested filters and permits evidence-free no-result expectations", () => {
+    const dataset = parseGoldenDataset({
+      version: "2.0.0",
+      name: "negative-filter",
+      queries: [{
+        id: "q1",
+        query: "missing symbol",
+        queryType: "definition",
+        language: "typescript",
+        difficulty: "hard",
+        tags: ["negative", "filter"],
+        args: { symbol: "missing", fileType: "ts", directory: "missing/path" },
+        expected: { expectedOutcome: "no-results" },
+      }],
+    }, "dataset.json");
+
+    expect(dataset.queries[0]).toMatchObject({
+      args: { symbol: "missing", fileType: "ts", directory: "missing/path" },
+      difficulty: "hard",
+    });
+  });
+
+  it("rejects invalid difficulty and unbounded tags", () => {
+    const base = {
+      version: "2.0.0",
+      name: "invalid-axes",
+      queries: [{
+        id: "q1",
+        query: "query",
+        queryType: "conceptual",
+        expected: { filePath: "src/index.ts" },
+      }],
+    };
+    expect(() => parseGoldenDataset({
+      ...base,
+      queries: [{ ...base.queries[0], difficulty: "extreme" }],
+    }, "dataset.json")).toThrow(/difficulty.*easy, medium, hard/);
+    expect(() => parseGoldenDataset({
+      ...base,
+      queries: [{ ...base.queries[0], tags: Array.from({ length: 17 }, (_, i) => `tag-${i}`) }],
+    }, "dataset.json")).toThrow(/at most 16 tags/);
+  });
+
+  it("rejects invalid gradedEvidence entries", () => {
+    expect(() =>
+      parseGoldenDataset(
+        {
+          version: "1.0.0",
+          name: "invalid",
+          queries: [
+            {
+              id: "q1",
+              query: "where",
+              queryType: "conceptual",
+              expected: {
+                gradedEvidence: [{ path: 42, symbol: "rankHybridResults" }],
+              },
+            },
+          ],
+        },
+        "dataset.json"
+      )
+    ).toThrow(/0\] must be an object|must be a non-empty string/i);
   });
 
   it("rejects duplicate query ids", () => {

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -686,6 +686,81 @@ end
       expect(results[0].path).toBe("a.ts");
       expect(results[1].path).toBe("b.ts");
     });
+
+    it("extracts nested class methods as symbols without changing semantic chunks", () => {
+      const [result] = parseFiles([{
+        path: "service.ts",
+        content: `export class Service {
+  async getStatus(): Promise<string> {
+    return "ready";
+  }
+}`,
+      }]);
+
+      expect(result.symbols).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "Service", kind: "class_declaration" }),
+        expect.objectContaining({ name: "getStatus", kind: "method_definition" }),
+      ]));
+      expect(result.chunks.some((chunk) => chunk.name === "getStatus")).toBe(false);
+    });
+
+    it("names TypeScript arrow-function symbols using variable bindings", () => {
+      const [result] = parseFiles([
+        {
+          path: "arrows.ts",
+          content: `
+const handler = (event: string) => {
+  return event.toLowerCase();
+};
+
+const normalize = (value: number) => value * 2;
+const values = [1, 2].map(item => item * 2);
+`,
+        },
+      ]);
+
+      const arrowSymbols = result.symbols.filter((symbol) => symbol.kind === "arrow_function");
+      const names = arrowSymbols.map((symbol) => symbol.name);
+
+      expect(names).toEqual(expect.arrayContaining(["handler", "normalize"]));
+      expect(names).not.toContain("event");
+      expect(names).not.toContain("value");
+      expect(names).not.toContain("item");
+    });
+
+    it("includes exported abstract class declarations and their methods", () => {
+      const [result] = parseFiles([
+        {
+          path: "animals.ts",
+          content: `export abstract class AbstractAnimal {
+  identify(): string {
+    return "animal";
+  }
+
+  describe(): string {
+    return this.identify();
+  }
+}`,
+        },
+      ]);
+
+      expect(result.symbols).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "class_declaration",
+            name: "AbstractAnimal",
+          }),
+          expect.objectContaining({
+            kind: "method_definition",
+            name: "identify",
+          }),
+          expect.objectContaining({
+            kind: "method_definition",
+            name: "describe",
+          }),
+        ]),
+      );
+    });
   });
 
   describe("hashContent", () => {

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -22,6 +22,10 @@ function branchCommitMetadataKey(catalogIdentity: string): string {
   return `index.branchCommit.${hashContent(catalogIdentity).slice(0, 24)}`;
 }
 
+function symbolExtractorMetadataKey(catalogIdentity: string): string {
+  return `index.symbolExtractorVersion.${hashContent(catalogIdentity).slice(0, 24)}`;
+}
+
 vi.mock("../src/tools/changed-files.js", () => ({
   getChangedFiles: vi.fn(),
 }));
@@ -520,6 +524,7 @@ describe("pr_impact tool", () => {
     db.addSymbolsToBranch("feature-branch", ["sym_a", "sym_b", "sym_c"]);
     db.addSymbolsToBranch("other-branch", ["sym_b"]);
     db.setMetadata(branchCommitMetadataKey("feature-branch"), "1111111111111111111111111111111111111111");
+    db.setMetadata(symbolExtractorMetadataKey("feature-branch"), "1");
 
     db.upsertCallEdge({
       id: "edge_ab",
@@ -618,6 +623,7 @@ describe("pr_impact tool", () => {
     db.addSymbolsToBranch("feature-branch", ["sym_a_feature"]);
     db.addSymbolsToBranch("other-branch", ["sym_a_other"]);
     db.setMetadata(branchCommitMetadataKey("feature-branch"), "1111111111111111111111111111111111111111");
+    db.setMetadata(symbolExtractorMetadataKey("feature-branch"), "1");
 
     const result = await indexer.getPrImpact({ pr: 1, checkConflicts: true });
 

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { parseConfig } from "../src/config/schema.js";
 import { buildSymbolDefinitionLane, Indexer } from "../src/indexer/index.js";
-import { Database } from "../src/native/index.js";
+import { Database, hashContent } from "../src/native/index.js";
 
 describe("search integration", () => {
   let tempDir: string;
@@ -179,6 +179,119 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     });
     expect(results[0]?.startLine).toBeGreaterThan(1);
     expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
+  });
+
+  it("returns nested class methods that are not standalone semantic chunks", async () => {
+    const classFile = path.join(tempDir, "app", "indexer", "service.ts");
+    fs.writeFileSync(classFile, `export class Service {
+  async getStatus(): Promise<string> {
+    return "ready";
+  }
+}
+`, "utf-8");
+
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: { watchFiles: false },
+      search: { maxResults: 10, minScore: 0 },
+    });
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const status = await indexer.getStatus();
+    const database = new Database(path.join(status.indexPath, "codebase.db"));
+    try {
+      expect(database.getSymbolsByName("getStatus")).toEqual([
+        expect.objectContaining({ filePath: classFile, kind: "method_definition" }),
+      ]);
+      expect(database.getChunksByName("getStatus")).toHaveLength(0);
+    } finally {
+      database.close();
+    }
+
+    const results = await indexer.search("find the getStatus method definition", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+    expect(results[0]).toMatchObject({ filePath: classFile, name: "getStatus" });
+  });
+
+  it("reparses symbols for unchanged files with stale symbolExtractorVersion metadata and restores nested class methods", async () => {
+    const classFile = path.join(tempDir, "app", "indexer", "service.ts");
+    fs.writeFileSync(
+      classFile,
+      `export class Service {
+  getStatus(): string {
+    return "ready";
+  }
+}
+`,
+      "utf-8",
+    );
+
+    const symbolExtractorVersionKey = `index.symbolExtractorVersion.${hashContent("default").slice(0, 24)}`;
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: { watchFiles: false },
+      search: { maxResults: 10, minScore: 0 },
+    });
+
+    const firstIndexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await firstIndexer.index();
+
+    const firstStatus = await firstIndexer.getStatus();
+    const initialDb = new Database(path.join(firstStatus.indexPath, "codebase.db"));
+    try {
+      const beforeReindex = initialDb.getSymbolsByFile(classFile);
+      expect(beforeReindex).toContainEqual(expect.objectContaining({
+        filePath: classFile,
+        name: "getStatus",
+        kind: "method_definition",
+      }));
+      expect(initialDb.getChunksByName("getStatus")).toHaveLength(0);
+    } finally {
+      initialDb.close();
+    }
+
+    await firstIndexer.close();
+
+    const staleDb = new Database(path.join(firstStatus.indexPath, "codebase.db"));
+    try {
+      staleDb.deleteSymbolsByFile(classFile);
+      staleDb.setMetadata(symbolExtractorVersionKey, "stale");
+    } finally {
+      staleDb.close();
+    }
+
+    const secondIndexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const embeddingCallsBeforeReindex = fetchSpy.mock.calls.length;
+    await secondIndexer.index();
+
+    const secondStatus = await secondIndexer.getStatus();
+    const restoredDb = new Database(path.join(secondStatus.indexPath, "codebase.db"));
+    try {
+      const restoredSymbols = restoredDb.getSymbolsByName("getStatus");
+      expect(restoredSymbols).toContainEqual(expect.objectContaining({
+        filePath: classFile,
+        name: "getStatus",
+        kind: "method_definition",
+      }));
+      expect(restoredDb.getMetadata(symbolExtractorVersionKey)).toBe("1");
+    } finally {
+      restoredDb.close();
+    }
+
+    expect(fetchSpy.mock.calls.length).toBe(embeddingCallsBeforeReindex);
   });
 
   it("does not rescue capped symbols from another branch", () => {

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -274,6 +274,66 @@ describe("native OpenCode codebase_context", () => {
     expect(countContextTokens(result)).toBeLessThanOrEqual(512);
   });
 
+  it("packs implementation evidence before higher-scoring docs for source-intent queries", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([
+      {
+        filePath: "README.md",
+        startLine: 1,
+        endLine: 10,
+        chunkType: "other",
+        content: "documentation",
+        score: 0.99,
+      },
+      {
+        filePath: "src/auth.ts",
+        startLine: 20,
+        endLine: 40,
+        name: "validateToken",
+        chunkType: "function",
+        content: "implementation",
+        score: 0.60,
+      },
+    ]);
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "where is authentication implemented",
+      tokenBudget: 512,
+    }, context);
+
+    expect(result.indexOf("src/auth.ts")).toBeLessThan(result.indexOf("README.md"));
+  });
+
+  it("keeps higher-scoring docs first for documentation-intent queries", async () => {
+    operationMocks.searchCodebase.mockResolvedValue([
+      {
+        filePath: "README.md",
+        startLine: 1,
+        endLine: 10,
+        chunkType: "other",
+        content: "documentation",
+        score: 0.99,
+      },
+      {
+        filePath: "src/auth.ts",
+        startLine: 20,
+        endLine: 40,
+        name: "validateToken",
+        chunkType: "function",
+        content: "implementation",
+        score: 0.60,
+      },
+    ]);
+
+    const result = await codebase_context.execute({
+      ...commonArgs,
+      query: "show the authentication documentation",
+      tokenBudget: 512,
+    }, context);
+
+    expect(result.indexOf("README.md")).toBeLessThan(result.indexOf("src/auth.ts"));
+  });
+
   it("routes explicit definitions to compact location evidence", async () => {
     operationMocks.implementationLookup.mockResolvedValue([{
       filePath: "src/auth.ts",

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -776,6 +776,74 @@ describe("tools utils", () => {
       expect(names).toEqual(["a1", "b1", "c1", "a2"]);
     });
 
+    it("puts implementation files before docs and tests when source evidence is requested", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "README.md",
+          startLine: 1,
+          endLine: 5,
+          content: "docs",
+          score: 0.99,
+          chunkType: "other",
+        },
+        {
+          filePath: "tests/feature.test.ts",
+          startLine: 1,
+          endLine: 8,
+          content: "test",
+          score: 0.98,
+          chunkType: "function",
+        },
+        {
+          filePath: "src/feature.ts",
+          startLine: 10,
+          endLine: 20,
+          content: "implementation",
+          score: 0.60,
+          chunkType: "function",
+          name: "implementFeature",
+        },
+      ];
+
+      const packed = buildContextPack(results, {
+        tokenBudget: 2048,
+        preferImplementationPaths: true,
+      });
+
+      expect(packed.results.map((result) => result.filePath)).toEqual([
+        "src/feature.ts",
+        "README.md",
+        "tests/feature.test.ts",
+      ]);
+    });
+
+    it("preserves score ordering when implementation preference is disabled", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "README.md",
+          startLine: 1,
+          endLine: 5,
+          content: "docs",
+          score: 0.99,
+          chunkType: "other",
+        },
+        {
+          filePath: "src/feature.ts",
+          startLine: 10,
+          endLine: 20,
+          content: "implementation",
+          score: 0.60,
+          chunkType: "function",
+        },
+      ];
+
+      const packed = buildContextPack(results, { tokenBudget: 2048 });
+      expect(packed.results.map((result) => result.filePath)).toEqual([
+        "README.md",
+        "src/feature.ts",
+      ]);
+    });
+
     it("is deterministic for identical input", () => {
       const results: SearchResult[] = [
         {


### PR DESCRIPTION
## Summary

- add a versioned representative retrieval kernel with graded path and symbol evidence, route/outcome/recovery diagnostics, strict dataset fingerprints, and corrected nDCG
- extract uncapped recursive symbols, including nested methods, correctly named variable-bound arrows, and exported abstract classes, with branch-catalog-scoped migration that reuses existing embeddings
- prefer implementation source paths when packing conceptual context while preserving documentation and test intent

## Measured result

Corrected apples-to-apples Ollama evaluation on isolated indexes using the same 14-query dataset and identical query embedding usage:

| Metric | `d09a3f6` | Candidate |
|---|---:|---:|
| Hit@1 | 30.77% | 53.85% |
| Hit@5 | 38.46% | 69.23% |
| MRR@10 | 0.3333 | 0.5897 |
| nDCG@10 | 0.2873 | 0.5272 |
| Route accuracy | 100% | 100% |
| Outcome accuracy | 100% | 100% |
| Recovery accuracy | 100% | 100% |
| Query embedding calls | 28 | 28 |
| Embedding tokens | 2,778 | 2,778 |

Single-run p95 latency was 106ms before and 124ms after, so this PR makes no latency-improvement claim. A controlled unchanged-index migration regression verifies that symbol refresh adds no embedding calls.

This benchmark measures this repository's retrieval and context packing. It does not claim universal SOTA or end-to-end agent success.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` with 1,217 passing tests
- `git diff --check`
- two independent strong-model reviews, including a blocker-fix re-review
- protected local `AGENTS.md` modification excluded and hash-preserved
