### PR TITLE
feat: add standalone index CLI command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Build TypeScript
         run: npm run build:ts
 
+      - name: Smoke-test packed CLI identities
+        run: npm run smoke:package
+
       - name: Run typecheck
         run: npm run typecheck
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Direct index CLI subcommand for MCP binary**: Added `index` command support to the shared MCP CLI entrypoint with `--project`, `--host`, `--config`, `--force`, `--estimate-only`, and `--verbose` flags. The command uses shared indexing execution and lock/callback semantics, prints diagnostics to `stderr`, exits non-zero on usage and runtime errors, and preserves existing MCP/eval/visualize modes.
+
 ## [0.21.0] - 2026-07-30
 
 ### Added

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -177,6 +177,24 @@ open-codebase-index-mcp --host jcode
 
 Use `--host` when you want the corresponding host's configuration and storage paths. Without it, the CLI uses OpenCode-compatible behavior.
 
+The same binary also accepts a dedicated indexing mode:
+
+```bash
+open-codebase-index-mcp index --project /path/to/repo --estimate-only
+open-codebase-index-mcp index --project /path/to/repo --force
+open-codebase-index-mcp index --project /path/to/repo --config /path/to/config.json --host jcode
+opencode-codebase-index-mcp index --project /path/to/repo --estimate-only
+```
+
+When using `index`:
+
+- `--estimate-only` prints the estimate directly and exits.
+- `--force` bypasses stale-index checks.
+- `--verbose` includes detailed final index statistics.
+- `--config` loads and parses that file, then initializes the runtime from it before indexing.
+
+Progress and diagnostics for `index` are written to `stderr`; the final formatted result is written to `stdout`.
+
 ## Local source checkout
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "build": "npm run build:ts && npm run build:native",
     "build:ts": "tsup && node scripts/smoke-test-built-cli.mjs",
+    "smoke:package": "node scripts/smoke-test-packed-cli.mjs",
     "build:native": "cd native && cargo build --release && napi build --release --platform",
     "build:native:all": "cd native && napi build --release --platform --target x86_64-apple-darwin --target aarch64-apple-darwin --target x86_64-unknown-linux-gnu --target aarch64-unknown-linux-gnu --target x86_64-pc-windows-msvc",
     "visualize": "node dist/cli.js visualize",

--- a/scripts/smoke-test-built-cli.mjs
+++ b/scripts/smoke-test-built-cli.mjs
@@ -3,31 +3,52 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
+function runCliCommand(args, { killAfterMs = null } = {}) {
+  return new Promise((resolve, reject) => {
+    const command = [cliPath, ...args];
+    const child = spawn(process.execPath, command, {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    child.once("error", reject);
+
+    const cleanupTimer = killAfterMs
+      ? setTimeout(() => {
+        child.kill("SIGTERM");
+      }, killAfterMs)
+      : null;
+
+    child.once("exit", (code, signal) => {
+      if (cleanupTimer !== null) {
+        clearTimeout(cleanupTimer);
+      }
+      resolve({ code, signal, stdout, stderr, survived: signal === "SIGTERM" });
+    });
+  });
+}
+
 const cliPath = process.argv[2] ?? "dist/cli.js";
-const child = spawn(process.execPath, [cliPath, "--host", "jcode"], {
-  cwd: process.cwd(),
-  stdio: ["pipe", "pipe", "pipe"],
-});
 
-let stderr = "";
-child.stderr.setEncoding("utf8");
-child.stderr.on("data", (chunk) => {
-  stderr += chunk;
-});
-child.stdin.end();
+const mcpStartup = await runCliCommand(["--host", "jcode"], { killAfterMs: 2_000 });
+if (!mcpStartup.survived && mcpStartup.code !== 0) {
+  throw new Error(`Built ESM CLI failed in MCP startup mode with exit code ${mcpStartup.code}:\n${mcpStartup.stderr}`);
+}
 
-const result = await new Promise((resolve, reject) => {
-  child.once("error", reject);
-  child.once("exit", (code, signal) => resolve({ code, signal, survived: false }));
-
-  setTimeout(() => {
-    child.kill();
-    resolve({ code: null, signal: "SIGTERM", survived: true });
-  }, 2_000).unref();
-});
-
-if (!result.survived && result.code !== 0) {
-  throw new Error(`Built ESM CLI failed with exit code ${result.code}:\n${stderr}`);
+const indexHelp = await runCliCommand(["index", "--help"]);
+if (indexHelp.code !== 0 || !indexHelp.stderr.includes("Usage:")) {
+  throw new Error(`Built ESM CLI failed in index mode:\n${indexHelp.stderr}`);
 }
 
 const cjsModule = require("../dist/index.cjs");

--- a/scripts/smoke-test-packed-cli.mjs
+++ b/scripts/smoke-test-packed-cli.mjs
@@ -1,0 +1,88 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+const catalog = JSON.parse(readFileSync(path.join(repositoryRoot, "src", "identity-catalog.json"), "utf-8"));
+const scratchRoot = mkdtempSync(path.join(os.tmpdir(), "packed-cli-smoke-"));
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function binaryPath(installRoot, binaryName) {
+  const suffix = process.platform === "win32" ? ".cmd" : "";
+  return path.join(installRoot, "node_modules", ".bin", `${binaryName}${suffix}`);
+}
+
+function smokeIdentity(identity, expectedBinaries) {
+  const stageRoot = path.join(scratchRoot, `stage-${identity.packageName}`);
+  const installRoot = path.join(scratchRoot, `install-${identity.packageName}`);
+  const projectRoot = path.join(scratchRoot, `project-${identity.packageName}`);
+
+  mkdirSync(installRoot, { recursive: true });
+  mkdirSync(projectRoot, { recursive: true });
+
+  run(process.execPath, [
+    path.join(repositoryRoot, "scripts", "prepare-package-metadata.mjs"),
+    "--package-name",
+    identity.packageName,
+    "--project-root",
+    repositoryRoot,
+    "--output-dir",
+    stageRoot,
+  ], repositoryRoot);
+
+  const packOutput = JSON.parse(run("npm", ["pack", "--ignore-scripts", "--json"], stageRoot));
+  const tarballPath = path.join(stageRoot, packOutput[0].filename);
+
+  writeFileSync(path.join(scratchRoot, `pack-${identity.packageName}.json`), JSON.stringify(packOutput, null, 2));
+  writeFileSync(path.join(installRoot, "package.json"), "{\"private\":true}\n", { flag: "wx" });
+  run("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarballPath], installRoot);
+
+  writeFileSync(path.join(projectRoot, "notes.txt"), "packed CLI smoke test\n", { flag: "wx" });
+  const configPath = path.join(projectRoot, "config.json");
+  writeFileSync(configPath, JSON.stringify({
+    embeddingProvider: "custom",
+    include: ["**/*.txt"],
+    customProvider: {
+      baseUrl: "http://127.0.0.1/v1",
+      model: "smoke-test-embed",
+      dimensions: 1024,
+    },
+  }));
+
+  for (const binaryName of expectedBinaries) {
+    const executable = binaryPath(installRoot, binaryName);
+    if (!existsSync(executable)) {
+      throw new Error(`Packed package ${identity.packageName} is missing binary ${binaryName}`);
+    }
+
+    const result = spawnSync(executable, [
+      "index",
+      "--project",
+      projectRoot,
+      "--host",
+      "jcode",
+      "--config",
+      configPath,
+      "--estimate-only",
+    ], { cwd: projectRoot, encoding: "utf8" });
+
+    if (result.status !== 0 || !result.stdout.includes("Indexing Estimate")) {
+      throw new Error([
+        `Packed CLI smoke failed for ${identity.packageName}/${binaryName} with exit ${String(result.status)}`,
+        result.stdout,
+        result.stderr,
+      ].join("\n"));
+    }
+  }
+}
+
+try {
+  smokeIdentity(catalog.product.current, [catalog.product.current.mcpBinary]);
+  smokeIdentity(catalog.product.future, [catalog.product.future.mcpBinary, catalog.product.current.mcpBinary]);
+} finally {
+  rmSync(scratchRoot, { recursive: true, force: true });
+}

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -1,3 +1,5 @@
+import type { SharedIndexCodebaseArgs } from "../../tools/contracts.js";
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { realpathSync, writeFileSync } from "fs";
 import * as os from "os";
@@ -11,6 +13,8 @@ import { Indexer } from "../../indexer/index.js";
 import { createMcpServer } from "../../mcp-server.js";
 import { loadConfigFile, loadMergedConfig } from "../../config/merger.js";
 import { getIndexerForProject } from "../../tools/operations.js";
+import { initializeTools } from "../../tools/operation-runtime.js";
+import { executeIndexCodebase } from "../../tools/execute-common.js";
 import { hasProjectMarker } from "../../utils/files.js";
 import { isHomeDirectory, stopAutoIndex } from "../../utils/auto-index.js";
 import { createWatcherWithIndexer, type CombinedWatcher } from "../../watcher/index.js";
@@ -21,6 +25,15 @@ export interface CliArgs {
   project: string;
   config?: string;
   host: HostMode;
+}
+
+export interface CliIndexArgs {
+  project: string;
+  host: HostMode;
+  config?: string;
+  force: boolean;
+  estimateOnly: boolean;
+  verbose: boolean;
 }
 
 interface VisualizeArgs {
@@ -50,8 +63,98 @@ export function parseArgs(argv: string[]): CliArgs {
   return { project, config, host };
 }
 
+export function parseIndexArgs(argv: string[], cwd: string): CliIndexArgs {
+  let project = cwd;
+  let host: HostMode = "opencode";
+  let config: string | undefined;
+  let force = false;
+  let estimateOnly = false;
+  let verbose = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if (arg === "--project" || arg.startsWith("--project=")) {
+      const value = arg.startsWith("--project=") ? arg.slice("--project=".length) : next;
+      if (!value || (!arg.includes("=") && value.startsWith("--"))) {
+        throw new Error("--project requires a value.");
+      }
+      if (!arg.startsWith("--project=")) {
+        i += 1;
+      }
+      project = path.resolve(cwd, value);
+      continue;
+    }
+
+    if (arg === "--config" || arg.startsWith("--config=")) {
+      const value = arg.startsWith("--config=") ? arg.slice("--config=".length) : next;
+      if (!value || (!arg.includes("=") && value.startsWith("--"))) {
+        throw new Error("--config requires a value.");
+      }
+      if (!arg.startsWith("--config=")) {
+        i += 1;
+      }
+      config = path.resolve(cwd, value);
+      continue;
+    }
+
+    if (arg === "--host" || arg.startsWith("--host=")) {
+      const value = arg.startsWith("--host=") ? arg.slice("--host=".length) : next;
+      if (!value || (!arg.includes("=") && value.startsWith("--"))) {
+        throw new Error("--host requires a value.");
+      }
+      if (!arg.startsWith("--host=")) {
+        i += 1;
+      }
+      host = parseHostMode(value);
+      continue;
+    }
+
+    if (arg === "--force" || arg === "--estimate-only" || arg === "--verbose") {
+      if (arg === "--force") {
+        force = true;
+      }
+      if (arg === "--estimate-only") {
+        estimateOnly = true;
+      }
+      if (arg === "--verbose") {
+        verbose = true;
+      }
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error("help-requested");
+    }
+
+    throw new Error(`Unknown index option: ${arg}`);
+  }
+
+  return { project, host, config, force, estimateOnly, verbose };
+}
+
 export function loadCliRawConfig(args: CliArgs): unknown {
   return args.config ? loadConfigFile(args.config) : loadMergedConfig(args.project, args.host);
+}
+
+export function printUsage(output: (text: string) => void = (text) => console.error(text)): void {
+  output(`
+Usage:
+  ${process.argv[1]} index [options]
+
+Options:
+  --project <path>       Project root (default: cwd)
+  --host <mode>          opencode, codex, claude, pi, or jcode
+  --config <path>        Explicit JSON config path
+  --force                Rebuild index even if already up to date
+  --estimate-only        Estimate indexing cost only
+  --verbose              Include detailed final index statistics
+  --help                 Show this message
+
+Run '${process.argv[1]} eval' and '${process.argv[1]} visualize' for existing behavior.
+Progress and diagnostics are written to stderr. Final index output is written to stdout.`
+  );
 }
 
 export function isCliEntrypoint(moduleUrl: string, argvPath: string | undefined): boolean {
@@ -127,6 +230,10 @@ async function handleVisualizeCommand(argv: string[], cwd: string): Promise<numb
 }
 
 export async function runMcpCli(argv: string[]): Promise<void> {
+  if (argv[2] === "index") {
+    const exitCode = await handleIndexCommand(argv.slice(3), process.cwd());
+    process.exit(exitCode);
+  }
   if (argv[2] === "eval") {
     const exitCode = await handleEvalCommand(argv.slice(3), process.cwd());
     process.exit(exitCode);
@@ -178,6 +285,94 @@ export async function runMcpCli(argv: string[]): Promise<void> {
   process.on("SIGTERM", () => { void shutdown(); });
 }
 
+interface CliIndexCommandDeps {
+  runIndex?: (
+    projectRoot: string | undefined,
+    host: HostMode,
+    args: SharedIndexCodebaseArgs,
+    onProgress?: (title: string, metadata: Record<string, unknown>) => void,
+  ) => Promise<{ text: string; isError?: boolean }>;
+  initializeRuntimeForConfig?: (projectRoot: string, parsedConfig: ReturnType<typeof parseConfig>, host: HostMode) => void;
+  readCliConfigFile?: (filePath: string) => unknown;
+  printStdout?: (text: string) => void;
+  printStderr?: (text: string) => void;
+}
+
+function printIndexProgress(onProgress: (text: string) => void, title: string, metadata: Record<string, unknown>): void {
+  const details = Object.entries(metadata)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}=${isSensitiveKey(key) ? "[REDACTED]" : String(value)}`)
+    .join(" ");
+  onProgress(details.length === 0 ? title : `${title} ${details}`);
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /(?:api[-_]?key|token|password|secret|authorization)/i.test(key);
+}
+
+function redactSensitiveText(text: string): string {
+  return text.replace(
+    /((?:api[-_]?key|token|password|secret|authorization)\s*[=:]\s*)([^\s,;]+)/gi,
+    "$1[REDACTED]",
+  );
+}
+
+export async function handleIndexCommand(
+  argv: string[],
+  cwd: string,
+  deps: CliIndexCommandDeps = {},
+): Promise<number> {
+  const runIndex = deps.runIndex ?? executeIndexCodebase;
+  const initializeRuntimeForConfig = deps.initializeRuntimeForConfig ?? initializeTools;
+  const readCliConfigFile = deps.readCliConfigFile ?? loadConfigFile;
+  const printStdout = deps.printStdout ?? ((text) => console.log(text));
+  const printStderr = deps.printStderr ?? ((text) => console.error(redactSensitiveText(text)));
+
+  let parsedArgs: CliIndexArgs;
+  try {
+    parsedArgs = parseIndexArgs(argv, cwd);
+  } catch (error) {
+    if (error instanceof Error && error.message === "help-requested") {
+      printUsage(printStderr);
+      return 0;
+    }
+    printStderr(error instanceof Error ? error.message : String(error));
+    printUsage(printStderr);
+    return 1;
+  }
+
+  try {
+    if (parsedArgs.config !== undefined) {
+      const rawConfig = readCliConfigFile(parsedArgs.config);
+      if (rawConfig === null) {
+        throw new Error(`Config file not found: ${parsedArgs.config}`);
+      }
+      initializeRuntimeForConfig(parsedArgs.project, parseConfig(rawConfig), parsedArgs.host);
+    }
+
+    const indexArgs: SharedIndexCodebaseArgs = {
+      force: parsedArgs.force,
+      estimateOnly: parsedArgs.estimateOnly,
+      verbose: parsedArgs.verbose,
+    };
+
+    const result = await runIndex(parsedArgs.project, parsedArgs.host, indexArgs, (title, metadata) => {
+      printIndexProgress(printStderr, title, metadata);
+    });
+
+    if (result.isError) {
+      printStderr(result.text);
+      return 1;
+    }
+
+    printStdout(result.text);
+    return 0;
+  } catch (error) {
+    printStderr(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
 export function handleMainError(error: unknown): never {
   if (error instanceof Error && error.message.startsWith("Invalid host mode")) {
     console.error(`Invalid host mode. Allowed values: ${HOST_MODES.join(", ")}.`);
@@ -192,4 +387,3 @@ export function handleMainError(error: unknown): never {
   console.error("Fatal: failed to start MCP server");
   process.exit(1);
 }
-

--- a/tests/mcp-cli-index.test.ts
+++ b/tests/mcp-cli-index.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleIndexCommand, parseIndexArgs } from "../src/adapters/mcp/cli.js";
+
+describe("mcp cli index arg parsing", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "mcp-index-cli-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("parses index defaults", () => {
+    expect(parseIndexArgs([], tempDir)).toEqual({
+      project: tempDir,
+      host: "opencode",
+      config: undefined,
+      force: false,
+      estimateOnly: false,
+      verbose: false,
+    });
+  });
+
+  it("parses index flags and path-like args", () => {
+    const result = parseIndexArgs(
+      [
+        "--project",
+        "./repo",
+        "--host",
+        "jcode",
+        "--config",
+        "./my.config.json",
+        "--force",
+        "--estimate-only",
+        "--verbose",
+      ],
+      tempDir,
+    );
+
+    expect(result).toEqual({
+      project: path.join(tempDir, "repo"),
+      host: "jcode",
+      config: path.join(tempDir, "my.config.json"),
+      force: true,
+      estimateOnly: true,
+      verbose: true,
+    });
+  });
+
+  it("rejects unknown index options", () => {
+    expect(() => parseIndexArgs(["--bad-option"], tempDir)).toThrow("Unknown index option: --bad-option");
+  });
+
+  it("rejects missing values for valued index flags", () => {
+    expect(() => parseIndexArgs(["--project"], tempDir)).toThrow("--project requires a value.");
+    expect(() => parseIndexArgs(["--project", "--force"], tempDir)).toThrow("--project requires a value.");
+    expect(() => parseIndexArgs(["--config"], tempDir)).toThrow("--config requires a value.");
+    expect(() => parseIndexArgs(["--config", "--verbose"], tempDir)).toThrow("--config requires a value.");
+    expect(() => parseIndexArgs(["--host"], tempDir)).toThrow("--host requires a value.");
+    expect(() => parseIndexArgs(["--host", "--force"], tempDir)).toThrow("--host requires a value.");
+  });
+
+  it("rejects invalid host values", () => {
+    expect(() => parseIndexArgs(["--host", "bad"], tempDir)).toThrow("Invalid host mode: bad.");
+  });
+});
+
+describe("mcp cli index command execution", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "mcp-index-cli-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes diagnostics to stderr and final text to stdout", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const runIndex = vi.fn(async (_projectRoot: string | undefined, _host: string, _args: Record<string, unknown>, onProgress?: (title: string, metadata: Record<string, unknown>) => Promise<void> | void) => {
+      if (onProgress) {
+        await onProgress("scan", { phase: "collect", files: 12, apiKey: "should-not-leak" });
+      }
+      return { text: "ok" };
+    });
+
+    const exitCode = await handleIndexCommand(
+      ["--force", "--verbose", "--estimate-only"],
+      tempDir,
+      {
+        runIndex,
+        printStdout: (text) => stdout.push(text),
+        printStderr: (text) => stderr.push(text),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual(["ok"]);
+    expect(stderr.join("\n")).toContain("scan phase=collect files=12");
+    expect(stderr.join("\n")).toContain("apiKey=[REDACTED]");
+    expect(stderr.join("\n")).not.toContain("should-not-leak");
+    expect(runIndex).toHaveBeenCalledWith(tempDir, "opencode", {
+      force: true,
+      estimateOnly: true,
+      verbose: true,
+    }, expect.any(Function));
+  });
+
+  it("prints busy and exits non-zero on index errors", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const runIndex = vi.fn(async () => ({ text: "indexer already running", isError: true }));
+
+    const exitCode = await handleIndexCommand(["--project", tempDir], tempDir, {
+      runIndex,
+      printStdout: (text) => stdout.push(text),
+      printStderr: (text) => stderr.push(text),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr.join("\n")).toContain("indexer already running");
+  });
+
+  it("exits non-zero when indexing throws", async () => {
+    const stderr: string[] = [];
+    const exitCode = await handleIndexCommand([], tempDir, {
+      runIndex: vi.fn(async () => { throw new Error("embedding provider unavailable"); }),
+      printStderr: (text) => stderr.push(text),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toEqual(["embedding provider unavailable"]);
+  });
+
+  it("exits non-zero when an explicit config file is missing", async () => {
+    const stderr: string[] = [];
+    const configPath = path.join(tempDir, "missing.json");
+    const exitCode = await handleIndexCommand(["--config", configPath], tempDir, {
+      readCliConfigFile: () => null,
+      printStderr: (text) => stderr.push(text),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toEqual([`Config file not found: ${configPath}`]);
+  });
+
+  it("uses explicit --config with initializeTools before running index", async () => {
+    const configFile = path.join(tempDir, "index-config.json");
+    writeFileSync(
+      configFile,
+      JSON.stringify(
+        {
+          embeddingProvider: "custom",
+          customProvider: {
+            baseUrl: "http://localhost:8080/v1",
+            model: "test-embed",
+            dimensions: 1024,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const initialized: Array<{ projectRoot: string; host: string; provider: string }> = [];
+    const runIndex = vi.fn(async () => ({ text: "ok" }));
+    const initializeRuntimeForConfig = vi.fn((projectRoot: string, parsedConfig: { embeddingProvider: string }, host: string) => {
+      initialized.push({ projectRoot, host, provider: parsedConfig.embeddingProvider });
+    });
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+
+    const exitCode = await handleIndexCommand(
+      ["--config", configFile],
+      tempDir,
+      {
+        runIndex,
+        initializeRuntimeForConfig,
+        printStdout: (text) => stdout.push(text),
+        printStderr: (text) => stderr.push(text),
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(initialized).toEqual([{ projectRoot: tempDir, host: "opencode", provider: "custom" }]);
+    expect(runIndex).toHaveBeenCalledWith(tempDir, "opencode", { force: false, estimateOnly: false, verbose: false }, expect.any(Function));
+    expect(stdout).toEqual(["ok"]);
+    expect(stderr).toEqual([]);
+  });
+
+  it("returns usage and exits zero on --help", async () => {
+    const stderr: string[] = [];
+    const exitCode = await handleIndexCommand(["--help"], tempDir, {
+      printStderr: (text) => stderr.push(text),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr.join("\n")).toContain("Usage:");
+  });
+});

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -241,7 +241,7 @@ describe("watcher config refresh", () => {
           undefined,
         );
         expect(indexer.index).toHaveBeenCalledTimes(1);
-      }, { timeout: 2500 });
+      }, { timeout: 5000 });
     } finally {
       await watcher.stop();
     }


### PR DESCRIPTION
## Summary

- add an `index` subcommand to the shared MCP CLI entrypoint
- support host-aware project/config selection, force rebuilds, estimates, verbose output, stderr progress, and reliable failure exits
- add parser/runtime tests plus clean-install packed-package smoke coverage for both package identities and binary aliases
- document representative host-neutral and compatibility usage
- stabilize one watcher creation assertion that repeatedly timed out only under full-suite load

## Validation

- `npm run build`
- `npm run smoke:package`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run` (69 files, 1,284 tests)
- isolated watcher test passed twice before timeout stabilization

Closes #223