### PR TITLE
chore: prepare v0.20.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.20.0"
+      "version": "0.20.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-07-29
+
+### Changed
+
+- **Maintainable internal boundaries**: Split the TypeScript native facade, search and definition ranking, embedding batches, tool adapters and runtime, context packing and recovery, Git branch resolution, native Database bindings, and SQLite call-graph persistence into focused modules while preserving existing public APIs and behavior.
+- **Focused documentation**: Reorganized the README into a concise entry point with dedicated installation, configuration, and tool-reference guides, and refreshed architecture, contribution, troubleshooting, and language-support documentation to match the current source tree.
+
+### Fixed
+
+- **Stable filesystem path identities** (#178): Canonicalize physical, symlinked, missing-descendant, case-insensitive, and Unicode-equivalent paths before comparing project ownership and index state, preventing duplicate identities and incomplete cleanup across equivalent checkout paths. Added cross-platform path-semantics CI coverage and bundled the pinned Unicode case-folding dependency with its license notice.
+- **Watcher file-descriptor exhaustion** (#179): Fall back once from native file watching to polling after `EMFILE`, while preserving readiness, pending changes, restart behavior, asynchronous shutdown, and the native-watcher default.
+
 ## [0.20.0] - 2026-07-28
 
 ### Added
@@ -535,7 +547,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.1...HEAD
+[0.20.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.0...v0.20.1
+[0.20.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...v0.18.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -12,8 +12,9 @@ describe("Claude Code plugin", () => {
       mcpServers?: Record<string, { command: string; args: string[] }>;
     };
 
+    const packageManifest = JSON.parse(fs.readFileSync("package.json", "utf-8")) as { version: string };
     expect(pluginManifest.name).toBe("codebase-index");
-    expect(pluginManifest.version).toBe("0.20.0");
+    expect(pluginManifest.version).toBe(packageManifest.version);
     expect(pluginManifest.hooks).toBeUndefined();
     expect(pluginManifest.skills).toBe("./skills/");
 
@@ -38,11 +39,12 @@ describe("Claude Code plugin", () => {
       plugins: Array<{ name: string; source: string; version: string }>;
     };
 
+    const packageManifest = JSON.parse(fs.readFileSync("package.json", "utf-8")) as { version: string };
     expect(marketplace.name).toBe("helweg-plugins");
     expect(marketplace.owner.name).toBeTruthy();
     expect(marketplace.plugins).toContainEqual(expect.objectContaining({
       name: "codebase-index",
-      version: "0.20.0",
+      version: packageManifest.version,
     }));
   });
 });


### PR DESCRIPTION
## Summary

- publish the reconciled `v0.20.1` changelog for everything merged since `v0.20.0`
- bump npm, Claude plugin, Claude marketplace, and Codex plugin manifests to `0.20.1`
- keep Claude plugin version assertions synchronized with `package.json`

PR #202 is intentionally excluded because it is not merged into `main`.

## Validation

- `npm run build:native`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (67 files, 1,244 tests)
- `cargo fmt --manifest-path native/Cargo.toml -- --check`
- `cargo test --manifest-path native/Cargo.toml --lib`
- `npm pack --dry-run --ignore-scripts`

## Release Labels

- `skip-changelog` because this PR contains only release metadata for changes already represented in the release notes