### PR TITLE
refactor: extract embedding batch helpers

### DIFF
--- a/src/indexer/embedding-batches.ts
+++ b/src/indexer/embedding-batches.ts
@@ -1,0 +1,245 @@
+import type { ChunkMetadata } from "../native/index.js";
+import { createEmbeddingTexts, createDynamicBatches, estimateTokens } from "../native/index.js";
+
+export interface PendingChunk {
+  id: string;
+  texts: Array<{
+    text: string;
+    tokenCount: number;
+  }>;
+  storageText: string;
+  content: string;
+  contentHash: string;
+  metadata: ChunkMetadata;
+}
+
+export interface PendingEmbeddingRequest {
+  chunk: PendingChunk;
+  partIndex: number;
+  text: string;
+  tokenCount: number;
+}
+
+export interface FailedBatch {
+  chunks: PendingChunk[];
+  error: string;
+  attemptCount: number;
+  lastAttempt: string;
+}
+
+export interface RetryableFailedChunk {
+  chunk: PendingChunk;
+  attemptCount: number;
+}
+
+export interface SerializedFailedBatch {
+  chunks: unknown[];
+  error: string;
+  attemptCount: number;
+  lastAttempt: string;
+}
+
+export function createPendingChunkStorageText(texts: PendingChunk["texts"]): string {
+  const primaryText = texts[0]?.text ?? "";
+  if (texts.length <= 1) {
+    return primaryText;
+  }
+
+  return `${primaryText}\n\n... [split into ${texts.length} parts for embedding]`;
+}
+
+export function normalizePendingChunk(rawChunk: unknown, maxChunkTokens?: number): PendingChunk | null {
+  if (!rawChunk || typeof rawChunk !== "object") {
+    return null;
+  }
+
+  const chunk = rawChunk as {
+    id?: unknown;
+    text?: unknown;
+    texts?: Array<{ text?: unknown; tokenCount?: unknown }>;
+    storageText?: unknown;
+    content?: unknown;
+    contentHash?: unknown;
+    metadata?: unknown;
+  };
+
+  if (typeof chunk.id !== "string" || typeof chunk.contentHash !== "string" || !chunk.metadata || typeof chunk.metadata !== "object") {
+    return null;
+  }
+
+  const texts = Array.isArray(chunk.texts)
+    ? chunk.texts
+      .map((entry) => {
+        if (!entry || typeof entry.text !== "string") {
+          return null;
+        }
+
+        return {
+          text: entry.text,
+          tokenCount: typeof entry.tokenCount === "number" && Number.isFinite(entry.tokenCount)
+            ? entry.tokenCount
+            : estimateTokens(entry.text),
+        };
+      })
+      .filter((entry): entry is PendingChunk["texts"][number] => entry !== null)
+    : [];
+
+  if (texts.length === 0 && typeof chunk.text === "string") {
+    if (typeof chunk.content === "string" && chunk.content.length > 0 && chunk.metadata && typeof chunk.metadata === "object") {
+      const metadata = chunk.metadata as Partial<ChunkMetadata>;
+      const rebuiltChunk = {
+        content: chunk.content,
+        startLine: typeof metadata.startLine === "number" ? metadata.startLine : 1,
+        endLine: typeof metadata.endLine === "number" ? metadata.endLine : 1,
+        chunkType: typeof metadata.chunkType === "string" ? metadata.chunkType : "other",
+        name: typeof metadata.name === "string" ? metadata.name : undefined,
+        language: typeof metadata.language === "string" ? metadata.language : "text",
+      };
+      const filePath = typeof metadata.filePath === "string" ? metadata.filePath : "unknown";
+      texts.push(
+        ...createEmbeddingTexts(rebuiltChunk, filePath, maxChunkTokens).map((text) => ({
+          text,
+          tokenCount: estimateTokens(text),
+        }))
+      );
+    } else {
+      texts.push({
+        text: chunk.text,
+        tokenCount: estimateTokens(chunk.text),
+      });
+    }
+  }
+
+  if (texts.length === 0) {
+    return null;
+  }
+
+  return {
+    id: chunk.id,
+    texts,
+    storageText: typeof chunk.storageText === "string" ? chunk.storageText : createPendingChunkStorageText(texts),
+    content: typeof chunk.content === "string" ? chunk.content : "",
+    contentHash: chunk.contentHash,
+    metadata: chunk.metadata as ChunkMetadata,
+  };
+}
+
+export function getPendingChunkFilePath(rawChunk: unknown): string | null {
+  if (!rawChunk || typeof rawChunk !== "object") {
+    return null;
+  }
+
+  const chunk = rawChunk as { metadata?: unknown };
+  if (!chunk.metadata || typeof chunk.metadata !== "object") {
+    return null;
+  }
+
+  const metadata = chunk.metadata as { filePath?: unknown };
+  return typeof metadata.filePath === "string" ? metadata.filePath : null;
+}
+
+export function normalizeFailedBatch(batch: SerializedFailedBatch, maxChunkTokens?: number): FailedBatch | null {
+  const chunks = batch.chunks
+    .map((chunk) => normalizePendingChunk(chunk, maxChunkTokens))
+    .filter((chunk): chunk is PendingChunk => chunk !== null);
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  return {
+    chunks,
+    error: batch.error,
+    attemptCount: batch.attemptCount,
+    lastAttempt: batch.lastAttempt,
+  } satisfies FailedBatch;
+}
+
+export function createPendingEmbeddingRequests(chunks: PendingChunk[]): PendingEmbeddingRequest[] {
+  return chunks.flatMap((chunk) =>
+    chunk.texts.map((textPart, partIndex) => ({
+      chunk,
+      partIndex,
+      text: textPart.text,
+      tokenCount: textPart.tokenCount,
+    }))
+  );
+}
+
+export function createPendingEmbeddingRequestBatches(
+  chunks: PendingChunk[],
+  options: { maxBatchTokens?: number; maxBatchItems?: number } = {}
+): PendingEmbeddingRequest[][] {
+  return createDynamicBatches(createPendingEmbeddingRequests(chunks), options);
+}
+
+export function getUniquePendingChunksFromRequests(requests: PendingEmbeddingRequest[]): PendingChunk[] {
+  const uniqueChunks = new Map<string, PendingChunk>();
+  for (const request of requests) {
+    uniqueChunks.set(request.chunk.id, request.chunk);
+  }
+  return Array.from(uniqueChunks.values());
+}
+
+export function coalesceFailedBatches(batches: FailedBatch[]): FailedBatch[] {
+  const grouped = new Map<string, FailedBatch>();
+
+  for (const batch of batches) {
+    const key = `${batch.attemptCount}:${batch.lastAttempt}:${batch.error}`;
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, {
+        ...batch,
+        chunks: [...batch.chunks],
+      });
+      continue;
+    }
+
+    existing.chunks.push(...batch.chunks);
+  }
+
+  return Array.from(grouped.values());
+}
+
+export function poolEmbeddingVectors(vectors: number[][], weights: number[]): number[] {
+  const firstVector = vectors[0];
+  if (!firstVector) {
+    return [];
+  }
+
+  const pooled = new Array<number>(firstVector.length).fill(0);
+  let totalWeight = 0;
+
+  for (let index = 0; index < vectors.length; index++) {
+    const vector = vectors[index];
+    const weight = Math.max(1, weights[index] ?? 1);
+    totalWeight += weight;
+
+    for (let dimension = 0; dimension < vector.length; dimension++) {
+      pooled[dimension] += vector[dimension] * weight;
+    }
+  }
+
+  if (totalWeight === 0) {
+    return firstVector;
+  }
+
+  return pooled.map((value) => value / totalWeight);
+}
+
+export function hasAllEmbeddingParts(
+  parts: Array<{ vector: number[]; tokenCount: number } | undefined>,
+  expectedPartCount: number
+): boolean {
+  if (parts.length !== expectedPartCount) {
+    return false;
+  }
+
+  for (let index = 0; index < expectedPartCount; index++) {
+    if (parts[index] === undefined) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -27,7 +27,6 @@ import {
   generateChunkHash,
   ChunkMetadata,
   ChunkData,
-  createDynamicBatches,
   hashFile,
   hashContent,
   extractCalls,
@@ -77,6 +76,20 @@ import {
   type IndexLockOwner,
   type IndexMutationOperation,
 } from "./index-lock.js";
+import {
+  type FailedBatch,
+  type PendingChunk,
+  type RetryableFailedChunk,
+  type SerializedFailedBatch,
+  coalesceFailedBatches,
+  createPendingChunkStorageText,
+  createPendingEmbeddingRequestBatches,
+  getPendingChunkFilePath,
+  getUniquePendingChunksFromRequests,
+  hasAllEmbeddingParts,
+  normalizeFailedBatch,
+  poolEmbeddingVectors,
+} from "./embedding-batches.js";
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
@@ -395,44 +408,6 @@ export interface IndexProgress {
 
 export type ProgressCallback = (progress: IndexProgress) => void;
 
-interface PendingChunk {
-  id: string;
-  texts: Array<{
-    text: string;
-    tokenCount: number;
-  }>;
-  storageText: string;
-  content: string;
-  contentHash: string;
-  metadata: ChunkMetadata;
-}
-
-interface PendingEmbeddingRequest {
-  chunk: PendingChunk;
-  partIndex: number;
-  text: string;
-  tokenCount: number;
-}
-
-interface FailedBatch {
-  chunks: PendingChunk[];
-  error: string;
-  attemptCount: number;
-  lastAttempt: string;
-}
-
-interface RetryableFailedChunk {
-  chunk: PendingChunk;
-  attemptCount: number;
-}
-
-interface SerializedFailedBatch {
-  chunks: unknown[];
-  error: string;
-  attemptCount: number;
-  lastAttempt: string;
-}
-
 type SearchFilterOptions = {
   fileType?: string;
   directory?: string;
@@ -524,211 +499,6 @@ const SWIFT_PARSER_VERSION = "1";
 const METAL_PARSER_VERSION = "1";
 const SYMBOL_EXTRACTOR_VERSION = "1";
 const RANKING_TOKEN_CACHE_LIMIT = 4096;
-
-function createPendingChunkStorageText(texts: PendingChunk["texts"]): string {
-  const primaryText = texts[0]?.text ?? "";
-  if (texts.length <= 1) {
-    return primaryText;
-  }
-
-  return `${primaryText}\n\n... [split into ${texts.length} parts for embedding]`;
-}
-
-function normalizePendingChunk(rawChunk: unknown, maxChunkTokens?: number): PendingChunk | null {
-  if (!rawChunk || typeof rawChunk !== "object") {
-    return null;
-  }
-
-  const chunk = rawChunk as {
-    id?: unknown;
-    text?: unknown;
-    texts?: Array<{ text?: unknown; tokenCount?: unknown }>;
-    storageText?: unknown;
-    content?: unknown;
-    contentHash?: unknown;
-    metadata?: unknown;
-  };
-
-  if (typeof chunk.id !== "string" || typeof chunk.contentHash !== "string" || !chunk.metadata || typeof chunk.metadata !== "object") {
-    return null;
-  }
-
-  const texts = Array.isArray(chunk.texts)
-    ? chunk.texts
-      .map((entry) => {
-        if (!entry || typeof entry.text !== "string") {
-          return null;
-        }
-
-        return {
-          text: entry.text,
-          tokenCount: typeof entry.tokenCount === "number" && Number.isFinite(entry.tokenCount)
-            ? entry.tokenCount
-            : estimateTokens(entry.text),
-        };
-      })
-      .filter((entry): entry is PendingChunk["texts"][number] => entry !== null)
-    : [];
-
-  if (texts.length === 0 && typeof chunk.text === "string") {
-    if (typeof chunk.content === "string" && chunk.content.length > 0 && chunk.metadata && typeof chunk.metadata === "object") {
-      const metadata = chunk.metadata as Partial<ChunkMetadata>;
-      const rebuiltChunk = {
-        content: chunk.content,
-        startLine: typeof metadata.startLine === "number" ? metadata.startLine : 1,
-        endLine: typeof metadata.endLine === "number" ? metadata.endLine : 1,
-        chunkType: typeof metadata.chunkType === "string" ? metadata.chunkType : "other",
-        name: typeof metadata.name === "string" ? metadata.name : undefined,
-        language: typeof metadata.language === "string" ? metadata.language : "text",
-      };
-      const filePath = typeof metadata.filePath === "string" ? metadata.filePath : "unknown";
-      texts.push(
-        ...createEmbeddingTexts(rebuiltChunk, filePath, maxChunkTokens).map((text) => ({
-          text,
-          tokenCount: estimateTokens(text),
-        }))
-      );
-    } else {
-      texts.push({
-        text: chunk.text,
-        tokenCount: estimateTokens(chunk.text),
-      });
-    }
-  }
-
-  if (texts.length === 0) {
-    return null;
-  }
-
-  return {
-    id: chunk.id,
-    texts,
-    storageText: typeof chunk.storageText === "string" ? chunk.storageText : createPendingChunkStorageText(texts),
-    content: typeof chunk.content === "string" ? chunk.content : "",
-    contentHash: chunk.contentHash,
-    metadata: chunk.metadata as ChunkMetadata,
-  };
-}
-
-function getPendingChunkFilePath(rawChunk: unknown): string | null {
-  if (!rawChunk || typeof rawChunk !== "object") {
-    return null;
-  }
-
-  const chunk = rawChunk as { metadata?: unknown };
-  if (!chunk.metadata || typeof chunk.metadata !== "object") {
-    return null;
-  }
-
-  const metadata = chunk.metadata as { filePath?: unknown };
-  return typeof metadata.filePath === "string" ? metadata.filePath : null;
-}
-
-function normalizeFailedBatch(batch: SerializedFailedBatch, maxChunkTokens?: number): FailedBatch | null {
-  const chunks = batch.chunks
-    .map((chunk) => normalizePendingChunk(chunk, maxChunkTokens))
-    .filter((chunk): chunk is PendingChunk => chunk !== null);
-
-  if (chunks.length === 0) {
-    return null;
-  }
-
-  return {
-    chunks,
-    error: batch.error,
-    attemptCount: batch.attemptCount,
-    lastAttempt: batch.lastAttempt,
-  } satisfies FailedBatch;
-}
-
-function createPendingEmbeddingRequests(chunks: PendingChunk[]): PendingEmbeddingRequest[] {
-  return chunks.flatMap((chunk) =>
-    chunk.texts.map((textPart, partIndex) => ({
-      chunk,
-      partIndex,
-      text: textPart.text,
-      tokenCount: textPart.tokenCount,
-    }))
-  );
-}
-
-function createPendingEmbeddingRequestBatches(
-  chunks: PendingChunk[],
-  options: { maxBatchTokens?: number; maxBatchItems?: number } = {}
-): PendingEmbeddingRequest[][] {
-  return createDynamicBatches(createPendingEmbeddingRequests(chunks), options);
-}
-
-function getUniquePendingChunksFromRequests(requests: PendingEmbeddingRequest[]): PendingChunk[] {
-  const uniqueChunks = new Map<string, PendingChunk>();
-  for (const request of requests) {
-    uniqueChunks.set(request.chunk.id, request.chunk);
-  }
-  return Array.from(uniqueChunks.values());
-}
-
-function coalesceFailedBatches(batches: FailedBatch[]): FailedBatch[] {
-  const grouped = new Map<string, FailedBatch>();
-
-  for (const batch of batches) {
-    const key = `${batch.attemptCount}:${batch.lastAttempt}:${batch.error}`;
-    const existing = grouped.get(key);
-    if (!existing) {
-      grouped.set(key, {
-        ...batch,
-        chunks: [...batch.chunks],
-      });
-      continue;
-    }
-
-    existing.chunks.push(...batch.chunks);
-  }
-
-  return Array.from(grouped.values());
-}
-
-function poolEmbeddingVectors(vectors: number[][], weights: number[]): number[] {
-  const firstVector = vectors[0];
-  if (!firstVector) {
-    return [];
-  }
-
-  const pooled = new Array<number>(firstVector.length).fill(0);
-  let totalWeight = 0;
-
-  for (let index = 0; index < vectors.length; index++) {
-    const vector = vectors[index];
-    const weight = Math.max(1, weights[index] ?? 1);
-    totalWeight += weight;
-
-    for (let dimension = 0; dimension < vector.length; dimension++) {
-      pooled[dimension] += vector[dimension] * weight;
-    }
-  }
-
-  if (totalWeight === 0) {
-    return firstVector;
-  }
-
-  return pooled.map((value) => value / totalWeight);
-}
-
-function hasAllEmbeddingParts(
-  parts: Array<{ vector: number[]; tokenCount: number } | undefined>,
-  expectedPartCount: number
-): boolean {
-  if (parts.length !== expectedPartCount) {
-    return false;
-  }
-
-  for (let index = 0; index < expectedPartCount; index++) {
-    if (parts[index] === undefined) {
-      return false;
-    }
-  }
-
-  return true;
-}
 
 function isPathWithinRoot(filePath: string, rootPath: string): boolean {
   const normalizedFilePath = path.resolve(filePath);

--- a/tests/embedding-batches.test.ts
+++ b/tests/embedding-batches.test.ts
@@ -1,0 +1,145 @@
+import type { ChunkMetadata } from "../src/native/index.js";
+
+import {
+  coalesceFailedBatches,
+  createPendingChunkStorageText,
+  createPendingEmbeddingRequestBatches,
+  createPendingEmbeddingRequests,
+  getPendingChunkFilePath,
+  getUniquePendingChunksFromRequests,
+  hasAllEmbeddingParts,
+  normalizeFailedBatch,
+  normalizePendingChunk,
+  poolEmbeddingVectors,
+  type FailedBatch,
+  type PendingChunk,
+} from "../src/indexer/embedding-batches.js";
+
+function metadata(filePath = "src/example.ts"): ChunkMetadata {
+  return {
+    filePath,
+    startLine: 1,
+    endLine: 3,
+    chunkType: "function",
+    name: "example",
+    language: "typescript",
+    hash: "hash",
+  };
+}
+
+function pendingChunk(id: string, tokenCounts = [10]): PendingChunk {
+  const texts = tokenCounts.map((tokenCount, index) => ({
+    text: `${id}-part-${index}`,
+    tokenCount,
+  }));
+  return {
+    id,
+    texts,
+    storageText: createPendingChunkStorageText(texts),
+    content: `content-${id}`,
+    contentHash: `hash-${id}`,
+    metadata: metadata(`src/${id}.ts`),
+  };
+}
+
+describe("embedding batch helpers", () => {
+  it("normalizes persisted multipart chunks and fills derived fields", () => {
+    const normalized = normalizePendingChunk({
+      id: "chunk-1",
+      texts: [
+        { text: "first", tokenCount: 5 },
+        { text: "second", tokenCount: Number.NaN },
+      ],
+      content: "source",
+      contentHash: "content-hash",
+      metadata: metadata(),
+    });
+
+    expect(normalized).not.toBeNull();
+    expect(normalized?.texts).toEqual([
+      { text: "first", tokenCount: 5 },
+      { text: "second", tokenCount: 2 },
+    ]);
+    expect(normalized?.storageText).toBe("first\n\n... [split into 2 parts for embedding]");
+  });
+
+  it("rebuilds legacy single-text chunks from source metadata", () => {
+    const normalized = normalizePendingChunk({
+      id: "legacy",
+      text: "legacy embedding text",
+      content: "export function legacy() { return true; }",
+      contentHash: "legacy-hash",
+      metadata: metadata("src/legacy.ts"),
+    }, 512);
+
+    expect(normalized).not.toBeNull();
+    expect(normalized?.texts).toHaveLength(1);
+    expect(normalized?.texts[0]?.text).toContain("legacy");
+    expect(normalized?.texts[0]?.text).toContain("export function legacy");
+    expect(normalized?.storageText).toBe(normalized?.texts[0]?.text);
+  });
+
+  it("normalizes failed batches while dropping invalid chunks", () => {
+    const normalized = normalizeFailedBatch({
+      chunks: [pendingChunk("valid"), { id: 1 }],
+      error: "rate limited",
+      attemptCount: 2,
+      lastAttempt: "2026-07-29T00:00:00.000Z",
+    });
+
+    expect(normalized?.chunks.map((chunk) => chunk.id)).toEqual(["valid"]);
+    expect(normalized?.attemptCount).toBe(2);
+  });
+
+  it("preserves request order, batching limits, and first-seen chunk order", () => {
+    const chunks = [pendingChunk("a", [3, 4]), pendingChunk("b", [5])];
+    const requests = createPendingEmbeddingRequests(chunks);
+    const batches = createPendingEmbeddingRequestBatches(chunks, { maxBatchItems: 2 });
+
+    expect(requests.map((request) => [request.chunk.id, request.partIndex])).toEqual([
+      ["a", 0],
+      ["a", 1],
+      ["b", 0],
+    ]);
+    expect(batches.map((batch) => batch.length)).toEqual([2, 1]);
+    expect(getUniquePendingChunksFromRequests([requests[0], requests[2], requests[1]])
+      .map((chunk) => chunk.id)).toEqual(["a", "b"]);
+  });
+
+  it("coalesces failed batches only when retry state is identical", () => {
+    const first: FailedBatch = {
+      chunks: [pendingChunk("a")],
+      error: "failed",
+      attemptCount: 1,
+      lastAttempt: "now",
+    };
+    const second: FailedBatch = { ...first, chunks: [pendingChunk("b")] };
+    const differentAttempt: FailedBatch = { ...first, chunks: [pendingChunk("c")], attemptCount: 2 };
+
+    const result = coalesceFailedBatches([first, second, differentAttempt]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.chunks.map((chunk) => chunk.id)).toEqual(["a", "b"]);
+    expect(result[1]?.chunks.map((chunk) => chunk.id)).toEqual(["c"]);
+    expect(first.chunks.map((chunk) => chunk.id)).toEqual(["a"]);
+  });
+
+  it("pools multipart vectors by clamped token weight", () => {
+    expect(poolEmbeddingVectors([[1, 3], [5, 7]], [1, 3])).toEqual([4, 6]);
+    expect(poolEmbeddingVectors([[2, 4]], [0])).toEqual([2, 4]);
+    expect(poolEmbeddingVectors([], [])).toEqual([]);
+  });
+
+  it("detects complete embedding parts and extracts persisted paths", () => {
+    const parts = [
+      { vector: [1], tokenCount: 2 },
+      { vector: [2], tokenCount: 3 },
+    ];
+
+    expect(hasAllEmbeddingParts(parts, 2)).toBe(true);
+    expect(hasAllEmbeddingParts([parts[0], undefined], 2)).toBe(false);
+    expect(hasAllEmbeddingParts(parts, 1)).toBe(false);
+    expect(getPendingChunkFilePath(pendingChunk("path"))).toBe("src/path.ts");
+    expect(getPendingChunkFilePath({ metadata: {} })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- extract pending-embedding normalization, batching, retry-state, and vector-pooling helpers from `src/indexer/index.ts`
- keep provider I/O, persistence, and Indexer orchestration unchanged
- add focused edge-case coverage for legacy normalization, multipart batching, coalescing, pooling, and missing parts

`src/indexer/index.ts` is reduced from 6,399 to 6,169 lines. All 10 helper implementations and 5 related interfaces are exact moves modulo exports and whitespace.

## Validation

- `npx vitest run tests/embedding-batches.test.ts tests/indexer-failed-batches.test.ts` (34 tests)
- `npm run build:ts` and built CLI smoke
- `npm run typecheck`
- `npm run lint`
- `npx vitest run` (66 files, 1,237 tests)
- ESM and CJS built-package import smoke checks
- `git diff --check`

No public API, dependency, provider, persistence, or runtime behavior changes are intended.