### PR TITLE
chore: prepare v0.21.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.20.1"
+      "version": "0.21.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-30
+
+### Added
+
+- **Host-neutral package identity**: Published `open-codebase-index` as the preferred package with both `open-codebase-index-mcp` and `opencode-codebase-index-mcp` binaries. The existing `opencode-codebase-index` package remains fully supported and is published from the same implementation.
+- **Safe rename roadmap**: Documented the staged package, repository, compatibility, deprecation, storage, native-artifact, validation, and rollback plan for the transition to `open-codebase-index`.
+
 ### Changed
 
+- **Host-neutral adapter architecture**: Isolated OpenCode, MCP, and Pi registration behind dedicated adapters, moved MCP CLI runtime behind its adapter, centralized portable tool-name contracts, and require explicit host context wherever runtime paths or behavior differ. Tool names, schemas, outputs, and host-specific aliases remain unchanged.
 - **Portable project indexes across Git worktrees**: Project-owned paths are now persisted relative to the project root. Worktrees that inherit project configuration share the main checkout's index and reuse unchanged chunks and embeddings, while an explicit worktree-local project config keeps its index isolated. Existing project indexes with absolute stored paths require a one-time force rebuild.
-- **Phase 1 rename preparation**: Added dual-identity package metadata staging, including `open-codebase-index` support with both MCP binary aliases, while keeping the checked-in legacy identity and native/tool/storage naming stable.
+- **Compatibility-aware release pipeline**: Package metadata and host manifests are staged per package identity, native artifacts remain stable, new installation examples prefer `open-codebase-index`, and release retries skip package versions already published.
 
 ## [0.20.1] - 2026-07-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- prepare the first host-neutral dual-package release at v0.21.0
- publish `open-codebase-index` as the preferred identity while preserving `opencode-codebase-index`
- synchronize npm, Claude, marketplace, and Codex versions
- reconcile the complete v0.20.1-to-main changelog delta

## Compatibility
- legacy package and MCP binary remain supported
- future package contains both MCP binary aliases
- repository, tool, storage, server, and native artifact identities remain unchanged
- both package identities are staged from the same implementation

## Validation
- `npm run build:native`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (68 files, 1,273 tests)
- focused Claude, Codex, and identity tests (12 tests)
- Rust formatting and 116 Rust tests
- current/future tarball inventories match exactly (35 files)
- clean future-package install succeeds
- both `open-codebase-index-mcp` and `opencode-codebase-index-mcp` aliases execute
- `git diff --check`

## Release hold
This PR is intentionally not being merged yet. Tagging and publication remain blocked until the new npm package bootstrap and trusted-publisher setup are confirmed.
