### PR TITLE
Make project indexes portable across Git worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Portable project indexes across Git worktrees**: Project-owned paths are now persisted relative to the project root. Worktrees that inherit project configuration share the main checkout's index and reuse unchanged chunks and embeddings, while an explicit worktree-local project config keeps its index isolated. Existing project indexes with absolute stored paths require a one-time force rebuild.
+
 ## [0.20.1] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Only specify values you want to override. See [Configuration](docs/configuration
 
 ## Branch-aware indexing
 
-The index stores reusable content by hash and maintains branch catalogs for chunks and symbols. On a branch switch, unchanged content can be reused while results remain scoped to the active branch. Project indexes are kept separate for linked worktrees, while configuration may fall back to the main repository.
+The index stores reusable content by hash and maintains branch catalogs for chunks and symbols. On a branch switch, unchanged content can be reused while results remain scoped to the active branch. Linked worktrees without a local project config share the main checkout's portable project index; adding a worktree-local config creates an isolated index boundary.
 
 ## Knowledge bases and reranking
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -197,6 +197,12 @@ Or run `/index force`.
 
 Only use force reindex for a full rebuild. If `/status` reports failed embedding batches, fix the provider/auth issue first and rerun `/index` normally.
 
+### Persisted Runtime Cache Warnings
+
+Git project indexes keep branch-specific runtime state in `file-hashes.<branch-hash>.json` and `failed-batches.<branch-hash>.json`. Non-Git project indexes and global indexes use the corresponding unnamespaced filenames.
+
+If debug logs report that one of these files is corrupted or unreadable, the indexer safely resets that branch's in-memory hash cache or skips its persisted retry batches for the run. If the warning recurs, remove the exact affected file reported in the warning and rebuild with `/index force`.
+
 ### Reset Everything
 Delete the index directory for your host only after confirming you no longer need the existing index:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,13 @@ Configuration is optional. Defaults are applied when fields are omitted.
 | Claude | `.claude/codebase-index.json` | `.claude/index/` | `~/.claude/codebase-index.json` | `~/.claude/global-index/` |
 | Codex, Pi, Jcode | `.codebase-index/config.json` | `.codebase-index/index/` | `~/.config/codebase-index/config.json` | `~/.codebase-index/global-index/` |
 
-Non-OpenCode hosts can fall back to existing OpenCode configuration or index state when a host-specific location does not exist. Linked worktrees may inherit configuration from the main repository, but mutable project indexes remain separate.
+Non-OpenCode hosts can fall back to existing OpenCode configuration or index state when a host-specific location does not exist.
+
+Linked worktrees without their own host-specific project config inherit both the config and project index from the main checkout. Project-owned paths are stored relative to the project root, while branch catalogs and branch-scoped runtime state keep each checkout's contents separate. Adding a project config inside a worktree creates a local config and index boundary instead.
+
+Because inheriting worktrees operate on the same project index, clearing or force-rebuilding it from one checkout affects the main checkout and every other inheriting worktree. Legacy project indexes that contain absolute stored paths must be rebuilt once with `index_codebase` and `force: true`. Global indexes continue to use canonical absolute paths.
+
+Git project indexes store file-change and retry state in `file-hashes.<branch-hash>.json` and `failed-batches.<branch-hash>.json`. Non-Git project indexes and global indexes keep the unnamespaced `file-hashes.json` and `failed-batches.json` filenames.
 
 ## Minimal example
 

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -18,7 +18,7 @@ pub enum DbError {
 pub type DbResult<T> = Result<T, DbError>;
 
 /// Schema version for migrations
-const SCHEMA_VERSION: i32 = 6;
+const SCHEMA_VERSION: i32 = 7;
 
 /// Maximum number of SQL bind parameters per query.
 /// SQLite defaults to 999 (SQLITE_MAX_VARIABLE_NUMBER). We use 900 to stay safely under.
@@ -56,7 +56,7 @@ pub fn init_db(db_path: &Path) -> DbResult<Connection> {
     Ok(conn)
 }
 
-/// Ouvre une base publiée sans créer de fichier ni exécuter de migration.
+/// Opens a published database without creating files or running migrations.
 pub fn open_db_read_only(db_path: &Path) -> DbResult<Connection> {
     let conn = Connection::open_with_flags(
         db_path,
@@ -82,7 +82,10 @@ pub fn open_db_read_only(db_path: &Path) -> DbResult<Connection> {
         ))
     })?;
 
-    if current_version != SCHEMA_VERSION {
+    // v7 changes path-storage semantics without changing the SQLite layout.
+    // The TypeScript layer knows the index scope and decides whether v6 paths
+    // require a project rebuild or remain valid for a global index.
+    if current_version != 6 && current_version != SCHEMA_VERSION {
         return Err(DbError::ReadOnlySchema(format!(
             "found version {current_version}, expected {SCHEMA_VERSION}; a writer must migrate the index"
         )));
@@ -91,7 +94,7 @@ pub fn open_db_read_only(db_path: &Path) -> DbResult<Connection> {
     Ok(conn)
 }
 
-/// Crée un catalogue vide en mémoire, puis le verrouille en lecture seule.
+/// Creates an empty in-memory catalog, then locks it for read-only access.
 pub fn create_empty_read_only_db() -> DbResult<Connection> {
     let conn = Connection::open_in_memory()?;
     migrate_schema(&conn, 0)?;
@@ -301,6 +304,15 @@ fn migrate_schema(conn: &Connection, from_version: i32) -> DbResult<()> {
             "#,
         )?;
 
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
+            params![SCHEMA_VERSION.to_string()],
+        )?;
+    }
+
+    if from_version == 6 {
+        // v7 is the schema gate for project-relative catalog paths. The writer
+        // owns the cross-artifact rebuild, so this step only advances the marker.
         conn.execute(
             "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
             params![SCHEMA_VERSION.to_string()],
@@ -1179,7 +1191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_init_db() {
+    fn test_schema_v7_fresh_database() {
         let (_temp_dir, conn) = setup_test_db();
         let version: String = conn
             .query_row(
@@ -1188,7 +1200,129 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "6");
+        assert_eq!(version, "7");
+    }
+
+    #[test]
+    fn test_schema_v7_read_only_accepts_structurally_compatible_v6() {
+        let (temp_dir, conn) = setup_test_db();
+        let db_path = temp_dir.path().join("test.db");
+        set_metadata(&conn, "schema_version", "6").unwrap();
+        drop(conn);
+
+        let read_only = open_db_read_only(&db_path).unwrap();
+        assert_eq!(
+            get_metadata(&read_only, "schema_version").unwrap().unwrap(),
+            "6"
+        );
+        drop(read_only);
+
+        let conn = Connection::open(&db_path).unwrap();
+        assert_eq!(get_metadata(&conn, "schema_version").unwrap().unwrap(), "6");
+        set_metadata(&conn, "schema_version", "5").unwrap();
+        drop(conn);
+
+        let error = open_db_read_only(&db_path).err().unwrap();
+        assert_eq!(
+            error.to_string(),
+            "Read-only database schema error: found version 5, expected 7; a writer must migrate the index"
+        );
+    }
+
+    #[test]
+    fn test_schema_v7_migration_preserves_catalog_and_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("migration-v6.db");
+        let legacy_path = "/legacy/worktree-link/../checkout/src/main.ts";
+
+        {
+            let conn = init_db(&db_path).unwrap();
+            upsert_embedding(
+                &conn,
+                "legacy-hash",
+                &[1, 2, 3],
+                "legacy content",
+                "legacy-model",
+            )
+            .unwrap();
+            upsert_chunk(
+                &conn,
+                "legacy-chunk",
+                "legacy-hash",
+                legacy_path,
+                1,
+                3,
+                Some("function"),
+                Some("legacyFunction"),
+                "typescript",
+            )
+            .unwrap();
+            add_chunks_to_branch(&conn, "main", &["legacy-chunk".to_string()]).unwrap();
+
+            upsert_symbol(
+                &conn,
+                &SymbolRow {
+                    id: "legacy-symbol".to_string(),
+                    file_path: legacy_path.to_string(),
+                    name: "legacyFunction".to_string(),
+                    kind: "function".to_string(),
+                    start_line: 1,
+                    start_col: 0,
+                    end_line: 3,
+                    end_col: 1,
+                    language: "typescript".to_string(),
+                },
+            )
+            .unwrap();
+            add_symbols_to_branch(&conn, "main", &["legacy-symbol".to_string()]).unwrap();
+            upsert_call_edge(
+                &conn,
+                &CallEdgeRow {
+                    id: "legacy-edge".to_string(),
+                    from_symbol_id: "legacy-symbol".to_string(),
+                    target_name: "dependency".to_string(),
+                    to_symbol_id: None,
+                    call_type: "Call".to_string(),
+                    confidence: "Direct".to_string(),
+                    line: 2,
+                    col: 4,
+                    is_resolved: false,
+                },
+            )
+            .unwrap();
+            set_metadata(&conn, "index.embeddingModel", "legacy-model").unwrap();
+            set_metadata(&conn, "schema_version", "6").unwrap();
+        }
+
+        let conn = init_db(&db_path).unwrap();
+
+        assert_eq!(get_metadata(&conn, "schema_version").unwrap().unwrap(), "7");
+        assert_eq!(
+            get_metadata(&conn, "index.embeddingModel")
+                .unwrap()
+                .unwrap(),
+            "legacy-model"
+        );
+        assert_eq!(
+            get_metadata(&conn, "index.pathStorageVersion").unwrap(),
+            None
+        );
+        assert_eq!(
+            get_chunk(&conn, "legacy-chunk").unwrap().unwrap().file_path,
+            legacy_path
+        );
+        assert_eq!(
+            get_symbols_for_branch(&conn, "main").unwrap()[0].file_path,
+            legacy_path
+        );
+
+        let stats = get_stats(&conn).unwrap();
+        assert_eq!(stats.embedding_count, 1);
+        assert_eq!(stats.chunk_count, 1);
+        assert_eq!(stats.branch_chunk_count, 1);
+        assert_eq!(stats.branch_count, 1);
+        assert_eq!(stats.symbol_count, 1);
+        assert_eq!(stats.call_edge_count, 1);
     }
 
     #[test]
@@ -1915,7 +2049,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(schema_version, "6");
+        assert_eq!(schema_version, "7");
 
         let on_delete: String = conn
             .query_row("PRAGMA foreign_key_list(call_edges)", [], |row| row.get(6))

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 
 import type { HostMode } from "./host.js";
 import { resolveWorktreeMainRepoRoot } from "../git/index.js";
+import { canonicalizePathForComparison } from "../utils/canonical-path.js";
 
 const OPENCODE_PROJECT_CONFIG_RELATIVE_PATH = path.join(".opencode", "codebase-index.json");
 const OPENCODE_PROJECT_INDEX_RELATIVE_PATH = path.join(".opencode", "index");
@@ -54,6 +55,31 @@ export function getHostProjectConfigRelativePath(host: HostMode): string {
 
 export function getHostProjectIndexRelativePath(host: HostMode): string {
   return getProjectIndexRelativePath(host);
+}
+
+export function isProjectIndexPathOwnedByProject(
+  projectRoot: string,
+  indexPath: string,
+  host: HostMode = "opencode",
+): boolean {
+  const projectRoots = [projectRoot];
+  const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
+  if (mainRepoRoot) {
+    projectRoots.push(mainRepoRoot);
+  }
+
+  const ownedIndexPaths = projectRoots.flatMap((root) => {
+    const indexPaths = [path.join(root, getProjectIndexRelativePath(host))];
+    if (host !== "opencode") {
+      indexPaths.push(path.join(root, OPENCODE_PROJECT_INDEX_RELATIVE_PATH));
+    }
+    return indexPaths;
+  });
+
+  const canonicalIndexPath = canonicalizePathForComparison(indexPath);
+  return ownedIndexPaths.some(
+    (ownedPath) => canonicalizePathForComparison(ownedPath) === canonicalIndexPath,
+  );
 }
 
 function hasHostProjectConfig(projectRoot: string, host: HostMode): boolean {
@@ -166,6 +192,37 @@ export function resolveProjectIndexPath(
   }
 
   const localIndexPath = path.join(projectRoot, getProjectIndexRelativePath(host));
+  const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
+  if (mainRepoRoot) {
+    if (hasHostProjectConfig(projectRoot, host)) {
+      return localIndexPath;
+    }
+
+    if (host !== "opencode") {
+      const localLegacyConfigPath = path.join(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH);
+      if (existsSync(localLegacyConfigPath)) {
+        return path.join(projectRoot, OPENCODE_PROJECT_INDEX_RELATIVE_PATH);
+      }
+
+      const mainHostConfigPath = path.join(mainRepoRoot, getProjectConfigRelativePath(host));
+      const mainHostIndexPath = path.join(mainRepoRoot, getProjectIndexRelativePath(host));
+      const mainLegacyConfigPath = path.join(mainRepoRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH);
+      const mainLegacyIndexPath = path.join(mainRepoRoot, OPENCODE_PROJECT_INDEX_RELATIVE_PATH);
+      if (
+        !existsSync(mainHostConfigPath)
+        && !existsSync(mainHostIndexPath)
+        && (existsSync(mainLegacyConfigPath) || existsSync(mainLegacyIndexPath))
+      ) {
+        return mainLegacyIndexPath;
+      }
+    }
+
+    // Project indexes use root-relative paths and are serialized by the shared
+    // index lease, so inherited worktrees can safely reuse the main checkout.
+    // A stale worktree-local index is ignored unless a local config opts out.
+    return path.join(mainRepoRoot, getProjectIndexRelativePath(host));
+  }
+
   if (existsSync(localIndexPath)) {
     return localIndexPath;
   }
@@ -178,11 +235,6 @@ export function resolveProjectIndexPath(
   }
 
   if (hasHostProjectConfig(projectRoot, host)) {
-    return localIndexPath;
-  }
-
-  // A worktree may inherit project configuration, but never a mutable project index.
-  if (resolveWorktreeMainRepoRoot(projectRoot)) {
     return localIndexPath;
   }
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -57,10 +57,30 @@ export function getHostProjectIndexRelativePath(host: HostMode): string {
   return getProjectIndexRelativePath(host);
 }
 
+export function getProjectConfigCandidatePaths(
+  projectRoot: string,
+  host: HostMode,
+): string[] {
+  const candidates = [path.join(projectRoot, getProjectConfigRelativePath(host))];
+  if (host !== "opencode") {
+    candidates.push(path.join(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH));
+  }
+
+  const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
+  if (mainRepoRoot) {
+    candidates.push(path.join(mainRepoRoot, getProjectConfigRelativePath(host)));
+    if (host !== "opencode") {
+      candidates.push(path.join(mainRepoRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH));
+    }
+  }
+
+  return [...new Set(candidates)];
+}
+
 export function isProjectIndexPathOwnedByProject(
   projectRoot: string,
   indexPath: string,
-  host: HostMode = "opencode",
+  host: HostMode,
 ): boolean {
   const projectRoots = [projectRoot];
   const mainRepoRoot = resolveWorktreeMainRepoRoot(projectRoot);
@@ -151,31 +171,9 @@ export function resolveGlobalIndexPath(host: HostMode): string {
 }
 
 export function resolveProjectConfigPath(projectRoot: string, host: HostMode): string {
-  const hostConfigPath = path.join(projectRoot, getProjectConfigRelativePath(host));
-  if (existsSync(hostConfigPath)) {
-    return hostConfigPath;
-  }
-
-  if (host !== "opencode") {
-    const legacyConfigPath = path.join(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH);
-    if (existsSync(legacyConfigPath)) {
-      return legacyConfigPath;
-    }
-  }
-
-  const hostFallback = resolveWorktreeFallbackPath(projectRoot, getProjectConfigRelativePath(host));
-  if (hostFallback) {
-    return hostFallback;
-  }
-
-  if (host !== "opencode") {
-    const legacyFallback = resolveWorktreeFallbackPath(projectRoot, OPENCODE_PROJECT_CONFIG_RELATIVE_PATH);
-    if (legacyFallback) {
-      return legacyFallback;
-    }
-  }
-
-  return hostConfigPath;
+  const candidates = getProjectConfigCandidatePaths(projectRoot, host);
+  return candidates.find((candidate) => existsSync(candidate))
+    ?? path.join(projectRoot, getProjectConfigRelativePath(host));
 }
 
 export function resolveWritableProjectConfigPath(projectRoot: string, host: HostMode): string {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4284,6 +4284,58 @@ export class Indexer {
     };
   }
 
+  private searchCandidatesWithBranchPrefilter<T>(
+    initialLimit: number,
+    totalCount: number,
+    branchChunkIds: Set<string> | null,
+    shouldPrefilterByBranch: boolean,
+    search: (limit: number) => T[],
+    getChunkId: (candidate: T) => string,
+  ): T[] {
+    const normalizedLimit = Math.max(0, Math.floor(initialLimit));
+    if (normalizedLimit === 0) return [];
+    if (!shouldPrefilterByBranch || !branchChunkIds) {
+      return search(normalizedLimit);
+    }
+
+    const targetCount = Math.min(normalizedLimit, branchChunkIds.size);
+    if (targetCount === 0 || totalCount === 0) return [];
+
+    let requestedLimit = Math.min(normalizedLimit, totalCount);
+    while (true) {
+      const results = search(requestedLimit);
+      const branchResults = results.filter((candidate) => branchChunkIds.has(getChunkId(candidate)));
+      if (
+        branchResults.length >= targetCount
+        || results.length < requestedLimit
+        || requestedLimit >= totalCount
+      ) {
+        return branchResults;
+      }
+
+      const nextLimit = Math.min(totalCount, Math.max(requestedLimit + 1, requestedLimit * 2));
+      if (nextLimit === requestedLimit) return branchResults;
+      requestedLimit = nextLimit;
+    }
+  }
+
+  private searchSemanticCandidates(
+    store: VectorStore,
+    embedding: number[],
+    initialLimit: number,
+    branchChunkIds: Set<string> | null,
+    shouldPrefilterByBranch: boolean,
+  ): RankedCandidate[] {
+    return this.searchCandidatesWithBranchPrefilter(
+      initialLimit,
+      store.count(),
+      branchChunkIds,
+      shouldPrefilterByBranch,
+      (requestedLimit) => store.search(embedding, requestedLimit),
+      (candidate) => candidate.id,
+    );
+  }
+
   async search(
     query: string,
     limit?: number,
@@ -4355,14 +4407,7 @@ export class Indexer {
     }
     const embeddingMs = performance.now() - embeddingStartTime;
 
-    const vectorStartTime = performance.now();
-    const semanticResults = embedding ? store.search(embedding, maxResults * 4) : [];
-    const vectorMs = performance.now() - vectorStartTime;
-
-    const keywordStartTime = performance.now();
-    const keywordResults = await this.keywordSearch(query, maxResults * 4, store, invertedIndex);
-    const keywordMs = performance.now() - keywordStartTime;
-
+    const prefilterStartTime = performance.now();
     let branchChunkIds: Set<string> | null = null;
     let branchSymbolIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
@@ -4370,23 +4415,39 @@ export class Indexer {
       branchChunkIds = new Set(branchCatalogKeys.flatMap((branchKey) => database.getBranchChunkIds(branchKey)));
       branchSymbolIds = new Set(branchCatalogKeys.flatMap((branchKey) => database.getBranchSymbolIds(branchKey)));
     }
-
-    const prefilterStartTime = performance.now();
     const { hasInitializedBranchCatalog, shouldPrefilterByBranch } =
       this.getBranchPrefilterState(database, branchChunkIds);
-    const semanticCandidates = shouldPrefilterByBranch && branchChunkIds
-      ? semanticResults.filter((r) => branchChunkIds.has(r.id))
-      : semanticResults;
-    const keywordCandidates = shouldPrefilterByBranch && branchChunkIds
-      ? keywordResults.filter((r) => branchChunkIds.has(r.id))
-      : keywordResults;
+    const prefilterMs = performance.now() - prefilterStartTime;
+
+    const vectorStartTime = performance.now();
+    const semanticCandidates = embedding
+      ? this.searchSemanticCandidates(
+          store,
+          embedding,
+          maxResults * 4,
+          branchChunkIds,
+          shouldPrefilterByBranch,
+        )
+      : [];
+    const vectorMs = performance.now() - vectorStartTime;
+
+    const keywordStartTime = performance.now();
+    const keywordCandidates = await this.keywordSearch(
+      query,
+      maxResults * 4,
+      store,
+      invertedIndex,
+      branchChunkIds,
+      shouldPrefilterByBranch,
+    );
+    const keywordMs = performance.now() - keywordStartTime;
+
     const scopedSemanticCandidates = semanticCandidates.filter((candidate) =>
       matchesHardSearchFilters(candidate, options, this.projectRoot)
     );
     const scopedKeywordCandidates = keywordCandidates.filter((candidate) =>
       matchesHardSearchFilters(candidate, options, this.projectRoot)
     );
-    const prefilterMs = performance.now() - prefilterStartTime;
 
     if (this.config.scope !== "global" && branchChunkIds && !hasInitializedBranchCatalog) {
       this.logger.search("warn", "Branch prefilter skipped because branch catalog is empty", {
@@ -4541,8 +4602,21 @@ export class Indexer {
     limit: number,
     store: VectorStore,
     invertedIndex: InvertedIndex,
+    branchChunkIds: Set<string> | null = null,
+    shouldPrefilterByBranch = false,
   ): Promise<Array<{ id: string; score: number; metadata: ChunkMetadata }>> {
-    const scores = invertedIndex.search(query);
+    const normalizedLimit = Math.max(0, Math.floor(limit));
+    if (normalizedLimit === 0) return [];
+
+    const scoreEntries = this.searchCandidatesWithBranchPrefilter(
+      normalizedLimit,
+      invertedIndex.getDocumentCount(),
+      branchChunkIds,
+      shouldPrefilterByBranch,
+      (requestedLimit) => Array.from(invertedIndex.search(query, requestedLimit)),
+      ([chunkId]) => chunkId,
+    );
+    const scores = new Map(scoreEntries);
 
     if (scores.size === 0) {
       return [];
@@ -4562,7 +4636,7 @@ export class Indexer {
     }
 
     results.sort((a, b) => b.score - a.score);
-    return results.slice(0, limit);
+    return results.slice(0, normalizedLimit);
   }
 
   async getStatus(): Promise<StatusResult> {
@@ -5205,24 +5279,26 @@ export class Indexer {
     const embeddingMs = performance.now() - embeddingStartTime;
     this.logger.recordEmbeddingApiCall(tokensUsed);
 
-    const vectorStartTime = performance.now();
-    const semanticResults = store.search(embedding, limit * 2);
-    const vectorMs = performance.now() - vectorStartTime;
-
+    const prefilterStartTime = performance.now();
     let branchChunkIds: Set<string> | null = null;
     if (filterByBranch && (this.config.scope === "global" || this.currentBranch !== "default")) {
       branchChunkIds = new Set(
         this.getBranchCatalogKeys().flatMap((branchKey) => database.getBranchChunkIds(branchKey))
       );
     }
-
-    const prefilterStartTime = performance.now();
     const { hasInitializedBranchCatalog, shouldPrefilterByBranch } =
       this.getBranchPrefilterState(database, branchChunkIds);
-    const semanticCandidates = shouldPrefilterByBranch && branchChunkIds
-      ? semanticResults.filter((r) => branchChunkIds.has(r.id))
-      : semanticResults;
     const prefilterMs = performance.now() - prefilterStartTime;
+
+    const vectorStartTime = performance.now();
+    const semanticCandidates = this.searchSemanticCandidates(
+      store,
+      embedding,
+      limit * 2,
+      branchChunkIds,
+      shouldPrefilterByBranch,
+    );
+    const vectorMs = performance.now() - vectorStartTime;
 
     if (this.config.scope !== "global" && branchChunkIds && !hasInitializedBranchCatalog) {
       this.logger.search("warn", "Branch prefilter skipped because branch catalog is empty", {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1414,37 +1414,50 @@ export class Indexer {
     return `index.forceReembed.${this.projectIdentityHash}`;
   }
 
-  private getCallGraphResolutionMetadataKey(): string {
-    if (this.config.scope !== "global") {
-      return "index.callGraphResolutionVersion";
-    }
-
-    return `index.callGraphResolutionVersion.${this.projectIdentityHash}`;
+  private getBranchMigrationMetadataKey(
+    prefix: string,
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): string {
+    const branchKey = this.getBranchCatalogKeyFor(catalogIdentity);
+    return `${prefix}.${hashContent(branchKey).slice(0, 24)}`;
   }
 
-  private getSwiftParserVersionMetadataKey(): string {
-    const key = "index.parser.swiftVersion";
-    if (this.config.scope !== "global") {
-      return key;
-    }
-
-    return `${key}.${this.projectIdentityHash}`;
+  private getCallGraphResolutionMetadataKey(
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): string {
+    return this.getBranchMigrationMetadataKey("index.callGraphResolutionVersion", catalogIdentity);
   }
 
-  private getMetalParserVersionMetadataKey(): string {
-    const key = "index.parser.metalVersion";
-    if (this.config.scope !== "global") {
-      return key;
-    }
+  private getSwiftParserVersionMetadataKey(
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): string {
+    return this.getBranchMigrationMetadataKey("index.parser.swiftVersion", catalogIdentity);
+  }
 
-    return `${key}.${this.projectIdentityHash}`;
+  private getMetalParserVersionMetadataKey(
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): string {
+    return this.getBranchMigrationMetadataKey("index.parser.metalVersion", catalogIdentity);
   }
 
   private getSymbolExtractorVersionMetadataKey(
     catalogIdentity = this.getBranchCatalogIdentity(),
   ): string {
-    const branchKey = this.getBranchCatalogKeyFor(catalogIdentity);
-    return `index.symbolExtractorVersion.${hashContent(branchKey).slice(0, 24)}`;
+    return this.getBranchMigrationMetadataKey("index.symbolExtractorVersion", catalogIdentity);
+  }
+
+  private areBranchMigrationVersionsCurrent(
+    database: Database,
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): boolean {
+    return database.getMetadata(this.getCallGraphResolutionMetadataKey(catalogIdentity))
+      === CALL_GRAPH_RESOLUTION_VERSION
+      && database.getMetadata(this.getSwiftParserVersionMetadataKey(catalogIdentity))
+      === SWIFT_PARSER_VERSION
+      && database.getMetadata(this.getMetalParserVersionMetadataKey(catalogIdentity))
+      === METAL_PARSER_VERSION
+      && database.getMetadata(this.getSymbolExtractorVersionMetadataKey(catalogIdentity))
+      === SYMBOL_EXTRACTOR_VERSION;
   }
 
   private hasProjectForceReembedPending(): boolean {
@@ -3206,9 +3219,8 @@ export class Indexer {
       const branchKey = this.getBranchCatalogKey();
       const alreadyIndexed = database.getBranchChunkIds(branchKey).length > 0
         && database.getBranchSymbolIds(branchKey).length > 0;
-      const symbolsCurrent = database.getMetadata(this.getSymbolExtractorVersionMetadataKey())
-        === SYMBOL_EXTRACTOR_VERSION;
-      if (alreadyIndexed && symbolsCurrent && this.getStoredBranchCommit(database) === normalizedCommit) {
+      const migrationsCurrent = this.areBranchMigrationVersionsCurrent(database);
+      if (alreadyIndexed && migrationsCurrent && this.getStoredBranchCommit(database) === normalizedCommit) {
         return { prepared: false };
       }
 
@@ -4256,6 +4268,22 @@ export class Indexer {
     return intersection / union;
   }
 
+  private getBranchPrefilterState(
+    database: Database,
+    branchChunkIds: Set<string> | null,
+  ): {
+    hasInitializedBranchCatalog: boolean;
+    shouldPrefilterByBranch: boolean;
+  } {
+    const hasInitializedBranchCatalog = branchChunkIds !== null
+      && database.getAllBranches().length > 0;
+    return {
+      hasInitializedBranchCatalog,
+      shouldPrefilterByBranch: branchChunkIds !== null
+        && (this.config.scope === "global" || hasInitializedBranchCatalog),
+    };
+  }
+
   async search(
     query: string,
     limit?: number,
@@ -4344,21 +4372,14 @@ export class Indexer {
     }
 
     const prefilterStartTime = performance.now();
-    const shouldPrefilterByBranch = branchChunkIds !== null && (this.config.scope === "global" || branchChunkIds.size > 0);
-    const allowBranchPrefilterFallback = this.config.scope !== "global";
-    const prefilteredSemantic = shouldPrefilterByBranch && branchChunkIds
+    const { hasInitializedBranchCatalog, shouldPrefilterByBranch } =
+      this.getBranchPrefilterState(database, branchChunkIds);
+    const semanticCandidates = shouldPrefilterByBranch && branchChunkIds
       ? semanticResults.filter((r) => branchChunkIds.has(r.id))
       : semanticResults;
-    const prefilteredKeyword = shouldPrefilterByBranch && branchChunkIds
+    const keywordCandidates = shouldPrefilterByBranch && branchChunkIds
       ? keywordResults.filter((r) => branchChunkIds.has(r.id))
       : keywordResults;
-
-    const semanticCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0)
-      ? semanticResults
-      : prefilteredSemantic;
-    const keywordCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0)
-      ? keywordResults
-      : prefilteredKeyword;
     const scopedSemanticCandidates = semanticCandidates.filter((candidate) =>
       matchesHardSearchFilters(candidate, options, this.projectRoot)
     );
@@ -4367,20 +4388,8 @@ export class Indexer {
     );
     const prefilterMs = performance.now() - prefilterStartTime;
 
-    if (this.config.scope !== "global" && branchChunkIds && branchChunkIds.size === 0) {
+    if (this.config.scope !== "global" && branchChunkIds && !hasInitializedBranchCatalog) {
       this.logger.search("warn", "Branch prefilter skipped because branch catalog is empty", {
-        branch: this.currentBranch,
-      });
-    }
-
-    if (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0) {
-      this.logger.search("warn", "Branch prefilter produced no semantic overlap, using unfiltered semantic candidates", {
-        branch: this.currentBranch,
-      });
-    }
-
-    if (allowBranchPrefilterFallback && shouldPrefilterByBranch && keywordResults.length > 0 && prefilteredKeyword.length === 0) {
-      this.logger.search("warn", "Branch prefilter produced no keyword overlap, using unfiltered keyword candidates", {
         branch: this.currentBranch,
       });
     }
@@ -4640,23 +4649,7 @@ export class Indexer {
       }
     }
 
-    const hasSwiftFiles = Array.from(currentFileHashes.keys()).some(
-      (filePath) => path.extname(filePath).toLowerCase() === ".swift",
-    );
-    const hasMetalFiles = Array.from(currentFileHashes.keys()).some(
-      (filePath) => path.extname(filePath).toLowerCase() === ".metal",
-    );
-    const hasCallGraphMigrationFiles = Array.from(currentFileHashes.keys()).some((filePath) => {
-      const extension = path.extname(filePath).toLowerCase();
-      return extension === ".php" || extension === ".c" || extension === ".cc" || extension === ".cpp" || extension === ".cxx";
-    });
-    if (
-      (hasSwiftFiles && database.getMetadata(this.getSwiftParserVersionMetadataKey()) !== SWIFT_PARSER_VERSION)
-      || (hasMetalFiles && database.getMetadata(this.getMetalParserVersionMetadataKey()) !== METAL_PARSER_VERSION)
-      || database.getMetadata(this.getSymbolExtractorVersionMetadataKey()) !== SYMBOL_EXTRACTOR_VERSION
-      || (hasCallGraphMigrationFiles
-        && database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION)
-    ) {
+    if (!this.areBranchMigrationVersionsCurrent(database)) {
       return { readable: true, current: false, reason: "migration-required" };
     }
 
@@ -5224,24 +5217,15 @@ export class Indexer {
     }
 
     const prefilterStartTime = performance.now();
-    const shouldPrefilterByBranch = branchChunkIds !== null && (this.config.scope === "global" || branchChunkIds.size > 0);
-    const allowBranchPrefilterFallback = this.config.scope !== "global";
-    const prefilteredSemantic = shouldPrefilterByBranch && branchChunkIds
+    const { hasInitializedBranchCatalog, shouldPrefilterByBranch } =
+      this.getBranchPrefilterState(database, branchChunkIds);
+    const semanticCandidates = shouldPrefilterByBranch && branchChunkIds
       ? semanticResults.filter((r) => branchChunkIds.has(r.id))
       : semanticResults;
-    const semanticCandidates = (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0)
-      ? semanticResults
-      : prefilteredSemantic;
     const prefilterMs = performance.now() - prefilterStartTime;
 
-    if (this.config.scope !== "global" && branchChunkIds && branchChunkIds.size === 0) {
+    if (this.config.scope !== "global" && branchChunkIds && !hasInitializedBranchCatalog) {
       this.logger.search("warn", "Branch prefilter skipped because branch catalog is empty", {
-        branch: this.currentBranch,
-      });
-    }
-
-    if (allowBranchPrefilterFallback && shouldPrefilterByBranch && semanticResults.length > 0 && prefilteredSemantic.length === 0) {
-      this.logger.search("warn", "Branch prefilter produced no semantic overlap, using unfiltered semantic candidates", {
         branch: this.currentBranch,
       });
     }
@@ -5587,11 +5571,9 @@ export class Indexer {
     const storedCommit = this.getStoredBranchCommit(database, catalogIdentity);
     const catalogIdentityMatches = storedCommit === expectedCommit;
 
-    const symbolsCurrent = database.getMetadata(
-      this.getSymbolExtractorVersionMetadataKey(catalogIdentity),
-    ) === SYMBOL_EXTRACTOR_VERSION;
+    const migrationsCurrent = this.areBranchMigrationVersionsCurrent(database, catalogIdentity);
 
-    if (branchSymbols.length === 0 || !catalogIdentityMatches || !symbolsCurrent) {
+    if (branchSymbols.length === 0 || !catalogIdentityMatches || !migrationsCurrent) {
       if (!resolvedBranch || resolvedBranch === "default") {
         throw new Error("Run index_codebase first to build the call graph and symbol index for this project.");
       }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -37,7 +37,7 @@ import type { SymbolData, CallEdgeData, PathHopData, ReachabilityData, Community
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 import { isFullGitCommit, resolveLocalGitCommit, withMaterializedBranch } from "../git/branch-materialization.js";
 import type { HostMode } from "../config/host.js";
-import { getHostProjectIndexRelativePath, resolveProjectIndexPath } from "../config/paths.js";
+import { isProjectIndexPathOwnedByProject, resolveProjectIndexPath } from "../config/paths.js";
 import { getChangedFiles } from "../tools/changed-files.js";
 import type { PrImpactResult } from "./pr-impact-types.js";
 import { getChunkGitBlame, type GitBlameMetadata } from "./git-blame.js";
@@ -432,6 +432,7 @@ interface RerankDocumentPayload {
 
 interface IndexMetadata {
   indexVersion: string;
+  pathStorageVersion: string;
   embeddingProvider: string;
   embeddingModel: string;
   embeddingDimensions: number;
@@ -444,6 +445,7 @@ enum IncompatibilityCode {
   DIMENSION_MISMATCH = "DIMENSION_MISMATCH",
   MODEL_MISMATCH = "MODEL_MISMATCH",
   EMBEDDING_STRATEGY_MISMATCH = "EMBEDDING_STRATEGY_MISMATCH",
+  PATH_STORAGE_MISMATCH = "PATH_STORAGE_MISMATCH",
 }
 
 interface IndexCompatibility {
@@ -454,6 +456,8 @@ interface IndexCompatibility {
 }
 
 const INDEX_METADATA_VERSION = "1";
+const PROJECT_PATH_STORAGE_VERSION = "2";
+const GLOBAL_PATH_STORAGE_VERSION = "1";
 const EMBEDDING_STRATEGY_VERSION = "2";
 const SWIFT_PARSER_VERSION = "1";
 const METAL_PARSER_VERSION = "1";
@@ -893,7 +897,8 @@ export function selectIndexableChunks<T extends { chunkType: string }>(
 
 function matchesHardSearchFilters(
   candidate: RankedCandidate,
-  options: SearchFilterOptions | undefined
+  options: SearchFilterOptions | undefined,
+  projectRoot: string,
 ): boolean {
   if (options?.fileType) {
     const ext = candidate.metadata.filePath.split(".").pop()?.toLowerCase();
@@ -902,14 +907,13 @@ function matchesHardSearchFilters(
   }
 
   if (options?.directory) {
-    const normalizedPath = candidate.metadata.filePath.replace(/\\/g, "/");
-    const normalizedDir = options.directory.trim().replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
-    const isAbsoluteDirectory = normalizedDir.startsWith("/");
-    const matchesDirectory = isAbsoluteDirectory
-      ? normalizedPath === normalizedDir || normalizedPath.startsWith(`${normalizedDir}/`)
-      : normalizedPath === normalizedDir || normalizedPath.startsWith(`${normalizedDir}/`) ||
-        normalizedPath.includes(`/${normalizedDir}/`) || normalizedPath.endsWith(`/${normalizedDir}`);
-    if (!matchesDirectory) return false;
+    const candidatePath = canonicalizePathForComparison(
+      path.resolve(projectRoot, candidate.metadata.filePath.replace(/\\/g, path.sep)),
+    );
+    const directoryPath = canonicalizePathForComparison(
+      path.resolve(projectRoot, options.directory.trim().replace(/\\/g, path.sep)),
+    );
+    if (!isPathWithinRoot(candidatePath, directoryPath)) return false;
   }
 
   if (options?.chunkType && candidate.metadata.chunkType !== options.chunkType) {
@@ -940,9 +944,10 @@ function matchesHardSearchFilters(
 function matchesSearchFilters(
   candidate: RankedCandidate,
   options: SearchFilterOptions | undefined,
-  minScore: number
+  minScore: number,
+  projectRoot: string,
 ): boolean {
-  return candidate.score >= minScore && matchesHardSearchFilters(candidate, options);
+  return candidate.score >= minScore && matchesHardSearchFilters(candidate, options, projectRoot);
 }
 
 function unionCandidates(
@@ -1017,9 +1022,15 @@ export class Indexer {
     this.indexPathOverride = runtimeOptions.indexPath;
     this.config = config;
     this.host = host;
+    if (isGitRepo(this.materializedProjectRoot)) {
+      this.currentBranch = this.branchNameOverride ?? getBranchOrDefault(this.materializedProjectRoot);
+      this.baseBranch = getBaseBranch(this.materializedProjectRoot);
+    } else {
+      this.currentBranch = "default";
+      this.baseBranch = "default";
+    }
     this.indexPath = this.getIndexPath();
-    this.fileHashCachePath = this.getRuntimeArtifactPath("file-hashes.json");
-    this.failedBatchesPath = this.getRuntimeArtifactPath("failed-batches.json");
+    this.refreshRuntimeArtifactPaths();
     this.logger = initializeLogger(config.debug);
   }
 
@@ -1028,6 +1039,9 @@ export class Indexer {
   }
 
   private toCanonicalFilePath(filePath: string): string {
+    if (!path.isAbsolute(filePath)) {
+      return this.resolveStoredFilePath(filePath, this.projectRoot);
+    }
     if (
       path.resolve(this.materializedProjectRoot) === path.resolve(this.projectRoot)
       || !isPathWithinRoot(filePath, this.materializedProjectRoot)
@@ -1037,14 +1051,55 @@ export class Indexer {
     return path.resolve(this.projectRoot, path.relative(this.materializedProjectRoot, filePath));
   }
 
-  private toMaterializedFilePath(filePath: string): string {
+  private toStoredFilePath(filePath: string): string {
+    const canonicalFilePath = this.toCanonicalFilePath(filePath);
     if (
-      path.resolve(this.materializedProjectRoot) === path.resolve(this.projectRoot)
-      || !isPathWithinRoot(filePath, this.projectRoot)
+      this.config.scope !== "project"
+      || !isPathWithinRoot(canonicalFilePath, this.projectRoot)
     ) {
+      return canonicalFilePath;
+    }
+
+    return path.relative(this.projectRoot, canonicalFilePath).split(path.sep).join("/");
+  }
+
+  private resolveStoredFilePath(filePath: string, rootPath = this.projectRoot): string {
+    if (path.isAbsolute(filePath)) {
       return filePath;
     }
-    return path.resolve(this.materializedProjectRoot, path.relative(this.projectRoot, filePath));
+
+    const resolvedPath = path.resolve(rootPath, ...filePath.split("/"));
+    if (!isPathWithinRoot(resolvedPath, rootPath)) {
+      throw new Error(`Stored project path escapes project root: ${JSON.stringify(filePath)}`);
+    }
+    return resolvedPath;
+  }
+
+  private getCanonicalStoredFilePath(filePath: string): string {
+    return this.getCanonicalPath(this.resolveStoredFilePath(filePath));
+  }
+
+  private resolveFilePathRecord<T extends { filePath: string }>(record: T): T {
+    return {
+      ...record,
+      filePath: this.resolveStoredFilePath(record.filePath),
+    };
+  }
+
+  private resolveCallEdgeFilePath(edge: CallEdgeData): CallEdgeData {
+    if (!edge.fromSymbolFilePath) return edge;
+    return {
+      ...edge,
+      fromSymbolFilePath: this.resolveStoredFilePath(edge.fromSymbolFilePath),
+    };
+  }
+
+  private toMaterializedFilePath(filePath: string): string {
+    const storedFilePath = this.toStoredFilePath(filePath);
+    if (path.isAbsolute(storedFilePath)) {
+      return storedFilePath;
+    }
+    return this.resolveStoredFilePath(storedFilePath, this.materializedProjectRoot);
   }
 
   private getPreparedBranchNamespace(): string | null {
@@ -1052,12 +1107,24 @@ export class Indexer {
     return hashContent(this.getBranchCatalogKey()).slice(0, 16);
   }
 
+  private getRuntimeArtifactNamespace(): string | null {
+    if (this.config.scope !== "project" || this.getBranchCatalogIdentity() === "default") {
+      return this.getPreparedBranchNamespace();
+    }
+    return hashContent(this.getBranchCatalogKey()).slice(0, 16);
+  }
+
   private getRuntimeArtifactPath(fileName: string): string {
-    const namespace = this.getPreparedBranchNamespace();
+    const namespace = this.getRuntimeArtifactNamespace();
     if (!namespace) return path.join(this.indexPath, fileName);
     const extension = path.extname(fileName);
     const baseName = fileName.slice(0, fileName.length - extension.length);
     return path.join(this.indexPath, `${baseName}.${namespace}${extension}`);
+  }
+
+  private refreshRuntimeArtifactPaths(): void {
+    this.fileHashCachePath = this.getRuntimeArtifactPath("file-hashes.json");
+    this.failedBatchesPath = this.getRuntimeArtifactPath("failed-batches.json");
   }
 
   private getPreparedChunkId(chunkId: string): string {
@@ -1090,20 +1157,8 @@ export class Indexer {
     }
   }
 
-  private isLocalProjectIndexPath(): boolean {
-    const localProjectIndexPaths = [path.join(this.projectRoot, getHostProjectIndexRelativePath(this.host))];
-    if (this.host !== "opencode") {
-      localProjectIndexPaths.push(path.join(this.projectRoot, getHostProjectIndexRelativePath("opencode")));
-    }
-
-    return localProjectIndexPaths.some((localPath) => {
-      if (!existsSync(localPath) || !existsSync(this.indexPath)) {
-        return path.resolve(this.indexPath) === path.resolve(localPath);
-      }
-      const indexStats = statSync(this.indexPath);
-      const localStats = statSync(localPath);
-      return indexStats.dev === localStats.dev && indexStats.ino === localStats.ino;
-    });
+  private isProjectOwnedIndexPath(): boolean {
+    return isProjectIndexPathOwnedByProject(this.projectRoot, this.indexPath, this.host);
   }
 
   private resetLoadedIndexState(retireDatabase = false): void {
@@ -1144,10 +1199,10 @@ export class Indexer {
     operation: IndexMutationOperation,
     callback: (recoveredOwners: readonly IndexLockOwner[]) => Promise<T>,
   ): Promise<T> {
+    this.refreshBranchInfo();
     const lease = acquireIndexLock(this.indexPath, operation);
     this.indexPath = lease.canonicalIndexPath;
-    this.fileHashCachePath = this.getRuntimeArtifactPath("file-hashes.json");
-    this.failedBatchesPath = this.getRuntimeArtifactPath("failed-batches.json");
+    this.refreshRuntimeArtifactPaths();
     this.activeIndexLease = lease;
 
     let result: T | undefined;
@@ -1564,14 +1619,15 @@ export class Indexer {
   }
 
   private isFileInCurrentScope(filePath: string, roots: string[]): boolean {
-    if (roots.some((root) => isPathWithinRoot(filePath, root))) return true;
-    const canonicalFilePath = this.getCanonicalPath(filePath);
+    const canonicalFilePath = this.getCanonicalStoredFilePath(filePath);
     return roots.some((root) => isPathWithinRoot(canonicalFilePath, root));
   }
 
   private isFileInProjectRoot(filePath: string): boolean {
-    if (isPathWithinRoot(filePath, this.projectRoot)) return true;
-    return isPathWithinRoot(this.getCanonicalPath(filePath), this.getCanonicalPath(this.projectRoot));
+    return isPathWithinRoot(
+      this.getCanonicalStoredFilePath(filePath),
+      this.getCanonicalPath(this.projectRoot),
+    );
   }
 
   private clearScopedFileHashCache(roots: string[]): void {
@@ -2093,7 +2149,10 @@ export class Indexer {
     parts.push(`intent_hint: ${intent}`);
 
     try {
-      const fileContent = await fsPromises.readFile(candidate.metadata.filePath, "utf-8");
+      const fileContent = await fsPromises.readFile(
+        this.toMaterializedFilePath(candidate.metadata.filePath),
+        "utf-8",
+      );
       const lines = fileContent.split("\n");
       const snippetStartLine = Math.max(1, candidate.metadata.startLine);
       const snippetEndLine = Math.min(lines.length, candidate.metadata.endLine);
@@ -2190,7 +2249,7 @@ export class Indexer {
     if (this.config.scope === "global") {
       return "Shared vector index could not be read. Restore or repair the complete fingerprinted shared vector artifacts; automatic reset is disabled for global scope.";
     }
-    if (!this.isLocalProjectIndexPath()) {
+    if (!this.isProjectOwnedIndexPath()) {
       return "Vector index could not be read from an inherited project index. Restore or fingerprint it from the checkout that owns the index; do not remove or rebuild it from this worktree.";
     }
     return "Vector index could not be read. Run index_codebase after the active writer finishes to fingerprint a structurally valid legacy pair, or remove this checkout's local index directory and run index_codebase to rebuild it.";
@@ -2200,7 +2259,7 @@ export class Indexer {
     if (this.config.scope === "global") {
       return "Shared keyword index could not be read; semantic search remains available. Restore or repair the shared keyword artifact; automatic reset is disabled for global scope.";
     }
-    if (!this.isLocalProjectIndexPath()) {
+    if (!this.isProjectOwnedIndexPath()) {
       return "Keyword index could not be read from an inherited project index; semantic search remains available. Restore or repair it from the checkout that owns the index; do not rebuild it from this worktree.";
     }
     return "Keyword index could not be read; semantic search remains available. Restore a readable published keyword index, or run index_codebase with force=true after the active writer finishes.";
@@ -2210,10 +2269,10 @@ export class Indexer {
     if (this.config.scope === "global") {
       return "Shared index database could not be read. Restore or repair the shared SQLite database; automatic reset is disabled for global scope.";
     }
-    if (!this.isLocalProjectIndexPath()) {
+    if (!this.isProjectOwnedIndexPath()) {
       return "Index database could not be read from an inherited project index. Restore or repair it from the checkout that owns the index; do not migrate or rebuild it from this worktree.";
     }
-    return "Index database could not be read. Run index_codebase after the active writer finishes to repair or migrate it under the writer lease.";
+    return "Index database could not be read. Run index_codebase with force=true to rebuild a legacy absolute-path schema, or repair the database after the active writer finishes.";
   }
 
   private getReaderFileFingerprint(filePath: string, identityOnly = false): string {
@@ -2452,7 +2511,7 @@ export class Indexer {
       await fsPromises.mkdir(this.indexPath, { recursive: true });
 
       // Interrupted recovery remains entirely under the writer lease.
-      if (recoveredOwners.length > 0 && this.config.scope === "project" && !this.isLocalProjectIndexPath()) {
+      if (recoveredOwners.length > 0 && this.config.scope === "project" && !this.isProjectOwnedIndexPath()) {
         throw new Error(
           "Interrupted indexing recovery is unsafe while using an inherited worktree index. " +
           "Run index_codebase with force=true to create a local project index boundary."
@@ -2561,6 +2620,7 @@ export class Indexer {
       this.baseBranch = "default";
       this.logger.branch("debug", "Not a git repository, using default branch");
     }
+    this.refreshRuntimeArtifactPaths();
 
     if (mode === "writer" && recoveredOwners.length > 0) {
       await this.recoverFromInterruptedIndexingUnlocked(recoveredOwners);
@@ -2758,6 +2818,18 @@ export class Indexer {
     return `Detected a corrupted local SQLite index at ${dbPath} and reset the local index. Run index_codebase to rebuild search data.`;
   }
 
+  private async removeProjectRuntimeStateArtifacts(): Promise<void> {
+    if (!existsSync(this.indexPath)) return;
+
+    const names = await fsPromises.readdir(this.indexPath);
+    const runtimeStatePattern = /^(?:file-hashes|failed-batches)(?:\.[a-f0-9]{16})?\.json$/;
+    await Promise.all(
+      names
+        .filter((name) => runtimeStatePattern.test(name))
+        .map((name) => fsPromises.rm(path.join(this.indexPath, name), { force: true })),
+    );
+  }
+
   private async resetLocalIndexArtifacts(): Promise<void> {
     this.store = null;
     this.invertedIndex = null;
@@ -2779,11 +2851,10 @@ export class Indexer {
       path.join(this.indexPath, "vectors.usearch"),
       path.join(this.indexPath, "vectors.meta.json"),
       path.join(this.indexPath, "inverted-index.json"),
-      path.join(this.indexPath, "file-hashes.json"),
-      path.join(this.indexPath, "failed-batches.json"),
     ];
 
     await Promise.all(resetPaths.map((targetPath) => fsPromises.rm(targetPath, { recursive: true, force: true })));
+    await this.removeProjectRuntimeStateArtifacts();
     await fsPromises.mkdir(this.indexPath, { recursive: true });
   }
 
@@ -2843,21 +2914,36 @@ export class Indexer {
     this.database.addChunksToBranchBatch(this.getBranchCatalogKey(), chunkIds);
   }
 
+  private getExpectedPathStorageVersion(): string {
+    return this.config.scope === "project"
+      ? PROJECT_PATH_STORAGE_VERSION
+      : GLOBAL_PATH_STORAGE_VERSION;
+  }
+
+  private hasStoredIndexData(): boolean {
+    const stats = this.database?.getStats();
+    return (this.store?.count() ?? 0) > 0
+      || (stats?.chunkCount ?? 0) > 0
+      || (stats?.symbolCount ?? 0) > 0
+      || this.fileHashCache.size > 0;
+  }
+
   private loadIndexMetadata(): IndexMetadata | null {
     if (!this.database) return null;
 
     const version = this.database.getMetadata("index.version");
     if (!version) return null;
 
-      return {
-        indexVersion: version,
-        embeddingProvider: this.database.getMetadata("index.embeddingProvider") ?? "",
-        embeddingModel: this.database.getMetadata("index.embeddingModel") ?? "",
-        embeddingDimensions: parseInt(this.database.getMetadata("index.embeddingDimensions") ?? "0", 10),
-        embeddingStrategyVersion: this.loadStoredEmbeddingStrategyVersion() ?? EMBEDDING_STRATEGY_VERSION,
-        createdAt: this.database.getMetadata("index.createdAt") ?? "",
-        updatedAt: this.database.getMetadata("index.updatedAt") ?? "",
-      };
+    return {
+      indexVersion: version,
+      pathStorageVersion: this.database.getMetadata("index.pathStorageVersion") ?? GLOBAL_PATH_STORAGE_VERSION,
+      embeddingProvider: this.database.getMetadata("index.embeddingProvider") ?? "",
+      embeddingModel: this.database.getMetadata("index.embeddingModel") ?? "",
+      embeddingDimensions: parseInt(this.database.getMetadata("index.embeddingDimensions") ?? "0", 10),
+      embeddingStrategyVersion: this.loadStoredEmbeddingStrategyVersion() ?? EMBEDDING_STRATEGY_VERSION,
+      createdAt: this.database.getMetadata("index.createdAt") ?? "",
+      updatedAt: this.database.getMetadata("index.updatedAt") ?? "",
+    };
   }
 
   private saveIndexMetadata(provider: ConfiguredProviderInfo): void {
@@ -2868,6 +2954,7 @@ export class Indexer {
     const completeProjectEmbeddingStrategyReset = !this.hasProjectForceReembedPending();
 
     this.database.setMetadata("index.version", INDEX_METADATA_VERSION);
+    this.database.setMetadata("index.pathStorageVersion", this.getExpectedPathStorageVersion());
     this.database.setMetadata("index.embeddingProvider", provider.provider);
     this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
     this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
@@ -2892,6 +2979,18 @@ export class Indexer {
 
   private validateIndexCompatibility(provider: ConfiguredProviderInfo): IndexCompatibility {
     const storedMetadata = this.loadIndexMetadata();
+
+    const storedPathStorageVersion = this.database?.getMetadata("index.pathStorageVersion")
+      ?? GLOBAL_PATH_STORAGE_VERSION;
+    const expectedPathStorageVersion = this.getExpectedPathStorageVersion();
+    if (this.hasStoredIndexData() && storedPathStorageVersion !== expectedPathStorageVersion) {
+      return {
+        compatible: false,
+        code: IncompatibilityCode.PATH_STORAGE_MISMATCH,
+        reason: `Path storage format mismatch: index uses v${storedPathStorageVersion} checkout-absolute paths, but this project requires portable v${expectedPathStorageVersion} paths. Run index_codebase with force=true to rebuild the shared project index once.`,
+        storedMetadata: storedMetadata ?? undefined,
+      };
+    }
 
     if (!storedMetadata) {
       return { compatible: true };
@@ -2961,6 +3060,7 @@ export class Indexer {
     readIssues: readonly IndexReadIssue[];
     compatibility: IndexCompatibility;
   }> {
+    this.refreshBranchInfo();
     let initializedReader = false;
     while (true) {
       if (this.initializationPromise) {
@@ -3236,22 +3336,22 @@ export class Indexer {
       database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION;
 
     for (const f of files) {
-      const canonicalPath = this.toCanonicalFilePath(f.path);
+      const storedPath = this.toStoredFilePath(f.path);
       const currentHash = hashFile(f.path);
-      currentFileHashes.set(canonicalPath, currentHash);
+      currentFileHashes.set(storedPath, currentHash);
 
-      const cachedHashMatches = this.fileHashCache.get(canonicalPath) === currentHash;
+      const cachedHashMatches = this.fileHashCache.get(storedPath) === currentHash;
       const needsCallGraphRefresh = cachedHashMatches &&
         needsCallGraphResolutionMigration &&
-        database.getChunksByFile(canonicalPath).some((chunk) =>
+        database.getChunksByFile(storedPath).some((chunk) =>
           chunk.language === "php" || chunk.language === "c" || chunk.language === "cpp"
         );
       const requiresSwiftParserUpgrade =
         reparseCachedSwiftFiles &&
-        path.extname(canonicalPath).toLowerCase() === ".swift";
+        path.extname(storedPath).toLowerCase() === ".swift";
       const requiresMetalParserUpgrade =
         reparseCachedMetalFiles &&
-        path.extname(canonicalPath).toLowerCase() === ".metal";
+        path.extname(storedPath).toLowerCase() === ".metal";
 
       if (
         cachedHashMatches &&
@@ -3260,11 +3360,11 @@ export class Indexer {
         !requiresMetalParserUpgrade &&
         !refreshCachedSymbols
       ) {
-        unchangedFilePaths.add(canonicalPath);
+        unchangedFilePaths.add(storedPath);
         this.logger.recordCacheHit();
       } else {
         const content = await fsPromises.readFile(f.path, "utf-8");
-        changedFiles.push({ path: canonicalPath, content, hash: currentHash });
+        changedFiles.push({ path: storedPath, content, hash: currentHash });
         this.logger.recordCacheMiss();
       }
     }
@@ -3391,8 +3491,9 @@ export class Indexer {
       currentFilePaths.add(parsed.path);
 
       if (parsed.chunks.length === 0) {
-        const relativePath = path.relative(this.projectRoot, parsed.path);
-        stats.parseFailures.push(relativePath);
+        stats.parseFailures.push(path.isAbsolute(parsed.path)
+          ? path.relative(this.projectRoot, parsed.path)
+          : parsed.path);
       }
 
       let chunksToProcess = parsed.chunks;
@@ -4259,10 +4360,10 @@ export class Indexer {
       ? keywordResults
       : prefilteredKeyword;
     const scopedSemanticCandidates = semanticCandidates.filter((candidate) =>
-      matchesHardSearchFilters(candidate, options)
+      matchesHardSearchFilters(candidate, options, this.projectRoot)
     );
     const scopedKeywordCandidates = keywordCandidates.filter((candidate) =>
-      matchesHardSearchFilters(candidate, options)
+      matchesHardSearchFilters(candidate, options, this.projectRoot)
     );
     const prefilterMs = performance.now() - prefilterStartTime;
 
@@ -4343,7 +4444,9 @@ export class Indexer {
     const tiered = mergeTieredResults(primaryLane, rescued, maxResults * 4);
     const hasCodeHints = extractCodeTermHints(query).length > 0 || identifierHints.length > 0;
 
-    const baseFiltered = tiered.filter((r) => matchesSearchFilters(r, options, this.config.search.minScore));
+    const baseFiltered = tiered.filter((r) =>
+      matchesSearchFilters(r, options, this.config.search.minScore, this.projectRoot)
+    );
 
     const implementationOnly = baseFiltered.filter((r) =>
       isLikelyImplementationPath(r.metadata.filePath) &&
@@ -4357,7 +4460,7 @@ export class Indexer {
 
     const identifierFallback = (!options?.definitionIntent && filtered.length === 0 && identifierHints.length > 0)
       ? buildSymbolDefinitionLane(query, database, branchChunkIds, branchSymbolIds, maxResults, union, true)
-        .filter((r) => matchesSearchFilters(r, options, this.config.search.minScore))
+        .filter((r) => matchesSearchFilters(r, options, this.config.search.minScore, this.projectRoot))
         .slice(0, maxResults)
       : [];
 
@@ -4388,11 +4491,12 @@ export class Indexer {
         let content = "";
         let contextStartLine = r.metadata.startLine;
         let contextEndLine = r.metadata.endLine;
+        const resolvedFilePath = this.resolveStoredFilePath(r.metadata.filePath);
 
         if (!metadataOnly && this.config.search.includeContext) {
           try {
             const fileContent = await fsPromises.readFile(
-              r.metadata.filePath,
+              resolvedFilePath,
               "utf-8"
             );
             const lines = fileContent.split("\n");
@@ -4410,7 +4514,7 @@ export class Indexer {
         }
 
         return {
-          filePath: r.metadata.filePath,
+          filePath: resolvedFilePath,
           startLine: contextStartLine,
           endLine: contextEndLine,
           content,
@@ -4520,7 +4624,7 @@ export class Indexer {
     );
     const currentFileHashes = new Map<string, string>();
     for (const file of files) {
-      currentFileHashes.set(this.toCanonicalFilePath(file.path), hashFile(file.path));
+      currentFileHashes.set(this.toStoredFilePath(file.path), hashFile(file.path));
     }
 
     const scopedRoots = this.config.scope === "global" ? this.getScopedRoots() : null;
@@ -4630,6 +4734,7 @@ export class Indexer {
         this.saveFailedBatches([]);
 
         database.deleteMetadata("index.version");
+        database.deleteMetadata("index.pathStorageVersion");
         database.deleteMetadata("index.embeddingProvider");
         database.deleteMetadata("index.embeddingModel");
         database.deleteMetadata("index.embeddingDimensions");
@@ -4651,7 +4756,7 @@ export class Indexer {
       return;
     }
 
-    if (!this.isLocalProjectIndexPath()) {
+    if (!this.isProjectOwnedIndexPath()) {
       throw new Error(
         "Project-scoped force rebuild is unsafe while using an inherited worktree index. " +
         "Create a local project config boundary before clearing the index."
@@ -4664,16 +4769,15 @@ export class Indexer {
     invertedIndex.clear();
     this.saveInvertedIndex(invertedIndex);
 
-    // Clear file hash cache so all files are re-parsed
     this.fileHashCache.clear();
-    this.saveFileHashCache();
+    await this.removeProjectRuntimeStateArtifacts();
 
     // cannot reuse stale chunks, symbols, or embeddings from a prior provider.
     database.clearAllIndexedData();
     this.deleteBranchCommitMetadata(database, clearedBranchKeys);
-    this.saveFailedBatches([]);
 
     database.deleteMetadata("index.version");
+    database.deleteMetadata("index.pathStorageVersion");
     database.deleteMetadata("index.embeddingProvider");
     database.deleteMetadata("index.embeddingModel");
     database.deleteMetadata("index.embeddingDimensions");
@@ -4708,35 +4812,51 @@ export class Indexer {
       filePathsToChunkKeys.set(metadata.filePath, existing);
     }
 
-    const removedFilePaths: string[] = [];
-    const removedChunkKeys: string[] = [];
+    const missingStoredFilePaths: string[] = [];
+    const missingChunkKeys: string[] = [];
     const chunkKeysByRemovedFile = new Map<string, string[]>();
 
     for (const [filePath, chunkKeys] of filePathsToChunkKeys) {
-      if (!existsSync(filePath)) {
+      if (!existsSync(this.toMaterializedFilePath(filePath))) {
         chunkKeysByRemovedFile.set(filePath, chunkKeys);
         for (const key of chunkKeys) {
-          removedChunkKeys.push(key);
+          missingChunkKeys.push(key);
         }
-        removedFilePaths.push(filePath);
+        missingStoredFilePaths.push(filePath);
       }
     }
+
+    const branchCatalogKeys = this.getBranchCatalogKeys();
+    for (const branchKey of branchCatalogKeys) {
+      database.deleteBranchChunksForBranch(branchKey, missingChunkKeys);
+    }
+    const referencedChunkKeys = new Set(database.getReferencedChunkIds(missingChunkKeys));
+    const removedChunkKeys = missingChunkKeys.filter((key) => !referencedChunkKeys.has(key));
 
     if (removedChunkKeys.length > 0) {
       this.rebuildVectorStoreExcludingChunkIds(store, database, removedChunkKeys);
       for (const key of removedChunkKeys) {
         invertedIndex.removeChunk(key);
       }
+      database.deleteChunksByIds(removedChunkKeys);
     }
 
-    for (const filePath of removedFilePaths) {
-      const fileChunkKeys = chunkKeysByRemovedFile.get(filePath) ?? [];
-      if (fileChunkKeys.length > 0) {
-        database.deleteChunksByIds(fileChunkKeys);
-      }
-      database.deleteCallEdgesByFile(filePath);
-      database.deleteSymbolsByFile(filePath);
+    const missingSymbolIds = Array.from(new Set(
+      missingStoredFilePaths.flatMap((filePath) =>
+        database.getSymbolsByFile(filePath).map((symbol) => symbol.id)
+      )
+    ));
+    for (const branchKey of branchCatalogKeys) {
+      database.deleteBranchSymbolsForBranch(branchKey, missingSymbolIds);
     }
+    const referencedSymbolIds = new Set(database.getReferencedSymbolIds(missingSymbolIds));
+    const removedSymbolIds = missingSymbolIds.filter((symbolId) => !referencedSymbolIds.has(symbolId));
+    database.clearCallEdgeTargetsForSymbols(removedSymbolIds);
+
+    const removedChunkKeySet = new Set(removedChunkKeys);
+    const removedStoredFilePaths = missingStoredFilePaths.filter((filePath) =>
+      (chunkKeysByRemovedFile.get(filePath) ?? []).some((key) => removedChunkKeySet.has(key))
+    );
 
     const removedCount = removedChunkKeys.length;
 
@@ -4779,10 +4899,17 @@ export class Indexer {
       removedStale: removedCount,
       orphanEmbeddings: gcOrphanEmbeddings,
       orphanChunks: gcOrphanChunks,
-      removedFiles: removedFilePaths.length,
+      removedFiles: removedStoredFilePaths.length,
     });
 
-    return { removed: removedCount, filePaths: removedFilePaths, gcOrphanEmbeddings, gcOrphanChunks, gcOrphanSymbols, gcOrphanCallEdges };
+    return {
+      removed: removedCount,
+      filePaths: removedStoredFilePaths.map((filePath) => this.resolveStoredFilePath(filePath)),
+      gcOrphanEmbeddings,
+      gcOrphanChunks,
+      gcOrphanSymbols,
+      gcOrphanCallEdges,
+    };
   }
 
   async retryFailedBatches(): Promise<{ succeeded: number; failed: number; remaining: number }> {
@@ -5015,9 +5142,19 @@ export class Indexer {
   }
 
   refreshBranchInfo(): void {
+    const previousBranch = this.currentBranch;
     if (isGitRepo(this.materializedProjectRoot)) {
       this.currentBranch = this.branchNameOverride ?? getBranchOrDefault(this.materializedProjectRoot);
       this.baseBranch = getBaseBranch(this.materializedProjectRoot);
+    } else {
+      this.currentBranch = "default";
+      this.baseBranch = "default";
+    }
+
+    if (this.currentBranch !== previousBranch) {
+      this.refreshRuntimeArtifactPaths();
+      this.fileHashCache.clear();
+      this.loadFileHashCache();
     }
   }
 
@@ -5060,6 +5197,9 @@ export class Indexer {
     }
 
     const filterByBranch = options?.filterByBranch ?? true;
+    const excludedStoredFile = options?.excludeFile
+      ? this.toStoredFilePath(options.excludeFile)
+      : undefined;
 
     this.logger.search("debug", "Starting find similar", {
       codeLength: code.length,
@@ -5117,26 +5257,11 @@ export class Indexer {
     const filtered = ranked.filter((r) => {
       if (r.score < this.config.search.minScore) return false;
 
-      if (options?.excludeFile) {
-        if (r.metadata.filePath === options.excludeFile) return false;
+      if (excludedStoredFile) {
+        if (r.metadata.filePath === excludedStoredFile) return false;
       }
 
-      if (options?.fileType) {
-        const ext = r.metadata.filePath.split(".").pop()?.toLowerCase();
-        if (ext !== options.fileType.toLowerCase().replace(/^\./, "")) return false;
-      }
-
-      if (options?.directory) {
-        const normalizedDir = options.directory.replace(/^\/|\/$/g, "");
-        if (!r.metadata.filePath.includes(`/${normalizedDir}/`) &&
-          !r.metadata.filePath.includes(`${normalizedDir}/`)) return false;
-      }
-
-      if (options?.chunkType) {
-        if (r.metadata.chunkType !== options.chunkType) return false;
-      }
-
-      return true;
+      return matchesHardSearchFilters(r, options, this.projectRoot);
     }).slice(0, limit);
 
     const totalSearchMs = performance.now() - searchStartTime;
@@ -5158,11 +5283,12 @@ export class Indexer {
     return Promise.all(
       filtered.map(async (r) => {
         let content = "";
+        const resolvedFilePath = this.resolveStoredFilePath(r.metadata.filePath);
 
         if (this.config.search.includeContext) {
           try {
             const fileContent = await fsPromises.readFile(
-              r.metadata.filePath,
+              resolvedFilePath,
               "utf-8"
             );
             const lines = fileContent.split("\n");
@@ -5175,7 +5301,7 @@ export class Indexer {
         }
 
         return {
-          filePath: r.metadata.filePath,
+          filePath: resolvedFilePath,
           startLine: r.metadata.startLine,
           endLine: r.metadata.endLine,
           content,
@@ -5198,7 +5324,7 @@ export class Indexer {
       for (const edge of database.getCallersWithContext(targetName, branchKey, callTypeFilter)) {
         if (!seen.has(edge.id)) {
           seen.add(edge.id);
-          results.push(edge);
+          results.push(this.resolveCallEdgeFilePath(edge));
         }
       }
     }
@@ -5227,7 +5353,7 @@ export class Indexer {
         if ((!matchesResolvedSymbol && !safelyMatchesUnresolvedSymbol) || seen.has(edge.id)) continue;
 
         seen.add(edge.id);
-        results.push(edge);
+        results.push(this.resolveCallEdgeFilePath(edge));
       }
     }
 
@@ -5244,7 +5370,7 @@ export class Indexer {
       for (const edge of database.getCallees(symbolId, branchKey, callTypeFilter)) {
         if (!seen.has(edge.id)) {
           seen.add(edge.id);
-          results.push(edge);
+          results.push(this.resolveCallEdgeFilePath(edge));
         }
       }
     }
@@ -5264,7 +5390,7 @@ export class Indexer {
       }
     }
 
-    return shortest;
+    return shortest.map((hop) => this.resolveFilePathRecord(hop));
   }
 
   async findCallPathBySymbolIds(
@@ -5349,7 +5475,7 @@ export class Indexer {
       }
     }
 
-    return shortest;
+    return shortest.map((hop) => this.resolveFilePathRecord(hop));
   }
 
   async getCallGraphSymbols(): Promise<SymbolData[]> {
@@ -5359,7 +5485,7 @@ export class Indexer {
 
     for (const branchKey of this.getBranchCatalogKeys()) {
       for (const symbol of database.getSymbolsForBranch(branchKey)) {
-        symbols.set(symbol.id, symbol);
+        symbols.set(symbol.id, this.resolveFilePathRecord(symbol));
       }
     }
 
@@ -5370,14 +5496,17 @@ export class Indexer {
     const { database, readIssues } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
-    return database.getSymbolsForBranch(resolvedBranch);
+    return database.getSymbolsForBranch(resolvedBranch)
+      .map((symbol) => this.resolveFilePathRecord(symbol));
   }
 
   async getSymbolsForFiles(filePaths: string[], branch?: string): Promise<SymbolData[]> {
     const { database, readIssues } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
-    return database.getSymbolsForFiles(filePaths, resolvedBranch);
+    const storedFilePaths = filePaths.map((filePath) => this.toStoredFilePath(filePath));
+    return database.getSymbolsForFiles(storedFilePaths, resolvedBranch)
+      .map((symbol) => this.resolveFilePathRecord(symbol));
   }
 
   async getTransitiveReachability(
@@ -5388,21 +5517,24 @@ export class Indexer {
     const { database, readIssues } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "database");
     const branch = this.getBranchCatalogKey();
-    return database.getTransitiveReachability(rootSymbolIds, branch, direction, maxDepth);
+    return database.getTransitiveReachability(rootSymbolIds, branch, direction, maxDepth)
+      .map((entry) => this.resolveFilePathRecord(entry));
   }
 
   async detectCommunities(branch?: string, symbolIds?: string[]): Promise<CommunityData[]> {
     const { database, readIssues } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
-    return database.detectCommunities(resolvedBranch, symbolIds);
+    return database.detectCommunities(resolvedBranch, symbolIds)
+      .map((entry) => this.resolveFilePathRecord(entry));
   }
 
   async computeCentrality(branch?: string): Promise<CentralityData[]> {
     const { database, readIssues } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = branch ?? this.getBranchCatalogKey();
-    return database.computeCentrality(resolvedBranch);
+    return database.computeCentrality(resolvedBranch)
+      .map((entry) => this.resolveFilePathRecord(entry));
   }
 
   async getPrImpact(opts: {
@@ -5522,8 +5654,10 @@ export class Indexer {
       }
     }
 
-    const absoluteChangedFiles = changedFiles.map((f) => path.resolve(this.projectRoot, f));
-    const directSymbols = database.getSymbolsForFiles(absoluteChangedFiles, branchKey);
+    const toStoredChangedFiles = (filePaths: readonly string[]): string[] =>
+      filePaths.map((filePath) => this.toStoredFilePath(path.resolve(this.projectRoot, filePath)));
+    const storedChangedFiles = toStoredChangedFiles(changedFiles);
+    const directSymbols = database.getSymbolsForFiles(storedChangedFiles, branchKey);
     const directIds = directSymbols.map((s) => s.id);
 
     const direction = opts.direction ?? "both";
@@ -5571,7 +5705,7 @@ export class Indexer {
         id: c.symbolId,
         name: c.symbolName,
         callerCount: c.callerCount,
-        filePath: c.filePath,
+        filePath: this.resolveStoredFilePath(c.filePath),
       }));
 
     const totalAffected = allAffectedIds.length;
@@ -5618,9 +5752,9 @@ export class Indexer {
               projectRoot: this.projectRoot,
               baseBranch: this.baseBranch,
             });
-            const otherAbsolute = otherChanged.files.map((f) => path.resolve(this.projectRoot, f));
+            const otherStored = toStoredChangedFiles(otherChanged.files);
             const prBranchKey = this.getBranchCatalogKeyFor(otherChanged.catalogIdentity);
-            const otherSymbols = database.getSymbolsForFiles(otherAbsolute, prBranchKey);
+            const otherSymbols = database.getSymbolsForFiles(otherStored, prBranchKey);
             const otherLabels = new Set<string>();
             for (const sym of otherSymbols) {
               const label = symbolToCommunity.get(structuralKey(sym.filePath, sym.name));
@@ -5654,12 +5788,12 @@ export class Indexer {
         id: s.id,
         name: s.name,
         kind: s.kind,
-        filePath: s.filePath,
+        filePath: this.resolveStoredFilePath(s.filePath),
       })),
       transitiveCallers: transitiveCallers.map((c) => ({
         id: c.symbolId,
         name: c.symbolName,
-        filePath: c.filePath,
+        filePath: this.resolveStoredFilePath(c.filePath),
         depth: c.depth,
       })),
       totalAffected,
@@ -5702,7 +5836,7 @@ export class Indexer {
       // Gather symbols from each file
       for (const filePath of filePaths) {
         if (directory) {
-          const absoluteFilePath = path.resolve(filePath);
+          const absoluteFilePath = this.resolveStoredFilePath(filePath);
           const matchesRelative = filePath === directory || filePath.startsWith(directory + "/");
           const matchesProjectRelative = absoluteDirectoryFilter !== undefined && (
             absoluteFilePath === absoluteDirectoryFilter || absoluteFilePath.startsWith(absoluteDirectoryFilter + path.sep)
@@ -5713,7 +5847,7 @@ export class Indexer {
         }
         for (const sym of database.getSymbolsByFile(filePath)) {
           if (symbolIdSet.has(sym.id) && !seenSymbols.has(sym.id)) {
-            seenSymbols.set(sym.id, sym);
+            seenSymbols.set(sym.id, this.resolveFilePathRecord(sym));
           }
         }
       }
@@ -5722,7 +5856,7 @@ export class Indexer {
       for (const symbolId of seenSymbols.keys()) {
         for (const edge of database.getCallees(symbolId, branchKey)) {
           if (!seenEdges.has(edge.id)) {
-            seenEdges.set(edge.id, edge);
+            seenEdges.set(edge.id, this.resolveCallEdgeFilePath(edge));
           }
         }
       }

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -24,8 +24,8 @@ export class FileWatcher {
   private watcher: FSWatcher | null = null;
   private projectRoot: string;
   private config: CodebaseIndexConfig;
-  private host: HostMode;
   private configPath: string | undefined;
+  private projectConfigPaths: string[];
   private pendingChanges: Map<string, FileChangeType> = new Map();
   private debounceTimer: NodeJS.Timeout | null = null;
   private debounceMs = 1000;
@@ -38,8 +38,13 @@ export class FileWatcher {
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
     this.config = config;
-    this.host = host;
     this.configPath = options.configPath;
+    this.projectConfigPaths = options.configPath
+      ? [options.configPath]
+      : [
+          resolveProjectConfigPath(projectRoot, host),
+          resolveWritableProjectConfigPath(projectRoot, host),
+        ];
   }
 
   start(handler: ChangeHandler): void {
@@ -61,7 +66,19 @@ export class FileWatcher {
 
   private createWatcher(usePolling = false): void {
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
-    const watchTargets = this.configPath ? [this.projectRoot, this.configPath] : this.projectRoot;
+    let watchTargets: string | string[] = this.projectRoot;
+    if (this.configPath) {
+      watchTargets = [this.projectRoot, this.configPath];
+    } else {
+      const projectConfigPath = this.projectConfigPaths[0];
+      const relativeConfigPath = path.relative(this.projectRoot, projectConfigPath);
+      const configIsOutsideProject = relativeConfigPath === ".."
+        || relativeConfigPath.startsWith(`..${path.sep}`)
+        || path.isAbsolute(relativeConfigPath);
+      if (configIsOutsideProject) {
+        watchTargets = [this.projectRoot, projectConfigPath];
+      }
+    }
 
     const watcherOptions = {
       ignored: (filePath: string) => {
@@ -197,14 +214,9 @@ export class FileWatcher {
   }
 
   private getProjectConfigRelativePaths(): string[] {
-    if (this.configPath) {
-      return [path.normalize(path.relative(this.projectRoot, this.configPath))];
-    }
-
-    return [
-      resolveProjectConfigPath(this.projectRoot, this.host),
-      resolveWritableProjectConfigPath(this.projectRoot, this.host),
-    ].map((configPath) => path.normalize(path.relative(this.projectRoot, configPath)));
+    return this.projectConfigPaths.map(
+      (configPath) => path.normalize(path.relative(this.projectRoot, configPath)),
+    );
   }
 
   private scheduleFlush(): void {

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -1,9 +1,10 @@
+import { existsSync } from "fs";
 import { FSWatcher } from "chokidar";
 import * as path from "path";
 
 import type { HostMode } from "../config/host.js";
 import type { CodebaseIndexConfig } from "../config/schema.js";
-import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
+import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
@@ -41,10 +42,7 @@ export class FileWatcher {
     this.configPath = options.configPath;
     this.projectConfigPaths = options.configPath
       ? [options.configPath]
-      : [
-          resolveProjectConfigPath(projectRoot, host),
-          resolveWritableProjectConfigPath(projectRoot, host),
-        ];
+      : getProjectConfigCandidatePaths(projectRoot, host);
   }
 
   start(handler: ChangeHandler): void {
@@ -70,13 +68,17 @@ export class FileWatcher {
     if (this.configPath) {
       watchTargets = [this.projectRoot, this.configPath];
     } else {
-      const projectConfigPath = this.projectConfigPaths[0];
-      const relativeConfigPath = path.relative(this.projectRoot, projectConfigPath);
-      const configIsOutsideProject = relativeConfigPath === ".."
-        || relativeConfigPath.startsWith(`..${path.sep}`)
-        || path.isAbsolute(relativeConfigPath);
-      if (configIsOutsideProject) {
-        watchTargets = [this.projectRoot, projectConfigPath];
+      const externalConfigTargets = this.projectConfigPaths
+        .filter((projectConfigPath) => {
+          const relativeConfigPath = path.relative(this.projectRoot, projectConfigPath);
+          return this.isOutsideProjectPath(relativeConfigPath);
+        })
+        .map((projectConfigPath) => existsSync(projectConfigPath)
+          ? projectConfigPath
+          : this.getNearestExistingDirectory(path.dirname(projectConfigPath)));
+      const uniqueExternalConfigTargets = [...new Set(externalConfigTargets)];
+      if (uniqueExternalConfigTargets.length > 0) {
+        watchTargets = [this.projectRoot, ...uniqueExternalConfigTargets];
       }
     }
 
@@ -87,6 +89,10 @@ export class FileWatcher {
 
         if (this.isProjectConfigPathOrAncestor(relativePath)) {
           return false;
+        }
+
+        if (this.isOutsideProjectPath(relativePath)) {
+          return true;
         }
 
         if (hasFilteredPathSegment(relativePath, path.sep)) {
@@ -211,6 +217,22 @@ export class FileWatcher {
     return this.getProjectConfigRelativePaths().some(
       (configPath) => configPath === normalizedRelativePath || configPath.startsWith(`${normalizedRelativePath}${path.sep}`),
     );
+  }
+
+  private isOutsideProjectPath(relativePath: string): boolean {
+    return relativePath === ".."
+      || relativePath.startsWith(`..${path.sep}`)
+      || path.isAbsolute(relativePath);
+  }
+
+  private getNearestExistingDirectory(directoryPath: string): string {
+    let candidate = directoryPath;
+    while (!existsSync(candidate)) {
+      const parent = path.dirname(candidate);
+      if (parent === candidate) break;
+      candidate = parent;
+    }
+    return candidate;
   }
 
   private getProjectConfigRelativePaths(): string[] {

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -70,7 +70,9 @@ export function createWatcherWithIndexer(
   if (isGitRepo(projectRoot)) {
     gitWatcher = new GitHeadWatcher(projectRoot);
     gitWatcher.start(async (oldBranch, newBranch) => {
-      getIndexer().getLogger().branch("info", "Branch changed", {
+      const indexer = getIndexer();
+      indexer.refreshBranchInfo();
+      indexer.getLogger().branch("info", "Branch changed", {
         oldBranch,
         newBranch,
       });

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -3,7 +3,7 @@ import type { HostMode } from "../config/host.js";
 import type { Indexer } from "../indexer/index.js";
 
 import { parseConfig } from "../config/schema.js";
-import { resolveProjectConfigPath, resolveWritableProjectConfigPath } from "../config/paths.js";
+import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { loadConfigFile } from "../config/merger.js";
 import { isGitRepo } from "../git/index.js";
 import { refreshIndexerForDirectory } from "../tools/operations.js";
@@ -102,8 +102,7 @@ function getConfigPaths(projectRoot: string, host: HostMode, options: WatcherOpt
     return [pathNormalize(options.configPath)];
   }
 
-  return [
-    resolveProjectConfigPath(projectRoot, host),
-    resolveWritableProjectConfigPath(projectRoot, host),
-  ].map((configPath) => pathNormalize(configPath));
+  return getProjectConfigCandidatePaths(projectRoot, host).map(
+    (configPath) => pathNormalize(configPath),
+  );
 }

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -35,6 +35,7 @@ export function createWatcherWithIndexer(
   options: WatcherOptions = {},
 ): CombinedWatcher {
   const fileWatcher = new FileWatcher(projectRoot, config, host, options);
+  const configPaths = getConfigPaths(projectRoot, host, options);
   configureAutoIndex(projectRoot, host, parseConfig(config), getIndexer);
   let stopped = false;
   const requestReindex = () => {
@@ -53,7 +54,6 @@ export function createWatcherWithIndexer(
     const hasDelete = changes.some((c) => c.type === "unlink");
 
     if (hasAddOrChange || hasDelete) {
-      const configPaths = getConfigPaths(projectRoot, host, options);
       if (changes.some((change) => configPaths.includes(pathNormalize(change.path)))) {
         const parsedConfig = options.configPath ? parseConfig(loadConfigFile(options.configPath)) : undefined;
         const refreshedConfig = refreshIndexerForDirectory(projectRoot, host, parsedConfig);

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -36,6 +36,10 @@ function symbolExtractorMetadataKey(catalogIdentity: string): string {
   return `index.symbolExtractorVersion.${hashContent(catalogIdentity).slice(0, 24)}`;
 }
 
+function migrationMetadataKey(prefix: string, catalogIdentity: string): string {
+  return `${prefix}.${hashContent(catalogIdentity).slice(0, 24)}`;
+}
+
 describe("automatic branch index preparation", () => {
   let tempDir: string;
   let repo: string;
@@ -258,6 +262,69 @@ function changed(): number {
     const migratedDb = await database();
     expect(migratedDb.getMetadata(symbolExtractorMetadataKey("feature"))).toBe("1");
     expect(migratedDb.getMetadata(symbolExtractorMetadataKey("main"))).toBe("1");
+  });
+
+  it("reparses only the cached branch whose parser migration marker is stale", async () => {
+    git(repo, ["checkout", "feature"]);
+    fs.writeFileSync(
+      path.join(repo, "src", "feature.swift"),
+      "func featureSwiftMarker() -> Int { return 42 }\n",
+    );
+    git(repo, ["add", "--", "src/feature.swift"]);
+    git(repo, ["commit", "-m", "add feature swift source"]);
+    featureCommit = git(repo, ["rev-parse", "HEAD"]);
+    git(repo, ["checkout", "main"]);
+
+    await indexer.getPrImpact({ branch: "feature" });
+    const status = await indexer.getStatus();
+    await indexer.close();
+
+    const swiftPrefix = "index.parser.swiftVersion";
+    const directDatabase = new Database(path.join(status.indexPath, "codebase.db"));
+    expect(
+      directDatabase.getSymbolsByFile("src/feature.swift").some(
+        (symbol) => symbol.name === "featureSwiftMarker",
+      ),
+    ).toBe(true);
+    directDatabase.deleteSymbolsByFile("src/feature.swift");
+    directDatabase.setMetadata(migrationMetadataKey(swiftPrefix, "feature"), "stale");
+    directDatabase.close();
+
+    git(repo, ["checkout", "feature"]);
+    indexer = new Indexer(repo, config);
+    await expect(indexer.getIndexFreshness()).resolves.toEqual({
+      readable: true,
+      current: false,
+      reason: "migration-required",
+    });
+    await indexer.close();
+    git(repo, ["checkout", "main"]);
+
+    indexer = new Indexer(repo, config);
+    const fetchesBeforeMigration = fetchSpy.mock.calls.length;
+    const migrated = await indexer.getPrImpact({ branch: "feature" });
+
+    expect(migrated.indexPreparation).toMatchObject({
+      prepared: true,
+      branch: "feature",
+      commit: featureCommit,
+    });
+    expect(fetchSpy.mock.calls.length).toBe(fetchesBeforeMigration);
+
+    const migratedDb = await database();
+    expect(
+      migratedDb.getSymbolsByFile("src/feature.swift").some(
+        (symbol) => symbol.name === "featureSwiftMarker",
+      ),
+    ).toBe(true);
+    for (const [prefix, version] of [
+      ["index.callGraphResolutionVersion", "4"],
+      [swiftPrefix, "1"],
+      ["index.parser.metalVersion", "1"],
+    ] as const) {
+      expect(migratedDb.getMetadata(migrationMetadataKey(prefix, "main"))).toBe(version);
+      expect(migratedDb.getMetadata(migrationMetadataKey(prefix, "feature"))).toBe(version);
+    }
   });
 
   it("reindexes a moved branch OID, replaces stale catalog data, and preserves primary data", async () => {

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -13,7 +13,7 @@ import {
   isIndexLockContentionError,
   releaseIndexLock,
 } from "../src/indexer/index-lock.js";
-import { Database, hashContent } from "../src/native/index.js";
+import { Database, hashContent, VectorStore } from "../src/native/index.js";
 import { createPullRequestCatalogIdentity } from "../src/tools/changed-files.js";
 
 function git(cwd: string, args: string[]): string {
@@ -156,6 +156,10 @@ function changed(): number {
     expect(progressPhases).toContain("complete");
     expect(first.changedFiles).toContain("src/feature.ts");
     expect(first.directSymbols.map((symbol) => symbol.name)).toContain("changed");
+    expect(first.directSymbols).toContainEqual(expect.objectContaining({
+      name: "changed",
+      filePath: path.join(repo, "src", "feature.ts"),
+    }));
     expect(git(repo, ["rev-parse", "HEAD"])).toBe(beforeHead);
     expect(git(repo, ["status", "--porcelain"])).toBe(beforeStatus);
     expect(git(repo, ["worktree", "list", "--porcelain"])).toBe(beforeWorktrees);
@@ -163,7 +167,7 @@ function changed(): number {
     const db = await database();
     const featureSymbols = db.getSymbolsForBranch("feature");
     expect(featureSymbols.length).toBeGreaterThan(0);
-    expect(featureSymbols.some((symbol) => symbol.filePath.startsWith(repo + path.sep))).toBe(true);
+    expect(featureSymbols.some((symbol) => symbol.filePath === "src/feature.ts")).toBe(true);
     expect(featureSymbols.some((symbol) => symbol.filePath.includes("codebase-index-branch-"))).toBe(false);
     expect(featureSymbols.some((symbol) => symbol.filePath === fs.realpathSync.native(path.join(knowledgeBase, "external.ts")))).toBe(true);
     expect(db.getMetadata(branchCommitMetadataKey("feature"))).toBe(featureCommit);
@@ -179,6 +183,54 @@ function changed(): number {
     const second = await indexer.getPrImpact({ branch: "feature" });
     expect(second.indexPreparation).toEqual({ prepared: false, branch: "feature" });
     expect(fetchSpy.mock.calls.length).toBe(fetchesAfterPreparation);
+  });
+
+  it("keeps alternate-branch data intact while health check removes stale active-branch data", async () => {
+    git(repo, ["checkout", "feature"]);
+    const featureOnlyPath = path.join(repo, "src", "feature-only.ts");
+    fs.writeFileSync(featureOnlyPath, "export function featureOnly(): number { return 7; }\n");
+    git(repo, ["add", "--", "src/feature-only.ts"]);
+    git(repo, ["commit", "-m", "add feature-only source"]);
+    featureCommit = git(repo, ["rev-parse", "HEAD"]);
+    git(repo, ["checkout", "main"]);
+
+    const mainOnlyPath = path.join(repo, "src", "main-only.ts");
+    fs.writeFileSync(mainOnlyPath, "export function mainOnly(): number { return 3; }\n");
+    await indexer.index();
+    await indexer.getPrImpact({ branch: "feature" });
+
+    const db = await database();
+    const featureOnlyChunkIds = db.getChunksByFile("src/feature-only.ts").map((chunk) => chunk.chunkId);
+    const featureOnlySymbolIds = db.getSymbolsByFile("src/feature-only.ts").map((symbol) => symbol.id);
+    const mainOnlyChunkIds = db.getChunksByFile("src/main-only.ts").map((chunk) => chunk.chunkId);
+    expect(featureOnlyChunkIds.length).toBeGreaterThan(0);
+    expect(featureOnlySymbolIds.length).toBeGreaterThan(0);
+    expect(mainOnlyChunkIds.length).toBeGreaterThan(0);
+    expect(db.getBranchChunkIds("feature")).toEqual(expect.arrayContaining(featureOnlyChunkIds));
+    expect(db.getBranchSymbolIds("feature")).toEqual(expect.arrayContaining(featureOnlySymbolIds));
+
+    fs.rmSync(mainOnlyPath);
+    const result = await indexer.healthCheck();
+
+    expect(result.removed).toBe(mainOnlyChunkIds.length);
+    expect(result.filePaths).toEqual([mainOnlyPath]);
+    expect(featureOnlyChunkIds.every((chunkId) => db.getChunk(chunkId) !== null)).toBe(true);
+    expect(mainOnlyChunkIds.every((chunkId) => db.getChunk(chunkId) === null)).toBe(true);
+    expect(db.getBranchChunkIds("feature")).toEqual(expect.arrayContaining(featureOnlyChunkIds));
+    expect(db.getBranchSymbolIds("feature")).toEqual(expect.arrayContaining(featureOnlySymbolIds));
+
+    for (const branch of db.getAllBranches()) {
+      expect(db.getBranchChunkIds(branch).every((chunkId) => db.getChunk(chunkId) !== null)).toBe(true);
+      const storedSymbolIds = new Set(db.getSymbolsForBranch(branch).map((symbol) => symbol.id));
+      expect(db.getBranchSymbolIds(branch).every((symbolId) => storedSymbolIds.has(symbolId))).toBe(true);
+    }
+
+    const status = await indexer.getStatus();
+    const vectorStore = new VectorStore(path.join(status.indexPath, "vectors"), 8);
+    vectorStore.loadStrict();
+    const vectorChunkIds = new Set(vectorStore.getAllMetadata().map(({ key }) => key));
+    expect(featureOnlyChunkIds.every((chunkId) => vectorChunkIds.has(chunkId))).toBe(true);
+    expect(mainOnlyChunkIds.every((chunkId) => !vectorChunkIds.has(chunkId))).toBe(true);
   });
 
   it("reparses a cached alternate branch when its symbol extractor metadata is stale", async () => {

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -55,6 +55,10 @@ function createIndexerConfig(): ReturnType<typeof parseConfig> {
   });
 }
 
+function migrationMetadataKey(prefix: string, catalogIdentity = "default"): string {
+  return `${prefix}.${hashContent(catalogIdentity).slice(0, 24)}`;
+}
+
   function buildFileSymbols(filePath: string, content: string): SymbolData[] {
     const parsed = parseFiles([{ path: filePath, content }])[0];
     const symbols: SymbolData[] = [];
@@ -451,7 +455,7 @@ function buildReport(): string {
         }
 
         const database = new Database(path.join(projectDir, ".opencode", "index", "codebase.db"));
-        database.deleteMetadata("index.callGraphResolutionVersion");
+        database.deleteMetadata(migrationMetadataKey("index.callGraphResolutionVersion"));
         database.close();
         const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
 
@@ -523,7 +527,7 @@ function caller(): string { return namespace\\helper(); }
         }
 
         const database = new Database(path.join(projectDir, ".opencode", "index", "codebase.db"));
-        database.setMetadata("index.callGraphResolutionVersion", "3");
+        database.setMetadata(migrationMetadataKey("index.callGraphResolutionVersion"), "3");
         database.close();
         const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
         indexer = new Indexer(projectDir, config, "opencode");
@@ -1370,7 +1374,7 @@ const math = @import("math.zig");
       }
 
       const database = new Database(path.join(tempDir, ".opencode", "index", "codebase.db"));
-      database.setMetadata("index.callGraphResolutionVersion", "2");
+      database.setMetadata(migrationMetadataKey("index.callGraphResolutionVersion"), "2");
       database.close();
       const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
 
@@ -1709,7 +1713,7 @@ struct Runner {
           path.join(tempDir, ".opencode", "index", "codebase.db"),
         );
         database.deleteSymbolsByFile("Runner.swift");
-        database.deleteMetadata("index.parser.swiftVersion");
+        database.deleteMetadata(migrationMetadataKey("index.parser.swiftVersion"));
         database.close();
         expect(
           (await indexer.getSymbolsForBranch()).some(
@@ -1920,7 +1924,7 @@ kernel void long_kernel(const device float* input [[buffer(0)]],
           path.join(tempDir, ".opencode", "index", "codebase.db"),
         );
         database.deleteSymbolsByFile("representative.metal");
-        database.deleteMetadata("index.parser.metalVersion");
+        database.deleteMetadata(migrationMetadataKey("index.parser.metalVersion"));
         database.close();
         expect(
           (await indexer.getSymbolsForBranch()).some(

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -1708,7 +1708,7 @@ struct Runner {
         const database = new Database(
           path.join(tempDir, ".opencode", "index", "codebase.db"),
         );
-        database.deleteSymbolsByFile(path.join(tempDir, "Runner.swift"));
+        database.deleteSymbolsByFile("Runner.swift");
         database.deleteMetadata("index.parser.swiftVersion");
         database.close();
         expect(
@@ -1919,7 +1919,7 @@ kernel void long_kernel(const device float* input [[buffer(0)]],
         const database = new Database(
           path.join(tempDir, ".opencode", "index", "codebase.db"),
         );
-        database.deleteSymbolsByFile(filePath);
+        database.deleteSymbolsByFile("representative.metal");
         database.deleteMetadata("index.parser.metalVersion");
         database.close();
         expect(

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -81,7 +81,7 @@ describe("Database", () => {
       const dbPath = path.join(tempDir, "test.db");
       db.setMetadata("schema_version", "5");
 
-      expect(() => Database.openReadOnly(dbPath)).toThrow(/found version 5, expected 6/i);
+      expect(() => Database.openReadOnly(dbPath)).toThrow(/found version 5, expected 7/i);
       expect(db.getMetadata("schema_version")).toBe("5");
     });
 

--- a/tests/host-mode-paths.test.ts
+++ b/tests/host-mode-paths.test.ts
@@ -192,8 +192,43 @@ describe("host-aware path resolution", () => {
     ["pi", ".codebase-index"],
     ["jcode", ".codebase-index"],
     ["claude", ".claude"],
-  ] as const)("keeps the %s project index local when only the main repo has an index", (host, indexDir) => {
+  ] as const)("inherits the %s project index from the main checkout", (host, indexDir) => {
     fs.mkdirSync(path.join(mainRepoDir, indexDir, "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(worktreeDir, "project", host)).toBe(
+      path.join(mainRepoDir, indexDir, "index"),
+    );
+  });
+
+  it.each([
+    ["opencode", ".opencode"],
+    ["codex", ".codebase-index"],
+    ["pi", ".codebase-index"],
+    ["jcode", ".codebase-index"],
+    ["claude", ".claude"],
+  ] as const)("ignores a stale local %s worktree index without a local config", (host, indexDir) => {
+    fs.mkdirSync(path.join(mainRepoDir, indexDir, "index"), { recursive: true });
+    fs.mkdirSync(path.join(worktreeDir, indexDir, "index"), { recursive: true });
+
+    expect(resolveProjectIndexPath(worktreeDir, "project", host)).toBe(
+      path.join(mainRepoDir, indexDir, "index"),
+    );
+  });
+
+  it.each([
+    ["opencode", ".opencode", "codebase-index.json"],
+    ["codex", ".codebase-index", "config.json"],
+    ["pi", ".codebase-index", "config.json"],
+    ["jcode", ".codebase-index", "config.json"],
+    ["claude", ".claude", "codebase-index.json"],
+  ] as const)("keeps an explicit %s worktree config boundary local", (host, indexDir, configFile) => {
+    fs.mkdirSync(path.join(mainRepoDir, indexDir, "index"), { recursive: true });
+    fs.mkdirSync(path.join(worktreeDir, indexDir), { recursive: true });
+    fs.writeFileSync(
+      path.join(worktreeDir, indexDir, configFile),
+      JSON.stringify({ knowledgeBases: ["worktree-docs"] }, null, 2),
+      "utf-8",
+    );
 
     expect(resolveProjectIndexPath(worktreeDir, "project", host)).toBe(
       path.join(worktreeDir, indexDir, "index"),
@@ -255,13 +290,13 @@ describe("host-aware path resolution", () => {
   });
 
   it.each(["codex", "pi", "jcode"] as const)(
-    "does not inherit the main repo's %s index when native and legacy indexes both exist",
+    "inherits the main checkout's %s native index when native and legacy indexes both exist",
     (host) => {
       fs.mkdirSync(path.join(mainRepoDir, ".codebase-index", "index"), { recursive: true });
       fs.mkdirSync(path.join(mainRepoDir, ".opencode", "index"), { recursive: true });
 
       expect(resolveProjectIndexPath(worktreeDir, "project", host)).toBe(
-        path.join(worktreeDir, ".codebase-index", "index"),
+        path.join(mainRepoDir, ".codebase-index", "index"),
       );
     },
   );

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -264,6 +264,33 @@ describe("indexer clearIndex force rebuild", () => {
     await expect(restartedIndexer.index()).rejects.toThrow("Run index_codebase with force=true to rebuild the index");
   });
 
+  it("marks legacy absolute path storage as incompatible until force rebuild", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+
+    const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
+    const db = trackDb(new Database(dbPath));
+    db.setMetadata("schema_version", "6");
+    db.setMetadata("index.pathStorageVersion", "1");
+
+    const restartedIndexer = createIndexer(tempDir, 8);
+    const callsBeforeCompatibilityCheck = fetchSpy.mock.calls.length;
+    const status = await restartedIndexer.getStatus();
+
+    expect(status.compatibility?.compatible).toBe(false);
+    expect(status.compatibility?.reason).toContain("Path storage format mismatch");
+    expect(status.compatibility?.reason).toContain("force=true");
+    await expect(restartedIndexer.index()).rejects.toThrow("Path storage format mismatch");
+    expect(fetchSpy.mock.calls).toHaveLength(callsBeforeCompatibilityCheck);
+
+    await restartedIndexer.forceIndex();
+
+    expect(db.getMetadata("schema_version")).toBe("7");
+    expect(db.getMetadata("index.pathStorageVersion")).toBe("2");
+    expect(db.getChunksByFile("src/index.ts").length).toBeGreaterThan(0);
+    expect(db.getChunksByFile(sourceFile)).toHaveLength(0);
+  });
+
   it("keeps an in-flight search usable while the same Indexer reloads for a mutation", async () => {
     const indexer = createIndexer(tempDir, 8);
     await indexer.index();
@@ -302,7 +329,7 @@ describe("indexer clearIndex force rebuild", () => {
     invertedLoad.mockRestore();
   });
 
-  it("clears only the worktree-local index when project config is inherited", async () => {
+  it("clears the shared main index when project config is inherited", async () => {
     const mainRepoDir = path.join(tempDir, "main-repo");
     const worktreeDir = path.join(tempDir, "worktree-feature");
     const worktreeGitDir = path.join(mainRepoDir, ".git", "worktrees", "feature");
@@ -327,18 +354,17 @@ describe("indexer clearIndex force rebuild", () => {
 
     await createIndexer(mainRepoDir, 8).index();
     const mainDb = trackDb(new Database(path.join(mainRepoDir, ".opencode", "index", "codebase.db")));
-    const mainStatsBefore = mainDb.getStats();
+    expect(mainDb.getStats().chunkCount).toBeGreaterThan(0);
 
     const worktreeIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode"));
     await expect(worktreeIndexer.clearIndex()).resolves.toBeUndefined();
 
-    expect(mainDb.getStats()).toEqual(mainStatsBefore);
-    const localDb = trackDb(new Database(path.join(worktreeDir, ".opencode", "index", "codebase.db")));
-    expect(localDb.getStats().chunkCount).toBe(0);
-    expect(localDb.getStats().embeddingCount).toBe(0);
+    expect(mainDb.getStats().chunkCount).toBe(0);
+    expect(mainDb.getStats().embeddingCount).toBe(0);
+    expect(fs.existsSync(path.join(worktreeDir, ".opencode", "index", "codebase.db"))).toBe(false);
   });
 
-  it("ignores a crashed main-index owner when indexing from an isolated worktree", async () => {
+  it("recovers a crashed shared-index owner when indexing from a worktree", async () => {
     const mainRepoDir = path.join(tempDir, "main-repo-recovery");
     const worktreeDir = path.join(tempDir, "worktree-recovery");
     const worktreeGitDir = path.join(mainRepoDir, ".git", "worktrees", "recovery");
@@ -377,8 +403,9 @@ describe("indexer clearIndex force rebuild", () => {
 
     const worktreeIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode"));
     await expect(worktreeIndexer.index()).resolves.toMatchObject({ failedChunks: 0 });
-    expect(fs.existsSync(path.join(worktreeDir, ".opencode", "index", "codebase.db"))).toBe(true);
-    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(fs.existsSync(path.join(mainIndexPath, "codebase.db"))).toBe(true);
+    expect(fs.existsSync(path.join(worktreeDir, ".opencode", "index", "codebase.db"))).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 
   it("allows codex force clearing a local legacy OpenCode project index", async () => {
@@ -437,6 +464,28 @@ describe("indexer clearIndex force rebuild", () => {
     expect(fs.existsSync(path.join(secondTarget, "codebase.db"))).toBe(false);
   });
 
+  it("keeps a schema-v6 global index readable because its paths remain absolute", async () => {
+    vi.stubEnv("HOME", tempHome);
+    vi.stubEnv("USERPROFILE", tempHome);
+
+    const writer = createIndexer(tempDir, 8, "global");
+    await writer.index();
+    await writer.close();
+
+    const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
+    const db = trackDb(new Database(dbPath));
+    db.setMetadata("schema_version", "6");
+
+    const reader = createIndexer(tempDir, 8, "global");
+    const status = await reader.getStatus();
+    const results = await reader.search("alpha", 5, { metadataOnly: true });
+
+    expect(status.indexed).toBe(true);
+    expect(status.compatibility?.compatible).toBe(true);
+    expect(results.some((result) => result.filePath === sourceFile)).toBe(true);
+    expect(db.getMetadata("schema_version")).toBe("6");
+  });
+
   it("clears only the current project from a shared global index when compatibility is unchanged", async () => {
     vi.stubEnv("HOME", tempHome);
     vi.stubEnv("USERPROFILE", tempHome);
@@ -468,6 +517,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempHome, ".opencode", "global-index", "codebase.db");
     const db = trackDb(new Database(dbPath));
+    expect(db.getMetadata("index.pathStorageVersion")).toBe("1");
     expect(db.getChunksByFile(projectAFile)).toHaveLength(0);
     expect(db.getChunksByFile(projectBFile).length).toBeGreaterThan(0);
 
@@ -489,7 +539,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
     const dbBefore = trackDb(new Database(dbPath));
-    const chunkIdsBefore = dbBefore.getChunksByFile(sourceFile).map((chunk) => chunk.chunkId);
+    const chunkIdsBefore = dbBefore.getChunksByFile("src/index.ts").map((chunk) => chunk.chunkId);
 
     fs.writeFileSync(
       sourceFile,
@@ -513,7 +563,7 @@ describe("indexer clearIndex force rebuild", () => {
     removeSpy.mockRestore();
 
     const dbAfter = trackDb(new Database(dbPath));
-    const chunkIdsAfter = new Set(dbAfter.getChunksByFile(sourceFile).map((chunk) => chunk.chunkId));
+    const chunkIdsAfter = new Set(dbAfter.getChunksByFile("src/index.ts").map((chunk) => chunk.chunkId));
     expect(chunkIdsBefore.some((chunkId) => !chunkIdsAfter.has(chunkId))).toBe(true);
   });
 
@@ -1097,7 +1147,7 @@ describe("indexer clearIndex force rebuild", () => {
 
     const dbPath = path.join(tempDir, ".opencode", "index", "codebase.db");
     const db = trackDb(new Database(dbPath));
-    expect(db.getChunksByFile(retainedFile).length).toBeGreaterThan(0);
+    expect(db.getChunksByFile("src/retained.ts").length).toBeGreaterThan(0);
   });
 
   it("refuses to auto-reset a corrupted shared global sqlite index", async () => {

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1428,7 +1428,7 @@ describe("indexer failed batch recovery", () => {
               content: "export function alpha() { return 'alpha'; }",
               contentHash: "stale-hash",
               metadata: {
-                filePath: sourceFile,
+                filePath: "src/index.ts",
                 startLine: 1,
                 endLine: 3,
                 language: "typescript",

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -392,6 +392,7 @@ describe("multiprocess indexing", () => {
     for (const chunkId of branchChunkIds) {
       const chunk = database.getChunk(chunkId);
       expect(chunk).not.toBeNull();
+      expect(chunk!.filePath).toBe("src/index.ts");
       expect(database.getEmbedding(chunk!.contentHash)).not.toBeNull();
     }
     database.close();
@@ -399,15 +400,17 @@ describe("multiprocess indexing", () => {
     const vectors = new VectorStore(path.join(indexPath, "vectors"), 8);
     vectors.load();
     expect(vectors.count()).toBe(stats?.chunkCount);
-    expect(vectors.getAllMetadata().map(({ key }) => key).sort()).toEqual([...branchChunkIds].sort());
+    const vectorMetadata = vectors.getAllMetadata();
+    expect(vectorMetadata.map(({ key }) => key).sort()).toEqual([...branchChunkIds].sort());
+    expect(vectorMetadata.every(({ metadata }) => metadata.filePath === "src/index.ts")).toBe(true);
 
     const inverted = new InvertedIndex(path.join(indexPath, "inverted-index.json"));
     inverted.load();
     expect(inverted.getDocumentCount()).toBe(stats?.chunkCount);
     expect(Array.from(inverted.search("function", 20).keys()).some((chunkId) => branchChunkIds.includes(chunkId))).toBe(true);
     const hashes = JSON.parse(fs.readFileSync(path.join(indexPath, "file-hashes.json"), "utf-8")) as Record<string, string>;
-    expect(Object.keys(hashes).length).toBeGreaterThan(0);
-    expect(hashes[sourcePath]).toBeTypeOf("string");
+    expect(Object.keys(hashes)).toEqual(["src/index.ts"]);
+    expect(hashes["src/index.ts"]).toBeTypeOf("string");
     expect(fs.existsSync(path.join(indexPath, "failed-batches.json"))).toBe(false);
     expect(fs.existsSync(path.join(indexPath, "indexing.lock"))).toBe(false);
     expect(fs.readdirSync(indexPath).some((name) => name.includes(".tmp.") || name.includes(".bak.") || name.startsWith("indexing.lock."))).toBe(false);
@@ -811,7 +814,7 @@ describe("multiprocess indexing", () => {
     assertIndexIntegrity();
   });
 
-  it("defers legacy database creation to the next writer without re-embedding", async () => {
+  it("requires a forced rebuild when only legacy vector artifacts remain", async () => {
     await seedIndex();
     embeddingServer.reset();
     const indexPath = path.join(projectRoot, ".opencode", "index");
@@ -829,19 +832,24 @@ describe("multiprocess indexing", () => {
     expect(fs.existsSync(dbPath)).toBe(false);
     expect(embeddingServer.requestCount).toBe(0);
 
-    const stats = await indexer.index();
+    await expect(indexer.index()).rejects.toThrow(/path storage format mismatch.*force=true/i);
+    expect(embeddingServer.requestCount).toBe(0);
+
+    const stats = await indexer.forceIndex();
     const writerStatus = await indexer.getStatus();
     const database = new Database(dbPath);
     try {
-      expect(stats.indexedChunks).toBe(0);
+      expect(stats.indexedChunks).toBeGreaterThan(0);
       expect(writerStatus.indexed).toBe(true);
       expect(writerStatus.warning).toBeUndefined();
       expect(database.getStats().chunkCount).toBeGreaterThan(0);
       expect(database.getBranchChunkIds("default").length).toBeGreaterThan(0);
-      expect(embeddingServer.requestCount).toBe(0);
+      expect(database.getMetadata("index.pathStorageVersion")).toBe("2");
+      expect(embeddingServer.requestCount).toBeGreaterThan(0);
     } finally {
       database.close();
     }
+    assertIndexIntegrity();
   });
 
   it("publishes BM25 atomically while a cold reader overlaps the writer save", async () => {

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -26,6 +26,14 @@ function symbolExtractorMetadataKey(catalogIdentity: string): string {
   return `index.symbolExtractorVersion.${hashContent(catalogIdentity).slice(0, 24)}`;
 }
 
+function setBranchMigrationMetadataCurrent(database: Database, catalogIdentity: string): void {
+  const suffix = hashContent(catalogIdentity).slice(0, 24);
+  database.setMetadata(`index.callGraphResolutionVersion.${suffix}`, "4");
+  database.setMetadata(`index.parser.swiftVersion.${suffix}`, "1");
+  database.setMetadata(`index.parser.metalVersion.${suffix}`, "1");
+  database.setMetadata(symbolExtractorMetadataKey(catalogIdentity), "1");
+}
+
 vi.mock("../src/tools/changed-files.js", () => ({
   getChangedFiles: vi.fn(),
 }));
@@ -527,7 +535,7 @@ describe("pr_impact tool", () => {
     db.addSymbolsToBranch("feature-branch", ["sym_a", "sym_b", "sym_c"]);
     db.addSymbolsToBranch("other-branch", ["sym_b"]);
     db.setMetadata(branchCommitMetadataKey("feature-branch"), "1111111111111111111111111111111111111111");
-    db.setMetadata(symbolExtractorMetadataKey("feature-branch"), "1");
+    setBranchMigrationMetadataCurrent(db, "feature-branch");
 
     db.upsertCallEdge({
       id: "edge_ab",
@@ -626,7 +634,7 @@ describe("pr_impact tool", () => {
     db.addSymbolsToBranch("feature-branch", ["sym_a_feature"]);
     db.addSymbolsToBranch("other-branch", ["sym_a_other"]);
     db.setMetadata(branchCommitMetadataKey("feature-branch"), "1111111111111111111111111111111111111111");
-    db.setMetadata(symbolExtractorMetadataKey("feature-branch"), "1");
+    setBranchMigrationMetadataCurrent(db, "feature-branch");
 
     const result = await indexer.getPrImpact({ pr: 1, checkConflicts: true });
 

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -127,7 +127,7 @@ describe("pr_impact tool", () => {
 
     db.upsertSymbol({
       id: "sym_a",
-      filePath: path.join(tempDir, "src", "a.ts"),
+      filePath: "src/a.ts",
       name: "funcA",
       kind: "function",
       startLine: 1,
@@ -138,7 +138,7 @@ describe("pr_impact tool", () => {
     });
     db.upsertSymbol({
       id: "sym_b",
-      filePath: path.join(tempDir, "src", "b.ts"),
+      filePath: "src/b.ts",
       name: "funcB",
       kind: "function",
       startLine: 1,
@@ -239,7 +239,7 @@ describe("pr_impact tool", () => {
     const db = await getDatabase(indexer);
     db.upsertSymbol({
       id: "sym_detached",
-      filePath: path.join(tempDir, "src", "a.ts"),
+      filePath: "src/a.ts",
       name: "detachedFunc",
       kind: "function",
       startLine: 1,
@@ -253,6 +253,9 @@ describe("pr_impact tool", () => {
     const result = await indexer.getPrImpact({});
 
     expect(result.directSymbols.map((s) => s.id)).toContain("sym_detached");
+    expect(result.directSymbols.find((symbol) => symbol.id === "sym_detached")?.filePath).toBe(
+      path.join(tempDir, "src", "a.ts"),
+    );
   });
 
   it("detects hub nodes and flags HIGH risk", async () => {
@@ -270,7 +273,7 @@ describe("pr_impact tool", () => {
 
     db.upsertSymbol({
       id: "sym_hub",
-      filePath: path.join(tempDir, "src", "db.ts"),
+      filePath: "src/db.ts",
       name: "DatabasePool",
       kind: "class",
       startLine: 1,
@@ -286,7 +289,7 @@ describe("pr_impact tool", () => {
       callerSymbols.push(id);
       db.upsertSymbol({
         id,
-        filePath: path.join(tempDir, "src", `caller${i}.ts`),
+        filePath: `src/caller${i}.ts`,
         name: `caller${i}`,
         kind: "function",
         startLine: 1,
@@ -323,7 +326,7 @@ describe("pr_impact tool", () => {
 
     db.upsertSymbol({
       id: "sym_x",
-      filePath: path.join(tempDir, "src", "x.ts"),
+      filePath: "src/x.ts",
       name: "funcX",
       kind: "function",
       startLine: 1,
@@ -334,7 +337,7 @@ describe("pr_impact tool", () => {
     });
     db.upsertSymbol({
       id: "sym_y",
-      filePath: path.join(tempDir, "src", "y.ts"),
+      filePath: "src/y.ts",
       name: "funcY",
       kind: "function",
       startLine: 1,
@@ -370,15 +373,15 @@ describe("pr_impact tool", () => {
 
     // Build: X -> A -> B (X calls A, A calls B)
     db.upsertSymbol({
-      id: "sym_x", filePath: path.join(tempDir, "src", "x.ts"), name: "funcX",
+      id: "sym_x", filePath: "src/x.ts", name: "funcX",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.upsertSymbol({
-      id: "sym_a", filePath: path.join(tempDir, "src", "a.ts"), name: "funcA",
+      id: "sym_a", filePath: "src/a.ts", name: "funcA",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.upsertSymbol({
-      id: "sym_b", filePath: path.join(tempDir, "src", "b.ts"), name: "funcB",
+      id: "sym_b", filePath: "src/b.ts", name: "funcB",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.addSymbolsToBranch("main", ["sym_x", "sym_a", "sym_b"]);
@@ -404,15 +407,15 @@ describe("pr_impact tool", () => {
 
     // Build: X -> A -> B
     db.upsertSymbol({
-      id: "sym_x", filePath: path.join(tempDir, "src", "x.ts"), name: "funcX",
+      id: "sym_x", filePath: "src/x.ts", name: "funcX",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.upsertSymbol({
-      id: "sym_a", filePath: path.join(tempDir, "src", "a.ts"), name: "funcA",
+      id: "sym_a", filePath: "src/a.ts", name: "funcA",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.upsertSymbol({
-      id: "sym_b", filePath: path.join(tempDir, "src", "b.ts"), name: "funcB",
+      id: "sym_b", filePath: "src/b.ts", name: "funcB",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.addSymbolsToBranch("main", ["sym_x", "sym_a", "sym_b"]);
@@ -438,15 +441,15 @@ describe("pr_impact tool", () => {
 
     // Build: X -> A -> B
     db.upsertSymbol({
-      id: "sym_x", filePath: path.join(tempDir, "src", "x.ts"), name: "funcX",
+      id: "sym_x", filePath: "src/x.ts", name: "funcX",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.upsertSymbol({
-      id: "sym_a", filePath: path.join(tempDir, "src", "a.ts"), name: "funcA",
+      id: "sym_a", filePath: "src/a.ts", name: "funcA",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.upsertSymbol({
-      id: "sym_b", filePath: path.join(tempDir, "src", "b.ts"), name: "funcB",
+      id: "sym_b", filePath: "src/b.ts", name: "funcB",
       kind: "function", startLine: 1, startCol: 0, endLine: 10, endCol: 0, language: "typescript",
     });
     db.addSymbolsToBranch("main", ["sym_x", "sym_a", "sym_b"]);
@@ -498,7 +501,7 @@ describe("pr_impact tool", () => {
 
     db.upsertSymbol({
       id: "sym_a",
-      filePath: path.join(tempDir, "src", "a.ts"),
+      filePath: "src/a.ts",
       name: "funcA",
       kind: "function",
       startLine: 1, startCol: 0, endLine: 10, endCol: 0,
@@ -506,7 +509,7 @@ describe("pr_impact tool", () => {
     });
     db.upsertSymbol({
       id: "sym_b",
-      filePath: path.join(tempDir, "src", "b.ts"),
+      filePath: "src/b.ts",
       name: "funcB",
       kind: "function",
       startLine: 1, startCol: 0, endLine: 10, endCol: 0,
@@ -514,7 +517,7 @@ describe("pr_impact tool", () => {
     });
     db.upsertSymbol({
       id: "sym_c",
-      filePath: path.join(tempDir, "src", "c.ts"),
+      filePath: "src/c.ts",
       name: "funcC",
       kind: "function",
       startLine: 1, startCol: 0, endLine: 10, endCol: 0,
@@ -592,7 +595,7 @@ describe("pr_impact tool", () => {
     const indexer = await createIndexer();
     const db = await getDatabase(indexer);
 
-    const filePath = path.join(tempDir, "src", "a.ts");
+    const filePath = "src/a.ts";
 
     // Symbol on the current branch at line 1.
     db.upsertSymbol({

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -115,6 +115,55 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(topPaths).not.toContain(path.join("benchmarks", "run.ts"));
   });
 
+  it("treats relative and absolute directory filters equivalently", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: { watchFiles: false },
+      search: { maxResults: 10, minScore: 0 },
+    });
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    await indexer.index();
+
+    const relativeDirectory = path.join("app", "indexer");
+    const absoluteDirectory = `${path.join(tempDir, relativeDirectory)}${path.sep}`;
+    const source = fs.readFileSync(path.join(tempDir, relativeDirectory, "index.ts"), "utf-8");
+
+    const relativeSearch = await indexer.search("rankHybridResults implementation", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+      directory: relativeDirectory,
+    });
+    const absoluteSearch = await indexer.search("rankHybridResults implementation", 10, {
+      metadataOnly: true,
+      filterByBranch: false,
+      directory: absoluteDirectory,
+    });
+
+    expect(relativeSearch.length).toBeGreaterThan(0);
+    expect(absoluteSearch.map((result) => result.filePath)).toEqual(
+      relativeSearch.map((result) => result.filePath),
+    );
+
+    const relativeSimilar = await indexer.findSimilar(source, 10, {
+      filterByBranch: false,
+      directory: relativeDirectory,
+    });
+    const absoluteSimilar = await indexer.findSimilar(source, 10, {
+      filterByBranch: false,
+      directory: absoluteDirectory,
+    });
+
+    expect(relativeSimilar.length).toBeGreaterThan(0);
+    expect(absoluteSimilar.map((result) => result.filePath)).toEqual(
+      relativeSimilar.map((result) => result.filePath),
+    );
+  });
+
   it("returns exact symbols whose semantic chunks were omitted by the per-file cap", async () => {
     const largeFile = path.join(tempDir, "app", "indexer", "large.ts");
     const declarations = Array.from({ length: 30 }, (_, index) =>
@@ -162,7 +211,9 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     const status = await indexer.getStatus();
     const database = new Database(path.join(status.indexPath, "codebase.db"));
     try {
-      expect(database.getSymbolsByName("cappedExactDefinition")).toHaveLength(1);
+      expect(database.getSymbolsByName("cappedExactDefinition")).toEqual([
+        expect.objectContaining({ filePath: "app/indexer/large.ts" }),
+      ]);
       expect(database.getChunksByName("cappedExactDefinition")).toHaveLength(0);
     } finally {
       database.close();
@@ -207,7 +258,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     const database = new Database(path.join(status.indexPath, "codebase.db"));
     try {
       expect(database.getSymbolsByName("getStatus")).toEqual([
-        expect.objectContaining({ filePath: classFile, kind: "method_definition" }),
+        expect.objectContaining({ filePath: "app/indexer/service.ts", kind: "method_definition" }),
       ]);
       expect(database.getChunksByName("getStatus")).toHaveLength(0);
     } finally {
@@ -223,6 +274,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
 
   it("reparses symbols for unchanged files with stale symbolExtractorVersion metadata and restores nested class methods", async () => {
     const classFile = path.join(tempDir, "app", "indexer", "service.ts");
+    const storedClassFile = "app/indexer/service.ts";
     fs.writeFileSync(
       classFile,
       `export class Service {
@@ -252,9 +304,9 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     const firstStatus = await firstIndexer.getStatus();
     const initialDb = new Database(path.join(firstStatus.indexPath, "codebase.db"));
     try {
-      const beforeReindex = initialDb.getSymbolsByFile(classFile);
+      const beforeReindex = initialDb.getSymbolsByFile(storedClassFile);
       expect(beforeReindex).toContainEqual(expect.objectContaining({
-        filePath: classFile,
+        filePath: storedClassFile,
         name: "getStatus",
         kind: "method_definition",
       }));
@@ -267,7 +319,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
 
     const staleDb = new Database(path.join(firstStatus.indexPath, "codebase.db"));
     try {
-      staleDb.deleteSymbolsByFile(classFile);
+      staleDb.deleteSymbolsByFile(storedClassFile);
       staleDb.setMetadata(symbolExtractorVersionKey, "stale");
     } finally {
       staleDb.close();
@@ -282,7 +334,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     try {
       const restoredSymbols = restoredDb.getSymbolsByName("getStatus");
       expect(restoredSymbols).toContainEqual(expect.objectContaining({
-        filePath: classFile,
+        filePath: storedClassFile,
         name: "getStatus",
         kind: "method_definition",
       }));
@@ -292,6 +344,39 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     }
 
     expect(fetchSpy.mock.calls.length).toBe(embeddingCallsBeforeReindex);
+  });
+
+  it("keeps global-scope database paths absolute", async () => {
+    const sourceFile = path.join(tempDir, "app", "indexer", "index.ts");
+    const indexPath = path.join(tempDir, "global-index");
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      scope: "global",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      indexing: { watchFiles: false },
+      search: { maxResults: 10, minScore: 0 },
+    });
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode", { indexPath })) - 1];
+    await indexer.index();
+
+    const database = new Database(path.join(indexPath, "codebase.db"));
+    try {
+      expect(database.getSymbolsByName("rankHybridResults")).toContainEqual(
+        expect.objectContaining({ filePath: sourceFile }),
+      );
+    } finally {
+      database.close();
+    }
+
+    const results = await indexer.search("where is rankHybridResults implementation", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+    });
+    expect(results[0]?.filePath).toBe(sourceFile);
   });
 
   it("does not rescue capped symbols from another branch", () => {

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -12,13 +12,44 @@ vi.mock("../src/tools/operations.js", () => ({
   refreshIndexerForDirectory: operationMocks.refreshIndexerForDirectory,
 }));
 
-vi.mock("../src/git/index.js", () => ({
+vi.mock("../src/git/index.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/git/index.js")>()),
   isGitRepo: vi.fn(() => false),
-  resolveWorktreeMainRepoRoot: vi.fn(() => null),
 }));
 
 import { parseConfig } from "../src/config/schema.js";
 import { createWatcherWithIndexer } from "../src/watcher/index.js";
+
+function createLinkedWorktree(root: string): {
+  configPath: string;
+  worktreeDir: string;
+} {
+  const mainRepoDir = path.join(root, "main-repo");
+  const worktreeDir = path.join(root, "feature-worktree");
+  const worktreeGitDir = path.join(mainRepoDir, ".git", "worktrees", "feature");
+  const configPath = path.join(mainRepoDir, ".opencode", "codebase-index.json");
+  mkdirSync(worktreeGitDir, { recursive: true });
+  mkdirSync(worktreeDir, { recursive: true });
+  mkdirSync(path.dirname(configPath), { recursive: true });
+  writeFileSync(path.join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
+  writeFileSync(path.join(worktreeGitDir, "commondir"), "../..\n");
+  writeFileSync(configPath, JSON.stringify({ include: ["**/*.ts"] }));
+  return { configPath, worktreeDir };
+}
+
+function createLinkedWorktreeWatcher(root: string) {
+  const { configPath, worktreeDir } = createLinkedWorktree(root);
+  const indexer = {
+    index: vi.fn().mockResolvedValue(undefined),
+  };
+  const watcher = createWatcherWithIndexer(
+    () => indexer,
+    worktreeDir,
+    parseConfig({ include: ["**/*.ts"] }),
+    "opencode",
+  );
+  return { configPath, indexer, watcher, worktreeDir };
+}
 
 describe("watcher config refresh", () => {
   let tempDir: string;
@@ -134,6 +165,68 @@ describe("watcher config refresh", () => {
     }, { timeout: 2500 });
 
     await watcher.stop();
+  });
+
+  it("refreshes a linked worktree when its inherited project config changes", async () => {
+    const { configPath, indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir);
+
+    try {
+      await watcher.whenReady();
+      writeFileSync(configPath, JSON.stringify({ include: ["src/**/*.ts"] }));
+
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(
+          worktreeDir,
+          "opencode",
+          undefined,
+        );
+        expect(indexer.index).toHaveBeenCalledTimes(1);
+      }, { timeout: 2500 });
+    } finally {
+      await watcher.stop();
+    }
+  });
+
+  it("refreshes a linked worktree when its inherited project config is removed", async () => {
+    const { configPath, indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir);
+
+    try {
+      await watcher.whenReady();
+      rmSync(configPath);
+
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(
+          worktreeDir,
+          "opencode",
+          undefined,
+        );
+        expect(indexer.index).toHaveBeenCalledTimes(1);
+      }, { timeout: 2500 });
+    } finally {
+      await watcher.stop();
+    }
+  });
+
+  it("refreshes a linked worktree when a local project override is created", async () => {
+    const { indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir);
+    const localConfigPath = path.join(worktreeDir, ".opencode", "codebase-index.json");
+
+    try {
+      await watcher.whenReady();
+      mkdirSync(path.dirname(localConfigPath), { recursive: true });
+      writeFileSync(localConfigPath, JSON.stringify({ include: ["feature/**/*.ts"] }));
+
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(
+          worktreeDir,
+          "opencode",
+          undefined,
+        );
+        expect(indexer.index).toHaveBeenCalledTimes(1);
+      }, { timeout: 2500 });
+    } finally {
+      await watcher.stop();
+    }
   });
 
   it("refreshes from explicit config path when configured", async () => {

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const operationMocks = vi.hoisted(() => ({
   refreshIndexerForDirectory: vi.fn(),
@@ -20,7 +20,23 @@ vi.mock("../src/git/index.js", async (importOriginal) => ({
 import { parseConfig } from "../src/config/schema.js";
 import { createWatcherWithIndexer } from "../src/watcher/index.js";
 
-function createLinkedWorktree(root: string): {
+const originalUsePolling = process.env.CHOKIDAR_USEPOLLING;
+
+beforeAll(() => {
+  if (originalUsePolling === undefined) {
+    process.env.CHOKIDAR_USEPOLLING = "1";
+  }
+});
+
+afterAll(() => {
+  if (originalUsePolling === undefined) {
+    delete process.env.CHOKIDAR_USEPOLLING;
+  } else {
+    process.env.CHOKIDAR_USEPOLLING = originalUsePolling;
+  }
+});
+
+function createLinkedWorktree(root: string, writeMainConfig = true): {
   configPath: string;
   worktreeDir: string;
 } {
@@ -33,12 +49,14 @@ function createLinkedWorktree(root: string): {
   mkdirSync(path.dirname(configPath), { recursive: true });
   writeFileSync(path.join(worktreeDir, ".git"), `gitdir: ${worktreeGitDir}\n`);
   writeFileSync(path.join(worktreeGitDir, "commondir"), "../..\n");
-  writeFileSync(configPath, JSON.stringify({ include: ["**/*.ts"] }));
+  if (writeMainConfig) {
+    writeFileSync(configPath, JSON.stringify({ include: ["**/*.ts"] }));
+  }
   return { configPath, worktreeDir };
 }
 
-function createLinkedWorktreeWatcher(root: string) {
-  const { configPath, worktreeDir } = createLinkedWorktree(root);
+function createLinkedWorktreeWatcher(root: string, writeMainConfig = true) {
+  const { configPath, worktreeDir } = createLinkedWorktree(root, writeMainConfig);
   const indexer = {
     index: vi.fn().mockResolvedValue(undefined),
   };
@@ -223,6 +241,39 @@ describe("watcher config refresh", () => {
           undefined,
         );
         expect(indexer.index).toHaveBeenCalledTimes(1);
+      }, { timeout: 2500 });
+    } finally {
+      await watcher.stop();
+    }
+  });
+
+  it("refreshes a linked worktree across inherited config creation, deletion, and recreation", async () => {
+    const { configPath, indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir, false);
+
+    try {
+      await watcher.whenReady();
+      mkdirSync(path.dirname(configPath), { recursive: true });
+      writeFileSync(configPath, JSON.stringify({ include: ["created/**/*.ts"] }));
+
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(
+          worktreeDir,
+          "opencode",
+          undefined,
+        );
+        expect(indexer.index).toHaveBeenCalledTimes(1);
+      }, { timeout: 2500 });
+
+      rmSync(configPath);
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledTimes(2);
+        expect(indexer.index).toHaveBeenCalledTimes(2);
+      }, { timeout: 2500 });
+
+      writeFileSync(configPath, JSON.stringify({ include: ["recreated/**/*.ts"] }));
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledTimes(3);
+        expect(indexer.index).toHaveBeenCalledTimes(3);
       }, { timeout: 2500 });
     } finally {
       await watcher.stop();

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -204,6 +204,7 @@ describe("FileWatcher", () => {
       const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
       const indexer = {
         index: vi.fn().mockResolvedValue(undefined),
+        refreshBranchInfo: vi.fn(),
         getLogger: vi.fn().mockReturnValue({ branch }),
       };
       const combinedWatcher = createWatcherWithIndexer(
@@ -229,6 +230,7 @@ describe("FileWatcher", () => {
         });
       }, { timeout: 2500 });
       await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce(), { timeout: 2500 });
+      expect(indexer.refreshBranchInfo).toHaveBeenCalledOnce();
       expect(consoleLog).not.toHaveBeenCalled();
 
       await combinedWatcher.stop();

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -8,28 +8,13 @@ import { loadMergedConfig } from "../src/config/merger.js";
 import { parseConfig } from "../src/config/schema.js";
 import { resolveProjectConfigPath, resolveProjectIndexPath, resolveWritableProjectConfigPath } from "../src/config/paths.js";
 import { Indexer } from "../src/indexer/index.js";
-import { Database } from "../src/native/index.js";
+import { Database, hashContent, VectorStore } from "../src/native/index.js";
 
-function snapshotProjectIndex(indexPath: string): {
-  stats: ReturnType<Database["getStats"]>;
-  branches: Array<{ branch: string; chunks: Array<ReturnType<Database["getChunk"]>> }>;
-  fileHashes: string;
-} {
-  const database = new Database(path.join(indexPath, "codebase.db"));
-  try {
-    const branches = database.getAllBranches().sort().map((branch) => ({
-      branch,
-      chunks: database.getBranchChunkIds(branch).sort().map((chunkId) => database.getChunk(chunkId)),
-    }));
-
-    return {
-      stats: database.getStats(),
-      branches,
-      fileHashes: fs.readFileSync(path.join(indexPath, "file-hashes.json"), "utf-8"),
-    };
-  } finally {
-    database.close();
-  }
+function readBranchFileHashes(indexPath: string, branch: string): Record<string, string> {
+  const branchHash = hashContent(branch).slice(0, 16);
+  return JSON.parse(
+    fs.readFileSync(path.join(indexPath, `file-hashes.${branchHash}.json`), "utf-8"),
+  ) as Record<string, string>;
 }
 
 describe("worktree fallback (issue #60)", () => {
@@ -231,33 +216,116 @@ describe("worktree fallback (issue #60)", () => {
     expect(loaded.knowledgeBases).toEqual(["docs/reference"]);
   });
 
-  it("keeps the project index local when the worktree inherits its config", async () => {
+  it("shares the main project index when the worktree inherits its config", async () => {
     const config = parseConfig(loadMergedConfig(worktreeDir, "opencode"));
     const indexer = new Indexer(worktreeDir, config, "opencode");
     try {
       const status = await indexer.getStatus();
+      const sharedIndexPath = path.join(mainRepoDir, ".opencode", "index");
 
-      expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(path.join(worktreeDir, ".opencode", "index"));
-      expect(status.indexPath).toBe(path.join(worktreeDir, ".opencode", "index"));
+      expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(sharedIndexPath);
+      expect(status.indexPath).toBe(sharedIndexPath);
       expect(status.currentBranch).toBe("feature/x/y");
     } finally {
       await indexer.close();
     }
   });
 
-  it("does not mutate the main index when indexing and searching from a worktree", async () => {
+  it("rebinds branch-scoped runtime caches when one Indexer switches branches", async () => {
+    const mainSourcePath = path.join(mainRepoDir, "src", "branch-marker.ts");
+    const mainContent = "export function mainBranchMarker() { return 'main'; }\n";
+    const featureContent = "export function featureBranchMarker() { return 'feature'; }\n";
+    fs.mkdirSync(path.dirname(mainSourcePath), { recursive: true });
+    fs.writeFileSync(mainSourcePath, mainContent, "utf-8");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = Array.isArray(body.input) ? body.input : [];
+      return new Response(JSON.stringify({
+        data: texts.map((text) => ({
+          embedding: Array.from({ length: 8 }, (_, index) => ((text.length + index * 17) % 997) / 997),
+        })),
+        usage: { total_tokens: Math.max(1, texts.length * 8) },
+      }), { status: 200 });
+    });
+
+    const indexer = new Indexer(mainRepoDir, parseConfig(loadMergedConfig(mainRepoDir)));
+    const runtimePaths = indexer as unknown as {
+      fileHashCachePath: string;
+      failedBatchesPath: string;
+    };
+    const sharedIndexPath = fs.realpathSync.native(path.join(mainRepoDir, ".opencode", "index"));
+    const mainNamespace = hashContent("main").slice(0, 16);
+    const featureNamespace = hashContent("feature/x/y").slice(0, 16);
+
+    try {
+      await indexer.index();
+      const fetchesAfterMain = fetchSpy.mock.calls.length;
+      expect(runtimePaths.fileHashCachePath).toBe(
+        path.join(sharedIndexPath, `file-hashes.${mainNamespace}.json`),
+      );
+      expect(runtimePaths.failedBatchesPath).toBe(
+        path.join(sharedIndexPath, `failed-batches.${mainNamespace}.json`),
+      );
+      const mainHashes = readBranchFileHashes(sharedIndexPath, "main");
+
+      fs.writeFileSync(path.join(mainRepoDir, ".git", "HEAD"), "ref: refs/heads/feature/x/y\n");
+      fs.writeFileSync(mainSourcePath, featureContent, "utf-8");
+      await indexer.index();
+
+      expect(indexer.getCurrentBranch()).toBe("feature/x/y");
+      expect(runtimePaths.fileHashCachePath).toBe(
+        path.join(sharedIndexPath, `file-hashes.${featureNamespace}.json`),
+      );
+      expect(runtimePaths.failedBatchesPath).toBe(
+        path.join(sharedIndexPath, `failed-batches.${featureNamespace}.json`),
+      );
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(fetchesAfterMain);
+      expect(readBranchFileHashes(sharedIndexPath, "feature/x/y")).not.toEqual(mainHashes);
+
+      const database = new Database(path.join(sharedIndexPath, "codebase.db"));
+      try {
+        expect(database.getBranchChunkIds("main").length).toBeGreaterThan(0);
+        expect(database.getBranchChunkIds("feature/x/y").length).toBeGreaterThan(0);
+        expect(database.getSymbolsForBranch("main").some((symbol) => symbol.name === "mainBranchMarker")).toBe(true);
+        expect(database.getSymbolsForBranch("feature/x/y").some((symbol) => symbol.name === "featureBranchMarker")).toBe(true);
+      } finally {
+        database.close();
+      }
+
+      fs.writeFileSync(path.join(mainRepoDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+      fs.writeFileSync(mainSourcePath, mainContent, "utf-8");
+      await expect(indexer.getIndexFreshness()).resolves.toMatchObject({
+        readable: true,
+        current: true,
+      });
+      expect(indexer.getCurrentBranch()).toBe("main");
+      expect(runtimePaths.fileHashCachePath).toBe(
+        path.join(sharedIndexPath, `file-hashes.${mainNamespace}.json`),
+      );
+    } finally {
+      await indexer.close();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("shares portable branch catalogs without re-embedding identical worktree content", async () => {
     const homeDir = path.join(tempDir, "home");
     fs.mkdirSync(homeDir, { recursive: true });
     vi.stubEnv("HOME", homeDir);
     vi.stubEnv("USERPROFILE", homeDir);
 
-    const sourceContent = "export function worktreeIsolationMarker() { return 'isolated-worktree-index'; }\n";
+    const sourceContent = "export function sharedPortableMarker() { return 'shared-portable-index'; }\n";
     const mainSourcePath = path.join(mainRepoDir, "src", "worktree-marker.ts");
     const worktreeSourcePath = path.join(worktreeDir, "src", "worktree-marker.ts");
+    const storedSourcePath = "src/worktree-marker.ts";
+    const staleWorktreeIndexPath = path.join(worktreeDir, ".opencode", "index");
     fs.mkdirSync(path.dirname(mainSourcePath), { recursive: true });
     fs.mkdirSync(path.dirname(worktreeSourcePath), { recursive: true });
+    fs.mkdirSync(staleWorktreeIndexPath, { recursive: true });
     fs.writeFileSync(mainSourcePath, sourceContent, "utf-8");
     fs.writeFileSync(worktreeSourcePath, sourceContent, "utf-8");
+    fs.writeFileSync(path.join(staleWorktreeIndexPath, "legacy-marker"), "stale", "utf-8");
 
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
       const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
@@ -280,46 +348,89 @@ describe("worktree fallback (issue #60)", () => {
     const mainIndexer = new Indexer(mainRepoDir, mainConfig, "opencode");
     const worktreeIndexer = new Indexer(worktreeDir, worktreeConfig, "opencode");
     const indexers = [mainIndexer, worktreeIndexer];
+    const sharedIndexPath = path.join(mainRepoDir, ".opencode", "index");
 
     try {
-      await mainIndexer.index();
+      const mainStats = await mainIndexer.index();
       await mainIndexer.close();
+      const requestsAfterMain = fetchSpy.mock.calls.length;
+      expect(requestsAfterMain).toBeGreaterThan(0);
 
-      const mainIndexPath = path.join(mainRepoDir, ".opencode", "index");
-      const mainSnapshotBefore = snapshotProjectIndex(mainIndexPath);
+      const databaseBeforeWorktree = new Database(path.join(sharedIndexPath, "codebase.db"));
+      const statsBeforeWorktree = databaseBeforeWorktree.getStats();
+      const mainChunkIds = databaseBeforeWorktree.getBranchChunkIds("main").sort();
+      const mainSymbolIds = databaseBeforeWorktree.getBranchSymbolIds("main").sort();
+      databaseBeforeWorktree.close();
 
-      await worktreeIndexer.index();
+      const worktreeStats = await worktreeIndexer.index();
       await worktreeIndexer.close();
 
-      const worktreeIndexPath = path.join(worktreeDir, ".opencode", "index");
-      expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(worktreeIndexPath);
-      expect(snapshotProjectIndex(mainIndexPath)).toEqual(mainSnapshotBefore);
+      expect(resolveProjectIndexPath(mainRepoDir, "project", "opencode")).toBe(sharedIndexPath);
+      expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(sharedIndexPath);
+      expect(fs.readFileSync(path.join(staleWorktreeIndexPath, "legacy-marker"), "utf-8")).toBe("stale");
+      expect(worktreeStats.tokensUsed).toBe(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(requestsAfterMain);
 
-      const worktreeSnapshot = snapshotProjectIndex(worktreeIndexPath);
-      const worktreeChunks = worktreeSnapshot.branches.flatMap((entry) => entry.chunks);
-      expect(worktreeChunks.length).toBeGreaterThan(0);
-      expect(worktreeChunks.every((chunk) =>
-        chunk !== null && chunk.filePath.startsWith(`${path.resolve(worktreeDir)}${path.sep}`)
-      )).toBe(true);
+      const database = new Database(path.join(sharedIndexPath, "codebase.db"));
+      const statsAfterWorktree = database.getStats();
+      const featureChunkIds = database.getBranchChunkIds("feature/x/y").sort();
+      const featureSymbolIds = database.getBranchSymbolIds("feature/x/y").sort();
+      const rawChunks = mainChunkIds.map((chunkId) => database.getChunk(chunkId));
+      const rawSymbols = database.getSymbolsForBranch("main");
+
+      expect(mainStats.indexedChunks).toBeGreaterThan(0);
+      expect(mainChunkIds.length).toBeGreaterThan(0);
+      expect(mainSymbolIds.length).toBeGreaterThan(0);
+      expect(database.getAllBranches().sort()).toEqual(["feature/x/y", "main"]);
+      expect(featureChunkIds).toEqual(mainChunkIds);
+      expect(featureSymbolIds).toEqual(mainSymbolIds);
+      expect(statsAfterWorktree.embeddingCount).toBe(statsBeforeWorktree.embeddingCount);
+      expect(statsAfterWorktree.chunkCount).toBe(statsBeforeWorktree.chunkCount);
+      expect(statsAfterWorktree.symbolCount).toBe(statsBeforeWorktree.symbolCount);
+      expect(statsAfterWorktree.branchCount).toBe(2);
+      expect(statsAfterWorktree.branchChunkCount).toBe(statsBeforeWorktree.branchChunkCount * 2);
+      expect(rawChunks.every((chunk) => chunk?.filePath === storedSourcePath)).toBe(true);
+      expect(rawSymbols.some((symbol) => symbol.name === "sharedPortableMarker")).toBe(true);
+      expect(rawSymbols.every((symbol) => symbol.filePath === storedSourcePath)).toBe(true);
+      database.close();
+
+      const vectorStore = new VectorStore(path.join(sharedIndexPath, "vectors"), 8);
+      vectorStore.loadStrict();
+      const rawVectorMetadata = vectorStore.getAllMetadata();
+      expect(rawVectorMetadata).toHaveLength(statsAfterWorktree.chunkCount);
+      expect(rawVectorMetadata.every(({ metadata }) => metadata.filePath === storedSourcePath)).toBe(true);
+
+      const mainFileHashes = readBranchFileHashes(sharedIndexPath, "main");
+      const featureFileHashes = readBranchFileHashes(sharedIndexPath, "feature/x/y");
+      expect(Object.keys(mainFileHashes)).toEqual([storedSourcePath]);
+      expect(featureFileHashes).toEqual(mainFileHashes);
+      expect(path.isAbsolute(storedSourcePath)).toBe(false);
+      expect(storedSourcePath).not.toContain("\\");
 
       const mainReader = new Indexer(mainRepoDir, mainConfig, "opencode");
       const worktreeReader = new Indexer(worktreeDir, worktreeConfig, "opencode");
       indexers.push(mainReader, worktreeReader);
-      const [mainResults, worktreeResults] = await Promise.all([
-        mainReader.search("worktreeIsolationMarker", 5, { metadataOnly: true, filterByBranch: false }),
-        worktreeReader.search("worktreeIsolationMarker", 5, { metadataOnly: true, filterByBranch: false }),
-      ]);
+      const mainResults = await mainReader.search("sharedPortableMarker", 5, { metadataOnly: true });
+      const mainSymbols = await mainReader.getSymbolsForBranch();
+      const mainSymbolsForFile = await mainReader.getSymbolsForFiles([mainSourcePath]);
+      const worktreeResults = await worktreeReader.search("sharedPortableMarker", 5, { metadataOnly: true });
+      const worktreeSymbols = await worktreeReader.getSymbolsForBranch();
+      const worktreeSymbolsForFile = await worktreeReader.getSymbolsForFiles([worktreeSourcePath]);
 
-      expect(mainResults[0]?.filePath).toBe(mainSourcePath);
-      expect(worktreeResults[0]?.filePath).toBe(worktreeSourcePath);
+      expect(mainResults.find((result) => result.name === "sharedPortableMarker")?.filePath).toBe(mainSourcePath);
+      expect(worktreeResults.find((result) => result.name === "sharedPortableMarker")?.filePath).toBe(worktreeSourcePath);
+      expect(mainSymbols.find((symbol) => symbol.name === "sharedPortableMarker")?.filePath).toBe(mainSourcePath);
+      expect(worktreeSymbols.find((symbol) => symbol.name === "sharedPortableMarker")?.filePath).toBe(worktreeSourcePath);
+      expect(mainSymbolsForFile.find((symbol) => symbol.name === "sharedPortableMarker")?.filePath).toBe(mainSourcePath);
+      expect(worktreeSymbolsForFile.find((symbol) => symbol.name === "sharedPortableMarker")?.filePath).toBe(worktreeSourcePath);
     } finally {
       await Promise.all(indexers.map((indexer) => indexer.close()));
       fetchSpy.mockRestore();
     }
   });
 
-  it("keeps explicit worktree-local config and index when they exist", () => {
-    fs.mkdirSync(path.join(worktreeDir, ".opencode", "index"), { recursive: true });
+  it("keeps an explicit worktree-local config and its project index local", () => {
+    fs.mkdirSync(path.join(worktreeDir, ".opencode"), { recursive: true });
     fs.writeFileSync(
       path.join(worktreeDir, ".opencode", "codebase-index.json"),
       JSON.stringify({ scope: "project", knowledgeBases: ["worktree-only"] }, null, 2),
@@ -335,12 +446,12 @@ describe("worktree fallback (issue #60)", () => {
     expect(loaded.knowledgeBases).toEqual(["worktree-only"]);
   });
 
-  it("keeps a worktree-local config on a local worktree index boundary", () => {
+  it("ignores a stale worktree-local index while inheriting main config", () => {
     fs.mkdirSync(path.join(worktreeDir, ".opencode", "index"), { recursive: true });
 
     expect(resolveWritableProjectConfigPath(worktreeDir, "opencode")).toBe(path.join(worktreeDir, ".opencode", "codebase-index.json"));
     expect(resolveProjectConfigPath(worktreeDir, "opencode")).toBe(path.join(mainRepoDir, ".opencode", "codebase-index.json"));
-    expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(path.join(worktreeDir, ".opencode", "index"));
+    expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(path.join(mainRepoDir, ".opencode", "index"));
   });
 
   it("keeps explicit worktree-local config and index when they exist", () => {

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -429,6 +429,97 @@ describe("worktree fallback (issue #60)", () => {
     }
   });
 
+  it("keeps shared project search results strictly scoped to the active branch", async () => {
+    const mainSourcePath = path.join(mainRepoDir, "src", "main-only.ts");
+    const featureSourcePath = path.join(worktreeDir, "src", "feature-only.ts");
+    fs.mkdirSync(path.dirname(mainSourcePath), { recursive: true });
+    fs.mkdirSync(path.dirname(featureSourcePath), { recursive: true });
+    fs.writeFileSync(
+      mainSourcePath,
+      "export function mainOnlyBranchMarker() { return 'main-only'; }\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      featureSourcePath,
+      "export function featureOnlyBranchMarker() { return 'feature-only'; }\n",
+      "utf-8",
+    );
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = Array.isArray(body.input) ? body.input : [];
+      return new Response(JSON.stringify({
+        data: texts.map((text, index) => ({
+          embedding: Array.from(
+            { length: 8 },
+            (_, dimension) => ((text.length + index * 13 + dimension * 17) % 997) / 997,
+          ),
+        })),
+        usage: { total_tokens: Math.max(1, texts.length * 8) },
+      }), { status: 200 });
+    });
+
+    const mainIndexer = new Indexer(mainRepoDir, parseConfig(loadMergedConfig(mainRepoDir)));
+    const worktreeIndexer = new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+
+    try {
+      await mainIndexer.index();
+      await worktreeIndexer.index();
+
+      const runtime = worktreeIndexer as unknown as {
+        database: Database;
+        store: VectorStore;
+      };
+      const featureChunkIds = new Set(runtime.database.getBranchChunkIds("feature/x/y"));
+      const mainChunkId = runtime.database.getBranchChunkIds("main").find(
+        (chunkId) => !featureChunkIds.has(chunkId),
+      );
+      expect(mainChunkId).toBeDefined();
+      const mainMetadata = runtime.store.getMetadata(mainChunkId!);
+      expect(mainMetadata).toBeDefined();
+      vi.spyOn(runtime.store, "search").mockReturnValue([{
+        id: mainChunkId!,
+        score: 0.99,
+        metadata: mainMetadata!,
+      }]);
+
+      await expect(
+        worktreeIndexer.search("mainOnlyBranchMarker", 1, { metadataOnly: true }),
+      ).resolves.toEqual([]);
+      await expect(
+        worktreeIndexer.findSimilar("function mainOnlyBranchMarker() {}", 1),
+      ).resolves.toEqual([]);
+
+      const unscopedSearch = await worktreeIndexer.search(
+        "mainOnlyBranchMarker",
+        1,
+        { metadataOnly: true, filterByBranch: false },
+      );
+      const unscopedSimilar = await worktreeIndexer.findSimilar(
+        "function mainOnlyBranchMarker() {}",
+        1,
+        { filterByBranch: false },
+      );
+      expect(unscopedSearch[0]?.name).toBe("mainOnlyBranchMarker");
+      expect(unscopedSimilar[0]?.name).toBe("mainOnlyBranchMarker");
+
+      for (const branch of runtime.database.getAllBranches()) {
+        runtime.database.clearBranch(branch);
+        runtime.database.clearBranchSymbols(branch);
+      }
+      expect(runtime.database.getAllBranches()).toEqual([]);
+      expect(
+        (await worktreeIndexer.search("mainOnlyBranchMarker", 1, { metadataOnly: true }))[0]?.name,
+      ).toBe("mainOnlyBranchMarker");
+      expect(
+        (await worktreeIndexer.findSimilar("function mainOnlyBranchMarker() {}", 1))[0]?.name,
+      ).toBe("mainOnlyBranchMarker");
+    } finally {
+      await Promise.all([mainIndexer.close(), worktreeIndexer.close()]);
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("keeps an explicit worktree-local config and its project index local", () => {
     fs.mkdirSync(path.join(worktreeDir, ".opencode"), { recursive: true });
     fs.writeFileSync(

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -8,7 +8,7 @@ import { loadMergedConfig } from "../src/config/merger.js";
 import { parseConfig } from "../src/config/schema.js";
 import { resolveProjectConfigPath, resolveProjectIndexPath, resolveWritableProjectConfigPath } from "../src/config/paths.js";
 import { Indexer } from "../src/indexer/index.js";
-import { Database, hashContent, VectorStore } from "../src/native/index.js";
+import { Database, hashContent, InvertedIndex, VectorStore } from "../src/native/index.js";
 
 function readBranchFileHashes(indexPath: string, branch: string): Record<string, string> {
   const branchHash = hashContent(branch).slice(0, 16);
@@ -430,15 +430,17 @@ describe("worktree fallback (issue #60)", () => {
   });
 
   it("keeps shared project search results strictly scoped to the active branch", async () => {
-    const mainSourcePath = path.join(mainRepoDir, "src", "main-only.ts");
+    const mainSourceDir = path.join(mainRepoDir, "src");
     const featureSourcePath = path.join(worktreeDir, "src", "feature-only.ts");
-    fs.mkdirSync(path.dirname(mainSourcePath), { recursive: true });
+    fs.mkdirSync(mainSourceDir, { recursive: true });
     fs.mkdirSync(path.dirname(featureSourcePath), { recursive: true });
-    fs.writeFileSync(
-      mainSourcePath,
-      "export function mainOnlyBranchMarker() { return 'main-only'; }\n",
-      "utf-8",
-    );
+    for (let index = 0; index < 6; index++) {
+      fs.writeFileSync(
+        path.join(mainSourceDir, `main-only-${index}.ts`),
+        `export function mainOnlyBranchMarker${index}() { return 'main-only-${index}'; }\n`,
+        "utf-8",
+      );
+    }
     fs.writeFileSync(
       featureSourcePath,
       "export function featureOnlyBranchMarker() { return 'feature-only'; }\n",
@@ -468,40 +470,83 @@ describe("worktree fallback (issue #60)", () => {
 
       const runtime = worktreeIndexer as unknown as {
         database: Database;
+        invertedIndex: InvertedIndex;
         store: VectorStore;
       };
       const featureChunkIds = new Set(runtime.database.getBranchChunkIds("feature/x/y"));
-      const mainChunkId = runtime.database.getBranchChunkIds("main").find(
-        (chunkId) => !featureChunkIds.has(chunkId),
+      const featureChunkId = Array.from(featureChunkIds).find(
+        (chunkId) => runtime.store.getMetadata(chunkId)?.name === "featureOnlyBranchMarker",
       );
-      expect(mainChunkId).toBeDefined();
-      const mainMetadata = runtime.store.getMetadata(mainChunkId!);
-      expect(mainMetadata).toBeDefined();
-      vi.spyOn(runtime.store, "search").mockReturnValue([{
-        id: mainChunkId!,
-        score: 0.99,
-        metadata: mainMetadata!,
-      }]);
+      expect(featureChunkId).toBeDefined();
+      const featureMetadata = runtime.store.getMetadata(featureChunkId!);
+      expect(featureMetadata).toBeDefined();
+      const foreignCandidates = runtime.database.getBranchChunkIds("main")
+        .filter((chunkId) => !featureChunkIds.has(chunkId))
+        .map((chunkId) => ({ chunkId, metadata: runtime.store.getMetadata(chunkId) }))
+        .filter((candidate) => candidate.metadata?.name?.startsWith("mainOnlyBranchMarker"))
+        .slice(0, 5)
+        .map(({ chunkId, metadata }, index) => ({
+          id: chunkId,
+          score: 0.99 - index * 0.01,
+          metadata: metadata!,
+        }));
+      expect(foreignCandidates).toHaveLength(5);
+      const activeCandidate = {
+        id: featureChunkId!,
+        score: 0.8,
+        metadata: featureMetadata!,
+      };
+      const rankedCandidates = [...foreignCandidates, activeCandidate];
+      const semanticSearchSpy = vi.spyOn(runtime.store, "search").mockImplementation(
+        (_embedding, requestedLimit = 10) => rankedCandidates.slice(0, requestedLimit),
+      );
+      const keywordSearchSpy = vi.spyOn(runtime.invertedIndex, "search").mockImplementation(
+        (_query, requestedLimit = 100) => new Map(
+          rankedCandidates.slice(0, requestedLimit).map((candidate) => [candidate.id, candidate.score]),
+        ),
+      );
 
+      const scopedSearch = await worktreeIndexer.search(
+        "ranked branch retrieval probe",
+        1,
+        { metadataOnly: true },
+      );
+      expect(scopedSearch[0]?.name).toBe("featureOnlyBranchMarker");
+      expect(semanticSearchSpy.mock.calls.some(([, requestedLimit]) => requestedLimit > 4)).toBe(true);
+      expect(keywordSearchSpy.mock.calls.some(([, requestedLimit]) => (requestedLimit ?? 0) > 4)).toBe(true);
+
+      semanticSearchSpy.mockClear();
+      const scopedSimilar = await worktreeIndexer.findSimilar("ranked branch retrieval probe", 1);
+      expect(scopedSimilar[0]?.name).toBe("featureOnlyBranchMarker");
+      expect(semanticSearchSpy.mock.calls.some(([, requestedLimit]) => requestedLimit > 2)).toBe(true);
+
+      semanticSearchSpy.mockImplementation(
+        (_embedding, requestedLimit = 10) => foreignCandidates.slice(0, requestedLimit),
+      );
+      keywordSearchSpy.mockImplementation(
+        (_query, requestedLimit = 100) => new Map(
+          foreignCandidates.slice(0, requestedLimit).map((candidate) => [candidate.id, candidate.score]),
+        ),
+      );
       await expect(
-        worktreeIndexer.search("mainOnlyBranchMarker", 1, { metadataOnly: true }),
+        worktreeIndexer.search("ranked branch retrieval probe", 1, { metadataOnly: true }),
       ).resolves.toEqual([]);
       await expect(
-        worktreeIndexer.findSimilar("function mainOnlyBranchMarker() {}", 1),
+        worktreeIndexer.findSimilar("ranked branch retrieval probe", 1),
       ).resolves.toEqual([]);
 
       const unscopedSearch = await worktreeIndexer.search(
-        "mainOnlyBranchMarker",
+        "ranked branch retrieval probe",
         1,
         { metadataOnly: true, filterByBranch: false },
       );
       const unscopedSimilar = await worktreeIndexer.findSimilar(
-        "function mainOnlyBranchMarker() {}",
+        "ranked branch retrieval probe",
         1,
         { filterByBranch: false },
       );
-      expect(unscopedSearch[0]?.name).toBe("mainOnlyBranchMarker");
-      expect(unscopedSimilar[0]?.name).toBe("mainOnlyBranchMarker");
+      expect(unscopedSearch[0]?.name).toBe(foreignCandidates[0]?.metadata.name);
+      expect(unscopedSimilar[0]?.name).toBe(foreignCandidates[0]?.metadata.name);
 
       for (const branch of runtime.database.getAllBranches()) {
         runtime.database.clearBranch(branch);
@@ -509,11 +554,11 @@ describe("worktree fallback (issue #60)", () => {
       }
       expect(runtime.database.getAllBranches()).toEqual([]);
       expect(
-        (await worktreeIndexer.search("mainOnlyBranchMarker", 1, { metadataOnly: true }))[0]?.name,
-      ).toBe("mainOnlyBranchMarker");
+        (await worktreeIndexer.search("ranked branch retrieval probe", 1, { metadataOnly: true }))[0]?.name,
+      ).toBe(foreignCandidates[0]?.metadata.name);
       expect(
-        (await worktreeIndexer.findSimilar("function mainOnlyBranchMarker() {}", 1))[0]?.name,
-      ).toBe("mainOnlyBranchMarker");
+        (await worktreeIndexer.findSimilar("ranked branch retrieval probe", 1))[0]?.name,
+      ).toBe(foreignCandidates[0]?.metadata.name);
     } finally {
       await Promise.all([mainIndexer.close(), worktreeIndexer.close()]);
       fetchSpy.mockRestore();


### PR DESCRIPTION
Hi again! We have covered a lot of ground together in this repository over the past couple of weeks: multiprocess index locking (#149), parser and call-graph coverage (#150–#155), worktree isolation (#156), canonical paths (#178), watcher resilience (#179), and battery-aware indexing (#187). Thank you again for the careful reviews and for integrating so much of that work.

This PR revisits a tradeoff from my own #156. Keeping project indexes local to each worktree fixed stale absolute paths and cross-worktree mutations, but after continuing to use the plugin heavily across parallel worktrees, the cost became clear: every checkout rebuilds and re-embeds almost identical code. With local embedding providers, that means repeated GPU time, energy use, and waiting.

The later canonical-path work in #178 also helped clarify a better boundary: keep branch and catalog state isolated, while making project-owned persisted paths portable and sharing the underlying project index when a worktree intentionally inherits its configuration.

This PR makes project-scoped indexes portable and reusable across those worktrees:

- stores project-owned chunk and file-hash paths relative to the project root
- resolves stored paths back to the active checkout at public read boundaries
- lets worktrees that inherit project configuration share the main checkout's index
- keeps an explicit worktree-local config as an isolation boundary
- namespaces hash and failed-batch state by branch, including long-lived Indexer branch switches
- preserves branch ownership during health checks so one checkout cannot collect another branch's data
- keeps global and external knowledge-base paths canonical and absolute
- bumps the native schema gate and path-storage metadata so legacy project indexes rebuild safely

This is not intended to remove worktree isolation entirely. A worktree-local project config still creates an explicit local index boundary. The practical change is that worktrees which already choose to inherit configuration can now reuse unchanged content and embeddings instead of repeatedly spending GPU resources on identical source.

Compatibility is intentionally scoped: legacy project indexes with absolute paths require a one-time force rebuild, while existing global indexes remain readable because their absolute-path contract is unchanged.

Validation completed:

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `cargo fmt --manifest-path native/Cargo.toml --check`
- `cargo clippy --manifest-path native/Cargo.toml --all-targets --all-features -- -D warnings`
- full Vitest suite: 65 files / 1,245 tests
- post-rebase targeted suite, including canonical paths and the extracted embedding helpers: 9 files / 171 tests
- `git diff --check`

Thanks for taking another look! I am very happy to adjust the sharing boundary or migration wording if you would prefer a different shape.