### PR TITLE
docs: refresh final architecture boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,6 +134,13 @@ The central orchestrator. Responsibilities:
 - Handles rate limiting and retries
 - Tracks per-file hashes for delta detection
 
+Focused helpers keep ranking and batch mechanics out of the orchestrator:
+
+- `search-ranking.ts` handles generic fusion, filtering, diversity, and result assembly.
+- `definition-ranking.ts` handles definition-query normalization and evidence ranking.
+- `embedding-batches.ts` handles pending embedding batches, retry state, and vector pooling.
+- `call-graph-constants.ts` owns the shared declaration chunk-type allowlist.
+
 Key public methods include:
 
 | Method | Purpose |
@@ -168,6 +175,20 @@ Rust components exposed via NAPI:
 | Database | rusqlite | Persistent storage with batch ops |
 | InvertedIndex | Custom | BM25 keyword search |
 | Hasher | xxhash-rust | Fast content hashing |
+
+The crate root in `native/src/lib.rs` remains the NAPI assembly facade. The Database NAPI class lives in `native/src/bindings/database.rs`. SQLite call-graph rows and queries live in `native/src/db/call_graph.rs`, while the remaining schema, migrations, chunk, embedding, and branch persistence stay in `native/src/db.rs`.
+
+### Tool Runtime (`src/tools/`)
+
+Tool adapters keep their existing public facades while delegating cohesive mechanics:
+
+- `context.ts` owns path/direct-edge routing and effectiveness reporting; `context-search.ts` owns definition/conceptual recovery.
+- `utils.ts` owns general response formatting; `context-pack.ts` owns token budgeting, evidence selection, and packing.
+- `operations.ts` owns repository operations; `operation-runtime.ts` owns Indexer caches, initialization, retrieval readiness, and best-effort metrics plumbing.
+
+### Git Branch Materialization (`src/git/`)
+
+`branch-resolution.ts` validates and resolves local, remote, and pull-request refs through temporary fetch refs. `branch-materialization.ts` owns temporary worktree registration, callback execution, rollback, and cleanup.
 
 ### Watcher (`src/watcher/index.ts`)
 
@@ -368,7 +389,11 @@ No credentials are stored by the plugin.
 
 ### Adding a New Storage Backend
 
-1. Implement storage interface (see `native/src/db.rs`)
-2. Expose via NAPI in `native/src/lib.rs`
-3. Update `src/native/index.ts` wrapper
+1. Implement persistence in `native/src/db.rs` or a focused `native/src/db/` submodule
+2. Expose Database methods in `native/src/bindings/database.rs` and re-export through `native/src/lib.rs`
+3. Update the focused wrapper under `src/native/` and preserve `src/native/index.ts` as the facade
 4. Update `src/indexer/index.ts` to use new backend
+
+### Structural Boundaries
+
+Large files are not split solely by line count. `src/utils/auto-index.ts` remains one state machine because lease, retry, and publication transitions must be reviewed together. `native/src/parser.rs` and `native/src/call_extractor.rs` keep language policy beside their extensive grammar tests. `native/src/community.rs` remains a cohesive graph-algorithm module, and `native/src/store.rs` remains the vector persistence boundary because its format and publication invariants are tightly coupled.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,15 +131,19 @@ If you're contributing parser or call-graph support for a new language, use [`do
 
 ```
 src/                  # TypeScript source
-  ├── indexer/        # Core indexing logic
+  ├── indexer/        # Index orchestration, ranking, batching, locks, and impact analysis
   ├── embeddings/     # Embedding providers
-  ├── tools/          # OpenCode tool definitions
-  ├── native/         # Rust module wrapper
+  ├── tools/          # Tool contracts, operations, context routing, and formatting
+  ├── git/            # Branch detection, ref resolution, and temporary materialization
+  ├── native/         # Focused TypeScript wrappers around Rust bindings
   └── config/         # Configuration schema
 
 native/src/           # Rust native module
-  ├── parser.rs       # Tree-sitter parsing
-  ├── store.rs        # Vector storage
+  ├── bindings/       # NAPI class facades
+  ├── db/             # Focused SQLite persistence domains
+  ├── parser.rs       # Tree-sitter parsing and parser policy
+  ├── call_extractor.rs # Language-aware call extraction
+  ├── store.rs        # Vector storage and publication
   └── inverted_index.rs # BM25 search
 
 tests/                # Unit tests

--- a/docs/adding-language-support.md
+++ b/docs/adding-language-support.md
@@ -63,7 +63,7 @@ If you are unsure, aim for **semantic parsing first**. It is much easier to land
 - a `native/queries/<language>-calls.scm` file exists
 - `native/src/call_extractor.rs` routes the language correctly
 - `src/indexer/index.ts` includes the language in `CALL_GRAPH_LANGUAGES`
-- `src/indexer/index.ts` includes the relevant declaration chunk types in `CALL_GRAPH_SYMBOL_CHUNK_TYPES`
+- `src/indexer/call-graph-constants.ts` includes the relevant declaration chunk types in `CALL_GRAPH_SYMBOL_CHUNK_TYPES`
 - `tests/call-graph.test.ts` covers the supported call/query forms
 - full verification passes again
 
@@ -80,7 +80,8 @@ If you are unsure, aim for **semantic parsing first**. It is much easier to land
 
 - `native/src/call_extractor.rs` — call extraction routing
 - `native/queries/<language>-calls.scm` — tree-sitter query file
-- `src/indexer/index.ts` — call-graph language + symbol chunk-type allowlists
+- `src/indexer/index.ts` — call-graph language allowlist and indexing integration
+- `src/indexer/call-graph-constants.ts` — shared symbol chunk-type allowlist
 - `tests/call-graph.test.ts` — call-graph coverage
 
 ### Only when adding a grammar dependency
@@ -120,7 +121,8 @@ Use this exact sequence:
 - [ ] Run `npm run build` and `npm run test:run`
 - [ ] If call graph is needed, add `native/queries/<language>-calls.scm`
 - [ ] Wire the language into `native/src/call_extractor.rs`
-- [ ] Add the language and chunk types to `src/indexer/index.ts`
+- [ ] Add the language to `CALL_GRAPH_LANGUAGES` in `src/indexer/index.ts`
+- [ ] Add its declaration chunk types to `src/indexer/call-graph-constants.ts`
 - [ ] Add call-graph tests in `tests/call-graph.test.ts`
 - [ ] Update `README.md` if supported-language claims changed
 - [ ] Verify the third-party notice with `npm pack --dry-run --ignore-scripts`
@@ -210,7 +212,7 @@ Add the language to:
 
 Add the language to `CALL_GRAPH_LANGUAGES` and add relevant declaration chunk types to `CALL_GRAPH_SYMBOL_CHUNK_TYPES`.
 
-Those chunk-type strings must match the tree-sitter node kinds that actually become chunks in `native/src/parser.rs`.
+Those chunk-type strings in `src/indexer/call-graph-constants.ts` must match the tree-sitter node kinds that actually become chunks in `native/src/parser.rs`.
 
 ### `tests/call-graph.test.ts`
 
@@ -244,7 +246,7 @@ Also check that the query capture names match what `native/src/call_extractor.rs
 
 ### Call extraction works, but `call_graph` is still empty
 
-The language is missing from `CALL_GRAPH_LANGUAGES` or its symbol chunk types are missing from `CALL_GRAPH_SYMBOL_CHUNK_TYPES` in `src/indexer/index.ts`.
+The language is missing from `CALL_GRAPH_LANGUAGES` in `src/indexer/index.ts`, or its symbol chunk types are missing from `CALL_GRAPH_SYMBOL_CHUNK_TYPES` in `src/indexer/call-graph-constants.ts`.
 
 ## Verification
 
@@ -266,7 +268,7 @@ npm run test:run
 
 ## Practical note for PHP
 
-PHP is already integrated at all three levels: file discovery, semantic parsing, and call graph extraction. Changes must therefore preserve `native/src/types.rs`, `native/src/parser.rs`, `native/queries/php-calls.scm`, `src/indexer/index.ts`, and their tests together.
+PHP is already integrated at all three levels: file discovery, semantic parsing, and call graph extraction. Changes must therefore preserve `native/src/types.rs`, `native/src/parser.rs`, `native/queries/php-calls.scm`, `src/indexer/index.ts`, `src/indexer/call-graph-constants.ts`, and their tests together.
 
 A `parseFile()` content assertion alone does not prove syntax compatibility because Tree-sitter can return chunks while the tree still contains `ERROR` nodes. PHP grammar tests must also assert `!tree.root_node().has_error()` in Rust, then verify the chunk names and types exposed through NAPI.
 


### PR DESCRIPTION
## Summary
- document the focused Indexer, native persistence, tool runtime, and Git materialization boundaries introduced by the completed restructure
- update contributor and language-support paths to match the current source tree
- record the deliberate structural stopping points for cohesive state-machine, parser, graph, and storage modules

## Validation
- Markdown links, anchors, and balanced fences across 30 files
- `git diff --check`
- `npm run build:native`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (67 files, 1,244 tests)
- `cargo fmt --manifest-path native/Cargo.toml -- --check`
- `cargo test --manifest-path native/Cargo.toml --lib` (114 tests)
- ESM and CJS import smoke checks
