### PR TITLE
feat: prepare open-codebase-index compatibility release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      package_name:
-        description: "Package identity to validate (manual runs never publish)"
-        required: true
-        default: "opencode-codebase-index"
-        type: choice
-        options:
-          - "opencode-codebase-index"
-          - "open-codebase-index"
 
 permissions:
   contents: read
@@ -21,13 +12,17 @@ permissions:
 jobs:
   package-metadata:
     runs-on: ubuntu-latest
-    env:
-      PACKAGE_NAME: ${{ inputs.package_name || vars.NPM_PACKAGE_NAME || 'opencode-codebase-index' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Prepare package metadata
-        run: node scripts/prepare-package-metadata.mjs --package-name "${PACKAGE_NAME}" --output-dir "${RUNNER_TEMP}/package-metadata"
+        run: |
+          for packageName in open-codebase-index opencode-codebase-index; do
+            node scripts/prepare-package-metadata.mjs \
+              --package-name "${packageName}" \
+              --project-root "${GITHUB_WORKSPACE}" \
+              --output-dir "${RUNNER_TEMP}/package-metadata/${packageName}"
+          done
 
   build:
     strategy:
@@ -92,8 +87,6 @@ jobs:
     needs: [package-metadata, build]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    env:
-      PACKAGE_NAME: ${{ inputs.package_name || vars.NPM_PACKAGE_NAME || 'opencode-codebase-index' }}
     permissions:
       contents: read
       id-token: write
@@ -119,11 +112,34 @@ jobs:
       - name: Build TypeScript
         run: npm run build:ts
 
+      - name: Read package version
+        id: package-version
+        run: |
+          packageVersion=$(node -p "require('./package.json').version")
+          echo "version=${packageVersion}" >> "$GITHUB_OUTPUT"
+
       - name: List native binaries
         run: ls -la native/*.node
 
-      - name: Prepare package metadata
-        run: node scripts/prepare-package-metadata.mjs --package-name "${PACKAGE_NAME}"
-
       - name: Publish to npm
-        run: npm publish --access public
+        env:
+          PACKAGE_VERSION: ${{ steps.package-version.outputs.version }}
+        run: |
+          for packageName in open-codebase-index opencode-codebase-index; do
+            stagingDir="${RUNNER_TEMP}/package-metadata/${packageName}"
+            node scripts/prepare-package-metadata.mjs \
+              --package-name "${packageName}" \
+              --project-root "${GITHUB_WORKSPACE}" \
+              --output-dir "${stagingDir}"
+
+            if npm view "${packageName}@${PACKAGE_VERSION}" --json >/dev/null 2>&1; then
+              echo "Skipping ${packageName} because version already exists."
+              continue
+            fi
+
+            cd "${stagingDir}"
+            # Artifacts were built before staging, which intentionally excludes
+            # development dependencies and cannot rerun prepublishOnly.
+            npm publish --ignore-scripts --access public
+            cd "${GITHUB_WORKSPACE}"
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Portable project indexes across Git worktrees**: Project-owned paths are now persisted relative to the project root. Worktrees that inherit project configuration share the main checkout's index and reuse unchanged chunks and embeddings, while an explicit worktree-local project config keeps its index isolated. Existing project indexes with absolute stored paths require a one-time force rebuild.
+- **Phase 1 rename preparation**: Added dual-identity package metadata staging, including `open-codebase-index` support with both MCP binary aliases, while keeping the checked-in legacy identity and native/tool/storage naming stable.
 
 ## [0.20.1] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# opencode-codebase-index
+# open-codebase-index
 
-[![npm version](https://img.shields.io/npm/v/opencode-codebase-index.svg)](https://www.npmjs.com/package/opencode-codebase-index)
+[![npm version](https://img.shields.io/npm/v/open-codebase-index.svg)](https://www.npmjs.com/package/open-codebase-index)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Downloads](https://img.shields.io/npm/dm/opencode-codebase-index.svg)](https://www.npmjs.com/package/opencode-codebase-index)
+[![Downloads](https://img.shields.io/npm/dm/open-codebase-index.svg)](https://www.npmjs.com/package/open-codebase-index)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/Helweg/opencode-codebase-index/ci.yml?branch=main)](https://github.com/Helweg/opencode-codebase-index/actions)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 
 > Search a codebase by meaning, then follow the result into definitions, callers, and dependency paths.
 
-`opencode-codebase-index` is a local semantic code index for OpenCode, Jcode, Pi, Codex, Claude Code, and other MCP clients. It combines embeddings, BM25 keyword search, branch-aware filtering, symbol lookup, and a call graph behind agent-friendly tools.
+`open-codebase-index` is a local semantic code index for OpenCode, Jcode, Pi, Codex, Claude Code, and other MCP clients. It combines embeddings, BM25 keyword search, branch-aware filtering, symbol lookup, and a call graph behind agent-friendly tools.
+
+New installs should use `open-codebase-index` and `open-codebase-index-mcp`. The legacy package `opencode-codebase-index` and `opencode-codebase-index-mcp` remain supported aliases.
 
 ## Highlights
 
@@ -27,10 +29,24 @@ Requires Node.js 20 or newer.
 1. Install the package:
 
    ```bash
+   npm install open-codebase-index
+   ```
+
+   Legacy installs continue to work with:
+
+   ```bash
    npm install opencode-codebase-index
    ```
 
 2. Add it to `opencode.json`:
+
+   ```json
+   {
+     "plugin": ["open-codebase-index"]
+   }
+   ```
+
+   Legacy alias:
 
    ```json
    {
@@ -54,7 +70,7 @@ The first index creates embeddings. Later runs reuse unchanged content and proce
 | Pi | Pi package | `.codebase-index/` |
 | Codex | Marketplace plugin with MCP and skill guidance | `.codebase-index/` |
 | Claude Code | Marketplace plugin with MCP and skill guidance | `.claude/` |
-| Cursor, Windsurf, other MCP clients | `opencode-codebase-index-mcp` | Selected by `--host`; default is OpenCode-compatible |
+| Cursor, Windsurf, other MCP clients | `open-codebase-index-mcp` (legacy alias: `opencode-codebase-index-mcp`) | Selected by `--host`; default is OpenCode-compatible |
 
 See [Installation and host setup](docs/installation.md) for complete instructions.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,16 +1,32 @@
 # Installation and host setup
 
-`opencode-codebase-index` requires Node.js 20 or newer. The published package includes the MCP server dependencies and native binaries for supported platforms.
+`open-codebase-index` requires Node.js 20 or newer and is the preferred package identity. `opencode-codebase-index` remains a supported legacy package alias, and `open-codebase-index-mcp` is the preferred binary alias.
+
+The published package includes the MCP server dependencies and native binaries for supported platforms.
 
 ## OpenCode
 
 Install the package:
 
 ```bash
+npm install open-codebase-index
+```
+
+Legacy install:
+
+```bash
 npm install opencode-codebase-index
 ```
 
 Add it to `opencode.json`:
+
+```json
+{
+  "plugin": ["open-codebase-index"]
+}
+```
+
+Legacy OpenCode alias:
 
 ```json
 {
@@ -39,8 +55,8 @@ Jcode starts non-shared MCP servers in each session's working directory. Configu
       "args": [
         "-y",
         "--package",
-        "opencode-codebase-index@latest",
-        "opencode-codebase-index-mcp",
+        "open-codebase-index@latest",
+        "open-codebase-index-mcp",
         "--host",
         "jcode"
       ],
@@ -60,13 +76,13 @@ Restart Jcode after changing the MCP configuration. Jcode uses `.codebase-index/
 Install the Pi package:
 
 ```bash
-pi install npm:opencode-codebase-index
+pi install npm:open-codebase-index
 ```
 
 For local development:
 
 ```bash
-pi install ./path/to/opencode-codebase-index
+pi install ./path/to/open-codebase-index
 ```
 
 The package provides native tools and the `codebase-search` skill. Pi uses `.codebase-index/` project storage.
@@ -114,6 +130,12 @@ Claude uses:
 Run the published MCP server with `npx`:
 
 ```bash
+npx -y --package open-codebase-index open-codebase-index-mcp --project /path/to/repo
+```
+
+Legacy command:
+
+```bash
 npx -y --package opencode-codebase-index opencode-codebase-index-mcp --project /path/to/repo
 ```
 
@@ -127,8 +149,8 @@ Example MCP configuration:
       "args": [
         "-y",
         "--package",
-        "opencode-codebase-index",
-        "opencode-codebase-index-mcp",
+        "open-codebase-index",
+        "open-codebase-index-mcp",
         "--project",
         "/path/to/repo"
       ]
@@ -148,9 +170,9 @@ Example MCP configuration:
 Examples:
 
 ```bash
-opencode-codebase-index-mcp --project /path/to/repo
-opencode-codebase-index-mcp --config /path/to/config.json
-opencode-codebase-index-mcp --host jcode
+open-codebase-index-mcp --project /path/to/repo
+open-codebase-index-mcp --config /path/to/config.json
+open-codebase-index-mcp --host jcode
 ```
 
 Use `--host` when you want the corresponding host's configuration and storage paths. Without it, the CLI uses OpenCode-compatible behavior.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-codebase-index",
   "version": "0.20.1",
-  "description": "Semantic codebase indexing and search for OpenCode - find code by meaning, not just keywords",
+  "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -22,13 +22,13 @@
     "url": "https://github.com/Helweg/opencode-codebase-index"
   },
   "keywords": [
-    "opencode",
     "semantic-search",
     "codebase-indexing",
     "vector-search",
     "embeddings",
     "tree-sitter",
     "ai-coding",
+    "agent-extensions",
     "pi-package",
     "pi"
   ],

--- a/scripts/prepare-package-metadata.mjs
+++ b/scripts/prepare-package-metadata.mjs
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import * as path from "node:path";
 import { fileURLToPath } from "url";
 
@@ -64,24 +64,70 @@ if (typeof cliTarget !== "string") {
   fail(`Missing current MCP binary entry: ${catalog.product.current.mcpBinary}`);
 }
 
-const preparedBins = selectedIdentity.packageName === catalog.product.current.packageName
+function copyProject() {
+  if (outputDir === projectRoot) return;
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(outputDir, { recursive: true });
+  cpSync(projectRoot, outputDir, {
+    recursive: true,
+    force: true,
+    filter: (currentPath) => {
+      const relative = path.relative(projectRoot, currentPath);
+      if (relative === "") return true;
+      const segments = relative.split(path.sep);
+      const firstSegment = segments[0];
+      if (firstSegment === ".git" || firstSegment === "node_modules") return false;
+      return !(firstSegment === "native" && segments[1] === "target");
+    },
+  });
+}
+
+if (!isCurrentIdentity() && outputDir === projectRoot) {
+  fail("Future identity staging requires --output-dir because this operation preserves checked-in metadata.");
+}
+
+function isCurrentIdentity() {
+  return selectedIdentity.packageName === catalog.product.current.packageName;
+}
+
+function prepareManifest(manifestPath, host) {
+  if (!existsSync(manifestPath)) fail(`Missing host manifest at ${manifestPath}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const server = manifest.mcpServers?.["codebase-index"];
+  if (!server?.command || !Array.isArray(server.args)) {
+    fail(`Missing codebase-index MCP server in ${manifestPath}`);
+  }
+  server.args = ["-y", "--package", selectedIdentity.packageName, selectedIdentity.mcpBinary, "--host", host];
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+const preparedBins = isCurrentIdentity()
   ? { [catalog.product.current.mcpBinary]: cliTarget }
   : {
       [catalog.product.future.mcpBinary]: cliTarget,
       [catalog.product.current.mcpBinary]: cliTarget,
     };
 
-packageJson.name = selectedIdentity.packageName;
-packageJson.bin = preparedBins;
-packageLock.name = selectedIdentity.packageName;
-if (!packageLock.packages?.[""]) {
-  fail("package-lock.json is missing the root package entry");
-}
-packageLock.packages[""].name = selectedIdentity.packageName;
-packageLock.packages[""].bin = preparedBins;
+const targetPackageJsonPath = path.join(outputDir, "package.json");
+const targetPackageLockPath = path.join(outputDir, "package-lock.json");
 
-mkdirSync(outputDir, { recursive: true });
-writeFileSync(path.join(outputDir, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`, "utf-8");
-writeFileSync(path.join(outputDir, "package-lock.json"), `${JSON.stringify(packageLock, null, 2)}\n`, "utf-8");
+copyProject();
+
+if (!isCurrentIdentity()) {
+  packageJson.name = selectedIdentity.packageName;
+  packageJson.bin = preparedBins;
+  packageLock.name = selectedIdentity.packageName;
+  if (!packageLock.packages?.[""]) {
+    fail("package-lock.json is missing the root package entry");
+  }
+  packageLock.packages[""].name = selectedIdentity.packageName;
+  packageLock.packages[""].bin = preparedBins;
+
+  writeFileSync(targetPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf-8");
+  writeFileSync(targetPackageLockPath, `${JSON.stringify(packageLock, null, 2)}\n`, "utf-8");
+
+  prepareManifest(path.join(outputDir, ".mcp.json"), "codex");
+  prepareManifest(path.join(outputDir, ".claude-plugin", "plugin.json"), "claude");
+}
 
 console.log(`Prepared metadata for ${selectedIdentity.packageName}`);

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -24,6 +24,10 @@ function readJson<T>(filePath: string): T {
   return JSON.parse(readFileSync(filePath, "utf-8")) as T;
 }
 
+function readText(filePath: string): string {
+  return readFileSync(filePath, "utf-8");
+}
+
 function prepareMetadata(packageName: string, outputDir: string): void {
   execFileSync(process.execPath, [
     path.join(process.cwd(), "scripts", "prepare-package-metadata.mjs"),
@@ -36,7 +40,7 @@ function prepareMetadata(packageName: string, outputDir: string): void {
   ]);
 }
 
-describe("Phase 0 product identity compatibility", () => {
+describe("Phase 1 product identity compatibility", () => {
   it("keeps the checked-in legacy package and host manifests unchanged", () => {
     const current = IDENTITY_CATALOG.product.current;
     const packageJson = readJson<PackageMetadata>("package.json");
@@ -98,8 +102,12 @@ describe("Phase 0 product identity compatibility", () => {
       expect(packageLock.name).toBe(IDENTITY_CATALOG.product.current.packageName);
       expect(packageLock.packages[""]?.bin).toEqual(expectedBin);
 
-      expect(readFileSync(path.join(tempDir, "package.json"), "utf-8")).toBe(readFileSync("package.json", "utf-8"));
-      expect(readFileSync(path.join(tempDir, "package-lock.json"), "utf-8")).toBe(readFileSync("package-lock.json", "utf-8"));
+      expect(readText(path.join(tempDir, "package.json"))).toBe(readText("package.json"));
+      expect(readText(path.join(tempDir, "package-lock.json"))).toBe(readText("package-lock.json"));
+      expect(readText(path.join(tempDir, ".mcp.json"))).toBe(readText(".mcp.json"));
+      expect(readText(path.join(tempDir, ".claude-plugin", "plugin.json"))).toBe(
+        readText(".claude-plugin/plugin.json"),
+      );
       expect(packageJson).toEqual(checkedInPackageJson);
       expect(packageLock).toEqual(checkedInPackageLock);
     } finally {
@@ -113,16 +121,45 @@ describe("Phase 0 product identity compatibility", () => {
       prepareMetadata(IDENTITY_CATALOG.product.future.packageName, tempDir);
       const packageJson = readJson<PackageMetadata>(path.join(tempDir, "package.json"));
       const packageLock = readJson<PackageLockMetadata>(path.join(tempDir, "package-lock.json"));
+      const stagedMcpManifest = readJson<{
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      }>(path.join(tempDir, ".mcp.json"));
+      const stagedClaudeManifest = readJson<{
+        homepage: string;
+        repository: string;
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      }>(path.join(tempDir, ".claude-plugin", "plugin.json"));
       const expectedBin = {
         [IDENTITY_CATALOG.product.future.mcpBinary]: "dist/cli.js",
         [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js",
       };
+      const expectedMcpArgs = [
+        "-y",
+        "--package",
+        IDENTITY_CATALOG.product.future.packageName,
+        IDENTITY_CATALOG.product.future.mcpBinary,
+        "--host",
+        "codex",
+      ];
+      const expectedClaudeArgs = [
+        "-y",
+        "--package",
+        IDENTITY_CATALOG.product.future.packageName,
+        IDENTITY_CATALOG.product.future.mcpBinary,
+        "--host",
+        "claude",
+      ];
 
       expect(packageJson.name).toBe(IDENTITY_CATALOG.product.future.packageName);
       expect(packageJson.bin).toEqual(expectedBin);
+      expect(packageJson.repository.url).toBe(IDENTITY_CATALOG.product.current.repository);
       expect(packageLock.name).toBe(IDENTITY_CATALOG.product.future.packageName);
       expect(packageLock.packages[""]?.name).toBe(IDENTITY_CATALOG.product.future.packageName);
       expect(packageLock.packages[""]?.bin).toEqual(expectedBin);
+      expect(stagedMcpManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedMcpArgs });
+      expect(stagedClaudeManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedClaudeArgs });
+      expect(stagedClaudeManifest.homepage).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedClaudeManifest.repository).toBe(IDENTITY_CATALOG.product.current.repository);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -157,9 +194,16 @@ describe("Phase 0 product identity compatibility", () => {
 
   it("keeps publication release-gated while accepting an explicit known package identity", () => {
     const workflow = readFileSync(".github/workflows/build.yml", "utf-8");
-    expect(workflow).toContain("package_name:");
-    expect(workflow).toContain("inputs.package_name || vars.NPM_PACKAGE_NAME || 'opencode-codebase-index'");
+    expect(workflow).not.toContain("inputs:");
+    expect(workflow).toContain("for packageName in open-codebase-index opencode-codebase-index;");
     expect(workflow).toContain("if: github.event_name == 'release'");
-    expect(workflow).toContain("node scripts/prepare-package-metadata.mjs --package-name");
+    expect(workflow).toContain("npm publish --ignore-scripts --access public");
+    expect(workflow).toContain("npm view \"${packageName}@${PACKAGE_VERSION}\" --json");
+    expect(workflow).toContain("stagingDir=\"${RUNNER_TEMP}/package-metadata/${packageName}\"");
+
+    const openFirst = workflow.indexOf("open-codebase-index");
+    const legacyAfter = workflow.indexOf("opencode-codebase-index", openFirst + 1);
+    expect(openFirst).toBeGreaterThan(-1);
+    expect(legacyAfter).toBeGreaterThan(openFirst);
   });
 });


### PR DESCRIPTION
## Summary
- stage `open-codebase-index` with both new and legacy MCP binary aliases while leaving the checked-in legacy package identity intact
- stage Codex and Claude MCP manifests with the selected package identity without changing repository provenance
- publish the new package first and the legacy package second from one release, skipping versions already present so reruns are safe
- make new installation guidance prefer the host-neutral package while retaining explicit legacy commands
- make package description and keywords host-neutral

## Compatibility boundaries
- no version bump, tag, npm publication, or repository rename in this PR
- no storage path, tool contract, MCP server name, native artifact, or persistence change
- checked-in `package.json`, lockfile, and host manifests retain the legacy package and binary identity
- repository metadata remains `Helweg/opencode-codebase-index` until Phase 2

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (68 files, 1,273 tests)
- `cargo fmt --manifest-path native/Cargo.toml --check`
- `cargo test --manifest-path native/Cargo.toml --lib` (116 tests)
- focused package and host tests (71 tests)
- workflow YAML, Markdown links/fences, and diff checks
- current/future package inventories match at 35 files
- clean future-package tarball install executes both MCP binary aliases

## Publication prerequisite
The `open-codebase-index` npm name is currently unclaimed. Its first publication still requires npm ownership/bootstrap and trusted-publisher configuration before the synchronized release workflow can publish it through OIDC.