### PR TITLE
feat: prepare phase 0 package identity compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,31 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      package_name:
+        description: "Package identity to validate (manual runs never publish)"
+        required: true
+        default: "opencode-codebase-index"
+        type: choice
+        options:
+          - "opencode-codebase-index"
+          - "open-codebase-index"
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
+  package-metadata:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: ${{ inputs.package_name || vars.NPM_PACKAGE_NAME || 'opencode-codebase-index' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Prepare package metadata
+        run: node scripts/prepare-package-metadata.mjs --package-name "${PACKAGE_NAME}" --output-dir "${RUNNER_TEMP}/package-metadata"
+
   build:
     strategy:
       fail-fast: false
@@ -70,9 +89,11 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: build
+    needs: [package-metadata, build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    env:
+      PACKAGE_NAME: ${{ inputs.package_name || vars.NPM_PACKAGE_NAME || 'opencode-codebase-index' }}
     permissions:
       contents: read
       id-token: write
@@ -100,6 +121,9 @@ jobs:
 
       - name: List native binaries
         run: ls -la native/*.node
+
+      - name: Prepare package metadata
+        run: node scripts/prepare-package-metadata.mjs --package-name "${PACKAGE_NAME}"
 
       - name: Publish to npm
         run: npm publish --access public

--- a/scripts/prepare-package-metadata.mjs
+++ b/scripts/prepare-package-metadata.mjs
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import * as path from "node:path";
+import { fileURLToPath } from "url";
+
+/**
+ * @typedef {{
+ *   product: {
+ *     current: { packageName: string, mcpBinary: string },
+ *     future: { packageName: string, mcpBinary: string }
+ *   }
+ * }} IdentityCatalog
+ */
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) continue;
+
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      args.set(arg, next);
+      i += 1;
+    } else {
+      args.set(arg, "");
+    }
+  }
+  return args;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+/** @type {IdentityCatalog} */
+const catalog = JSON.parse(readFileSync(path.join(repositoryRoot, "src", "identity-catalog.json"), "utf-8"));
+const args = parseArgs(process.argv.slice(2));
+const packageName = args.get("--package-name");
+
+if (!packageName) {
+  fail("Usage: node scripts/prepare-package-metadata.mjs --package-name <known-name> [--project-root <path>] [--output-dir <path>]");
+}
+
+const selectedIdentity = [catalog.product.current, catalog.product.future]
+  .find((identity) => identity.packageName === packageName);
+if (!selectedIdentity) {
+  fail(`Unknown package name: ${packageName}`);
+}
+
+const projectRoot = path.resolve(args.get("--project-root") || process.cwd());
+const outputDir = path.resolve(args.get("--output-dir") || projectRoot);
+const packageJsonPath = path.join(projectRoot, "package.json");
+const packageLockPath = path.join(projectRoot, "package-lock.json");
+
+if (!existsSync(packageJsonPath)) fail(`Missing package.json at ${packageJsonPath}`);
+if (!existsSync(packageLockPath)) fail(`Missing package-lock.json at ${packageLockPath}`);
+
+const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+const packageLock = JSON.parse(readFileSync(packageLockPath, "utf-8"));
+const cliTarget = packageJson.bin?.[catalog.product.current.mcpBinary];
+if (typeof cliTarget !== "string") {
+  fail(`Missing current MCP binary entry: ${catalog.product.current.mcpBinary}`);
+}
+
+const preparedBins = selectedIdentity.packageName === catalog.product.current.packageName
+  ? { [catalog.product.current.mcpBinary]: cliTarget }
+  : {
+      [catalog.product.future.mcpBinary]: cliTarget,
+      [catalog.product.current.mcpBinary]: cliTarget,
+    };
+
+packageJson.name = selectedIdentity.packageName;
+packageJson.bin = preparedBins;
+packageLock.name = selectedIdentity.packageName;
+if (!packageLock.packages?.[""]) {
+  fail("package-lock.json is missing the root package entry");
+}
+packageLock.packages[""].name = selectedIdentity.packageName;
+packageLock.packages[""].bin = preparedBins;
+
+mkdirSync(outputDir, { recursive: true });
+writeFileSync(path.join(outputDir, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`, "utf-8");
+writeFileSync(path.join(outputDir, "package-lock.json"), `${JSON.stringify(packageLock, null, 2)}\n`, "utf-8");
+
+console.log(`Prepared metadata for ${selectedIdentity.packageName}`);

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { ParsedCodebaseIndexConfig } from "../../config/schema.js";
 import type { HostMode } from "../../config/host.js";
+import { MCP_SERVER_CURRENT_NAME } from "../../identity-catalog.js";
 import { getPackageVersion } from "../../package-metadata.js";
 import { registerMcpPrompts } from "./register-prompts.js";
 import { registerMcpTools } from "./register-tools.js";
@@ -19,7 +20,7 @@ export function createMcpServer(
   host: HostMode,
 ): McpServer {
   const server = new McpServer({
-    name: "opencode-codebase-index",
+    name: MCP_SERVER_CURRENT_NAME,
     version: getPackageVersion(),
   }, {
     instructions: getServerInstructions(host),

--- a/src/eval/cli-parser.ts
+++ b/src/eval/cli-parser.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 
+import { MCP_BINARY_CURRENT_NAME } from "../identity-catalog.js";
 import type { EvalRunOptions, SweepDefinition } from "./types.js";
 
 export interface ParsedArgs {
@@ -27,9 +28,9 @@ export interface EvalSubcommandOptions {
 export function printUsage(): void {
   console.log(`
 Usage:
-  opencode-codebase-index-mcp eval run [options]
-  opencode-codebase-index-mcp eval compare --against <summary.json> [options]
-  opencode-codebase-index-mcp eval diff --current <summary.json> --against <summary.json> [options]
+  ${MCP_BINARY_CURRENT_NAME} eval run [options]
+  ${MCP_BINARY_CURRENT_NAME} eval compare --against <summary.json> [options]
+  ${MCP_BINARY_CURRENT_NAME} eval diff --current <summary.json> --against <summary.json> [options]
 
 Options:
   --project <path>                 Project root (default: cwd)

--- a/src/identity-catalog.json
+++ b/src/identity-catalog.json
@@ -1,0 +1,21 @@
+{
+  "product": {
+    "current": {
+      "productName": "opencode-codebase-index",
+      "packageName": "opencode-codebase-index",
+      "repository": "https://github.com/Helweg/opencode-codebase-index",
+      "mcpBinary": "opencode-codebase-index-mcp",
+      "mcpServerName": "opencode-codebase-index"
+    },
+    "future": {
+      "productName": "open-codebase-index",
+      "packageName": "open-codebase-index",
+      "repository": "https://github.com/Helweg/open-codebase-index",
+      "mcpBinary": "open-codebase-index-mcp",
+      "mcpServerName": "open-codebase-index"
+    }
+  },
+  "native": {
+    "binaryName": "codebase-index-native"
+  }
+}

--- a/src/identity-catalog.ts
+++ b/src/identity-catalog.ts
@@ -1,0 +1,32 @@
+import identityCatalogJson from "./identity-catalog.json";
+
+export interface ProductIdentity {
+  productName: string;
+  packageName: string;
+  repository: string;
+  mcpBinary: string;
+  mcpServerName: string;
+}
+
+export interface ProductIdentityCollection {
+  current: ProductIdentity;
+  future: ProductIdentity;
+}
+
+export interface NativeIdentity {
+  binaryName: string;
+}
+
+export interface IdentityCatalog {
+  product: ProductIdentityCollection;
+  native: NativeIdentity;
+}
+
+export const IDENTITY_CATALOG = identityCatalogJson as IdentityCatalog;
+
+export const CURRENT_PRODUCT = IDENTITY_CATALOG.product.current;
+export const FUTURE_PRODUCT = IDENTITY_CATALOG.product.future;
+
+export const MCP_SERVER_CURRENT_NAME = CURRENT_PRODUCT.mcpServerName;
+export const MCP_BINARY_CURRENT_NAME = CURRENT_PRODUCT.mcpBinary;
+export const STABLE_NATIVE_BINARY_NAME = IDENTITY_CATALOG.native.binaryName;

--- a/src/native/binding.ts
+++ b/src/native/binding.ts
@@ -3,26 +3,40 @@ import * as path from "node:path";
 import * as module from "node:module";
 import { fileURLToPath } from "node:url";
 
-function getNativeBinding() {
-  const platform = os.platform();
-  const arch = os.arch();
+import { STABLE_NATIVE_BINARY_NAME } from "../identity-catalog.js";
 
-  let bindingName: string;
-
+export function getNativeBindingFilename(
+  platform: NodeJS.Platform = os.platform(),
+  arch: NodeJS.Architecture = os.arch(),
+): string {
   if (platform === "darwin" && arch === "arm64") {
-    bindingName = "codebase-index-native.darwin-arm64.node";
-  } else if (platform === "darwin" && arch === "x64") {
-    bindingName = "codebase-index-native.darwin-x64.node";
-  } else if (platform === "linux" && arch === "x64") {
-    bindingName = "codebase-index-native.linux-x64-gnu.node";
-  } else if (platform === "linux" && arch === "arm64") {
-    bindingName = "codebase-index-native.linux-arm64-gnu.node";
-  } else if (platform === "win32" && arch === "x64") {
-    bindingName = "codebase-index-native.win32-x64-msvc.node";
-  } else {
-    throw new Error(`Unsupported platform: ${platform}-${arch}`);
+    return `${STABLE_NATIVE_BINARY_NAME}.darwin-arm64.node`;
+  }
+  if (platform === "darwin" && arch === "x64") {
+    return `${STABLE_NATIVE_BINARY_NAME}.darwin-x64.node`;
+  }
+  if (platform === "linux" && arch === "x64") {
+    return `${STABLE_NATIVE_BINARY_NAME}.linux-x64-gnu.node`;
+  }
+  if (platform === "linux" && arch === "arm64") {
+    return `${STABLE_NATIVE_BINARY_NAME}.linux-arm64-gnu.node`;
+  }
+  if (platform === "win32" && arch === "x64") {
+    return `${STABLE_NATIVE_BINARY_NAME}.win32-x64-msvc.node`;
   }
 
+  throw new Error(`Unsupported platform: ${platform}-${arch}`);
+}
+
+export function resolveNativeBindingPath(
+  packageRoot: string,
+  platform: NodeJS.Platform = os.platform(),
+  arch: NodeJS.Architecture = os.arch(),
+): string {
+  return path.join(packageRoot, "native", getNativeBindingFilename(platform, arch));
+}
+
+function getNativeBinding() {
   // Determine the current directory - handle ESM, CJS, and bundled contexts
   let currentDir: string;
   let requireTarget: string;
@@ -51,7 +65,7 @@ function getNativeBinding() {
   const packageRoot = isDevMode
     ? path.resolve(currentDir, "../..")
     : path.resolve(currentDir, "..");
-  const nativePath = path.join(packageRoot, "native", bindingName);
+  const nativePath = resolveNativeBindingPath(packageRoot);
 
   // Load the native module - use standard require for .node files
   const require = module.createRequire(requireTarget);

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { describe, expect, it } from "vitest";
+
+import { IDENTITY_CATALOG } from "../src/identity-catalog.js";
+import { getNativeBindingFilename, resolveNativeBindingPath } from "../src/native/binding.js";
+
+interface PackageMetadata {
+  name: string;
+  bin: Record<string, string>;
+  repository: { url: string };
+  napi: { binaryName: string };
+}
+
+interface PackageLockMetadata {
+  name: string;
+  packages: Record<string, { name?: string; bin?: Record<string, string> }>;
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, "utf-8")) as T;
+}
+
+function prepareMetadata(packageName: string, outputDir: string): void {
+  execFileSync(process.execPath, [
+    path.join(process.cwd(), "scripts", "prepare-package-metadata.mjs"),
+    "--package-name",
+    packageName,
+    "--project-root",
+    process.cwd(),
+    "--output-dir",
+    outputDir,
+  ]);
+}
+
+describe("Phase 0 product identity compatibility", () => {
+  it("keeps the checked-in legacy package and host manifests unchanged", () => {
+    const current = IDENTITY_CATALOG.product.current;
+    const packageJson = readJson<PackageMetadata>("package.json");
+    const packageLock = readJson<PackageLockMetadata>("package-lock.json");
+    const mcpManifest = readJson<{
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    }>(".mcp.json");
+    const claudeManifest = readJson<{
+      homepage: string;
+      repository: string;
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    }>(".claude-plugin/plugin.json");
+    const claudeMarketplace = readJson<{ owner: { url: string } }>(".claude-plugin/marketplace.json");
+    const codexManifest = readJson<{
+      homepage: string;
+      repository: string;
+      mcpServers: string;
+      interface: { websiteURL: string };
+    }>(".codex-plugin/plugin.json");
+
+    const expectedBin = { [current.mcpBinary]: "dist/cli.js" };
+    expect(packageJson.name).toBe(current.packageName);
+    expect(packageJson.bin).toEqual(expectedBin);
+    expect(packageJson.repository.url).toBe(current.repository);
+    expect(packageLock.name).toBe(current.packageName);
+    expect(packageLock.packages[""]?.name).toBe(current.packageName);
+    expect(packageLock.packages[""]?.bin).toEqual(expectedBin);
+    expect(packageJson.napi.binaryName).toBe(IDENTITY_CATALOG.native.binaryName);
+
+    const codexMcpManifest = readJson<{
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    }>(codexManifest.mcpServers);
+    const expectedCodexArgs = ["-y", "--package", current.packageName, current.mcpBinary, "--host", "codex"];
+    const expectedClaudeArgs = ["-y", "--package", current.packageName, current.mcpBinary, "--host", "claude"];
+
+    expect(mcpManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedCodexArgs });
+    expect(codexMcpManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedCodexArgs });
+    expect(claudeManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedClaudeArgs });
+    expect(claudeManifest.homepage).toBe(current.repository);
+    expect(claudeManifest.repository).toBe(current.repository);
+    expect(claudeMarketplace.owner.url).toBe(current.repository);
+    expect(codexManifest.homepage).toBe(current.repository);
+    expect(codexManifest.repository).toBe(current.repository);
+    expect(codexManifest.interface.websiteURL).toBe(current.repository);
+  });
+
+  it("stages current metadata with only the legacy binary", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-current-metadata-"));
+    try {
+      prepareMetadata(IDENTITY_CATALOG.product.current.packageName, tempDir);
+      const packageJson = readJson<PackageMetadata>(path.join(tempDir, "package.json"));
+      const packageLock = readJson<PackageLockMetadata>(path.join(tempDir, "package-lock.json"));
+      const checkedInPackageJson = readJson<PackageMetadata>("package.json");
+      const checkedInPackageLock = readJson<PackageLockMetadata>("package-lock.json");
+      const expectedBin = { [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js" };
+
+      expect(packageJson.name).toBe(IDENTITY_CATALOG.product.current.packageName);
+      expect(packageJson.bin).toEqual(expectedBin);
+      expect(packageLock.name).toBe(IDENTITY_CATALOG.product.current.packageName);
+      expect(packageLock.packages[""]?.bin).toEqual(expectedBin);
+
+      expect(readFileSync(path.join(tempDir, "package.json"), "utf-8")).toBe(readFileSync("package.json", "utf-8"));
+      expect(readFileSync(path.join(tempDir, "package-lock.json"), "utf-8")).toBe(readFileSync("package-lock.json", "utf-8"));
+      expect(packageJson).toEqual(checkedInPackageJson);
+      expect(packageLock).toEqual(checkedInPackageLock);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stages future metadata with both MCP binary aliases", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-future-metadata-"));
+    try {
+      prepareMetadata(IDENTITY_CATALOG.product.future.packageName, tempDir);
+      const packageJson = readJson<PackageMetadata>(path.join(tempDir, "package.json"));
+      const packageLock = readJson<PackageLockMetadata>(path.join(tempDir, "package-lock.json"));
+      const expectedBin = {
+        [IDENTITY_CATALOG.product.future.mcpBinary]: "dist/cli.js",
+        [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js",
+      };
+
+      expect(packageJson.name).toBe(IDENTITY_CATALOG.product.future.packageName);
+      expect(packageJson.bin).toEqual(expectedBin);
+      expect(packageLock.name).toBe(IDENTITY_CATALOG.product.future.packageName);
+      expect(packageLock.packages[""]?.name).toBe(IDENTITY_CATALOG.product.future.packageName);
+      expect(packageLock.packages[""]?.bin).toEqual(expectedBin);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects package identities outside the catalog", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-invalid-metadata-"));
+    try {
+      expect(() => prepareMetadata("unknown-codebase-index", tempDir)).toThrow();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps native artifact names stable and independent of the package directory name", () => {
+    expect(getNativeBindingFilename("darwin", "arm64")).toBe("codebase-index-native.darwin-arm64.node");
+    expect(getNativeBindingFilename("darwin", "x64")).toBe("codebase-index-native.darwin-x64.node");
+    expect(getNativeBindingFilename("linux", "x64")).toBe("codebase-index-native.linux-x64-gnu.node");
+    expect(getNativeBindingFilename("linux", "arm64")).toBe("codebase-index-native.linux-arm64-gnu.node");
+    expect(getNativeBindingFilename("win32", "x64")).toBe("codebase-index-native.win32-x64-msvc.node");
+
+    for (const packageName of [
+      IDENTITY_CATALOG.product.current.packageName,
+      IDENTITY_CATALOG.product.future.packageName,
+    ]) {
+      const packageRoot = path.join("/packages", packageName);
+      expect(resolveNativeBindingPath(packageRoot, "linux", "x64")).toBe(
+        path.join(packageRoot, "native", "codebase-index-native.linux-x64-gnu.node"),
+      );
+    }
+  });
+
+  it("keeps publication release-gated while accepting an explicit known package identity", () => {
+    const workflow = readFileSync(".github/workflows/build.yml", "utf-8");
+    expect(workflow).toContain("package_name:");
+    expect(workflow).toContain("inputs.package_name || vars.NPM_PACKAGE_NAME || 'opencode-codebase-index'");
+    expect(workflow).toContain("if: github.event_name == 'release'");
+    expect(workflow).toContain("node scripts/prepare-package-metadata.mjs --package-name");
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -17,6 +17,7 @@ import {
   initializeTools,
   searchCodebaseWithEffectiveness,
 } from "../src/tools/operations.js";
+import { MCP_SERVER_CURRENT_NAME } from "../src/identity-catalog.js";
 import { MCP_TOOL_NAMES } from "../src/tools/tool-names.js";
 
 const { testMainRepo } = vi.hoisted(() => ({
@@ -411,6 +412,10 @@ describe("MCP server tools and prompts", () => {
     const expectedToolNames = [...MCP_TOOL_NAMES];
 
     expect(toolNames).toEqual(expectedToolNames);
+  });
+
+  it("should preserve the current MCP server identity", () => {
+    expect(client.getServerVersion()?.name).toBe(MCP_SERVER_CURRENT_NAME);
   });
 
   it("should expose self-routing descriptions even when the client ignores server instructions", async () => {


### PR DESCRIPTION
## Summary
- add a typed current/future product identity catalog while retaining all currently shipped identities
- add a staging-only metadata preparation path for the future `open-codebase-index` package with both new and legacy MCP binary aliases
- add an explicit release package selector while keeping publication release-only and defaulting to `opencode-codebase-index`
- prove stable native artifact naming and package-root-independent loading

## Compatibility boundaries
- no repository rename or package publication
- no checked-in package, lockfile, host-manifest, storage, tool-name, or native-artifact identity changes
- the current package continues to expose only `opencode-codebase-index-mcp`
- future metadata exists only in temporary staging output

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (68 files, 1,273 tests)
- `cargo fmt --check --manifest-path native/Cargo.toml`
- `cargo test --manifest-path native/Cargo.toml --lib` (116 tests)
- current and future `npm pack --dry-run` inventories match
- clean install of the staged future tarball successfully runs both MCP binary aliases