### PR TITLE
refactor: require explicit host runtime context

### DIFF
--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -16,7 +16,7 @@ function getServerInstructions(host: string): string {
 export function createMcpServer(
   projectRoot: string,
   config: ParsedCodebaseIndexConfig,
-  host: HostMode = "opencode",
+  host: HostMode,
 ): McpServer {
   const server = new McpServer({
     name: "opencode-codebase-index",

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -98,7 +98,7 @@ interface ChatTransformOutput {
 const plugin: Plugin = async ({ directory, worktree }) => {
   try {
     const projectRoot = resolveProjectRoot(directory, worktree);
-    const rawConfig = loadMergedConfig(projectRoot);
+    const rawConfig = loadMergedConfig(projectRoot, "opencode");
     const config = parseConfig(rawConfig);
 
     initializeTools(projectRoot, config);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,8 +90,8 @@ function parseVisualizeArgs(argv: string[], cwd: string): VisualizeArgs {
 async function handleVisualizeCommand(argv: string[], cwd: string): Promise<number> {
   try {
     const args = parseVisualizeArgs(argv, cwd);
-    const config = parseConfig(loadMergedConfig(args.project));
-    const indexer = new Indexer(args.project, config);
+    const config = parseConfig(loadMergedConfig(args.project, "opencode"));
+    const indexer = new Indexer(args.project, config, "opencode");
     const rawData = await indexer.getVisualizationData({
       directory: args.directory,
     });

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -116,7 +116,7 @@ export function loadConfigFile(filePath: string): unknown {
   return loadJsonFile(filePath);
 }
 
-export function loadProjectConfigLayer(projectRoot: string, host: HostMode = "opencode"): Record<string, unknown> {
+export function loadProjectConfigLayer(projectRoot: string, host: HostMode): Record<string, unknown> {
   const projectConfigPath = resolveProjectConfigPath(projectRoot, host);
   const projectConfig = loadJsonFile(projectConfigPath) as Record<string, unknown> | null;
 
@@ -148,7 +148,7 @@ export function loadProjectConfigLayer(projectRoot: string, host: HostMode = "op
  * - For additionalInclude: merge arrays (union, deduplicated)
  * - For include/exclude: project overrides global if set, otherwise load global
  */
-export function loadMergedConfig(projectRoot: string, host: HostMode = "opencode"): unknown {
+export function loadMergedConfig(projectRoot: string, host: HostMode): unknown {
   const globalConfigPath = resolveGlobalConfigPath(host);
   const projectConfigPath = resolveProjectConfigPath(projectRoot, host);
   let globalConfig: Record<string, unknown> | null = null;

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -64,7 +64,7 @@ function hasHostGlobalConfig(host: HostMode): boolean {
   return existsSync(getGlobalConfigPath(host));
 }
 
-export function getGlobalIndexPath(host: HostMode = "opencode"): string {
+export function getGlobalIndexPath(host: HostMode): string {
   switch (host) {
     case "opencode":
       return path.join(os.homedir(), ".opencode", "global-index");
@@ -76,7 +76,7 @@ export function getGlobalIndexPath(host: HostMode = "opencode"): string {
   }
 }
 
-export function getGlobalConfigPath(host: HostMode = "opencode"): string {
+export function getGlobalConfigPath(host: HostMode): string {
   switch (host) {
     case "opencode":
       return path.join(os.homedir(), ".config", "opencode", "codebase-index.json");
@@ -88,7 +88,7 @@ export function getGlobalConfigPath(host: HostMode = "opencode"): string {
   }
 }
 
-export function resolveGlobalConfigPath(host: HostMode = "opencode"): string {
+export function resolveGlobalConfigPath(host: HostMode): string {
   const hostConfigPath = getGlobalConfigPath(host);
   if (existsSync(hostConfigPath)) {
     return hostConfigPath;
@@ -104,7 +104,7 @@ export function resolveGlobalConfigPath(host: HostMode = "opencode"): string {
   return hostConfigPath;
 }
 
-export function resolveGlobalIndexPath(host: HostMode = "opencode"): string {
+export function resolveGlobalIndexPath(host: HostMode): string {
   const hostIndexPath = getGlobalIndexPath(host);
   if (existsSync(hostIndexPath)) {
     return hostIndexPath;
@@ -124,7 +124,7 @@ export function resolveGlobalIndexPath(host: HostMode = "opencode"): string {
   return hostIndexPath;
 }
 
-export function resolveProjectConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
+export function resolveProjectConfigPath(projectRoot: string, host: HostMode): string {
   const hostConfigPath = path.join(projectRoot, getProjectConfigRelativePath(host));
   if (existsSync(hostConfigPath)) {
     return hostConfigPath;
@@ -152,14 +152,14 @@ export function resolveProjectConfigPath(projectRoot: string, host: HostMode = "
   return hostConfigPath;
 }
 
-export function resolveWritableProjectConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
+export function resolveWritableProjectConfigPath(projectRoot: string, host: HostMode): string {
   return path.join(projectRoot, getProjectConfigRelativePath(host));
 }
 
 export function resolveProjectIndexPath(
   projectRoot: string,
   scope: "project" | "global",
-  host: HostMode = "opencode",
+  host: HostMode,
 ): string {
   if (scope === "global") {
     return resolveGlobalIndexPath(host);

--- a/src/eval/runner-config.ts
+++ b/src/eval/runner-config.ts
@@ -108,7 +108,7 @@ function loadRawConfig(projectRoot: string, configPath?: string): unknown {
     );
   }
 
-  const projectConfig = resolveProjectConfigPath(projectRoot);
+  const projectConfig = resolveProjectConfigPath(projectRoot, "opencode");
   if (existsSync(projectConfig)) {
     return normalizeEvalConfigKnowledgeBases(
       parseJsonConfigFile(projectConfig),
@@ -127,8 +127,8 @@ function loadRawConfig(projectRoot: string, configPath?: string): unknown {
 
 function getIndexRootPath(projectRoot: string, scope: "project" | "global"): string {
   return scope === "global"
-    ? getGlobalIndexPath()
-    : resolveProjectIndexPath(projectRoot, scope);
+    ? getGlobalIndexPath("opencode")
+    : resolveProjectIndexPath(projectRoot, scope, "opencode");
 }
 
 function getLocalProjectIndexRoot(projectRoot: string): string {
@@ -152,7 +152,7 @@ export function ensureLocalEvalProjectConfig(projectRoot: string, configPath?: s
   const localConfigPath = getLocalProjectConfigPath(projectRoot);
   const resolvedConfigPath = configPath
     ? toAbsolute(projectRoot, configPath)
-    : resolveProjectConfigPath(projectRoot);
+    : resolveProjectConfigPath(projectRoot, "opencode");
 
   if (!configPath && existsSync(localConfigPath)) {
     return localConfigPath;

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -90,7 +90,7 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
     clearIndexRoot(options.projectRoot, effectiveConfig.scope);
   }
 
-  const indexer = new Indexer(options.projectRoot, effectiveConfig);
+  const indexer = new Indexer(options.projectRoot, effectiveConfig, "opencode");
 
   try {
     await indexer.index();

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1002,7 +1002,7 @@ export class Indexer {
   constructor(
     projectRoot: string,
     config: ParsedCodebaseIndexConfig,
-    host: HostMode = "opencode",
+    host: HostMode,
     runtimeOptions: IndexerRuntimeOptions = {},
   ) {
     this.projectRoot = projectRoot;

--- a/src/tools/config-state.ts
+++ b/src/tools/config-state.ts
@@ -29,19 +29,19 @@ function toConfigRecord(rawConfig: unknown): Record<string, unknown> {
   return { ...(rawConfig as Record<string, unknown>) };
 }
 
-export function getConfigPath(projectRoot: string, host: HostMode = "opencode"): string {
+export function getConfigPath(projectRoot: string, host: HostMode): string {
   return resolveWritableProjectConfigPath(projectRoot, host);
 }
 
-export function loadRuntimeConfig(projectRoot: string, host: HostMode = "opencode"): Record<string, unknown> {
+export function loadRuntimeConfig(projectRoot: string, host: HostMode): Record<string, unknown> {
   return normalizeKnowledgeBasePaths(toConfigRecord(loadMergedConfig(projectRoot, host)), projectRoot);
 }
 
-export function loadEditableConfig(projectRoot: string, host: HostMode = "opencode"): Record<string, unknown> {
+export function loadEditableConfig(projectRoot: string, host: HostMode): Record<string, unknown> {
   return normalizeKnowledgeBasePaths(toConfigRecord(loadProjectConfigLayer(projectRoot, host)), projectRoot);
 }
 
-export function saveConfig(projectRoot: string, config: Record<string, unknown>, host: HostMode = "opencode"): void {
+export function saveConfig(projectRoot: string, config: Record<string, unknown>, host: HostMode): void {
   const configPath = getConfigPath(projectRoot, host);
   const configDir = path.dirname(configPath);
   const configBaseDir = path.dirname(configDir);

--- a/src/tools/operation-runtime.ts
+++ b/src/tools/operation-runtime.ts
@@ -113,7 +113,7 @@ export function getOrCreateIndexer(projectRoot: string, host: HostMode): Indexer
   return indexer;
 }
 
-export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode = "opencode"): void {
+export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode): void {
   defaultProjectRoots.set(host, projectRoot);
   const key = getIndexerCacheKey(projectRoot, host);
   configCache.set(key, config);
@@ -121,11 +121,11 @@ export function initializeTools(projectRoot: string, config: ParsedCodebaseIndex
   configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host));
 }
 
-export function getSharedIndexer(host: HostMode = "opencode"): Indexer {
+export function getSharedIndexer(host: HostMode): Indexer {
   return getIndexerForProject(undefined, host);
 }
 
-export function getIndexerForProject(projectRoot: string | undefined, host: HostMode = "opencode"): Indexer {
+export function getIndexerForProject(projectRoot: string | undefined, host: HostMode): Indexer {
   const root = getProjectRoot(projectRoot, host);
   return getOrCreateIndexer(root, host);
 }
@@ -141,7 +141,7 @@ export function recordToolEffectiveness(
 
 export function refreshIndexerForDirectory(
   projectRoot: string,
-  host: HostMode = "opencode",
+  host: HostMode,
   config: ParsedCodebaseIndexConfig = parseConfig(loadRuntimeConfig(projectRoot, host)),
 ): ParsedCodebaseIndexConfig {
   const key = getIndexerCacheKey(projectRoot, host);

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -703,7 +703,7 @@ export function configureAutoIndex(
 
 export function startAutoIndex(
   projectRoot: string,
-  host: HostMode = "opencode",
+  host: HostMode,
   source: "startup" | "retrieval" = "startup",
 ): Promise<CoordinatedIndexResult> | null {
   return getCoordinator(projectRoot, host)?.start(source) ?? null;
@@ -711,7 +711,7 @@ export function startAutoIndex(
 
 export function requestBackgroundIndex(
   projectRoot: string,
-  host: HostMode = "opencode",
+  host: HostMode,
 ): Promise<CoordinatedIndexResult> | null {
   return getCoordinator(projectRoot, host)?.request({
     checkFreshness: false,
@@ -736,7 +736,7 @@ export function runCoordinatedIndex(
 
 export function getAutoIndexStatus(
   projectRoot: string,
-  host: HostMode = "opencode",
+  host: HostMode,
 ): AutoIndexStatusSnapshot {
   return getCoordinator(projectRoot, host)?.snapshot() ?? {
     enabled: false,
@@ -747,7 +747,7 @@ export function getAutoIndexStatus(
 
 export async function waitForAutoIndexForRetrieval(
   projectRoot: string,
-  host: HostMode = "opencode",
+  host: HostMode,
 ): Promise<AutoIndexRetrievalResult> {
   const coordinator = getCoordinator(projectRoot, host);
   if (!coordinator) return { ready: true };
@@ -804,7 +804,7 @@ export async function waitForAutoIndexForRetrieval(
 
 export async function stopAutoIndex(
   projectRoot: string,
-  host: HostMode = "opencode",
+  host: HostMode,
 ): Promise<void> {
   await getCoordinator(projectRoot, host)?.stop();
 }

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -35,7 +35,7 @@ export class FileWatcher {
   private pollingFallbackAttempted = false;
   private pendingClose: Promise<void> | null = null;
 
-  constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode = "opencode", options: FileWatcherOptions = {}) {
+  constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
     this.config = config;
     this.host = host;

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -31,7 +31,7 @@ export function createWatcherWithIndexer(
   getIndexer: () => Indexer,
   projectRoot: string,
   config: CodebaseIndexConfig,
-  host: HostMode = "opencode",
+  host: HostMode,
   options: WatcherOptions = {},
 ): CombinedWatcher {
   const fileWatcher = new FileWatcher(projectRoot, config, host, options);

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -114,7 +114,7 @@ function changed(): number {
       indexing: { watchFiles: false, autoGc: false },
       knowledgeBases: ["linked-knowledge-base"],
     });
-    indexer = new Indexer(repo, config);
+    indexer = new Indexer(repo, config, "opencode");
     await indexer.index();
   });
 
@@ -192,7 +192,7 @@ function changed(): number {
     const directDatabase = new Database(path.join(status.indexPath, "codebase.db"));
     directDatabase.setMetadata(symbolExtractorMetadataKey("feature"), "stale");
     directDatabase.close();
-    indexer = new Indexer(repo, config);
+    indexer = new Indexer(repo, config, "opencode");
     const fetchesBeforeMigration = fetchSpy.mock.calls.length;
 
     const migrated = await indexer.getPrImpact({ branch: "feature" });
@@ -261,7 +261,7 @@ function advancedChange(): number {
     directDatabase.deleteMetadata(branchCommitMetadataKey("feature"));
     directDatabase.close();
 
-    indexer = new Indexer(repo, config);
+    indexer = new Indexer(repo, config, "opencode");
     const rebuilt = await indexer.getPrImpact({ branch: "feature" });
     expect(rebuilt.indexPreparation).toMatchObject({
       prepared: true,

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -362,7 +362,7 @@ class ReportBuilder {
           },
           indexing: { watchFiles: false },
         });
-        const indexer = new Indexer(projectDir, config);
+        const indexer = new Indexer(projectDir, config, "opencode");
 
         try {
           await indexer.index();
@@ -435,7 +435,7 @@ function buildReport(): string {
         });
 
         CASE_INSENSITIVE_LANGUAGES.delete("php");
-        let indexer = new Indexer(projectDir, config);
+        let indexer = new Indexer(projectDir, config, "opencode");
         try {
           await indexer.index();
           const caller = (await indexer.getSymbolsForBranch()).find(
@@ -455,7 +455,7 @@ function buildReport(): string {
         database.close();
         const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
 
-        indexer = new Indexer(projectDir, config);
+        indexer = new Indexer(projectDir, config, "opencode");
         try {
           await indexer.index();
           const symbols = await indexer.getSymbolsForBranch();
@@ -509,7 +509,7 @@ function caller(): string { return namespace\\helper(); }
         });
 
         CALL_GRAPH_LANGUAGES.delete("php");
-        let indexer = new Indexer(projectDir, config);
+        let indexer = new Indexer(projectDir, config, "opencode");
         try {
           await indexer.index();
           const caller = (await indexer.getSymbolsForBranch()).find(
@@ -526,7 +526,7 @@ function caller(): string { return namespace\\helper(); }
         database.setMetadata("index.callGraphResolutionVersion", "3");
         database.close();
         const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
-        indexer = new Indexer(projectDir, config);
+        indexer = new Indexer(projectDir, config, "opencode");
         try {
           await indexer.index();
           const caller = (await indexer.getSymbolsForBranch()).find(
@@ -1258,7 +1258,7 @@ const math = @import("math.zig");
         },
         indexing: { watchFiles: false },
       });
-      const indexer = new Indexer(tempDir, config);
+      const indexer = new Indexer(tempDir, config, "opencode");
 
       try {
         await indexer.index();
@@ -1356,7 +1356,7 @@ const math = @import("math.zig");
       });
 
       CALL_GRAPH_LANGUAGES.delete("c");
-      let indexer = new Indexer(tempDir, config);
+      let indexer = new Indexer(tempDir, config, "opencode");
       try {
         await indexer.index();
         const caller = (await indexer.getSymbolsForBranch()).find(
@@ -1374,7 +1374,7 @@ const math = @import("math.zig");
       database.close();
       const embeddingCallsBeforeUpgrade = fetchSpy.mock.calls.length;
 
-      indexer = new Indexer(tempDir, config);
+      indexer = new Indexer(tempDir, config, "opencode");
       try {
         await indexer.index();
         const symbols = await indexer.getSymbolsForBranch();
@@ -1674,7 +1674,7 @@ struct Runner {
           retryDelayMs: 1,
         },
       });
-      const indexer = new Indexer(tempDir, config);
+      const indexer = new Indexer(tempDir, config, "opencode");
 
       try {
         await indexer.index();
@@ -1893,7 +1893,7 @@ kernel void long_kernel(const device float* input [[buffer(0)]],
         },
         indexing: { watchFiles: false },
       });
-      const indexer = new Indexer(tempDir, config);
+      const indexer = new Indexer(tempDir, config, "opencode");
 
       try {
         const stats = await indexer.index();
@@ -3237,7 +3237,7 @@ main() {
       });
 
       const callPath = async (fromSymbolId: string, toSymbolId: string, maxDepth = 10) => {
-        const indexer = new Indexer(tempDir, createIndexerConfig());
+        const indexer = new Indexer(tempDir, createIndexerConfig(), "opencode");
         try {
           return await indexer.findCallPathBySymbolIds(fromSymbolId, toSymbolId, maxDepth);
         } finally {

--- a/tests/custom-provider.test.ts
+++ b/tests/custom-provider.test.ts
@@ -622,7 +622,7 @@ describe("Indexer custom provider initialization", () => {
     // parseConfig() would normally reject this, but initialize() has its own guard for safety.
     const baseConfig = parseConfig({ embeddingProvider: "openai" });
     const config = { ...baseConfig, embeddingProvider: "custom" as const, customProvider: undefined };
-    const indexer = new Indexer(tempDir, config);
+    const indexer = new Indexer(tempDir, config, "opencode");
     await expect(indexer.initialize()).rejects.toThrow(
       "embeddingProvider is 'custom' but customProvider config is missing"
     );

--- a/tests/fixtures/multiprocess-index-worker.ts
+++ b/tests/fixtures/multiprocess-index-worker.ts
@@ -47,7 +47,7 @@ const config = parseConfig({
   debug: { enabled: false },
 });
 
-const indexer = new Indexer(projectRoot, config);
+const indexer = new Indexer(projectRoot, config, "opencode");
 let watcher: CombinedWatcher | null = null;
 let running = false;
 

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -115,7 +115,7 @@ describe("indexer clearIndex force rebuild", () => {
       },
     });
 
-    return trackIndexer(new Indexer(projectRoot, config));
+    return trackIndexer(new Indexer(projectRoot, config, "opencode"));
   }
 
   it("clears persisted embeddings before a force rebuild with new dimensions", async () => {
@@ -329,7 +329,7 @@ describe("indexer clearIndex force rebuild", () => {
     const mainDb = trackDb(new Database(path.join(mainRepoDir, ".opencode", "index", "codebase.db")));
     const mainStatsBefore = mainDb.getStats();
 
-    const worktreeIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir))));
+    const worktreeIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode"));
     await expect(worktreeIndexer.clearIndex()).resolves.toBeUndefined();
 
     expect(mainDb.getStats()).toEqual(mainStatsBefore);
@@ -375,7 +375,7 @@ describe("indexer clearIndex force rebuild", () => {
       operation: "index", token: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
     }));
 
-    const worktreeIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir))));
+    const worktreeIndexer = trackIndexer(new Indexer(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode"));
     await expect(worktreeIndexer.index()).resolves.toMatchObject({ failedChunks: 0 });
     expect(fs.existsSync(path.join(worktreeDir, ".opencode", "index", "codebase.db"))).toBe(true);
     expect(fs.existsSync(lockPath)).toBe(true);
@@ -823,7 +823,7 @@ describe("indexer clearIndex force rebuild", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    })));
+    }), "opencode"));
 
     await createKbIndexer(projectA).index();
     await createKbIndexer(projectB).index();
@@ -914,7 +914,7 @@ describe("indexer clearIndex force rebuild", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    })));
+    }), "opencode"));
 
     await createKbIndexer(projectA).index();
     await createKbIndexer(projectB).index();
@@ -1138,7 +1138,7 @@ describe("indexer clearIndex force rebuild", () => {
         autoGc: true,
         gcOrphanThreshold: 0,
       },
-    })));
+    }), "opencode"));
 
     const initialStats = await indexer.index();
     expect(initialStats.indexedChunks).toBeGreaterThan(0);
@@ -1217,7 +1217,7 @@ describe("indexer clearIndex force rebuild", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    })));
+    }), "opencode"));
 
     await createKbIndexer(projectA).index();
     await createKbIndexer(projectB).index();
@@ -1532,7 +1532,7 @@ describe("indexer clearIndex force rebuild", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    })));
+    }), "opencode"));
 
     await createKbIndexer(projectA).index();
     await createKbIndexer(projectB).index();
@@ -1675,7 +1675,7 @@ describe("indexer clearIndex force rebuild", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    })));
+    }), "opencode"));
 
     await createKbIndexer(projectA).index();
     await createKbIndexer(projectB).index();
@@ -1741,7 +1741,7 @@ describe("indexer clearIndex force rebuild", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    })));
+    }), "opencode"));
 
     await createKbIndexer(projectA).index();
     await createKbIndexer(projectB).index();

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -126,7 +126,7 @@ describe("indexer failed batch recovery", () => {
       },
     });
 
-    return _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    return _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
   }
 
   function createLimitedBatchIndexer(maxBatchSize: number): Indexer {
@@ -145,7 +145,7 @@ describe("indexer failed batch recovery", () => {
       },
     });
 
-    return _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    return _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
   }
 
   function createOllamaIndexer(): Indexer {
@@ -159,7 +159,7 @@ describe("indexer failed batch recovery", () => {
       },
     });
 
-    return _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    return _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
   }
 
   it("retries saved failed batches on a later successful rerun without force", async () => {
@@ -1190,7 +1190,7 @@ describe("indexer failed batch recovery", () => {
         retries: 0,
         retryDelayMs: 1,
       },
-    }))) - 1];
+    }), "opencode")) - 1];
 
     const stats = await indexer.index();
     expect(stats.failedChunks).toBe(0);
@@ -1276,7 +1276,7 @@ describe("indexer failed batch recovery", () => {
         retries: 3,
         retryDelayMs: 1,
       },
-    }))) - 1];
+    }), "opencode")) - 1];
 
     await retryingIndexer.initialize();
     const retry = await retryingIndexer.retryFailedBatches();
@@ -1358,7 +1358,7 @@ describe("indexer failed batch recovery", () => {
           retries: 0,
           retryDelayMs: 1,
         },
-      }));
+      }), "opencode");
       _indexers.push(idx);
       return idx;
     };

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -323,7 +323,7 @@ vi.mock("../src/indexer/index.js", () => {
 describe("createMcpServer", () => {
   it("should create a server instance", () => {
     const config = parseConfig({ effectivenessMetrics: { enabled: true } });
-    const server = createMcpServer("/tmp/test-project", config);
+    const server = createMcpServer("/tmp/test-project", config, "opencode");
 
     expect(server).toBeDefined();
     expect(server).toHaveProperty("connect");
@@ -331,7 +331,7 @@ describe("createMcpServer", () => {
 
   it("should have the correct server name", () => {
     const config = parseConfig({});
-    const server = createMcpServer("/tmp/test-project", config);
+    const server = createMcpServer("/tmp/test-project", config, "opencode");
 
     expect(server).toBeDefined();
   });
@@ -386,7 +386,7 @@ describe("MCP server tools and prompts", () => {
     };
 
     const config = parseConfig({ effectivenessMetrics: { enabled: true } });
-    server = createMcpServer("/tmp/test-project", config);
+    server = createMcpServer("/tmp/test-project", config, "opencode");
     client = new Client({ name: "test-client", version: "1.0.0" });
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -605,6 +605,7 @@ describe("MCP server tools and prompts", () => {
     const disabledServer = createMcpServer(
       `/tmp/effectiveness-disabled-host-${process.pid}`,
       parseConfig(undefined),
+      "opencode",
     );
     const disabledClient = new Client({ name: "disabled-test-client", version: "1.0.0" });
     const [disabledClientTransport, disabledServerTransport] = InMemoryTransport.createLinkedPair();
@@ -941,7 +942,7 @@ describe("MCP server tools and prompts", () => {
         pauseBackgroundIndexingOnBattery: true,
       },
     });
-    server = createMcpServer("/tmp/test-project", config);
+    server = createMcpServer("/tmp/test-project", config, "opencode");
     client = new Client({ name: "test-client", version: "1.0.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([
@@ -1078,7 +1079,7 @@ describe("MCP server tools and prompts", () => {
       },
       scope: "project",
     });
-    server = createMcpServer("/tmp/test-project", runtimeConfig);
+    server = createMcpServer("/tmp/test-project", runtimeConfig, "opencode");
     client = new Client({ name: "test-client", version: "1.0.0" });
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -371,7 +371,7 @@ describe("multiprocess indexing", () => {
       search,
       debug: { enabled: false },
     });
-    const indexer = new Indexer(projectRoot, config);
+    const indexer = new Indexer(projectRoot, config, "opencode");
     localIndexers.push(indexer);
     return indexer;
   }

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -100,8 +100,8 @@ describe("pr_impact tool", () => {
       },
       indexing: { watchFiles: false },
     });
-    initializeTools(tempDir, config);
-    const indexer = new Indexer(tempDir, config);
+    initializeTools(tempDir, config, "opencode");
+    const indexer = new Indexer(tempDir, config, "opencode");
     _indexers.push(indexer);
     await indexer.index();
     return indexer;

--- a/tests/retrieval-benchmark.test.ts
+++ b/tests/retrieval-benchmark.test.ts
@@ -373,7 +373,7 @@ describe("retrieval benchmark", () => {
         },
       });
 
-      indexer = new Indexer(tempDir, config);
+      indexer = new Indexer(tempDir, config, "opencode");
       await indexer.index();
 
       const samples: number[] = [];

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -516,7 +516,7 @@ describe("retrieval ranking", () => {
         topN: 3,
       },
     });
-    const indexer = new Indexer("/repo", config);
+    const indexer = new Indexer("/repo", config, "opencode");
 
     const firstPath = createTempFile("src/first.ts", "const SECRET_BEFORE = 'private';\nexport function firstThing() {\n  return 'first';\n}\nconst SECRET_AFTER = 'private';\n");
     const secondPath = createTempFile("src/second.ts", "export function secondThing() {\n  return 'second';\n}\n");
@@ -573,7 +573,7 @@ describe("retrieval ranking", () => {
         topN: 2,
       },
     });
-    const indexer = new Indexer("/repo", config);
+    const indexer = new Indexer("/repo", config, "opencode");
 
     const firstPath = createTempFile("src/first.ts", "export function firstThing() {\n  return 'first';\n}\n");
     const secondPath = createTempFile("src/second.ts", "export function secondThing() {\n  return 'second';\n}\n");
@@ -617,7 +617,7 @@ describe("retrieval ranking", () => {
         topN: 3,
       },
     });
-    const indexer = new Indexer("/repo", config);
+    const indexer = new Indexer("/repo", config, "opencode");
 
     const fetchSpy = globalThis.fetch;
     let rerankCalled = false;
@@ -672,7 +672,7 @@ describe("retrieval ranking", () => {
         topN: 3,
       },
     });
-    const indexer = new Indexer("/repo", config);
+    const indexer = new Indexer("/repo", config, "opencode");
 
     const fetchSpy = globalThis.fetch;
     let rerankCalled = false;
@@ -731,7 +731,7 @@ describe("retrieval ranking", () => {
         topN: 3,
       },
     });
-    const indexer = new Indexer("/repo", config);
+    const indexer = new Indexer("/repo", config, "opencode");
 
     const fileA1 = createTempFile("src/auth.ts", "export function validateAuth() {\n  return true;\n}\n");
     const fileA2 = fileA1;
@@ -785,7 +785,7 @@ describe("retrieval ranking", () => {
         topN: 3,
       },
     });
-    const indexer = new Indexer("/repo", config);
+    const indexer = new Indexer("/repo", config, "opencode");
 
     const authFile = createTempFile("src/auth.ts", "export function validateAuth() {\n  return true;\n}\nexport function refreshAuth() {\n  return false;\n}\n");
 

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -100,7 +100,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     const stats = await indexer.index();
     expect(stats.totalFiles).toBeGreaterThan(0);
 
@@ -156,7 +156,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const status = await indexer.getStatus();
@@ -200,7 +200,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       indexing: { watchFiles: false },
       search: { maxResults: 10, minScore: 0 },
     });
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const status = await indexer.getStatus();
@@ -246,7 +246,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       search: { maxResults: 10, minScore: 0 },
     });
 
-    const firstIndexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const firstIndexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await firstIndexer.index();
 
     const firstStatus = await firstIndexer.getStatus();
@@ -273,7 +273,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       staleDb.close();
     }
 
-    const secondIndexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const secondIndexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     const embeddingCallsBeforeReindex = fetchSpy.mock.calls.length;
     await secondIndexer.index();
 
@@ -376,7 +376,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       search: { maxResults: 10, minScore: 0 },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
     const results = await indexer.search("where is capped_python_definition implementation", 5, {
       metadataOnly: true,
@@ -494,7 +494,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
           minScore: 0,
         },
       });
-      const disabledIndexer = new Indexer(authoredDir, disabledConfig);
+      const disabledIndexer = new Indexer(authoredDir, disabledConfig, "opencode");
       await disabledIndexer.index();
       await disabledIndexer.close();
 
@@ -515,7 +515,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
         },
       });
 
-      const indexer = new Indexer(authoredDir, config);
+      const indexer = new Indexer(authoredDir, config, "opencode");
       _indexers.push(indexer);
       await indexer.index();
 
@@ -575,7 +575,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const results = await indexer.search("rankHybridResults documentation guide", 5, {
@@ -606,7 +606,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const results = await indexer.search("rankHybridResults", 5, {
@@ -640,7 +640,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const results = await indexer.search("rankHybridResults", 5, {
@@ -673,7 +673,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const withoutOverride = await indexer.search("where is rankHybridResults documentation", 5, {
@@ -747,7 +747,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const results = await indexer.search("where is rankHybridResults implementation", 5, {
@@ -813,7 +813,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
 
     const results = await indexer.search("rankHybridResults documentation guide", 5, {
@@ -914,7 +914,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
         },
       });
 
-      scopedIndexer = new Indexer(scopedDir, config);
+      scopedIndexer = new Indexer(scopedDir, config, "opencode");
       await scopedIndexer.index();
       const results = await scopedIndexer.search("authorize incoming requests with active sessions", 10, {
         metadataOnly: true,
@@ -957,7 +957,7 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
       },
     });
 
-    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config)) - 1];
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
     await indexer.index();
     fetchSpy.mockRejectedValue(new Error("embedding endpoint unavailable"));
     const warningLog = vi.spyOn(indexer.getLogger(), "warn");

--- a/tests/tools-knowledge-bases.test.ts
+++ b/tests/tools-knowledge-bases.test.ts
@@ -109,7 +109,7 @@ describe("knowledge base tool config refresh", () => {
     kbDir = fs.mkdtempSync(path.join(os.tmpdir(), "kb-source-"));
     vi.stubEnv("HOME", path.join(tempDir, "home"));
     vi.stubEnv("USERPROFILE", path.join(tempDir, "home"));
-    initializeTools(tempDir, parseConfig({ indexing: { watchFiles: false } }));
+    initializeTools(tempDir, parseConfig({ indexing: { watchFiles: false } }), "opencode");
   });
 
   afterEach(() => {
@@ -188,7 +188,7 @@ describe("knowledge base tool config refresh", () => {
     );
 
     indexerInstances.length = 0;
-    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode");
 
     await add_knowledge_base.execute({ path: kbDir });
 
@@ -235,7 +235,7 @@ describe("knowledge base tool config refresh", () => {
     );
 
     indexerInstances.length = 0;
-    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode");
 
     await add_knowledge_base.execute({ path: kbDir });
 
@@ -266,7 +266,7 @@ describe("knowledge base tool config refresh", () => {
     );
 
     indexerInstances.length = 0;
-    initializeTools(tempDir, parseConfig(loadMergedConfig(tempDir)));
+    initializeTools(tempDir, parseConfig(loadMergedConfig(tempDir, "opencode")), "opencode");
 
     await add_knowledge_base.execute({ path: kbDir });
 
@@ -313,7 +313,7 @@ describe("knowledge base tool config refresh", () => {
     );
 
     indexerInstances.length = 0;
-    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode");
 
     await add_knowledge_base.execute({ path: kbDir });
 
@@ -355,7 +355,7 @@ describe("knowledge base tool config refresh", () => {
         "utf-8"
       );
 
-      const merged = loadMergedConfig(tempDir) as { knowledgeBases?: string[] };
+      const merged = loadMergedConfig(tempDir, "opencode") as { knowledgeBases?: string[] };
       expect(merged.knowledgeBases).toEqual([path.normalize(kbDir)]);
     } finally {
       vi.unstubAllEnvs();
@@ -397,7 +397,7 @@ describe("knowledge base tool config refresh", () => {
     );
 
     indexerInstances.length = 0;
-    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode");
 
     await add_knowledge_base.execute({ path: kbDir });
 
@@ -435,7 +435,7 @@ describe("knowledge base tool config refresh", () => {
     );
 
     indexerInstances.length = 0;
-    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+    initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode");
 
     await index_codebase.execute({ force: true, estimateOnly: false, verbose: false }, {
       metadata: () => undefined,
@@ -450,7 +450,7 @@ describe("knowledge base tool config refresh", () => {
       JSON.stringify({ knowledgeBases: ["docs/updated"] }, null, 2),
       "utf-8"
     );
-    expect((loadMergedConfig(worktreeDir) as { knowledgeBases?: string[] }).knowledgeBases).toEqual(["docs/updated"]);
+    expect((loadMergedConfig(worktreeDir, "opencode") as { knowledgeBases?: string[] }).knowledgeBases).toEqual(["docs/updated"]);
   });
 
   it("does not snapshot global-only settings when materializing a local config boundary", async () => {
@@ -488,7 +488,7 @@ describe("knowledge base tool config refresh", () => {
       );
 
       indexerInstances.length = 0;
-      initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir)));
+      initializeTools(worktreeDir, parseConfig(loadMergedConfig(worktreeDir, "opencode")), "opencode");
 
       await add_knowledge_base.execute({ path: kbDir });
 

--- a/tests/watcher-emfile.test.ts
+++ b/tests/watcher-emfile.test.ts
@@ -33,7 +33,7 @@ describe("FileWatcher EMFILE recovery", () => {
       return this === addSpy.mock.instances[0] ? nativeClose : pollingClose;
     });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
 
     watcher.start(vi.fn());
 
@@ -78,7 +78,7 @@ describe("FileWatcher EMFILE recovery", () => {
     });
     vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
 
     watcher.start(vi.fn());
     const nativeWatcher = addSpy.mock.instances[0] as FSWatcher;
@@ -116,7 +116,7 @@ describe("FileWatcher EMFILE recovery", () => {
     });
     const firstHandler = vi.fn();
     const secondHandler = vi.fn();
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
 
     watcher.start(firstHandler);
     (addSpy.mock.instances[0] as FSWatcher).emit("ready");
@@ -162,7 +162,7 @@ describe("FileWatcher EMFILE recovery", () => {
     });
     vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }));
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
 
     watcher.start(vi.fn());
 

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -71,12 +71,12 @@ describe("FileWatcher", () => {
 
   describe("constructor and lifecycle", () => {
     it("should create watcher without starting", () => {
-      watcher = new FileWatcher(tempDir, createTestConfig());
+      watcher = new FileWatcher(tempDir, createTestConfig(), "opencode");
       expect(watcher.isRunning()).toBe(false);
     });
 
     it("should start and stop correctly", () => {
-      watcher = new FileWatcher(tempDir, createTestConfig());
+      watcher = new FileWatcher(tempDir, createTestConfig(), "opencode");
       const handler = vi.fn();
 
       watcher.start(handler);
@@ -87,7 +87,7 @@ describe("FileWatcher", () => {
     });
 
     it("should not start twice", () => {
-      watcher = new FileWatcher(tempDir, createTestConfig());
+      watcher = new FileWatcher(tempDir, createTestConfig(), "opencode");
       const handler1 = vi.fn();
       const handler2 = vi.fn();
 
@@ -98,7 +98,7 @@ describe("FileWatcher", () => {
     });
 
     it("should clear pending changes on stop", () => {
-      watcher = new FileWatcher(tempDir, createTestConfig());
+      watcher = new FileWatcher(tempDir, createTestConfig(), "opencode");
       const handler = vi.fn();
 
       watcher.start(handler);
@@ -111,7 +111,7 @@ describe("FileWatcher", () => {
   describe("file filtering", () => {
     it("should only watch files matching include patterns", async () => {
       const changes: FileChange[] = [];
-      watcher = new FileWatcher(tempDir, createTestConfig({ include: ["**/*.ts"] }));
+      watcher = new FileWatcher(tempDir, createTestConfig({ include: ["**/*.ts"] }), "opencode");
 
       watcher.start(async (c) => {
         changes.push(...c);
@@ -133,7 +133,7 @@ describe("FileWatcher", () => {
 
     it("should include matching root-level files", async () => {
       const changes: FileChange[] = [];
-      watcher = new FileWatcher(tempDir, createTestConfig({ include: ["**/*.ts"] }));
+      watcher = new FileWatcher(tempDir, createTestConfig({ include: ["**/*.ts"] }), "opencode");
 
       watcher.start(async (c) => {
         changes.push(...c);
@@ -216,6 +216,7 @@ describe("FileWatcher", () => {
             logBranch: false,
           },
         }),
+        "opencode",
       );
 
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -244,7 +245,8 @@ describe("FileWatcher", () => {
       const combinedWatcher = createWatcherWithIndexer(
         () => indexer,
         tempDir,
-        createTestConfig()
+        createTestConfig(),
+        "opencode",
       );
 
       await new Promise((r) => setTimeout(r, 100));
@@ -269,7 +271,8 @@ describe("FileWatcher", () => {
       const combinedWatcher = createWatcherWithIndexer(
         () => indexer,
         tempDir,
-        createTestConfig()
+        createTestConfig(),
+        "opencode",
       );
 
       await new Promise((r) => setTimeout(r, 100));
@@ -301,6 +304,7 @@ describe("FileWatcher", () => {
         () => indexer,
         tempDir,
         createTestConfig(),
+        "opencode",
       );
 
       await combinedWatcher.fileWatcher.waitUntilReady();
@@ -330,6 +334,7 @@ describe("FileWatcher", () => {
         () => indexer,
         tempDir,
         createTestConfig(),
+        "opencode",
       );
 
       await combinedWatcher.fileWatcher.waitUntilReady();
@@ -354,7 +359,8 @@ describe("FileWatcher", () => {
       const combinedWatcher = createWatcherWithIndexer(
         () => currentIndexer,
         tempDir,
-        createTestConfig()
+        createTestConfig(),
+        "opencode",
       );
 
       await new Promise((r) => setTimeout(r, 100));
@@ -378,7 +384,8 @@ describe("FileWatcher", () => {
       const combinedWatcher = createWatcherWithIndexer(
         () => indexer,
         tempDir,
-        createTestConfig()
+        createTestConfig(),
+        "opencode",
       );
 
       expect(combinedWatcher.fileWatcher.isRunning()).toBe(true);

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -86,8 +86,8 @@ describe("worktree fallback (issue #60)", () => {
   });
 
   it("loads project config from the main repo when the worktree has no local config", () => {
-    const configPath = resolveProjectConfigPath(worktreeDir);
-    const loaded = loadMergedConfig(worktreeDir) as Record<string, unknown>;
+    const configPath = resolveProjectConfigPath(worktreeDir, "opencode");
+    const loaded = loadMergedConfig(worktreeDir, "opencode") as Record<string, unknown>;
 
     expect(configPath).toBe(path.join(mainRepoDir, ".opencode", "codebase-index.json"));
     expect(loaded.scope).toBe("project");
@@ -99,7 +99,7 @@ describe("worktree fallback (issue #60)", () => {
     const configPath = path.join(mainRepoDir, ".opencode", "codebase-index.json");
     fs.writeFileSync(configPath, '{"embeddingProvider":"custom",', "utf-8");
 
-    expect(() => loadMergedConfig(worktreeDir)).toThrow(
+    expect(() => loadMergedConfig(worktreeDir, "opencode")).toThrow(
       new RegExp(`Failed to load config file ${configPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
     );
   });
@@ -108,7 +108,7 @@ describe("worktree fallback (issue #60)", () => {
     const configPath = path.join(mainRepoDir, ".opencode", "codebase-index.json");
     fs.writeFileSync(configPath, JSON.stringify({ knowledgeBases: "docs/reference" }, null, 2), "utf-8");
 
-    expect(() => loadMergedConfig(worktreeDir)).toThrow(/field 'knowledgeBases' must be an array of strings/);
+    expect(() => loadMergedConfig(worktreeDir, "opencode")).toThrow(/field 'knowledgeBases' must be an array of strings/);
   });
 
   it("throws a file-specific error when the global config is malformed", () => {
@@ -124,7 +124,7 @@ describe("worktree fallback (issue #60)", () => {
       const repoConfigPath = path.join(mainRepoDir, ".opencode", "codebase-index.json");
       fs.rmSync(repoConfigPath, { force: true });
 
-      expect(() => loadMergedConfig(worktreeDir)).toThrow(
+      expect(() => loadMergedConfig(worktreeDir, "opencode")).toThrow(
         new RegExp(`Failed to load config file ${globalConfigPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`)
       );
     } finally {
@@ -142,7 +142,7 @@ describe("worktree fallback (issue #60)", () => {
       fs.mkdirSync(path.dirname(globalConfigPath), { recursive: true });
       fs.writeFileSync(globalConfigPath, '{"debug":', "utf-8");
 
-      const loaded = loadMergedConfig(worktreeDir) as Record<string, unknown>;
+      const loaded = loadMergedConfig(worktreeDir, "opencode") as Record<string, unknown>;
 
       expect(loaded.scope).toBe("project");
       expect(loaded.additionalInclude).toEqual(["docs/**/*.md"]);
@@ -193,7 +193,7 @@ describe("worktree fallback (issue #60)", () => {
       "utf-8"
     );
 
-    const loaded = loadMergedConfig(worktreeDir) as {
+    const loaded = loadMergedConfig(worktreeDir, "opencode") as {
       indexing?: Record<string, unknown>;
     };
 
@@ -226,18 +226,18 @@ describe("worktree fallback (issue #60)", () => {
       "utf-8"
     );
 
-    const loaded = loadMergedConfig(worktreeDir) as Record<string, unknown>;
+    const loaded = loadMergedConfig(worktreeDir, "opencode") as Record<string, unknown>;
 
     expect(loaded.knowledgeBases).toEqual(["docs/reference"]);
   });
 
   it("keeps the project index local when the worktree inherits its config", async () => {
-    const config = parseConfig(loadMergedConfig(worktreeDir));
-    const indexer = new Indexer(worktreeDir, config);
+    const config = parseConfig(loadMergedConfig(worktreeDir, "opencode"));
+    const indexer = new Indexer(worktreeDir, config, "opencode");
     try {
       const status = await indexer.getStatus();
 
-      expect(resolveProjectIndexPath(worktreeDir, "project")).toBe(path.join(worktreeDir, ".opencode", "index"));
+      expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(path.join(worktreeDir, ".opencode", "index"));
       expect(status.indexPath).toBe(path.join(worktreeDir, ".opencode", "index"));
       expect(status.currentBranch).toBe("feature/x/y");
     } finally {
@@ -275,10 +275,10 @@ describe("worktree fallback (issue #60)", () => {
       }), { status: 200 });
     });
 
-    const mainConfig = parseConfig(loadMergedConfig(mainRepoDir));
-    const worktreeConfig = parseConfig(loadMergedConfig(worktreeDir));
-    const mainIndexer = new Indexer(mainRepoDir, mainConfig);
-    const worktreeIndexer = new Indexer(worktreeDir, worktreeConfig);
+    const mainConfig = parseConfig(loadMergedConfig(mainRepoDir, "opencode"));
+    const worktreeConfig = parseConfig(loadMergedConfig(worktreeDir, "opencode"));
+    const mainIndexer = new Indexer(mainRepoDir, mainConfig, "opencode");
+    const worktreeIndexer = new Indexer(worktreeDir, worktreeConfig, "opencode");
     const indexers = [mainIndexer, worktreeIndexer];
 
     try {
@@ -292,7 +292,7 @@ describe("worktree fallback (issue #60)", () => {
       await worktreeIndexer.close();
 
       const worktreeIndexPath = path.join(worktreeDir, ".opencode", "index");
-      expect(resolveProjectIndexPath(worktreeDir, "project")).toBe(worktreeIndexPath);
+      expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(worktreeIndexPath);
       expect(snapshotProjectIndex(mainIndexPath)).toEqual(mainSnapshotBefore);
 
       const worktreeSnapshot = snapshotProjectIndex(worktreeIndexPath);
@@ -302,8 +302,8 @@ describe("worktree fallback (issue #60)", () => {
         chunk !== null && chunk.filePath.startsWith(`${path.resolve(worktreeDir)}${path.sep}`)
       )).toBe(true);
 
-      const mainReader = new Indexer(mainRepoDir, mainConfig);
-      const worktreeReader = new Indexer(worktreeDir, worktreeConfig);
+      const mainReader = new Indexer(mainRepoDir, mainConfig, "opencode");
+      const worktreeReader = new Indexer(worktreeDir, worktreeConfig, "opencode");
       indexers.push(mainReader, worktreeReader);
       const [mainResults, worktreeResults] = await Promise.all([
         mainReader.search("worktreeIsolationMarker", 5, { metadataOnly: true, filterByBranch: false }),
@@ -326,9 +326,9 @@ describe("worktree fallback (issue #60)", () => {
       "utf-8"
     );
 
-    const configPath = resolveProjectConfigPath(worktreeDir);
-    const indexPath = resolveProjectIndexPath(worktreeDir, "project");
-    const loaded = loadMergedConfig(worktreeDir) as Record<string, unknown>;
+    const configPath = resolveProjectConfigPath(worktreeDir, "opencode");
+    const indexPath = resolveProjectIndexPath(worktreeDir, "project", "opencode");
+    const loaded = loadMergedConfig(worktreeDir, "opencode") as Record<string, unknown>;
 
     expect(configPath).toBe(path.join(worktreeDir, ".opencode", "codebase-index.json"));
     expect(indexPath).toBe(path.join(worktreeDir, ".opencode", "index"));
@@ -338,9 +338,9 @@ describe("worktree fallback (issue #60)", () => {
   it("keeps a worktree-local config on a local worktree index boundary", () => {
     fs.mkdirSync(path.join(worktreeDir, ".opencode", "index"), { recursive: true });
 
-    expect(resolveWritableProjectConfigPath(worktreeDir)).toBe(path.join(worktreeDir, ".opencode", "codebase-index.json"));
-    expect(resolveProjectConfigPath(worktreeDir)).toBe(path.join(mainRepoDir, ".opencode", "codebase-index.json"));
-    expect(resolveProjectIndexPath(worktreeDir, "project")).toBe(path.join(worktreeDir, ".opencode", "index"));
+    expect(resolveWritableProjectConfigPath(worktreeDir, "opencode")).toBe(path.join(worktreeDir, ".opencode", "codebase-index.json"));
+    expect(resolveProjectConfigPath(worktreeDir, "opencode")).toBe(path.join(mainRepoDir, ".opencode", "codebase-index.json"));
+    expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(path.join(worktreeDir, ".opencode", "index"));
   });
 
   it("keeps explicit worktree-local config and index when they exist", () => {
@@ -360,6 +360,6 @@ describe("worktree fallback (issue #60)", () => {
       "utf-8"
     );
 
-    expect(resolveProjectIndexPath(worktreeDir, "project")).toBe(path.join(worktreeDir, ".opencode", "index"));
+    expect(resolveProjectIndexPath(worktreeDir, "project", "opencode")).toBe(path.join(worktreeDir, ".opencode", "index"));
   });
 });


### PR DESCRIPTION
## Summary
- require callers to provide `HostMode` across shared runtime, config, indexing, watcher, and MCP APIs
- keep historical OpenCode behavior explicit at OpenCode, CLI visualization, evaluation, and test boundaries
- remove the remaining implicit OpenCode coupling from reusable runtime APIs

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (67 files, 1244 tests)
- `cargo fmt --manifest-path native/Cargo.toml -- --check`
- `cargo test --manifest-path native/Cargo.toml --lib` (114 tests)
