### PR TITLE
test: assert force indexing routes through Indexer.forceIndex

### DIFF
--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1097,6 +1097,12 @@ describe("MCP server tools and prompts", () => {
 
     expect(indexerMockState.constructorArgs.length).toBeGreaterThanOrEqual(2);
     expect(indexerMockState.constructorArgs.at(-1)).toEqual(["/tmp/test-project", runtimeConfig]);
+    const forcedIndexerIndex = indexerMockState.instances.findIndex(
+      (instance) => instance.forceIndex.mock.calls.length > 0,
+    );
+    expect(forcedIndexerIndex).toBeGreaterThanOrEqual(0);
+    expect(indexerMockState.instances[forcedIndexerIndex]?.forceIndex).toHaveBeenCalledOnce();
+    expect(indexerMockState.constructorArgs[forcedIndexerIndex]).toEqual(["/tmp/test-project", runtimeConfig]);
     expect(indexerMockState.instances[0]?.initialize).not.toHaveBeenCalled();
     expect(indexerMockState.instances[0]?.getStatus).not.toHaveBeenCalled();
   });

--- a/tests/tools-knowledge-bases.test.ts
+++ b/tests/tools-knowledge-bases.test.ts
@@ -9,6 +9,7 @@ const { indexerInstances, MockIndexer } = vi.hoisted(() => {
     projectRoot: string;
     config: Record<string, unknown>;
     getStatus: ReturnType<typeof vi.fn>;
+    forceIndex: ReturnType<typeof vi.fn>;
     healthCheck: ReturnType<typeof vi.fn>;
   }> = [];
 
@@ -28,7 +29,13 @@ const { indexerInstances, MockIndexer } = vi.hoisted(() => {
     public constructor(projectRoot: string, config: Record<string, unknown>) {
       this.projectRoot = projectRoot;
       this.config = config;
-      indexerInstances.push({ projectRoot, config, getStatus: this.getStatus, healthCheck: this.healthCheck });
+      indexerInstances.push({
+        projectRoot,
+        config,
+        getStatus: this.getStatus,
+        forceIndex: this.forceIndex,
+        healthCheck: this.healthCheck,
+      });
     }
 
     public estimateCost = vi.fn().mockResolvedValue({
@@ -443,6 +450,9 @@ describe("knowledge base tool config refresh", () => {
 
     expect(indexerInstances[0]?.getStatus).not.toHaveBeenCalled();
     expect(indexerInstances).toHaveLength(1);
+    expect(indexerInstances[0]?.forceIndex).toHaveBeenCalledOnce();
+    expect(indexerInstances[0]?.projectRoot).toBe(worktreeDir);
+    expect(indexerInstances[0]?.config.knowledgeBases).toEqual(["docs/reference"]);
     expect(fs.existsSync(path.join(worktreeDir, ".opencode", "codebase-index.json"))).toBe(false);
 
     fs.writeFileSync(


### PR DESCRIPTION
## Problem

Two tests are named after force indexing but never assert it happens.

- `tests/mcp-server.test.ts` > "should preserve runtime config on force refresh"
- `tests/tools-knowledge-bases.test.ts` > "keeps inherited project config during a worktree force rebuild"

Both call `index_codebase` with `force: true`, then only assert negative facts (`initialize` and `getStatus` were not called) plus constructor arguments. Neither one checks that the request actually reached `Indexer.forceIndex`.

`force: true` reaches `forceIndex` through the auto-index coordinator: `runIndexCodebase` calls `runCoordinatedIndex(...)` in `src/tools/operations.ts`, and the coordinator picks `request.force ? indexer.forceIndex : indexer.index` in `src/utils/auto-index.ts`. If that branch ever collapses to the incremental path, `force: true` silently becomes an incremental index: the user asks for a full rebuild, gets a delta update, and no error is raised. Both tests stay green.

`tests/auto-index.test.ts` does assert `forceIndex` once, but only by calling `runCoordinatedIndex(projectRoot, host, true)` directly. Nothing covers the tool and MCP entry points that users actually go through, so the wiring between the tool layer and the coordinator was untested.

## Change

Test-only. Assert that `forceIndex` was called exactly once, on the indexer instance built with the expected project root and config.

- MCP test: locate the instance whose `forceIndex` was invoked and verify its constructor arguments, so the assertion cannot pass because some unrelated instance was forced.
- Knowledge-base test: assert `forceIndex` was called on the single indexer, and that it kept the inherited `knowledgeBases` config from the main repo rather than a re-derived worktree config.

## Verification

To confirm these assertions actually bite, I temporarily replaced the force branch in `src/utils/auto-index.ts` with `indexer.index.bind(indexer)`:

- before this change: both tests still passed
- after this change: both tests fail (`expected -1 to be greater than or equal to 0`, and `expected "vi.fn()" to be called once, but got 0 times`)

The mutation was reverted; no production code is modified in this PR.

`npm run build`, `npm run typecheck`, `npm run lint` and `npm run test:run` all pass locally (1244 tests, 67 files).