### PR TITLE
feat(indexer): bound changed-file indexing memory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,6 +68,11 @@ Source Files → Parse → Chunk → Embed → Store
    └─ Compare file hashes (xxhash) against stored hashes
    └─ Only process new/modified files
 
+2a. BATCH: Bound changed-file working state
+   └─ Retain path, hash, and byte-size descriptors during discovery
+   └─ Process in discovery order, up to 64 files or 8 MiB of source per batch
+   └─ A single file larger than 8 MiB is processed alone
+
 3. PARSE: Tree-sitter language-aware parsing
    └─ native/src/parser.rs: parse_file()
    └─ Extracts: functions, classes, methods, interfaces
@@ -87,6 +92,10 @@ Source Files → Parse → Chunk → Embed → Store
    └─ usearch: vector index for similarity search
    └─ BM25: inverted index for keyword search
 ```
+
+Changed-file source, parse results, pending embedding text, and queued requests are released between file batches. Embedding requests still use provider-aware dynamic batches and queue backpressure. Failed embedding records are written incrementally as versioned JSONL and streamed during retry, while legacy JSON-array state remains readable.
+
+SQLite mutations participate in one coordinated write transaction, so an interrupted run does not expose partially indexed rows to other connections. Vector, BM25, file-hash, and branch-catalog publication remains at the existing final boundary. These separate artifacts are not claimed to form one cross-storage atomic transaction.
 
 ### Search Flow
 
@@ -139,6 +148,8 @@ Focused helpers keep ranking and batch mechanics out of the orchestrator:
 - `search-ranking.ts` handles generic fusion, filtering, diversity, and result assembly.
 - `definition-ranking.ts` handles definition-query normalization and evidence ranking.
 - `embedding-batches.ts` handles pending embedding batches, retry state, and vector pooling.
+- `file-batches.ts` defines deterministic file-count and source-byte batch limits.
+- `failed-state-persistence.ts` streams versioned JSONL failure state and legacy reads.
 - `call-graph-constants.ts` owns the shared declaration chunk-type allowlist.
 
 Key public methods include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Direct index CLI subcommand for MCP binary**: Added `index` command support to the shared MCP CLI entrypoint with `--project`, `--host`, `--config`, `--force`, `--estimate-only`, and `--verbose` flags. The command uses shared indexing execution and lock/callback semantics, prints diagnostics to `stderr`, exits non-zero on usage and runtime errors, and preserves existing MCP/eval/visualize modes.
 
+### Changed
+
+- **Bounded file-level indexing batches** (#224): Changed-file scans now retain only path, hash, and byte-size descriptors, then parse, chunk, extract call-graph data, and admit embeddings in fixed internal file batches with queue backpressure. Failed embedding state is incrementally written as versioned JSONL and retried as a bounded stream while preserving legacy JSON-array reads, branch catalogs, Git blame, duplicate embedding reuse, and prior-generation SQLite visibility after interrupted runs.
+
 ## [0.21.0] - 2026-07-30
 
 ### Added

--- a/benchmarks/fixtures/indexing-memory-worker.ts
+++ b/benchmarks/fixtures/indexing-memory-worker.ts
@@ -1,0 +1,187 @@
+import type { CallEdgeData } from "../../src/native/index.js";
+
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { parseConfig } from "../../src/config/schema.js";
+import { Indexer } from "../../src/indexer/index.js";
+import { Database, VectorStore } from "../../src/native/index.js";
+
+type BenchmarkMode = "unbounded" | "bounded";
+
+interface MemoryFixture {
+  version: number;
+  fileCount: number;
+  functionsPerFile: number;
+  payloadCharacters: number;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize).sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}
+
+function source(fileIndex: number, fixture: MemoryFixture): string {
+  return Array.from({ length: fixture.functionsPerFile }, (_, functionIndex) => {
+    const name = `fixture_${fileIndex}_${functionIndex}`;
+    const previous = functionIndex === 0 ? "" : `fixture_${fileIndex}_${functionIndex - 1}() + `;
+    const payload = `${fileIndex}:${functionIndex}:` + "x".repeat(fixture.payloadCharacters);
+    return `export function ${name}() { return ${previous}${JSON.stringify(payload)}; }`;
+  }).join("\n\n");
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2] as BenchmarkMode;
+  const fixturePath = process.argv[3];
+  if ((mode !== "unbounded" && mode !== "bounded") || !fixturePath) {
+    throw new Error("Usage: indexing-memory-worker <unbounded|bounded> <fixture.json>");
+  }
+
+  const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8")) as MemoryFixture;
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `indexing-memory-${mode}-`));
+  const indexPath = fs.mkdtempSync(path.join(os.tmpdir(), `indexing-memory-index-${mode}-`));
+  const sourceDir = path.join(projectDir, "src");
+  fs.mkdirSync(sourceDir, { recursive: true });
+
+  let sourceBytes = 0;
+  for (let fileIndex = 0; fileIndex < fixture.fileCount; fileIndex++) {
+    const content = source(fileIndex, fixture);
+    sourceBytes += Buffer.byteLength(content, "utf8");
+    fs.writeFileSync(path.join(sourceDir, `${fileIndex.toString().padStart(4, "0")}.ts`), content, "utf8");
+  }
+
+  const requestDigest = createHash("sha256");
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+    const texts = body.input ?? [];
+    for (const text of texts) {
+      requestDigest.update(text);
+      requestDigest.update("\0");
+    }
+    return new Response(JSON.stringify({
+      data: texts.map((text) => {
+        const seed = Array.from(text).reduce((total, char) => (total * 31 + char.charCodeAt(0)) % 997, 0);
+        return { embedding: Array.from({ length: 8 }, (_, index) => (seed + index * 17) / 997) };
+      }),
+      usage: { total_tokens: Math.max(1, texts.length * 8) },
+    }), { status: 200 });
+  };
+
+  let indexer: Indexer | undefined;
+  try {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://127.0.0.1:1/v1",
+        model: "indexing-memory-fixture",
+        dimensions: 8,
+        maxBatchSize: 128,
+        concurrency: 2,
+        requestIntervalMs: 0,
+      },
+      indexing: { watchFiles: false, retries: 0, autoGc: false, maxFilesPerDirectory: 2000 },
+    });
+    indexer = new Indexer(projectDir, config, "opencode", {
+      indexPath,
+      fileBatchLimits: mode === "unbounded"
+        ? { maxFiles: Number.MAX_SAFE_INTEGER, maxBytes: Number.MAX_SAFE_INTEGER }
+        : undefined,
+    });
+
+    global.gc?.();
+    const startedAt = performance.now();
+    const stats = await indexer.index();
+    const ranked = await indexer.search("fixture_12_3", 5, { definitionIntent: true });
+    const rankedTarget = ranked.find((result) => result.name === "fixture_12_3");
+    if (!rankedTarget) {
+      throw new Error("Expected fixture_12_3 in ranked search results");
+    }
+    const durationMs = performance.now() - startedAt;
+    await indexer.close();
+    indexer = undefined;
+
+    const fileHashes = JSON.parse(fs.readFileSync(path.join(indexPath, "file-hashes.json"), "utf8")) as Record<string, string>;
+    const filePaths = Object.keys(fileHashes).sort();
+    const database = new Database(path.join(indexPath, "codebase.db"));
+    const chunks = filePaths.flatMap((filePath) => database.getChunksByFile(filePath))
+      .sort((left, right) => left.chunkId.localeCompare(right.chunkId));
+    const symbols = filePaths.flatMap((filePath) => database.getSymbolsByFile(filePath))
+      .sort((left, right) => left.id.localeCompare(right.id));
+    const edgesById = new Map<string, CallEdgeData>();
+    const branches = database.getAllBranches().sort().map((branch) => {
+      for (const symbol of database.getSymbolsForBranch(branch)) {
+        for (const edge of database.getCallees(symbol.id, branch)) edgesById.set(edge.id, edge);
+      }
+      return {
+        branch,
+        chunks: database.getBranchChunkIds(branch).sort(),
+        symbols: database.getBranchSymbolIds(branch).sort(),
+      };
+    });
+    const embeddingDigests = chunks.map((chunk) => ({
+      contentHash: chunk.contentHash,
+      embedding: sha256(database.getEmbedding(chunk.contentHash) ?? Buffer.alloc(0)),
+    }));
+    const databaseStats = database.getStats();
+    database.close();
+
+    const vectors = new VectorStore(path.join(indexPath, "vectors"), 8);
+    vectors.loadStrict();
+    const vectorMetadata = vectors.getAllMetadata().sort((left, right) => left.key.localeCompare(right.key));
+    const invertedIndex = JSON.parse(fs.readFileSync(path.join(indexPath, "inverted-index.json"), "utf8")) as unknown;
+    const requestDigestValue = requestDigest.digest("hex");
+    const components = Object.fromEntries(Object.entries({
+      fileHashes,
+      chunks,
+      symbols,
+      edges: Array.from(edgesById.values()),
+      branches,
+      embeddingDigests,
+      databaseStats,
+      vectorMetadata,
+      invertedIndex,
+      rankedTarget: {
+        filePath: path.relative(projectDir, rankedTarget.filePath),
+        startLine: rankedTarget.startLine,
+        endLine: rankedTarget.endLine,
+        name: rankedTarget.name,
+      },
+    }).map(([key, value]) => [key, sha256(JSON.stringify(canonicalize(value)))]));
+    const digest = sha256(JSON.stringify(canonicalize({ fixtureVersion: fixture.version, components })));
+
+    console.log(JSON.stringify({
+      mode,
+      digest,
+      requestDigest: requestDigestValue,
+      components,
+      files: stats.totalFiles,
+      chunks: stats.totalChunks,
+      sourceBytes,
+      peakRssBytes: process.resourceUsage().maxRSS * 1024,
+      durationMs,
+    }));
+  } finally {
+    await indexer?.close();
+    globalThis.fetch = originalFetch;
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(indexPath, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/benchmarks/fixtures/indexing-memory.json
+++ b/benchmarks/fixtures/indexing-memory.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "fileCount": 512,
+  "functionsPerFile": 6,
+  "payloadCharacters": 5000
+}

--- a/benchmarks/indexing-memory.ts
+++ b/benchmarks/indexing-memory.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type BenchmarkMode = "unbounded" | "bounded";
+
+interface WorkerResult {
+  mode: BenchmarkMode;
+  digest: string;
+  requestDigest: string;
+  files: number;
+  chunks: number;
+  sourceBytes: number;
+  peakRssBytes: number;
+  durationMs: number;
+}
+
+const benchmarkDir = path.dirname(fileURLToPath(import.meta.url));
+const workerPath = path.join(benchmarkDir, "fixtures", "indexing-memory-worker.ts");
+const fixturePath = path.join(benchmarkDir, "fixtures", "indexing-memory.json");
+
+function run(mode: BenchmarkMode): WorkerResult {
+  const child = spawnSync(
+    process.execPath,
+    ["--expose-gc", "--import", "tsx", workerPath, mode, fixturePath],
+    { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+  );
+  if (child.status !== 0) {
+    throw new Error(`${mode} benchmark failed (${child.status}):\n${child.stderr || child.stdout}`);
+  }
+  const line = child.stdout.trim().split("\n").findLast((entry) => entry.startsWith("{"));
+  if (!line) {
+    throw new Error(`${mode} benchmark emitted no result:\n${child.stdout}`);
+  }
+  return JSON.parse(line) as WorkerResult;
+}
+
+function mib(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+const unbounded = run("unbounded");
+const bounded = run("bounded");
+if (unbounded.digest !== bounded.digest) {
+  throw new Error(`Deterministic output mismatch: ${unbounded.digest} != ${bounded.digest}`);
+}
+const reduction = ((unbounded.peakRssBytes - bounded.peakRssBytes) / unbounded.peakRssBytes) * 100;
+console.log(
+  `Indexing memory fixture: ${bounded.files} files, ${bounded.chunks} chunks, ${mib(bounded.sourceBytes)} MiB source`,
+);
+console.log(`Stable output digest: ${bounded.digest}`);
+console.log(`Request digests: unbounded ${unbounded.requestDigest}, bounded ${bounded.requestDigest}`);
+console.log("| Mode | Peak RSS | Duration |");
+console.log("|---|---:|---:|");
+for (const result of [unbounded, bounded]) {
+  console.log(`| ${result.mode} | ${mib(result.peakRssBytes)} MiB | ${result.durationMs.toFixed(0)} ms |`);
+}
+console.log(`Peak RSS reduction: ${reduction.toFixed(1)}%`);

--- a/native/src/bindings/database.rs
+++ b/native/src/bindings/database.rs
@@ -109,6 +109,27 @@ impl Database {
     }
 
     #[napi]
+    pub fn begin_write_transaction(&self) -> Result<()> {
+        self.with_conn_mut(|conn| {
+            db::begin_write_transaction(conn).map_err(|e| Error::from_reason(e.to_string()))
+        })
+    }
+
+    #[napi]
+    pub fn commit_write_transaction(&self) -> Result<()> {
+        self.with_conn_mut(|conn| {
+            db::commit_write_transaction(conn).map_err(|e| Error::from_reason(e.to_string()))
+        })
+    }
+
+    #[napi]
+    pub fn rollback_write_transaction(&self) -> Result<()> {
+        self.with_conn_mut(|conn| {
+            db::rollback_write_transaction(conn).map_err(|e| Error::from_reason(e.to_string()))
+        })
+    }
+
+    #[napi]
     pub fn close(&self) -> Result<()> {
         // Best-effort, idempotent shutdown: once the connection is taken, all
         // future calls fail fast with `Database is closed` and repeated close()

--- a/native/src/db.rs
+++ b/native/src/db.rs
@@ -13,6 +13,8 @@ pub enum DbError {
     Io(#[from] std::io::Error),
     #[error("Read-only database schema error: {0}")]
     ReadOnlySchema(String),
+    #[error("Invalid transaction state: {0}")]
+    TransactionState(String),
 }
 
 pub type DbResult<T> = Result<T, DbError>;
@@ -23,6 +25,56 @@ const SCHEMA_VERSION: i32 = 7;
 /// Maximum number of SQL bind parameters per query.
 /// SQLite defaults to 999 (SQLITE_MAX_VARIABLE_NUMBER). We use 900 to stay safely under.
 const SQL_BIND_PARAM_BATCH_SIZE: usize = 900;
+
+pub(crate) fn run_batch_with_write_transaction<T, F>(
+    conn: &mut Connection,
+    operation: F,
+) -> DbResult<T>
+where
+    F: FnOnce(&Connection) -> DbResult<T>,
+{
+    if conn.is_autocommit() {
+        let tx = conn.transaction()?;
+        let result = operation(&tx)?;
+        tx.commit()?;
+        Ok(result)
+    } else {
+        operation(conn)
+    }
+}
+
+pub fn begin_write_transaction(conn: &mut Connection) -> DbResult<()> {
+    if !conn.is_autocommit() {
+        return Err(DbError::TransactionState(String::from(
+            "Cannot begin write transaction: transaction already active",
+        )));
+    }
+
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    Ok(())
+}
+
+pub fn commit_write_transaction(conn: &mut Connection) -> DbResult<()> {
+    if conn.is_autocommit() {
+        return Err(DbError::TransactionState(String::from(
+            "Cannot commit write transaction: no active transaction",
+        )));
+    }
+
+    conn.execute_batch("COMMIT;")?;
+    Ok(())
+}
+
+pub fn rollback_write_transaction(conn: &mut Connection) -> DbResult<()> {
+    if conn.is_autocommit() {
+        return Err(DbError::TransactionState(String::from(
+            "Cannot rollback write transaction: no active transaction",
+        )));
+    }
+
+    conn.execute_batch("ROLLBACK;")?;
+    Ok(())
+}
 
 /// Initialize the database with the required schema
 pub fn init_db(db_path: &Path) -> DbResult<Connection> {
@@ -378,9 +430,8 @@ pub fn upsert_embeddings_batch(
         return Ok(());
     }
 
-    let tx = conn.transaction()?;
-    {
-        let mut stmt = tx.prepare(
+    run_batch_with_write_transaction(conn, |conn| {
+        let mut stmt = conn.prepare(
             r#"
             INSERT INTO embeddings (content_hash, embedding, chunk_text, model, created_at)
             VALUES (?, ?, ?, ?, strftime('%s', 'now'))
@@ -393,9 +444,8 @@ pub fn upsert_embeddings_batch(
         for (content_hash, embedding, chunk_text, model) in embeddings {
             stmt.execute(params![content_hash, embedding, chunk_text, model])?;
         }
-    }
-    tx.commit()?;
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Get multiple embeddings by content hashes
@@ -530,9 +580,8 @@ pub fn upsert_chunks_batch(conn: &mut Connection, chunks: &[ChunkRow]) -> DbResu
         return Ok(());
     }
 
-    let tx = conn.transaction()?;
-    {
-        let mut stmt = tx.prepare(
+    run_batch_with_write_transaction(conn, |conn| {
+        let mut stmt = conn.prepare(
             r#"
             INSERT INTO chunks (chunk_id, content_hash, file_path, start_line, end_line, node_type, name, language, blame_sha, blame_author, blame_author_email, blame_committed_at, blame_summary)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -569,9 +618,9 @@ pub fn upsert_chunks_batch(conn: &mut Connection, chunks: &[ChunkRow]) -> DbResu
                 chunk.blame_summary
             ])?;
         }
-    }
-    tx.commit()?;
-    Ok(())
+
+        Ok(())
+    })
 }
 
 /// Get chunk by ID
@@ -776,17 +825,16 @@ pub fn add_chunks_to_branch_batch(
         return Ok(());
     }
 
-    let tx = conn.transaction()?;
-    {
+    run_batch_with_write_transaction(conn, |conn| {
         let mut stmt =
-            tx.prepare("INSERT OR IGNORE INTO branch_chunks (branch, chunk_id) VALUES (?, ?)")?;
+            conn.prepare("INSERT OR IGNORE INTO branch_chunks (branch, chunk_id) VALUES (?, ?)")?;
 
         for chunk_id in chunk_ids {
             stmt.execute(params![branch, chunk_id])?;
         }
-    }
-    tx.commit()?;
-    Ok(())
+
+        Ok(())
+    })
 }
 
 /// Remove all chunks from a branch (for re-indexing)

--- a/native/src/db/call_graph.rs
+++ b/native/src/db/call_graph.rs
@@ -74,9 +74,8 @@ pub fn upsert_symbols_batch(conn: &mut Connection, symbols: &[SymbolRow]) -> DbR
         return Ok(());
     }
 
-    let tx = conn.transaction()?;
-    {
-        let mut stmt = tx.prepare(
+    super::run_batch_with_write_transaction(conn, |conn| {
+        let mut stmt = conn.prepare(
             r#"
             INSERT OR REPLACE INTO symbols (id, file_path, name, kind, start_line, start_col, end_line, end_col, language)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -96,9 +95,8 @@ pub fn upsert_symbols_batch(conn: &mut Connection, symbols: &[SymbolRow]) -> DbR
                 symbol.language
             ])?;
         }
-    }
-    tx.commit()?;
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Get all symbols in a file
@@ -347,9 +345,8 @@ pub fn upsert_call_edges_batch(conn: &mut Connection, edges: &[CallEdgeRow]) -> 
         return Ok(());
     }
 
-    let tx = conn.transaction()?;
-    {
-        let mut stmt = tx.prepare(
+    super::run_batch_with_write_transaction(conn, |conn| {
+        let mut stmt = conn.prepare(
             r#"
             INSERT OR REPLACE INTO call_edges (id, from_symbol_id, target_name, to_symbol_id, call_type, confidence, line, col, is_resolved)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -369,9 +366,8 @@ pub fn upsert_call_edges_batch(conn: &mut Connection, edges: &[CallEdgeRow]) -> 
                 edge.is_resolved as i32
             ])?;
         }
-    }
-    tx.commit()?;
-    Ok(())
+        Ok(())
+    })
 }
 
 fn is_case_insensitive_language(language: &str) -> bool {
@@ -974,17 +970,15 @@ pub fn add_symbols_to_branch_batch(
         return Ok(());
     }
 
-    let tx = conn.transaction()?;
-    {
+    super::run_batch_with_write_transaction(conn, |conn| {
         let mut stmt =
-            tx.prepare("INSERT OR IGNORE INTO branch_symbols (branch, symbol_id) VALUES (?, ?)")?;
+            conn.prepare("INSERT OR IGNORE INTO branch_symbols (branch, symbol_id) VALUES (?, ?)")?;
 
         for symbol_id in symbol_ids {
             stmt.execute(params![branch, symbol_id])?;
         }
-    }
-    tx.commit()?;
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Get all symbol IDs for a branch

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eval:ci:ollama": "npx tsx src/cli.ts eval run --config .github/eval-ollama-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json",
     "eval:compare": "npx tsx src/cli.ts eval compare",
     "eval:effectiveness": "npx tsx scripts/effectiveness-report.ts",
+    "benchmark:indexing-memory": "npx tsx benchmarks/indexing-memory.ts",
     "dev:link-mcp": "node scripts/link-local-mcp-bin.mjs",
     "test": "vitest",
     "pretest:run": "node scripts/run-build-native-with-rustflags.mjs && npm run build:ts",

--- a/src/indexer/failed-state-persistence.ts
+++ b/src/indexer/failed-state-persistence.ts
@@ -1,0 +1,304 @@
+import * as fs from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import * as path from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+const CURRENT_FAILED_BATCH_VERSION = 1;
+const DEFAULT_MALFORMED_LINE_ACTION = "skip" as const;
+
+export type MalformedLineAction = "skip" | "fail";
+
+export interface FailedBatchRecordInput<TChunk = unknown> {
+  readonly chunks: TChunk[];
+  readonly error: string;
+  readonly attemptCount: number;
+  readonly lastAttempt: string;
+}
+
+export interface FailedBatchRecord<TChunk = unknown> extends FailedBatchRecordInput<TChunk> {
+  readonly version: number;
+}
+
+export interface FailedBatchReadOptions {
+  readonly malformedLineAction?: MalformedLineAction;
+  readonly onMalformedLine?: (error: Error, line: string, lineNumber: number, filePath: string) => void;
+}
+
+export interface FailedBatchWriter<TChunk = unknown> {
+  write: (record: FailedBatchRecordInput<TChunk>) => void;
+  commit: () => void;
+  cleanup: () => void;
+  readonly temporaryPath: string;
+}
+
+export function* readFailedBatchRecords<TChunk = unknown>(
+  filePath: string,
+  options: FailedBatchReadOptions = {},
+): Generator<FailedBatchRecord<TChunk>, void, void> {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const fileFormat = detectFailedBatchFileFormat(filePath);
+  if (fileFormat === "legacy") {
+    yield* readLegacyFailedBatchRecords(filePath, options);
+    return;
+  }
+
+  yield* readJsonlFailedBatchRecords(filePath, options);
+}
+
+export function createFailedBatchWriter<TChunk = unknown>(targetPath: string): FailedBatchWriter<TChunk> {
+  const temporaryPath = createTemporaryPath(targetPath);
+  let finalized = false;
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.closeSync(fs.openSync(temporaryPath, "w"));
+
+  const write = (record: FailedBatchRecordInput<TChunk>): void => {
+    if (finalized) {
+      throw new Error("Failed batch writer has been finalized");
+    }
+
+    const lines = record.chunks.map((chunk) => {
+      const lineRecord: FailedBatchRecord<TChunk> = {
+        version: CURRENT_FAILED_BATCH_VERSION,
+        chunks: [chunk],
+        error: record.error,
+        attemptCount: record.attemptCount,
+        lastAttempt: record.lastAttempt,
+      };
+      return JSON.stringify(lineRecord);
+    });
+
+    if (lines.length === 0) {
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.appendFileSync(temporaryPath, `${lines.join("\n")}\n`, "utf-8");
+  };
+
+  const commit = (): void => {
+    if (finalized) {
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    fs.renameSync(temporaryPath, targetPath);
+    finalized = true;
+  };
+
+  const cleanup = (): void => {
+    if (finalized) {
+      return;
+    }
+    fs.rmSync(temporaryPath, { force: true });
+  };
+
+  return {
+    write,
+    commit,
+    cleanup,
+    temporaryPath,
+  };
+}
+
+export function writeFailedBatchRecords<TChunk = unknown>(
+  targetPath: string,
+  records: Iterable<FailedBatchRecordInput<TChunk>>,
+): void {
+  const writer = createFailedBatchWriter<TChunk>(targetPath);
+  try {
+    for (const record of records) {
+      writer.write(record);
+    }
+    writer.commit();
+  } catch (error) {
+    writer.cleanup();
+    throw error;
+  }
+}
+
+function* readLegacyFailedBatchRecords<TChunk = unknown>(
+  filePath: string,
+  options: FailedBatchReadOptions,
+): Generator<FailedBatchRecord<TChunk>, void, void> {
+  const rawData = fs.readFileSync(filePath, "utf-8");
+  const trimmed = stripLeadingBomAndWhitespace(rawData).trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    handleMalformedLine(filePath, 1, trimmed, error, options);
+    return;
+  }
+
+  if (!Array.isArray(parsed)) {
+    handleMalformedLine(filePath, 1, trimmed, new Error("Expected legacy failed-batch file to contain a JSON array"), options);
+    return;
+  }
+
+  for (const entry of parsed) {
+    const normalized = normalizeFailedBatchRecord<TChunk>(entry);
+    if (normalized) {
+      yield normalized;
+    }
+  }
+}
+
+function* readJsonlFailedBatchRecords<TChunk = unknown>(
+  filePath: string,
+  options: FailedBatchReadOptions,
+): Generator<FailedBatchRecord<TChunk>, void, void> {
+  const handle = fs.openSync(filePath, "r");
+  const decoder = new StringDecoder("utf8");
+  const readBuffer = Buffer.allocUnsafe(64 * 1024);
+  let buffer = "";
+  let lineNumber = 0;
+
+  try {
+    let bytesRead = 0;
+    do {
+      bytesRead = fs.readSync(handle, readBuffer, 0, readBuffer.length, null);
+      buffer += decoder.write(readBuffer.subarray(0, bytesRead));
+
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const rawLine = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        lineNumber += 1;
+
+        const normalized = parseFailedBatchLine<TChunk>(rawLine, filePath, lineNumber, options);
+        if (normalized) {
+          yield normalized;
+        }
+
+        newlineIndex = buffer.indexOf("\n");
+      }
+    } while (bytesRead > 0);
+
+    buffer += decoder.end();
+
+    const finalLine = buffer.trimEnd();
+    if (finalLine.length > 0) {
+      lineNumber += 1;
+      const normalized = parseFailedBatchLine<TChunk>(finalLine, filePath, lineNumber, options);
+      if (normalized) {
+        yield normalized;
+      }
+    }
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
+function parseFailedBatchLine<TChunk = unknown>(
+  rawLine: string,
+  filePath: string,
+  lineNumber: number,
+  options: FailedBatchReadOptions,
+): FailedBatchRecord<TChunk> | null {
+  const line = rawLine.trimEnd();
+  if (line.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(line);
+    const normalized = normalizeFailedBatchRecord<TChunk>(parsed);
+    if (!normalized) {
+      handleMalformedLine(filePath, lineNumber, line, new Error("Malformed failed-batch record"), options);
+      return null;
+    }
+    return normalized;
+  } catch (error) {
+    handleMalformedLine(filePath, lineNumber, line, error, options);
+    return null;
+  }
+}
+
+function normalizeFailedBatchRecord<TChunk = unknown>(rawRecord: unknown): FailedBatchRecord<TChunk> | null {
+  if (!rawRecord || typeof rawRecord !== "object" || Array.isArray(rawRecord)) {
+    return null;
+  }
+
+  const typed = rawRecord as {
+    chunks?: unknown;
+    error?: unknown;
+    attemptCount?: unknown;
+    lastAttempt?: unknown;
+    version?: unknown;
+  };
+
+  const chunks = Array.isArray(typed.chunks) ? typed.chunks : null;
+  if (!chunks || chunks.length === 0) {
+    return null;
+  }
+
+  return {
+    version: typeof typed.version === "number" && Number.isFinite(typed.version) ? typed.version : CURRENT_FAILED_BATCH_VERSION,
+    chunks: chunks as TChunk[],
+    error: typeof typed.error === "string" ? typed.error : "Unknown embedding error",
+    attemptCount: typeof typed.attemptCount === "number" && Number.isFinite(typed.attemptCount) ? typed.attemptCount : 1,
+    lastAttempt: typeof typed.lastAttempt === "string" ? typed.lastAttempt : new Date().toISOString(),
+  };
+}
+
+type FailedBatchFileFormat = "legacy" | "jsonl";
+
+function detectFailedBatchFileFormat(filePath: string): FailedBatchFileFormat {
+  const handle = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(4096);
+    const bytesRead = fs.readSync(handle, buffer, 0, buffer.length, 0);
+    if (bytesRead <= 0) {
+      return "jsonl";
+    }
+
+    const prefix = stripLeadingBomAndWhitespace(buffer.subarray(0, bytesRead).toString("utf-8"));
+    return prefix.startsWith("[") ? "legacy" : "jsonl";
+  } finally {
+    fs.closeSync(handle);
+  }
+}
+
+function stripLeadingBomAndWhitespace(value: string): string {
+  let result = value.trimStart();
+  if (result.charCodeAt(0) === 0xfeff) {
+    result = result.slice(1);
+  }
+  return result;
+}
+
+function createTemporaryPath(targetPath: string): string {
+  const randomId = createHash("sha1")
+    .update(`${Date.now()}:${randomBytes(8).toString("hex")}`)
+    .digest("hex");
+  const targetDir = path.dirname(targetPath);
+  const baseName = path.basename(targetPath);
+  return path.join(targetDir, `.${baseName}.${randomId}.tmp`);
+}
+
+function handleMalformedLine(
+  filePath: string,
+  lineNumber: number,
+  line: string,
+  error: unknown,
+  options: FailedBatchReadOptions,
+): void {
+  const action = options.malformedLineAction ?? DEFAULT_MALFORMED_LINE_ACTION;
+  const normalizedError = error instanceof Error ? error : new Error(String(error));
+
+  if (options.onMalformedLine) {
+    options.onMalformedLine(normalizedError, line, lineNumber, filePath);
+  }
+
+  if (action === "fail") {
+    throw normalizedError;
+  }
+}

--- a/src/indexer/file-batches.ts
+++ b/src/indexer/file-batches.ts
@@ -9,7 +9,7 @@ export const INDEX_FILE_BATCH_LIMITS: Readonly<FileBatchLimits> = Object.freeze(
 });
 
 export function* iterateOrderedFileBatches<T>(
-  items: readonly T[],
+  items: Iterable<T>,
   getBytes: (item: T) => number,
   limits: FileBatchLimits = INDEX_FILE_BATCH_LIMITS,
 ): Generator<T[]> {

--- a/src/indexer/file-batches.ts
+++ b/src/indexer/file-batches.ts
@@ -1,0 +1,36 @@
+export interface FileBatchLimits {
+  maxFiles: number;
+  maxBytes: number;
+}
+
+export const INDEX_FILE_BATCH_LIMITS: Readonly<FileBatchLimits> = Object.freeze({
+  maxFiles: 64,
+  maxBytes: 8 * 1024 * 1024,
+});
+
+export function* iterateOrderedFileBatches<T>(
+  items: readonly T[],
+  getBytes: (item: T) => number,
+  limits: FileBatchLimits = INDEX_FILE_BATCH_LIMITS,
+): Generator<T[]> {
+  const maxFiles = Math.max(1, Math.floor(limits.maxFiles));
+  const maxBytes = Math.max(1, Math.floor(limits.maxBytes));
+  let batch: T[] = [];
+  let batchBytes = 0;
+
+  for (const item of items) {
+    const itemBytes = Math.max(0, Math.floor(getBytes(item)));
+    if (batch.length > 0 && (batch.length >= maxFiles || batchBytes + itemBytes > maxBytes)) {
+      yield batch;
+      batch = [];
+      batchBytes = 0;
+    }
+
+    batch.push(item);
+    batchBytes += itemBytes;
+  }
+
+  if (batch.length > 0) {
+    yield batch;
+  }
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -87,11 +87,8 @@ import {
   type IndexMutationOperation,
 } from "./index-lock.js";
 import {
-  type FailedBatch,
   type PendingChunk,
-  type RetryableFailedChunk,
   type SerializedFailedBatch,
-  coalesceFailedBatches,
   createPendingChunkStorageText,
   createPendingEmbeddingRequestBatches,
   getPendingChunkFilePath,
@@ -100,6 +97,13 @@ import {
   normalizeFailedBatch,
   poolEmbeddingVectors,
 } from "./embedding-batches.js";
+import {
+  createFailedBatchWriter,
+  readFailedBatchRecords,
+  type FailedBatchRecordInput,
+  type FailedBatchWriter,
+} from "./failed-state-persistence.js";
+import { iterateOrderedFileBatches, type FileBatchLimits } from "./file-batches.js";
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
@@ -277,6 +281,8 @@ export interface IndexerRuntimeOptions {
   catalogIdentity?: string;
   expectedCommit?: string;
   indexPath?: string;
+  /** Internal test and benchmark override. Production uses the fixed limits. */
+  fileBatchLimits?: FileBatchLimits;
 }
 
 export interface BranchIndexResult {
@@ -369,6 +375,52 @@ export interface IndexProgress {
 }
 
 export type ProgressCallback = (progress: IndexProgress) => void;
+
+interface ChangedFileDescriptor {
+  storedPath: string;
+  materializedPath: string;
+  hash: string;
+  sourceBytes: number;
+}
+
+interface RetryableFailedChunkRecord {
+  chunk: PendingChunk;
+  attemptCount: number;
+}
+
+interface FailedChunkRecordMetadata {
+  attemptCount: number;
+  error: string;
+  lastAttempt: string;
+}
+
+interface FailedBatchWriteState {
+  writer: FailedBatchWriter<unknown>;
+  recordsWritten: number;
+}
+
+interface EmbeddingRateLimitState {
+  backoffMs: number;
+}
+
+interface PendingChunkBatchResult {
+  indexedChunks: number;
+  failedChunks: number;
+  tokensUsed: number;
+  failedChunkIds: Set<string>;
+}
+
+function getFailedBatchGroupKey(record: Pick<SerializedFailedBatch, "error" | "attemptCount" | "lastAttempt">): string {
+  return `${record.attemptCount}:${record.lastAttempt}:${record.error}`;
+}
+
+function getPendingChunkId(rawChunk: unknown): string | null {
+  if (!rawChunk || typeof rawChunk !== "object") {
+    return null;
+  }
+  const id = (rawChunk as { id?: unknown }).id;
+  return typeof id === "string" ? id : null;
+}
 
 type SearchFilterOptions = {
   fileType?: string;
@@ -1003,6 +1055,7 @@ export class Indexer {
   private readerArtifactFingerprint: ReaderArtifactFingerprint | null = null;
   private writerArtifactFingerprint: ReaderArtifactFingerprint | null = null;
   private readerArtifactRetryAfter = new Map<IndexReadIssue["component"], number>();
+  private readonly fileBatchLimits?: FileBatchLimits;
 
   constructor(
     projectRoot: string,
@@ -1020,6 +1073,7 @@ export class Indexer {
     }
     this.expectedCommitOverride = runtimeOptions.expectedCommit?.toLowerCase();
     this.indexPathOverride = runtimeOptions.indexPath;
+    this.fileBatchLimits = runtimeOptions.fileBatchLimits;
     this.config = config;
     this.host = host;
     if (isGitRepo(this.materializedProjectRoot)) {
@@ -1479,13 +1533,13 @@ export class Indexer {
       return true;
     }
 
-    if (this.loadSerializedFailedBatches().some((batch) =>
-      batch.chunks.some((chunk) => {
+    for (const batch of this.loadSerializedFailedBatches()) {
+      if (batch.chunks.some((chunk) => {
         const filePath = getPendingChunkFilePath(chunk);
         return filePath !== null && this.isFileInCurrentScope(filePath, roots);
-      })
-    )) {
-      return true;
+      })) {
+        return true;
+      }
     }
 
     if (!this.database) {
@@ -1666,38 +1720,11 @@ export class Indexer {
     this.saveFileHashCache();
   }
 
-  private partitionFailedBatches(roots: string[], maxChunkTokens?: number): { scoped: FailedBatch[]; retained: SerializedFailedBatch[] } {
-    const scoped: FailedBatch[] = [];
-    const retained: SerializedFailedBatch[] = [];
-
-    for (const batch of this.loadSerializedFailedBatches()) {
-      const scopedChunks = batch.chunks.filter((chunk) => {
-        const filePath = getPendingChunkFilePath(chunk);
-        return filePath !== null && this.isFileInCurrentScope(filePath, roots);
-      });
-      const retainedChunks = batch.chunks.filter((chunk) => {
-        const filePath = getPendingChunkFilePath(chunk);
-        return filePath === null || !this.isFileInCurrentScope(filePath, roots);
-      });
-
-      if (scopedChunks.length > 0) {
-        const normalizedBatch = normalizeFailedBatch({ ...batch, chunks: scopedChunks }, maxChunkTokens);
-        if (normalizedBatch) {
-          scoped.push(normalizedBatch);
-        }
-      }
-
-      if (retainedChunks.length > 0) {
-        retained.push({ ...batch, chunks: retainedChunks });
-      }
-    }
-
-    return { scoped, retained };
-  }
-
   private clearScopedFailedBatches(roots: string[]): void {
-    const { retained: retainedBatches } = this.partitionFailedBatches(roots);
-    this.saveFailedBatches(retainedBatches);
+    this.rewriteFailedBatchState((chunk) => {
+      const filePath = getPendingChunkFilePath(chunk);
+      return filePath === null || !this.isFileInCurrentScope(filePath, roots);
+    });
   }
 
   private hasForeignScopedFileHashData(roots: string[]): boolean {
@@ -1705,8 +1732,15 @@ export class Indexer {
   }
 
   private hasForeignScopedFailedBatches(roots: string[]): boolean {
-    const { retained } = this.partitionFailedBatches(roots);
-    return retained.length > 0;
+    for (const batch of this.loadSerializedFailedBatches()) {
+      if (batch.chunks.some((chunk) => {
+        const filePath = getPendingChunkFilePath(chunk);
+        return filePath === null || !this.isFileInCurrentScope(filePath, roots);
+      })) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private hasForeignScopedBranchData(): boolean {
@@ -1735,11 +1769,6 @@ export class Indexer {
         return !(referencesCurrentProjectChunks || referencesCurrentProjectSymbols);
       }
     );
-  }
-
-  private saveScopedFailedBatches(batches: FailedBatch[], roots: string[]): void {
-    const { retained } = this.partitionFailedBatches(roots);
-    this.saveFailedBatches([...retained, ...batches]);
   }
 
   private clearSharedIndexProjectData(
@@ -1864,93 +1893,167 @@ export class Indexer {
     this.logger.info("Recovery complete, next index will re-process all files");
   }
 
-  private loadFailedBatches(maxChunkTokens?: number): FailedBatch[] {
-    try {
-      return this.loadSerializedFailedBatches()
-        .map((batch) => normalizeFailedBatch(batch, maxChunkTokens))
-        .filter((batch): batch is FailedBatch => batch !== null);
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
+  private *loadSerializedFailedBatches(): Generator<SerializedFailedBatch> {
+    let warned = false;
+    const warn = (error: unknown): void => {
+      if (warned) return;
+      warned = true;
       this.logger.warn("Failed to load failed batch state, skipping persisted retries", {
         failedBatchesPath: this.failedBatchesPath,
-        error: message,
+        error: getErrorMessage(error),
       });
-      return [];
-    }
-  }
+    };
 
-  private loadSerializedFailedBatches(): SerializedFailedBatch[] {
-    if (!existsSync(this.failedBatchesPath)) {
-      return [];
-    }
-
-    const data = readFileSync(this.failedBatchesPath, "utf-8");
-    const parsed = JSON.parse(data) as Array<{
-      chunks?: unknown[];
-      error?: unknown;
-      attemptCount?: unknown;
-      lastAttempt?: unknown;
-    }>;
-
-    return parsed
-      .map((batch) => {
-        const chunks = Array.isArray(batch.chunks) ? batch.chunks : [];
-        if (chunks.length === 0) {
-          return null;
-        }
-
-        return {
-          chunks,
-          error: typeof batch.error === "string" ? batch.error : "Unknown embedding error",
-          attemptCount: typeof batch.attemptCount === "number" ? batch.attemptCount : 1,
-          lastAttempt: typeof batch.lastAttempt === "string" ? batch.lastAttempt : new Date().toISOString(),
-        } satisfies SerializedFailedBatch;
-      })
-      .filter((batch): batch is SerializedFailedBatch => batch !== null);
-  }
-
-  private saveFailedBatches(batches: SerializedFailedBatch[]): void {
-    if (batches.length === 0) {
-      if (existsSync(this.failedBatchesPath)) {
-        try {
-          unlinkSync(this.failedBatchesPath);
-        } catch {
-          // Ignore cleanup failures; stale diagnostics are best-effort only.
-        }
+    try {
+      for (const record of readFailedBatchRecords<unknown>(this.failedBatchesPath, {
+        malformedLineAction: "skip",
+        onMalformedLine: (error) => warn(error),
+      })) {
+        yield {
+          chunks: record.chunks,
+          error: record.error,
+          attemptCount: record.attemptCount,
+          lastAttempt: record.lastAttempt,
+        };
       }
+    } catch (error) {
+      warn(error);
+    }
+  }
+
+  private createFailedBatchWriteState(): FailedBatchWriteState {
+    return {
+      writer: createFailedBatchWriter<unknown>(this.failedBatchesPath),
+      recordsWritten: 0,
+    };
+  }
+
+  private writeFailedBatchRecord(
+    state: FailedBatchWriteState,
+    record: FailedBatchRecordInput<unknown>,
+  ): void {
+    state.writer.write(record);
+    state.recordsWritten += record.chunks.length;
+  }
+
+  private finalizeFailedBatchWriteState(state: FailedBatchWriteState): void {
+    if (state.recordsWritten > 0) {
+      state.writer.commit();
       return;
     }
-    this.atomicWriteSync(this.failedBatchesPath, JSON.stringify(batches, null, 2));
+
+    state.writer.cleanup();
+    this.clearFailedBatchState();
   }
 
-  private collectRetryableFailedChunks(
-    currentFileHashes: Map<string, string>,
-    unchangedFilePaths: Set<string>,
-    maxChunkTokens?: number
-  ): RetryableFailedChunk[] {
-    const retryableById = new Map<string, RetryableFailedChunk>();
-
-    for (const batch of this.loadFailedBatches(maxChunkTokens)) {
-      for (const chunk of batch.chunks) {
-        const filePath = chunk.metadata.filePath;
-        if (!currentFileHashes.has(filePath)) {
-          continue;
-        }
-        if (!unchangedFilePaths.has(filePath)) {
-          continue;
-        }
-
-        const existing = retryableById.get(chunk.id);
-        if (!existing || batch.attemptCount > existing.attemptCount) {
-          retryableById.set(chunk.id, {
-            chunk,
-            attemptCount: batch.attemptCount,
-          });
-        }
+  private clearFailedBatchState(): void {
+    if (existsSync(this.failedBatchesPath)) {
+      try {
+        unlinkSync(this.failedBatchesPath);
+      } catch {
+        // Ignore cleanup failures; stale diagnostics are best-effort only.
       }
     }
+  }
 
-    return Array.from(retryableById.values());
+  private rewriteFailedBatchState(shouldRetain: (chunk: unknown) => boolean): void {
+    const state = this.createFailedBatchWriteState();
+    try {
+      for (const batch of this.loadSerializedFailedBatches()) {
+        const retainedChunks = batch.chunks.filter(shouldRetain);
+        if (retainedChunks.length > 0) {
+          this.writeFailedBatchRecord(state, { ...batch, chunks: retainedChunks });
+        }
+      }
+      this.finalizeFailedBatchWriteState(state);
+    } catch (error) {
+      state.writer.cleanup();
+      throw error;
+    }
+  }
+
+  private prepareFailedBatchProcessing(
+    roots: string[] | null,
+    shouldProcess: (filePath: string | null) => boolean,
+  ): { state: FailedBatchWriteState; latestById: Map<string, FailedChunkRecordMetadata> } {
+    const state = this.createFailedBatchWriteState();
+    const latestById = new Map<string, FailedChunkRecordMetadata>();
+
+    try {
+      for (const batch of this.loadSerializedFailedBatches()) {
+        for (const rawChunk of batch.chunks) {
+          const filePath = getPendingChunkFilePath(rawChunk);
+          const inScope = roots === null || (filePath !== null && this.isFileInCurrentScope(filePath, roots));
+          if (!inScope) {
+            this.writeFailedBatchRecord(state, { ...batch, chunks: [rawChunk] });
+            continue;
+          }
+          if (!shouldProcess(filePath)) {
+            continue;
+          }
+
+          const chunkId = getPendingChunkId(rawChunk);
+          if (!chunkId) {
+            continue;
+          }
+          const existing = latestById.get(chunkId);
+          if (!existing || batch.attemptCount >= existing.attemptCount) {
+            latestById.set(chunkId, {
+              attemptCount: batch.attemptCount,
+              error: batch.error,
+              lastAttempt: batch.lastAttempt,
+            });
+          }
+        }
+      }
+      return { state, latestById };
+    } catch (error) {
+      state.writer.cleanup();
+      throw error;
+    }
+  }
+
+  private *iterateLatestFailedChunks(
+    latestById: ReadonlyMap<string, FailedChunkRecordMetadata>,
+    roots: string[] | null,
+    shouldProcess: (filePath: string | null) => boolean,
+    maxChunkTokens?: number,
+  ): Generator<RetryableFailedChunkRecord> {
+    const yielded = new Set<string>();
+    for (const batch of this.loadSerializedFailedBatches()) {
+      for (const rawChunk of batch.chunks) {
+        const chunkId = getPendingChunkId(rawChunk);
+        if (!chunkId || yielded.has(chunkId)) {
+          continue;
+        }
+        const latest = latestById.get(chunkId);
+        if (
+          !latest ||
+          latest.attemptCount !== batch.attemptCount ||
+          latest.error !== batch.error ||
+          latest.lastAttempt !== batch.lastAttempt
+        ) {
+          continue;
+        }
+
+        const filePath = getPendingChunkFilePath(rawChunk);
+        const inScope = roots === null || (filePath !== null && this.isFileInCurrentScope(filePath, roots));
+        if (!inScope || !shouldProcess(filePath)) {
+          continue;
+        }
+
+        const normalized = normalizeFailedBatch({ ...batch, chunks: [rawChunk] }, maxChunkTokens);
+        const chunk = normalized?.chunks[0];
+        if (!chunk) {
+          continue;
+        }
+        yielded.add(chunkId);
+        yield {
+          chunk,
+          attemptCount: batch.attemptCount,
+        };
+      }
+    }
   }
 
   private getProviderRateLimits(provider: string): {
@@ -1983,6 +2086,287 @@ export class Indexer {
       default:
         return { concurrency: 3, intervalMs: 1000, minRetryMs: 1000, maxRetryMs: 30000 };
     }
+  }
+
+  private async processPendingChunkBatch(
+    chunks: PendingChunk[],
+    options: {
+      store: VectorStore;
+      provider: EmbeddingProviderInterface;
+      invertedIndex: InvertedIndex;
+      database: Database;
+      configuredProviderInfo: ConfiguredProviderInfo;
+      queue: PQueue;
+      providerRateLimits: ReturnType<Indexer["getProviderRateLimits"]>;
+      rateLimitState: EmbeddingRateLimitState;
+      failedState: FailedBatchWriteState;
+      attemptCounts: Map<string, number>;
+      forceReembed: boolean;
+      reuseCachedEmbeddings: boolean;
+      incrementRepeatedFailures: boolean;
+      onSucceeded?: (chunks: PendingChunk[]) => void;
+      onProgress?: (progress: Readonly<PendingChunkBatchResult>) => void;
+    },
+  ): Promise<PendingChunkBatchResult> {
+    const result: PendingChunkBatchResult = {
+      indexedChunks: 0,
+      failedChunks: 0,
+      tokensUsed: 0,
+      failedChunkIds: new Set<string>(),
+    };
+    if (chunks.length === 0) {
+      return result;
+    }
+
+    const chunksNeedingEmbedding: PendingChunk[] = [];
+    let cachedChunkCount = 0;
+    if (options.reuseCachedEmbeddings && !options.forceReembed) {
+      const missingHashes = new Set(options.database.getMissingEmbeddings(chunks.map((chunk) => chunk.contentHash)));
+      for (const chunk of chunks) {
+        if (missingHashes.has(chunk.contentHash)) {
+          chunksNeedingEmbedding.push(chunk);
+          continue;
+        }
+
+        const embeddingBuffer = options.database.getEmbedding(chunk.contentHash);
+        if (!embeddingBuffer) {
+          chunksNeedingEmbedding.push(chunk);
+          continue;
+        }
+
+        options.store.add(chunk.id, Array.from(bufferToFloat32Array(embeddingBuffer)), chunk.metadata);
+        options.invertedIndex.removeChunk(chunk.id);
+        options.invertedIndex.addChunk(chunk.id, chunk.content);
+        options.onSucceeded?.([chunk]);
+        result.indexedChunks += 1;
+        cachedChunkCount += 1;
+      }
+    } else {
+      chunksNeedingEmbedding.push(...chunks);
+    }
+
+    this.logger.cache("info", "Embedding cache lookup", {
+      needsEmbedding: chunksNeedingEmbedding.length,
+      fromCache: cachedChunkCount,
+    });
+    if (cachedChunkCount > 0) {
+      this.logger.recordChunksFromCache(cachedChunkCount);
+      options.onProgress?.(result);
+    }
+
+    if (chunksNeedingEmbedding.length === 0) {
+      return result;
+    }
+
+    const pendingChunksById = new Map(chunksNeedingEmbedding.map((chunk) => [chunk.id, chunk]));
+    const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
+    const completedVectorsByChunkId = new Map<string, number[]>();
+    const completedChunkIds = new Set<string>();
+    const requestBatches = createPendingEmbeddingRequestBatches(
+      chunksNeedingEmbedding,
+      getDynamicBatchOptions(options.configuredProviderInfo),
+    );
+    let fatalError: unknown;
+
+    for (const requestBatch of requestBatches) {
+      await options.queue.onSizeLessThan(Math.max(1, options.providerRateLimits.concurrency));
+      const task = options.queue.add(async () => {
+        if (options.rateLimitState.backoffMs > 0) {
+          await new Promise(resolve => setTimeout(resolve, options.rateLimitState.backoffMs));
+        }
+
+        try {
+          const embeddingResult = await pRetry(
+            async () => {
+              const texts = requestBatch.map((request) => request.text);
+              return options.provider.embedBatch(texts);
+            },
+            {
+              retries: this.config.indexing.retries,
+              minTimeout: Math.max(this.config.indexing.retryDelayMs, options.providerRateLimits.minRetryMs),
+              maxTimeout: options.providerRateLimits.maxRetryMs,
+              factor: 2,
+              shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
+              onFailedAttempt: (error) => {
+                const message = getErrorMessage(error);
+                if (isRateLimitError(error)) {
+                  options.rateLimitState.backoffMs = Math.min(
+                    options.providerRateLimits.maxRetryMs,
+                    (options.rateLimitState.backoffMs || options.providerRateLimits.minRetryMs) * 2,
+                  );
+                  this.logger.embedding("warn", "Rate limited, backing off", {
+                    attempt: error.attemptNumber,
+                    retriesLeft: error.retriesLeft,
+                    backoffMs: options.rateLimitState.backoffMs,
+                  });
+                } else {
+                  this.logger.embedding("error", "Embedding batch failed", {
+                    attempt: error.attemptNumber,
+                    error: message,
+                  });
+                }
+              },
+            },
+          );
+
+          if (options.rateLimitState.backoffMs > 0) {
+            options.rateLimitState.backoffMs = Math.max(0, options.rateLimitState.backoffMs - 2000);
+          }
+
+          const touchedChunkIds = new Set<string>();
+          requestBatch.forEach((request, index) => {
+            if (result.failedChunkIds.has(request.chunk.id) || completedChunkIds.has(request.chunk.id)) {
+              return;
+            }
+
+            const vector = embeddingResult.embeddings[index];
+            if (!vector) {
+              throw new Error(`Embedding API returned too few vectors for chunk ${request.chunk.id}`);
+            }
+
+            const parts = embeddingPartsByChunk.get(request.chunk.id) ?? [];
+            parts[request.partIndex] = {
+              vector,
+              tokenCount: request.tokenCount,
+            };
+            embeddingPartsByChunk.set(request.chunk.id, parts);
+            touchedChunkIds.add(request.chunk.id);
+          });
+
+          const pooledResults: Array<{ chunk: PendingChunk; vector: number[] }> = [];
+          for (const chunkId of touchedChunkIds) {
+            if (result.failedChunkIds.has(chunkId) || completedChunkIds.has(chunkId)) {
+              continue;
+            }
+            const chunk = pendingChunksById.get(chunkId);
+            if (!chunk) {
+              continue;
+            }
+            const parts = embeddingPartsByChunk.get(chunk.id) ?? [];
+            if (!hasAllEmbeddingParts(parts, chunk.texts.length)) {
+              continue;
+            }
+
+            const orderedParts = parts as Array<{ vector: number[]; tokenCount: number }>;
+            pooledResults.push({
+              chunk,
+              vector: poolEmbeddingVectors(
+                orderedParts.map((part) => part.vector),
+                orderedParts.map((part) => part.tokenCount),
+              ),
+            });
+          }
+
+          if (pooledResults.length > 0) {
+            options.database.upsertEmbeddingsBatch(pooledResults.map(({ chunk, vector }) => ({
+              contentHash: chunk.contentHash,
+              embedding: float32ArrayToBuffer(vector),
+              chunkText: chunk.storageText,
+              model: options.configuredProviderInfo.modelInfo.model,
+            })));
+
+            const succeededChunks = pooledResults.map(({ chunk }) => chunk);
+            for (const { chunk, vector } of pooledResults) {
+              completedVectorsByChunkId.set(chunk.id, vector);
+            }
+            for (const chunk of succeededChunks) {
+              completedChunkIds.add(chunk.id);
+              embeddingPartsByChunk.delete(chunk.id);
+            }
+
+          }
+
+          result.tokensUsed += embeddingResult.totalTokensUsed;
+          this.logger.recordEmbeddingApiCall(embeddingResult.totalTokensUsed);
+          this.logger.embedding("debug", "Embedded batch", {
+            batchSize: pooledResults.length,
+            requestCount: requestBatch.length,
+            tokens: embeddingResult.totalTokensUsed,
+          });
+        } catch (error) {
+          const failedChunks = getUniquePendingChunksFromRequests(requestBatch)
+            .filter((chunk) => !completedChunkIds.has(chunk.id))
+            .filter((chunk) => options.incrementRepeatedFailures || !result.failedChunkIds.has(chunk.id));
+          const failureMessage = getErrorMessage(error);
+          const failureTimestamp = new Date().toISOString();
+
+          for (const chunk of failedChunks) {
+            if (!result.failedChunkIds.has(chunk.id)) {
+              result.failedChunkIds.add(chunk.id);
+              result.failedChunks += 1;
+            }
+            embeddingPartsByChunk.delete(chunk.id);
+            const attemptCount = (options.attemptCounts.get(chunk.id) ?? 0) + 1;
+            options.attemptCounts.set(chunk.id, attemptCount);
+            this.writeFailedBatchRecord(options.failedState, {
+              chunks: [chunk],
+              error: failureMessage,
+              attemptCount,
+              lastAttempt: failureTimestamp,
+            });
+          }
+
+          this.logger.recordEmbeddingError();
+          this.logger.embedding("error", "Failed to embed batch after retries", {
+            batchSize: failedChunks.length,
+            requestCount: requestBatch.length,
+            error: failureMessage,
+          });
+        }
+
+        options.onProgress?.(result);
+      });
+      void task.catch((error: unknown) => {
+        fatalError ??= error;
+      });
+    }
+
+    await options.queue.onIdle();
+    if (fatalError !== undefined) {
+      throw fatalError;
+    }
+
+    const orderedSucceededChunks = chunksNeedingEmbedding.filter((chunk) => completedVectorsByChunkId.has(chunk.id));
+    if (orderedSucceededChunks.length > 0) {
+      try {
+        options.store.addBatch(orderedSucceededChunks.map((chunk) => ({
+          id: chunk.id,
+          vector: completedVectorsByChunkId.get(chunk.id)!,
+          metadata: chunk.metadata,
+        })));
+        for (const chunk of orderedSucceededChunks) {
+          options.invertedIndex.removeChunk(chunk.id);
+          options.invertedIndex.addChunk(chunk.id, chunk.content);
+        }
+        options.onSucceeded?.(orderedSucceededChunks);
+        result.indexedChunks += orderedSucceededChunks.length;
+        this.logger.recordChunksEmbedded(orderedSucceededChunks.length);
+      } catch (error) {
+        const failureMessage = getErrorMessage(error);
+        const failureTimestamp = new Date().toISOString();
+        for (const chunk of orderedSucceededChunks) {
+          options.store.remove(chunk.id);
+          options.invertedIndex.removeChunk(chunk.id);
+          result.failedChunkIds.add(chunk.id);
+          result.failedChunks += 1;
+          const attemptCount = (options.attemptCounts.get(chunk.id) ?? 0) + 1;
+          options.attemptCounts.set(chunk.id, attemptCount);
+          this.writeFailedBatchRecord(options.failedState, {
+            chunks: [chunk],
+            error: failureMessage,
+            attemptCount,
+            lastAttempt: failureTimestamp,
+          });
+        }
+        this.logger.recordEmbeddingError();
+        this.logger.embedding("error", "Failed to publish embedded chunks", {
+          batchSize: orderedSucceededChunks.length,
+          error: failureMessage,
+        });
+      }
+      options.onProgress?.(result);
+    }
+    return result;
   }
 
   private async rerankCandidatesWithApi(
@@ -3261,7 +3645,7 @@ export class Indexer {
     if (!this.indexCompatibility?.compatible) {
       throw new Error(
         `${this.indexCompatibility?.reason} ` +
-        `Run index_codebase with force=true to rebuild the index.`
+        `Run index_codebase with force=true to rebuild the index.`,
       );
     }
 
@@ -3281,7 +3665,6 @@ export class Indexer {
       skippedFiles: [],
       parseFailures: [],
     };
-    const failedBatchesForCurrentRun: FailedBatch[] = [];
 
     onProgress?.({
       phase: "scanning",
@@ -3294,27 +3677,20 @@ export class Indexer {
     this.loadFileHashCache();
 
     const swiftParserMetadataKey = this.getSwiftParserVersionMetadataKey();
-    const reparseCachedSwiftFiles =
-      database.getMetadata(swiftParserMetadataKey) !== SWIFT_PARSER_VERSION;
+    const reparseCachedSwiftFiles = database.getMetadata(swiftParserMetadataKey) !== SWIFT_PARSER_VERSION;
     const metalParserMetadataKey = this.getMetalParserVersionMetadataKey();
-    const reparseCachedMetalFiles =
-      database.getMetadata(metalParserMetadataKey) !== METAL_PARSER_VERSION;
+    const reparseCachedMetalFiles = database.getMetadata(metalParserMetadataKey) !== METAL_PARSER_VERSION;
     const symbolExtractorMetadataKey = this.getSymbolExtractorVersionMetadataKey();
-    const refreshCachedSymbols =
-      database.getMetadata(symbolExtractorMetadataKey) !== SYMBOL_EXTRACTOR_VERSION;
+    const refreshCachedSymbols = database.getMetadata(symbolExtractorMetadataKey) !== SYMBOL_EXTRACTOR_VERSION;
     if (
       reparseCachedSwiftFiles &&
-      Array.from(this.fileHashCache.keys()).some(
-        (filePath) => path.extname(filePath).toLowerCase() === ".swift",
-      )
+      Array.from(this.fileHashCache.keys()).some((filePath) => path.extname(filePath).toLowerCase() === ".swift")
     ) {
       this.logger.info("Reindexing cached Swift files for parser support");
     }
     if (
       reparseCachedMetalFiles &&
-      Array.from(this.fileHashCache.keys()).some(
-        (filePath) => path.extname(filePath).toLowerCase() === ".metal",
-      )
+      Array.from(this.fileHashCache.keys()).some((filePath) => path.extname(filePath).toLowerCase() === ".metal")
     ) {
       this.logger.info("Reindexing cached Metal files for parser support");
     }
@@ -3326,7 +3702,7 @@ export class Indexer {
       this.config.exclude,
       this.config.indexing.maxFileSize,
       this.getMaterializedKnowledgeBases(),
-      { maxDepth: this.config.indexing.maxDepth, maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory }
+      { maxDepth: this.config.indexing.maxDepth, maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory },
     );
 
     stats.totalFiles = files.length;
@@ -3341,15 +3717,15 @@ export class Indexer {
       skippedFiles: skipped.length,
     });
 
-    const changedFiles: Array<{ path: string; content: string; hash: string }> = [];
+    const changedFileDescriptors: ChangedFileDescriptor[] = [];
     const unchangedFilePaths = new Set<string>();
     const currentFileHashes = new Map<string, string>();
     const needsCallGraphResolutionMigration =
       database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION;
 
-    for (const f of files) {
-      const storedPath = this.toStoredFilePath(f.path);
-      const currentHash = hashFile(f.path);
+    for (const file of files) {
+      const storedPath = this.toStoredFilePath(file.path);
+      const currentHash = hashFile(file.path);
       currentFileHashes.set(storedPath, currentHash);
 
       const cachedHashMatches = this.fileHashCache.get(storedPath) === currentHash;
@@ -3359,11 +3735,9 @@ export class Indexer {
           chunk.language === "php" || chunk.language === "c" || chunk.language === "cpp"
         );
       const requiresSwiftParserUpgrade =
-        reparseCachedSwiftFiles &&
-        path.extname(storedPath).toLowerCase() === ".swift";
+        reparseCachedSwiftFiles && path.extname(storedPath).toLowerCase() === ".swift";
       const requiresMetalParserUpgrade =
-        reparseCachedMetalFiles &&
-        path.extname(storedPath).toLowerCase() === ".metal";
+        reparseCachedMetalFiles && path.extname(storedPath).toLowerCase() === ".metal";
 
       if (
         cachedHashMatches &&
@@ -3375,32 +3749,28 @@ export class Indexer {
         unchangedFilePaths.add(storedPath);
         this.logger.recordCacheHit();
       } else {
-        const content = await fsPromises.readFile(f.path, "utf-8");
-        changedFiles.push({ path: storedPath, content, hash: currentHash });
+        changedFileDescriptors.push({
+          storedPath,
+          materializedPath: file.path,
+          hash: currentHash,
+          sourceBytes: file.size,
+        });
         this.logger.recordCacheMiss();
       }
     }
 
     this.logger.cache("info", "File hash cache results", {
       unchanged: unchangedFilePaths.size,
-      changed: changedFiles.length,
+      changed: changedFileDescriptors.length,
     });
 
     onProgress?.({
       phase: "parsing",
-      filesProcessed: 0,
+      filesProcessed: unchangedFilePaths.size,
       totalFiles: files.length,
       chunksProcessed: 0,
       totalChunks: 0,
     });
-
-    const parseStartTime = performance.now();
-    const parsedFiles = parseFiles(changedFiles);
-    const parseMs = performance.now() - parseStartTime;
-
-    this.logger.recordFilesParsed(parsedFiles.length);
-    this.logger.recordParseDuration(parseMs);
-    this.logger.debug("Parsed changed files", { parsedCount: parsedFiles.length, parseMs: parseMs.toFixed(2) });
 
     const existingChunks = new Map<string, string>();
     const existingChunksByFile = new Map<string, Set<string>>();
@@ -3410,9 +3780,9 @@ export class Indexer {
         continue;
       }
       if (
-        restrictExistingChunksToBranch
-        && this.isFileInProjectRoot(metadata.filePath)
-        && !previousBranchChunkIdSet.has(key)
+        restrictExistingChunksToBranch &&
+        this.isFileInProjectRoot(metadata.filePath) &&
+        !previousBranchChunkIdSet.has(key)
       ) {
         continue;
       }
@@ -3421,19 +3791,19 @@ export class Indexer {
       }
       existingChunks.set(key, metadata.hash);
       existingMetadataById.set(key, metadata);
-      const fileChunks = existingChunksByFile.get(metadata.filePath) || new Set();
+      const fileChunks = existingChunksByFile.get(metadata.filePath) ?? new Set<string>();
       fileChunks.add(key);
       existingChunksByFile.set(metadata.filePath, fileChunks);
     }
 
     const currentChunkIds = new Set<string>();
-    const currentFilePaths = new Set<string>();
-    const pendingChunks: PendingChunk[] = [];
+    const allSymbolIds = new Set<string>();
+    const failedChunkIds = new Set<string>();
+    const retryableChunksWithExistingData = new Set<string>();
     const gitBlameEnabled = this.config.indexing.gitBlame.enabled && isGitRepo(this.materializedProjectRoot);
     let backfilledBlameMetadata = false;
 
     for (const filePath of unchangedFilePaths) {
-      currentFilePaths.add(filePath);
       const fileChunks = existingChunksByFile.get(filePath);
       if (fileChunks) {
         for (const chunkId of fileChunks) {
@@ -3442,393 +3812,557 @@ export class Indexer {
       }
     }
 
-    const chunkDataBatch: ChunkData[] = [];
-
-    if (gitBlameEnabled) {
-      const backfillItems: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }> = [];
-
-      for (const chunkId of currentChunkIds) {
-        const metadata = existingMetadataById.get(chunkId);
-        if (!metadata || hasBlameMetadata(metadata)) {
-          continue;
-        }
-
-        const chunk = database.getChunk(chunkId);
-        if (!chunk) {
-          continue;
-        }
-
-        const blame = await getChunkGitBlame(
-          this.materializedProjectRoot,
-          this.toMaterializedFilePath(chunk.filePath),
-          chunk.startLine,
-          chunk.endLine,
-        );
-        const blameMetadata = metadataFromBlame(blame);
-        if (!blameMetadata.blameSha) {
-          continue;
-        }
-
-        chunkDataBatch.push({
-          ...chunk,
-          blameSha: blameMetadata.blameSha,
-          blameAuthor: blameMetadata.blameAuthor,
-          blameAuthorEmail: blameMetadata.blameAuthorEmail,
-          blameCommittedAt: blameMetadata.blameCommittedAt,
-          blameSummary: blameMetadata.blameSummary,
-        });
-
-        const embeddingBuffer = database.getEmbedding(chunk.contentHash);
-        if (!embeddingBuffer) {
-          continue;
-        }
-
-        backfillItems.push({
-          id: chunkId,
-          vector: Array.from(bufferToFloat32Array(embeddingBuffer)),
-          metadata: {
-            ...metadata,
-            ...blameMetadata,
-          },
-        });
-      }
-
-      if (backfillItems.length > 0) {
-        store.addBatch(backfillItems);
-        backfilledBlameMetadata = true;
-      }
-    }
-
-    for (const parsed of parsedFiles) {
-      currentFilePaths.add(parsed.path);
-
-      if (parsed.chunks.length === 0) {
-        stats.parseFailures.push(path.isAbsolute(parsed.path)
-          ? path.relative(this.projectRoot, parsed.path)
-          : parsed.path);
-      }
-
-      let chunksToProcess = parsed.chunks;
-
-      if (this.config.indexing.fallbackToTextOnMaxChunks && chunksToProcess.length > this.config.indexing.maxChunksPerFile) {
-        const changedFile = changedFiles.find(f => f.path === parsed.path);
-        if (changedFile) {
-          const textChunks = parseFileAsText(parsed.path, changedFile.content);
-          chunksToProcess = textChunks;
-        }
-      }
-
-      chunksToProcess = selectIndexableChunks(
-        chunksToProcess,
-        this.config.indexing.maxChunksPerFile,
-        this.config.indexing.semanticOnly,
-      );
-
-      for (const chunk of chunksToProcess) {
-        const id = this.getPreparedChunkId(generateChunkId(parsed.path, chunk));
-        const contentHash = generateChunkHash(chunk);
-        const existingContentHash = existingChunks.get(id);
-        const existingChunk = gitBlameEnabled ? database.getChunk(id) : null;
-        const blame = gitBlameEnabled && existingContentHash !== contentHash
-          ? await getChunkGitBlame(
-              this.materializedProjectRoot,
-              this.toMaterializedFilePath(parsed.path),
-              chunk.startLine,
-              chunk.endLine,
-            )
-          : blameFromChunkData(existingChunk);
-        const blameMetadata = metadataFromBlame(blame);
-        currentChunkIds.add(id);
-
-        chunkDataBatch.push({
-          chunkId: id,
-          contentHash,
-          filePath: parsed.path,
-          startLine: chunk.startLine,
-          endLine: chunk.endLine,
-          nodeType: chunk.chunkType,
-          name: chunk.name,
-          language: chunk.language,
-          blameSha: blameMetadata.blameSha,
-          blameAuthor: blameMetadata.blameAuthor,
-          blameAuthorEmail: blameMetadata.blameAuthorEmail,
-          blameCommittedAt: blameMetadata.blameCommittedAt,
-          blameSummary: blameMetadata.blameSummary,
-        });
-
-        if (existingContentHash === contentHash) {
-          continue;
-        }
-
-        const texts = createEmbeddingTexts(chunk, parsed.path, getSafeEmbeddingChunkTokenLimit(configuredProviderInfo)).map((text) => ({
-          text,
-          tokenCount: estimateTokens(text),
-        }));
-        const metadata: ChunkMetadata = {
-          filePath: parsed.path,
-          startLine: chunk.startLine,
-          endLine: chunk.endLine,
-          chunkType: chunk.chunkType,
-          name: chunk.name,
-          language: chunk.language,
-          hash: contentHash,
-          ...blameMetadata,
-        };
-
-        pendingChunks.push({
-          id,
-          texts,
-          storageText: createPendingChunkStorageText(texts),
-          content: chunk.content,
-          contentHash,
-          metadata,
-        });
-      }
-    }
-
-    const retryableFailedChunks = this.collectRetryableFailedChunks(
-      currentFileHashes,
-      unchangedFilePaths,
-      getSafeEmbeddingChunkTokenLimit(configuredProviderInfo)
-    );
-    const retryableFailedAttemptCounts = new Map<string, number>();
-    const retryableChunksWithExistingData = new Set<string>();
-    if (retryableFailedChunks.length > 0) {
-      const pendingChunkIds = new Set(pendingChunks.map((chunk) => chunk.id));
-      for (const { chunk, attemptCount } of retryableFailedChunks) {
-        retryableFailedAttemptCounts.set(chunk.id, attemptCount);
-        if (existingChunks.has(chunk.id)) {
-          retryableChunksWithExistingData.add(chunk.id);
-        }
-        if (!pendingChunkIds.has(chunk.id)) {
-          pendingChunks.push(chunk);
-          pendingChunkIds.add(chunk.id);
-          currentChunkIds.add(chunk.id);
-        }
-      }
-    }
-
-    database.beginWriteTransaction();
-    let writeTransactionActive = true;
+    const shouldRetryFailedPath = (filePath: string | null): boolean =>
+      filePath !== null && currentFileHashes.has(filePath) && unchangedFilePaths.has(filePath);
+    const failedProcessing = this.prepareFailedBatchProcessing(scopedRoots, shouldRetryFailedPath);
+    const maxChunkTokens = getSafeEmbeddingChunkTokenLimit(configuredProviderInfo);
+    const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
+    const queue = new PQueue({
+      concurrency: providerRateLimits.concurrency,
+      interval: providerRateLimits.intervalMs,
+      intervalCap: providerRateLimits.concurrency,
+    });
+    const rateLimitState: EmbeddingRateLimitState = { backoffMs: 0 };
+    let writeTransactionActive = false;
 
     try {
-      if (chunkDataBatch.length > 0) {
-        database.upsertChunksBatch(chunkDataBatch);
+      database.beginWriteTransaction();
+      writeTransactionActive = true;
+
+      const blameChunkDataBatch: ChunkData[] = [];
+      if (gitBlameEnabled) {
+        const backfillItems: Array<{ id: string; vector: number[]; metadata: ChunkMetadata }> = [];
+        for (const chunkId of currentChunkIds) {
+          const metadata = existingMetadataById.get(chunkId);
+          if (!metadata || hasBlameMetadata(metadata)) {
+            continue;
+          }
+          const chunk = database.getChunk(chunkId);
+          if (!chunk) {
+            continue;
+          }
+
+          const blame = await getChunkGitBlame(
+            this.materializedProjectRoot,
+            this.toMaterializedFilePath(chunk.filePath),
+            chunk.startLine,
+            chunk.endLine,
+          );
+          const blameMetadata = metadataFromBlame(blame);
+          if (!blameMetadata.blameSha) {
+            continue;
+          }
+
+          blameChunkDataBatch.push({
+            ...chunk,
+            blameSha: blameMetadata.blameSha,
+            blameAuthor: blameMetadata.blameAuthor,
+            blameAuthorEmail: blameMetadata.blameAuthorEmail,
+            blameCommittedAt: blameMetadata.blameCommittedAt,
+            blameSummary: blameMetadata.blameSummary,
+          });
+          const embeddingBuffer = database.getEmbedding(chunk.contentHash);
+          if (embeddingBuffer) {
+            backfillItems.push({
+              id: chunkId,
+              vector: Array.from(bufferToFloat32Array(embeddingBuffer)),
+              metadata: { ...metadata, ...blameMetadata },
+            });
+          }
+        }
+
+        if (blameChunkDataBatch.length > 0) {
+          database.upsertChunksBatch(blameChunkDataBatch);
+        }
+        if (backfillItems.length > 0) {
+          store.addBatch(backfillItems);
+          backfilledBlameMetadata = true;
+        }
       }
 
-    const allSymbolIds = new Set<string>();
-    const symbolsByFile = new Map<string, SymbolData[]>();
-
-    for (let i = 0; i < parsedFiles.length; i++) {
-      const parsed = parsedFiles[i];
-      const changedFile = changedFiles[i];
-
-      const fileSymbols: SymbolData[] = [];
-
-      for (const parsedSymbol of parsed.symbols) {
-        if (!CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(parsedSymbol.kind)) continue;
-
-        const preparedNamespace = this.getPreparedBranchNamespace();
-        const symbolId = `sym_${hashContent(
-          (preparedNamespace ? `${preparedNamespace}:` : "") +
-          parsed.path + ":" + parsedSymbol.name + ":" + parsedSymbol.kind + ":" +
-          parsedSymbol.startLine + ":" + parsedSymbol.startCol + ":" + changedFile.hash,
-        ).slice(0, 16)}`;
-        const symbol: SymbolData = {
-          id: symbolId,
-          filePath: parsed.path,
-          name: parsedSymbol.name,
-          kind: parsedSymbol.kind,
-          startLine: parsedSymbol.startLine,
-          startCol: parsedSymbol.startCol,
-          endLine: parsedSymbol.endLine,
-          endCol: parsedSymbol.endCol,
-          language: parsedSymbol.language,
-        };
-        fileSymbols.push(symbol);
-        allSymbolIds.add(symbolId);
+      for (const filePath of unchangedFilePaths) {
+        for (const symbol of database.getSymbolsByFile(filePath)) {
+          if (!restrictExistingChunksToBranch || previousBranchSymbolIdSet.has(symbol.id)) {
+            allSymbolIds.add(symbol.id);
+          }
+        }
       }
 
-      // For case-insensitive languages (e.g. Apex), the Rust call extractor
-      // already lowercases non-constructor / non-import callee names, so we
-      // must lowercase the symbol-map keys here too. Otherwise a declaration
-      // like `MyMethod` would not match a lowercased call edge target like
-      // `mymethod`, leaving same-file calls unresolved (toSymbolId = NULL).
-      const fileLanguage = parsed.symbols[0]?.language ?? parsed.chunks[0]?.language;
-      const isCaseInsensitiveLanguage =
-        !!fileLanguage && CASE_INSENSITIVE_LANGUAGES.has(fileLanguage);
-      const normalizeSymbolKey = (name: string): string =>
-        isCaseInsensitiveLanguage ? name.toLowerCase() : name;
-
-      const symbolsByName = new Map<string, SymbolData[]>();
-      for (const symbol of fileSymbols) {
-        const key = normalizeSymbolKey(symbol.name);
-        const existing = symbolsByName.get(key) ?? [];
-        existing.push(symbol);
-        symbolsByName.set(key, existing);
-      }
-
-      if (fileSymbols.length > 0) {
-        database.upsertSymbolsBatch(fileSymbols);
-        symbolsByFile.set(parsed.path, fileSymbols);
-      }
-
-      if (!fileLanguage || !CALL_GRAPH_LANGUAGES.has(fileLanguage)) continue;
-
-      const callSites = extractCalls(changedFile.content, fileLanguage);
-      if (callSites.length === 0) continue;
-
-      const edges: CallEdgeData[] = [];
-      for (const site of callSites) {
-        const enclosingSymbol = findEnclosingSymbol(
-          fileSymbols,
-          site.line,
-          site.column,
-        );
-        if (!enclosingSymbol) continue;
-
-        const edgeId = `edge_${hashContent(enclosingSymbol.id + ":" + site.calleeName + ":" + site.line + ":" + site.column).slice(0, 16)}`;
-        edges.push({
-          id: edgeId,
-          fromSymbolId: enclosingSymbol.id,
-          targetName: site.calleeName,
-          toSymbolId: undefined,
-          callType: site.callType,
-          confidence: site.confidence,
-          line: site.line,
-          col: site.column,
-          isResolved: false,
+      let processedChangedFiles = 0;
+      for (const descriptorBatch of iterateOrderedFileBatches(
+        changedFileDescriptors,
+        (descriptor) => descriptor.sourceBytes,
+        this.fileBatchLimits,
+      )) {
+        const loadedFiles = await Promise.all(descriptorBatch.map(async (descriptor) => ({
+          path: descriptor.storedPath,
+          content: await fsPromises.readFile(descriptor.materializedPath, "utf-8"),
+          hash: descriptor.hash,
+        })));
+        const loadedByPath = new Map(loadedFiles.map((file) => [file.path, file]));
+        const descriptorByPath = new Map(descriptorBatch.map((descriptor) => [descriptor.storedPath, descriptor]));
+        const parseStartTime = performance.now();
+        const parsedFiles = parseFiles(loadedFiles);
+        const parseMs = performance.now() - parseStartTime;
+        this.logger.recordFilesParsed(parsedFiles.length);
+        this.logger.recordParseDuration(parseMs);
+        this.logger.debug("Parsed changed file batch", {
+          parsedCount: parsedFiles.length,
+          parseMs: parseMs.toFixed(2),
         });
-      }
 
-      if (edges.length > 0) {
-        database.upsertCallEdgesBatch(edges);
+        const chunkDataBatch: ChunkData[] = [];
+        const pendingChunks: PendingChunk[] = [];
+        const symbolBatch: SymbolData[] = [];
+        const edgeBatch: CallEdgeData[] = [];
 
-        // Resolve same-file calls (with the same case-insensitivity rules
-        // used to build symbolsByName above).
-        for (const edge of edges) {
-          let candidates = symbolsByName.get(normalizeSymbolKey(edge.targetName));
-          if (fileLanguage === "php" && candidates) {
-            // PHP permits functions and classes whose names differ only by symbol kind.
-            // Resolve against the kind implied by the edge before checking uniqueness.
-            if (edge.callType === "Constructor") {
-              candidates = candidates.filter((candidate) =>
-                PHP_CLASS_SYMBOL_CHUNK_TYPES.has(candidate.kind)
-              );
-            } else if (edge.callType === "Call") {
-              candidates = candidates.filter((candidate) =>
-                PHP_FUNCTION_SYMBOL_CHUNK_TYPES.has(candidate.kind)
-              );
+        for (const parsed of parsedFiles) {
+          const loadedFile = loadedByPath.get(parsed.path);
+          const descriptor = descriptorByPath.get(parsed.path);
+          if (!loadedFile || !descriptor) {
+            throw new Error(`Parsed file was not present in its source batch: ${parsed.path}`);
+          }
+
+          if (parsed.chunks.length === 0) {
+            stats.parseFailures.push(path.isAbsolute(parsed.path)
+              ? path.relative(this.projectRoot, parsed.path)
+              : parsed.path);
+          }
+
+          let chunksToProcess = parsed.chunks;
+          if (
+            this.config.indexing.fallbackToTextOnMaxChunks &&
+            chunksToProcess.length > this.config.indexing.maxChunksPerFile
+          ) {
+            chunksToProcess = parseFileAsText(parsed.path, loadedFile.content);
+          }
+          chunksToProcess = selectIndexableChunks(
+            chunksToProcess,
+            this.config.indexing.maxChunksPerFile,
+            this.config.indexing.semanticOnly,
+          );
+
+          for (const chunk of chunksToProcess) {
+            const id = this.getPreparedChunkId(generateChunkId(parsed.path, chunk));
+            const contentHash = generateChunkHash(chunk);
+            const existingContentHash = existingChunks.get(id);
+            const existingChunk = gitBlameEnabled ? database.getChunk(id) : null;
+            const blame = gitBlameEnabled && existingContentHash !== contentHash
+              ? await getChunkGitBlame(
+                  this.materializedProjectRoot,
+                  descriptor.materializedPath,
+                  chunk.startLine,
+                  chunk.endLine,
+                )
+              : blameFromChunkData(existingChunk);
+            const blameMetadata = metadataFromBlame(blame);
+            currentChunkIds.add(id);
+
+            chunkDataBatch.push({
+              chunkId: id,
+              contentHash,
+              filePath: parsed.path,
+              startLine: chunk.startLine,
+              endLine: chunk.endLine,
+              nodeType: chunk.chunkType,
+              name: chunk.name,
+              language: chunk.language,
+              blameSha: blameMetadata.blameSha,
+              blameAuthor: blameMetadata.blameAuthor,
+              blameAuthorEmail: blameMetadata.blameAuthorEmail,
+              blameCommittedAt: blameMetadata.blameCommittedAt,
+              blameSummary: blameMetadata.blameSummary,
+            });
+
+            if (existingContentHash === contentHash) {
+              continue;
+            }
+
+            const texts = createEmbeddingTexts(chunk, parsed.path, maxChunkTokens).map((text) => ({
+              text,
+              tokenCount: estimateTokens(text),
+            }));
+            pendingChunks.push({
+              id,
+              texts,
+              storageText: createPendingChunkStorageText(texts),
+              content: chunk.content,
+              contentHash,
+              metadata: {
+                filePath: parsed.path,
+                startLine: chunk.startLine,
+                endLine: chunk.endLine,
+                chunkType: chunk.chunkType,
+                name: chunk.name,
+                language: chunk.language,
+                hash: contentHash,
+                ...blameMetadata,
+              },
+            });
+          }
+
+          const fileSymbols: SymbolData[] = [];
+          for (const parsedSymbol of parsed.symbols) {
+            if (!CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(parsedSymbol.kind)) {
+              continue;
+            }
+            const preparedNamespace = this.getPreparedBranchNamespace();
+            const symbolId = `sym_${hashContent(
+              (preparedNamespace ? `${preparedNamespace}:` : "") +
+              parsed.path + ":" + parsedSymbol.name + ":" + parsedSymbol.kind + ":" +
+              parsedSymbol.startLine + ":" + parsedSymbol.startCol + ":" + descriptor.hash,
+            ).slice(0, 16)}`;
+            const symbol: SymbolData = {
+              id: symbolId,
+              filePath: parsed.path,
+              name: parsedSymbol.name,
+              kind: parsedSymbol.kind,
+              startLine: parsedSymbol.startLine,
+              startCol: parsedSymbol.startCol,
+              endLine: parsedSymbol.endLine,
+              endCol: parsedSymbol.endCol,
+              language: parsedSymbol.language,
+            };
+            fileSymbols.push(symbol);
+            symbolBatch.push(symbol);
+            allSymbolIds.add(symbolId);
+          }
+
+          const fileLanguage = parsed.symbols[0]?.language ?? parsed.chunks[0]?.language;
+          if (!fileLanguage || !CALL_GRAPH_LANGUAGES.has(fileLanguage)) {
+            continue;
+          }
+          const isCaseInsensitiveLanguage = CASE_INSENSITIVE_LANGUAGES.has(fileLanguage);
+          const normalizeSymbolKey = (name: string): string =>
+            isCaseInsensitiveLanguage ? name.toLowerCase() : name;
+          const symbolsByName = new Map<string, SymbolData[]>();
+          for (const symbol of fileSymbols) {
+            const key = normalizeSymbolKey(symbol.name);
+            const symbols = symbolsByName.get(key) ?? [];
+            symbols.push(symbol);
+            symbolsByName.set(key, symbols);
+          }
+
+          for (const site of extractCalls(loadedFile.content, fileLanguage)) {
+            const enclosingSymbol = findEnclosingSymbol(fileSymbols, site.line, site.column);
+            if (!enclosingSymbol) {
+              continue;
+            }
+
+            let candidates = symbolsByName.get(normalizeSymbolKey(site.calleeName));
+            if (fileLanguage === "php" && candidates) {
+              if (site.callType === "Constructor") {
+                candidates = candidates.filter((candidate) => PHP_CLASS_SYMBOL_CHUNK_TYPES.has(candidate.kind));
+              } else if (site.callType === "Call") {
+                candidates = candidates.filter((candidate) => PHP_FUNCTION_SYMBOL_CHUNK_TYPES.has(candidate.kind));
+              }
+            }
+            candidates = candidates?.filter((symbol) =>
+              isCompatibleCFamilyCallTarget(fileLanguage, site.callType, symbol.kind)
+            );
+            const resolvedTarget = candidates?.length === 1 ? candidates[0] : undefined;
+            edgeBatch.push({
+              id: `edge_${hashContent(
+                enclosingSymbol.id + ":" + site.calleeName + ":" + site.line + ":" + site.column,
+              ).slice(0, 16)}`,
+              fromSymbolId: enclosingSymbol.id,
+              targetName: site.calleeName,
+              toSymbolId: resolvedTarget?.id,
+              callType: site.callType,
+              confidence: site.confidence,
+              line: site.line,
+              col: site.column,
+              isResolved: resolvedTarget !== undefined,
+            });
+          }
+        }
+
+        if (chunkDataBatch.length > 0) {
+          database.upsertChunksBatch(chunkDataBatch);
+        }
+        if (symbolBatch.length > 0) {
+          database.upsertSymbolsBatch(symbolBatch);
+        }
+        if (edgeBatch.length > 0) {
+          database.upsertCallEdgesBatch(edgeBatch);
+        }
+
+        processedChangedFiles += descriptorBatch.length;
+        stats.totalChunks += pendingChunks.length;
+        onProgress?.({
+          phase: "parsing",
+          filesProcessed: unchangedFilePaths.size + processedChangedFiles,
+          totalFiles: files.length,
+          chunksProcessed: stats.indexedChunks,
+          totalChunks: stats.totalChunks,
+        });
+
+        if (pendingChunks.length > 0) {
+          onProgress?.({
+            phase: "embedding",
+            filesProcessed: unchangedFilePaths.size + processedChangedFiles,
+            totalFiles: files.length,
+            chunksProcessed: stats.indexedChunks,
+            totalChunks: stats.totalChunks,
+          });
+          const batchResult = await this.processPendingChunkBatch(pendingChunks, {
+            store,
+            provider,
+            invertedIndex,
+            database,
+            configuredProviderInfo,
+            queue,
+            providerRateLimits,
+            rateLimitState,
+            failedState: failedProcessing.state,
+            attemptCounts: new Map<string, number>(),
+            forceReembed: forceScopedReembed,
+            reuseCachedEmbeddings: true,
+            incrementRepeatedFailures: true,
+            onProgress: (batchProgress) => onProgress?.({
+              phase: "embedding",
+              filesProcessed: unchangedFilePaths.size + processedChangedFiles,
+              totalFiles: files.length,
+              chunksProcessed: stats.indexedChunks + batchProgress.indexedChunks,
+              totalChunks: stats.totalChunks,
+            }),
+          });
+          stats.indexedChunks += batchResult.indexedChunks;
+          stats.failedChunks += batchResult.failedChunks;
+          stats.tokensUsed += batchResult.tokensUsed;
+          for (const chunkId of batchResult.failedChunkIds) {
+            failedChunkIds.add(chunkId);
+            if (forceScopedReembed) {
+              failedForcedChunkIds.add(chunkId);
             }
           }
-          candidates = candidates?.filter((symbol) =>
-            isCompatibleCFamilyCallTarget(fileLanguage, edge.callType, symbol.kind)
-          );
-          if (candidates && candidates.length === 1) {
-            database.resolveCallEdge(edge.id, candidates[0].id);
+        }
+      }
+
+      const retryableFailedChunks = this.iterateLatestFailedChunks(
+        failedProcessing.latestById,
+        scopedRoots,
+        shouldRetryFailedPath,
+        maxChunkTokens,
+      );
+      for (const retryBatch of iterateOrderedFileBatches(
+        retryableFailedChunks,
+        ({ chunk }) => Buffer.byteLength(chunk.content, "utf-8"),
+        this.fileBatchLimits,
+      )) {
+        const pendingChunks = retryBatch.map(({ chunk }) => chunk);
+        const attemptCounts = new Map(retryBatch.map(({ chunk, attemptCount }) => [chunk.id, attemptCount]));
+        for (const chunk of pendingChunks) {
+          currentChunkIds.add(chunk.id);
+          if (existingChunks.has(chunk.id)) {
+            retryableChunksWithExistingData.add(chunk.id);
+          }
+        }
+        stats.totalChunks += pendingChunks.length;
+        onProgress?.({
+          phase: "embedding",
+          filesProcessed: files.length,
+          totalFiles: files.length,
+          chunksProcessed: stats.indexedChunks,
+          totalChunks: stats.totalChunks,
+        });
+        const batchResult = await this.processPendingChunkBatch(pendingChunks, {
+          store,
+          provider,
+          invertedIndex,
+          database,
+          configuredProviderInfo,
+          queue,
+          providerRateLimits,
+          rateLimitState,
+          failedState: failedProcessing.state,
+          attemptCounts,
+          forceReembed: forceScopedReembed,
+          reuseCachedEmbeddings: true,
+          incrementRepeatedFailures: true,
+          onProgress: (batchProgress) => onProgress?.({
+            phase: "embedding",
+            filesProcessed: files.length,
+            totalFiles: files.length,
+            chunksProcessed: stats.indexedChunks + batchProgress.indexedChunks,
+            totalChunks: stats.totalChunks,
+          }),
+        });
+        stats.indexedChunks += batchResult.indexedChunks;
+        stats.failedChunks += batchResult.failedChunks;
+        stats.tokensUsed += batchResult.tokensUsed;
+        for (const chunkId of batchResult.failedChunkIds) {
+          failedChunkIds.add(chunkId);
+          if (forceScopedReembed) {
+            failedForcedChunkIds.add(chunkId);
           }
         }
       }
-    }
 
-    for (const filePath of unchangedFilePaths) {
-      const existingSymbols = database.getSymbolsByFile(filePath);
-      for (const sym of existingSymbols) {
-        if (!restrictExistingChunksToBranch || previousBranchSymbolIdSet.has(sym.id)) {
-          allSymbolIds.add(sym.id);
+      const removedChunkIds: string[] = [];
+      for (const [chunkId] of existingChunks) {
+        if (!currentChunkIds.has(chunkId)) {
+          removedChunkIds.push(chunkId);
         }
       }
-    }
+      const removedCount = removedChunkIds.length;
+      stats.existingChunks = currentChunkIds.size - stats.totalChunks;
+      stats.removedChunks = removedCount;
 
-    const removedChunkIds: string[] = [];
-    for (const [chunkId] of existingChunks) {
-      if (!currentChunkIds.has(chunkId)) {
-        removedChunkIds.push(chunkId);
+      this.logger.recordChunksProcessed(currentChunkIds.size);
+      this.logger.recordChunksRemoved(removedCount);
+      this.logger.info("Chunk analysis complete", {
+        pending: stats.totalChunks,
+        existing: stats.existingChunks,
+        removed: removedCount,
+      });
+
+      if (stats.totalChunks === 0 && removedCount === 0) {
+        const removedStoredChunks = this.replaceBranchCatalog(
+          store,
+          invertedIndex,
+          database,
+          branchCatalogKey,
+          previousBranchChunkIds,
+          Array.from(currentChunkIds),
+          previousBranchSymbolIds,
+          Array.from(allSymbolIds),
+        );
+        const vectorPath = path.join(this.indexPath, "vectors");
+        const shouldFingerprintLegacyPair = !store.hasFingerprint() &&
+          existsSync(vectorPath) &&
+          existsSync(`${vectorPath}.meta.json`);
+        if (backfilledBlameMetadata || shouldFingerprintLegacyPair || removedStoredChunks) {
+          store.save();
+        }
+        if (removedStoredChunks) {
+          this.saveInvertedIndex(invertedIndex);
+        }
+        if (scopedRoots) {
+          this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+        } else {
+          this.fileHashCache = currentFileHashes;
+          this.saveFileHashCache();
+        }
+        this.finalizeFailedBatchWriteState(failedProcessing.state);
+        database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
+        database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
+        database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
+        this.saveBranchCommit(database, indexedCommit);
+        this.saveIndexMetadata(configuredProviderInfo);
+        this.indexCompatibility = { compatible: true };
+        database.commitWriteTransaction();
+        writeTransactionActive = false;
+        stats.durationMs = Date.now() - startTime;
+        onProgress?.({
+          phase: "complete",
+          filesProcessed: files.length,
+          totalFiles: files.length,
+          chunksProcessed: 0,
+          totalChunks: 0,
+        });
+        return stats;
       }
-    }
 
-    const removedCount = removedChunkIds.length;
-
-    stats.totalChunks = pendingChunks.length;
-    stats.existingChunks = currentChunkIds.size - pendingChunks.length;
-    stats.removedChunks = removedCount;
-
-    this.logger.recordChunksProcessed(currentChunkIds.size);
-    this.logger.recordChunksRemoved(removedCount);
-    this.logger.info("Chunk analysis complete", {
-      pending: pendingChunks.length,
-      existing: stats.existingChunks,
-      removed: removedCount,
-    });
-
-    if (pendingChunks.length === 0 && removedCount === 0) {
-      const removedStoredChunks = this.replaceBranchCatalog(
-        store,
-        invertedIndex,
-        database,
-        branchCatalogKey,
-        previousBranchChunkIds,
-        Array.from(currentChunkIds),
-        previousBranchSymbolIds,
-        Array.from(allSymbolIds),
-      );
-      const vectorPath = path.join(this.indexPath, "vectors");
-      const shouldFingerprintLegacyPair = !store.hasFingerprint() &&
-        existsSync(vectorPath) &&
-        existsSync(`${vectorPath}.meta.json`);
-      if (backfilledBlameMetadata || shouldFingerprintLegacyPair || removedStoredChunks) {
+      if (stats.totalChunks === 0) {
+        this.replaceBranchCatalog(
+          store,
+          invertedIndex,
+          database,
+          branchCatalogKey,
+          previousBranchChunkIds,
+          Array.from(currentChunkIds),
+          previousBranchSymbolIds,
+          Array.from(allSymbolIds),
+        );
         store.save();
-      }
-      if (removedStoredChunks) {
         this.saveInvertedIndex(invertedIndex);
+        if (scopedRoots) {
+          this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
+        } else {
+          this.fileHashCache = currentFileHashes;
+          this.saveFileHashCache();
+        }
+        this.finalizeFailedBatchWriteState(failedProcessing.state);
+        database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
+        database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
+        database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
+        this.saveBranchCommit(database, indexedCommit);
+        this.saveIndexMetadata(configuredProviderInfo);
+        this.indexCompatibility = { compatible: true };
+        database.commitWriteTransaction();
+        writeTransactionActive = false;
+        stats.durationMs = Date.now() - startTime;
+        onProgress?.({
+          phase: "complete",
+          filesProcessed: files.length,
+          totalFiles: files.length,
+          chunksProcessed: 0,
+          totalChunks: 0,
+        });
+        return stats;
       }
-      if (scopedRoots) {
-        this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
-        this.clearScopedFailedBatches(scopedRoots);
-      } else {
-        this.fileHashCache = currentFileHashes;
-        this.saveFileHashCache();
-        this.saveFailedBatches([]);
-      }
-      database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
-      database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
-      database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
-      this.saveBranchCommit(database, indexedCommit);
-      this.saveIndexMetadata(configuredProviderInfo);
-      this.indexCompatibility = { compatible: true };
-      database.commitWriteTransaction();
-      writeTransactionActive = false;
-      stats.durationMs = Date.now() - startTime;
+
       onProgress?.({
-        phase: "complete",
+        phase: "storing",
         filesProcessed: files.length,
         totalFiles: files.length,
-        chunksProcessed: 0,
-        totalChunks: 0,
+        chunksProcessed: stats.indexedChunks,
+        totalChunks: stats.totalChunks,
       });
-      return stats;
-    }
 
-    if (pendingChunks.length === 0) {
+      const branchChunkIds = Array.from(currentChunkIds).filter((chunkId) => {
+        const isNewlyFailed = failedChunkIds.has(chunkId) && !retryableChunksWithExistingData.has(chunkId);
+        const isForcedFailed = forceScopedReembed && failedForcedChunkIds.has(chunkId);
+        return !isNewlyFailed && !isForcedFailed;
+      });
       this.replaceBranchCatalog(
         store,
         invertedIndex,
         database,
         branchCatalogKey,
         previousBranchChunkIds,
-        Array.from(currentChunkIds),
+        branchChunkIds,
         previousBranchSymbolIds,
         Array.from(allSymbolIds),
       );
+
       store.save();
       this.saveInvertedIndex(invertedIndex);
       if (scopedRoots) {
         this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
-        this.clearScopedFailedBatches(scopedRoots);
       } else {
         this.fileHashCache = currentFileHashes;
         this.saveFileHashCache();
-        this.saveFailedBatches([]);
+      }
+      this.finalizeFailedBatchWriteState(failedProcessing.state);
+
+      database.commitWriteTransaction();
+      writeTransactionActive = false;
+
+      if (this.config.indexing.autoGc && stats.removedChunks > 0) {
+        const gcReset = await this.maybeRunOrphanGc();
+        if (gcReset) {
+          stats.durationMs = Date.now() - startTime;
+          stats.warning = gcReset.warning;
+          stats.resetCorruptedIndex = true;
+          this.logger.recordIndexingEnd();
+          this.logger.warn("Indexing ended after resetting corrupted local index during automatic GC", {
+            files: stats.totalFiles,
+            indexed: stats.indexedChunks,
+            existing: stats.existingChunks,
+            removed: stats.removedChunks,
+            failed: stats.failedChunks,
+            tokens: stats.tokensUsed,
+            durationMs: stats.durationMs,
+          });
+          return stats;
+        }
+      }
+
+      stats.durationMs = Date.now() - startTime;
+      if (forceScopedReembed && failedForcedChunkIds.size === 0) {
+        database.deleteMetadata(this.getProjectForceReembedMetadataKey());
       }
       database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
       database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
@@ -3836,363 +4370,31 @@ export class Indexer {
       this.saveBranchCommit(database, indexedCommit);
       this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
-      database.commitWriteTransaction();
-      writeTransactionActive = false;
-      stats.durationMs = Date.now() - startTime;
+
+      this.logger.recordIndexingEnd();
+      this.logger.info("Indexing complete", {
+        files: stats.totalFiles,
+        indexed: stats.indexedChunks,
+        existing: stats.existingChunks,
+        removed: stats.removedChunks,
+        failed: stats.failedChunks,
+        tokens: stats.tokensUsed,
+        durationMs: stats.durationMs,
+      });
+
+      if (stats.failedChunks > 0) {
+        stats.failedBatchesPath = this.failedBatchesPath;
+      }
       onProgress?.({
         phase: "complete",
         filesProcessed: files.length,
         totalFiles: files.length,
-        chunksProcessed: 0,
-        totalChunks: 0,
+        chunksProcessed: stats.indexedChunks,
+        totalChunks: stats.totalChunks,
       });
       return stats;
-    }
-
-    onProgress?.({
-      phase: "embedding",
-      filesProcessed: files.length,
-      totalFiles: files.length,
-      chunksProcessed: 0,
-      totalChunks: pendingChunks.length,
-    });
-
-    const allContentHashes = pendingChunks.map((c) => c.contentHash);
-    const missingHashes = new Set(database.getMissingEmbeddings(allContentHashes));
-    const forcedReembedChunkIds = forceScopedReembed
-      ? new Set(pendingChunks.map((chunk) => chunk.id))
-      : new Set<string>();
-
-    const chunksNeedingEmbedding = pendingChunks.filter((c) => forcedReembedChunkIds.has(c.id) || missingHashes.has(c.contentHash));
-    const chunksWithExistingEmbedding = pendingChunks.filter((c) => !forcedReembedChunkIds.has(c.id) && !missingHashes.has(c.contentHash));
-
-    this.logger.cache("info", "Embedding cache lookup", {
-      needsEmbedding: chunksNeedingEmbedding.length,
-      fromCache: chunksWithExistingEmbedding.length,
-    });
-    this.logger.recordChunksFromCache(chunksWithExistingEmbedding.length);
-
-    for (const chunk of chunksWithExistingEmbedding) {
-      const embeddingBuffer = database.getEmbedding(chunk.contentHash);
-      if (embeddingBuffer) {
-        const vector = bufferToFloat32Array(embeddingBuffer);
-        store.add(chunk.id, Array.from(vector), chunk.metadata);
-        invertedIndex.removeChunk(chunk.id);
-        invertedIndex.addChunk(chunk.id, chunk.content);
-        stats.indexedChunks++;
-      }
-    }
-
-    const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
-    const queue = new PQueue({
-      concurrency: providerRateLimits.concurrency,
-      interval: providerRateLimits.intervalMs,
-      intervalCap: providerRateLimits.concurrency
-    });
-    const pendingChunksById = new Map(chunksNeedingEmbedding.map((chunk) => [chunk.id, chunk]));
-    const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
-    const completedChunkIds = new Set<string>();
-    const failedChunkIds = new Set<string>();
-    const requestBatches = createPendingEmbeddingRequestBatches(
-      chunksNeedingEmbedding,
-      getDynamicBatchOptions(configuredProviderInfo)
-    );
-    let rateLimitBackoffMs = 0;
-
-    for (const requestBatch of requestBatches) {
-      queue.add(async () => {
-        if (rateLimitBackoffMs > 0) {
-          await new Promise(resolve => setTimeout(resolve, rateLimitBackoffMs));
-        }
-
-        try {
-          const result = await pRetry(
-            async () => {
-              const texts = requestBatch.map((request) => request.text);
-              return provider.embedBatch(texts);
-            },
-            {
-              retries: this.config.indexing.retries,
-              minTimeout: Math.max(this.config.indexing.retryDelayMs, providerRateLimits.minRetryMs),
-              maxTimeout: providerRateLimits.maxRetryMs,
-              factor: 2,
-              shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
-              onFailedAttempt: (error) => {
-                const message = getErrorMessage(error);
-                if (isRateLimitError(error)) {
-                  rateLimitBackoffMs = Math.min(providerRateLimits.maxRetryMs, (rateLimitBackoffMs || providerRateLimits.minRetryMs) * 2);
-                  this.logger.embedding("warn", `Rate limited, backing off`, {
-                    attempt: error.attemptNumber,
-                    retriesLeft: error.retriesLeft,
-                    backoffMs: rateLimitBackoffMs,
-                  });
-                } else {
-                  this.logger.embedding("error", `Embedding batch failed`, {
-                    attempt: error.attemptNumber,
-                    error: message,
-                  });
-                }
-              },
-            }
-          );
-
-          if (rateLimitBackoffMs > 0) {
-            rateLimitBackoffMs = Math.max(0, rateLimitBackoffMs - 2000);
-          }
-
-          const touchedChunkIds = new Set<string>();
-
-          requestBatch.forEach((request, idx) => {
-            if (failedChunkIds.has(request.chunk.id) || completedChunkIds.has(request.chunk.id)) {
-              return;
-            }
-
-            const vector = result.embeddings[idx];
-            if (!vector) {
-              throw new Error(`Embedding API returned too few vectors for chunk ${request.chunk.id}`);
-            }
-
-            const parts = embeddingPartsByChunk.get(request.chunk.id) ?? [];
-            parts[request.partIndex] = {
-              vector,
-              tokenCount: request.tokenCount,
-            };
-            embeddingPartsByChunk.set(request.chunk.id, parts);
-            touchedChunkIds.add(request.chunk.id);
-          });
-
-          const pooledResults: Array<{ chunk: PendingChunk; vector: number[] }> = [];
-          for (const chunkId of touchedChunkIds) {
-            if (failedChunkIds.has(chunkId) || completedChunkIds.has(chunkId)) {
-              continue;
-            }
-
-            const chunk = pendingChunksById.get(chunkId);
-            if (!chunk) {
-              continue;
-            }
-
-            const parts = embeddingPartsByChunk.get(chunk.id) ?? [];
-            if (!hasAllEmbeddingParts(parts, chunk.texts.length)) {
-              continue;
-            }
-
-            const orderedParts = parts as Array<{ vector: number[]; tokenCount: number }>;
-            pooledResults.push({
-              chunk,
-              vector: poolEmbeddingVectors(
-                orderedParts.map((part) => part.vector),
-                orderedParts.map((part) => part.tokenCount)
-              ),
-            });
-          }
-
-          if (pooledResults.length > 0) {
-            const items = pooledResults.map(({ chunk, vector }) => ({
-              id: chunk.id,
-              vector,
-              metadata: chunk.metadata,
-            }));
-
-            store.addBatch(items);
-
-            const embeddingBatchItems = pooledResults.map(({ chunk, vector }) => ({
-              contentHash: chunk.contentHash,
-              embedding: float32ArrayToBuffer(vector),
-              chunkText: chunk.storageText,
-              model: configuredProviderInfo.modelInfo.model,
-            }));
-
-            try {
-              database.upsertEmbeddingsBatch(embeddingBatchItems);
-            } catch (dbError) {
-              this.rebuildVectorStoreExcludingChunkIds(
-                store,
-                database,
-                pooledResults.map(({ chunk }) => chunk.id)
-              );
-              throw dbError;
-            }
-
-            for (const { chunk } of pooledResults) {
-              invertedIndex.removeChunk(chunk.id);
-              invertedIndex.addChunk(chunk.id, chunk.content);
-              completedChunkIds.add(chunk.id);
-              embeddingPartsByChunk.delete(chunk.id);
-            }
-
-            stats.indexedChunks += pooledResults.length;
-            this.logger.recordChunksEmbedded(pooledResults.length);
-          }
-
-          stats.tokensUsed += result.totalTokensUsed;
-
-          this.logger.recordEmbeddingApiCall(result.totalTokensUsed);
-          this.logger.embedding("debug", `Embedded batch`, {
-            batchSize: pooledResults.length,
-            requestCount: requestBatch.length,
-            tokens: result.totalTokensUsed,
-          });
-
-          onProgress?.({
-            phase: "embedding",
-            filesProcessed: files.length,
-            totalFiles: files.length,
-            chunksProcessed: stats.indexedChunks,
-            totalChunks: pendingChunks.length,
-          });
-        } catch (error) {
-          const failedChunks = getUniquePendingChunksFromRequests(requestBatch)
-            .filter((chunk) => !completedChunkIds.has(chunk.id));
-          const failureMessage = getErrorMessage(error);
-          const failureTimestamp = new Date().toISOString();
-
-          for (const chunk of failedChunks) {
-            if (!failedChunkIds.has(chunk.id)) {
-              failedChunkIds.add(chunk.id);
-              stats.failedChunks += 1;
-            }
-
-            if (forceScopedReembed) {
-              failedForcedChunkIds.add(chunk.id);
-            }
-
-            embeddingPartsByChunk.delete(chunk.id);
-
-            const existingFailedBatchIndex = failedBatchesForCurrentRun.findIndex(
-              (failedBatch) => failedBatch.chunks[0]?.id === chunk.id
-            );
-            const existingFailedBatch = existingFailedBatchIndex === -1
-              ? undefined
-              : failedBatchesForCurrentRun[existingFailedBatchIndex];
-            const failedBatch = {
-              chunks: [chunk],
-              error: failureMessage,
-              attemptCount: (existingFailedBatch?.attemptCount ?? retryableFailedAttemptCounts.get(chunk.id) ?? 0) + 1,
-              lastAttempt: failureTimestamp,
-            } satisfies FailedBatch;
-
-            if (existingFailedBatchIndex === -1) {
-              failedBatchesForCurrentRun.push(failedBatch);
-            } else {
-              failedBatchesForCurrentRun[existingFailedBatchIndex] = failedBatch;
-            }
-          }
-
-          this.logger.recordEmbeddingError();
-          this.logger.embedding("error", `Failed to embed batch after retries`, {
-            batchSize: failedChunks.length,
-            requestCount: requestBatch.length,
-            error: failureMessage,
-          });
-        }
-      });
-    }
-
-    await queue.onIdle();
-    if (scopedRoots) {
-      this.saveScopedFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun), scopedRoots);
-    } else {
-      this.saveFailedBatches(coalesceFailedBatches(failedBatchesForCurrentRun));
-    }
-
-    onProgress?.({
-      phase: "storing",
-      filesProcessed: files.length,
-      totalFiles: files.length,
-      chunksProcessed: stats.indexedChunks,
-      totalChunks: pendingChunks.length,
-    });
-
-    const branchChunkIds = Array.from(currentChunkIds).filter(
-      (chunkId) => {
-        const isNewlyFailed = failedChunkIds.has(chunkId) && !retryableChunksWithExistingData.has(chunkId);
-        const isForcedFailed = forceScopedReembed && failedForcedChunkIds.has(chunkId);
-        return !isNewlyFailed && !isForcedFailed;
-      }
-    );
-    this.replaceBranchCatalog(
-      store,
-      invertedIndex,
-      database,
-      branchCatalogKey,
-      previousBranchChunkIds,
-      branchChunkIds,
-      previousBranchSymbolIds,
-      Array.from(allSymbolIds),
-    );
-
-    store.save();
-    this.saveInvertedIndex(invertedIndex);
-    if (scopedRoots) {
-      this.replaceScopedFileHashCache(currentFileHashes, scopedRoots);
-    } else {
-      this.fileHashCache = currentFileHashes;
-      this.saveFileHashCache();
-    }
-
-    database.commitWriteTransaction();
-    writeTransactionActive = false;
-
-    if (this.config.indexing.autoGc && stats.removedChunks > 0) {
-      const gcReset = await this.maybeRunOrphanGc();
-      if (gcReset) {
-        stats.durationMs = Date.now() - startTime;
-        stats.warning = gcReset.warning;
-        stats.resetCorruptedIndex = true;
-
-        this.logger.recordIndexingEnd();
-        this.logger.warn("Indexing ended after resetting corrupted local index during automatic GC", {
-          files: stats.totalFiles,
-          indexed: stats.indexedChunks,
-          existing: stats.existingChunks,
-          removed: stats.removedChunks,
-          failed: stats.failedChunks,
-          tokens: stats.tokensUsed,
-          durationMs: stats.durationMs,
-        });
-
-        return stats;
-      }
-    }
-
-    stats.durationMs = Date.now() - startTime;
-
-    if (forceScopedReembed && failedForcedChunkIds.size === 0) {
-      database.deleteMetadata(this.getProjectForceReembedMetadataKey());
-    }
-    database.setMetadata(swiftParserMetadataKey, SWIFT_PARSER_VERSION);
-    database.setMetadata(metalParserMetadataKey, METAL_PARSER_VERSION);
-    database.setMetadata(symbolExtractorMetadataKey, SYMBOL_EXTRACTOR_VERSION);
-    this.saveBranchCommit(database, indexedCommit);
-    this.saveIndexMetadata(configuredProviderInfo);
-    this.indexCompatibility = { compatible: true };
-
-    this.logger.recordIndexingEnd();
-    this.logger.info("Indexing complete", {
-      files: stats.totalFiles,
-      indexed: stats.indexedChunks,
-      existing: stats.existingChunks,
-      removed: stats.removedChunks,
-      failed: stats.failedChunks,
-      tokens: stats.tokensUsed,
-      durationMs: stats.durationMs,
-    });
-
-    if (stats.failedChunks > 0) {
-      stats.failedBatchesPath = this.failedBatchesPath;
-    }
-
-    onProgress?.({
-      phase: "complete",
-      filesProcessed: files.length,
-      totalFiles: files.length,
-      chunksProcessed: stats.indexedChunks,
-      totalChunks: pendingChunks.length,
-    });
-
-    return stats;
     } catch (error) {
+      failedProcessing.state.writer.cleanup();
       if (writeTransactionActive) {
         try {
           database.rollbackWriteTransaction();
@@ -4821,7 +5023,7 @@ export class Indexer {
 
         database.clearAllIndexedData();
         this.deleteBranchCommitMetadata(database, clearedBranchKeys);
-        this.saveFailedBatches([]);
+        this.clearFailedBatchState();
 
         database.deleteMetadata("index.version");
         database.deleteMetadata("index.pathStorageVersion");
@@ -5013,214 +5215,103 @@ export class Indexer {
     const { store, provider, invertedIndex, database, configuredProviderInfo } = this.requireLoadedIndexState();
     const maxChunkTokens = getSafeEmbeddingChunkTokenLimit(configuredProviderInfo);
     const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
-
     const roots = this.config.scope === "global" ? this.getScopedRoots() : null;
-    const { scoped: scopedFailedBatches, retained: retainedFailedBatches } = roots
-      ? this.partitionFailedBatches(roots, maxChunkTokens)
-      : { scoped: this.loadFailedBatches(maxChunkTokens), retained: [] as FailedBatch[] };
-    const failedBatches = scopedFailedBatches;
-    if (failedBatches.length === 0) {
+    const failedProcessing = this.prepareFailedBatchProcessing(roots, () => true);
+
+    if (failedProcessing.latestById.size === 0) {
+      this.finalizeFailedBatchWriteState(failedProcessing.state);
       return { succeeded: 0, failed: 0, remaining: 0 };
     }
 
+    const queue = new PQueue({ concurrency: 1 });
+    const rateLimitState: EmbeddingRateLimitState = { backoffMs: 0 };
     let succeeded = 0;
     let failed = 0;
-    const stillFailing: FailedBatch[] = [];
 
-    for (const batch of failedBatches) {
-      const batchChunksById = new Map(batch.chunks.map((chunk) => [chunk.id, chunk]));
-      const embeddingPartsByChunk = new Map<string, Array<{ vector: number[]; tokenCount: number } | undefined>>();
-      const completedChunkIds = new Set<string>();
-      const failedChunkIds = new Set<string>();
-      const failedChunksForBatch = new Map<string, FailedBatch>();
-      const pooledResults: Array<{ chunk: PendingChunk; vector: number[] }> = [];
-      try {
-        const requestBatches = createPendingEmbeddingRequestBatches(
-          batch.chunks,
-          getDynamicBatchOptions(configuredProviderInfo)
-        );
-
-        for (const requestBatch of requestBatches) {
-          try {
-            const result = await pRetry(
-              async () => {
-                const texts = requestBatch.map((request) => request.text);
-                return provider.embedBatch(texts);
-              },
-              {
-                retries: this.config.indexing.retries,
-                minTimeout: Math.max(this.config.indexing.retryDelayMs, providerRateLimits.minRetryMs),
-                maxTimeout: providerRateLimits.maxRetryMs,
-                factor: 2,
-                shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
-              }
+    try {
+      const retryableChunks = this.iterateLatestFailedChunks(
+        failedProcessing.latestById,
+        roots,
+        () => true,
+        maxChunkTokens,
+      );
+      for (const retryBatch of iterateOrderedFileBatches(
+        retryableChunks,
+        ({ chunk }) => Buffer.byteLength(chunk.content, "utf-8"),
+        this.fileBatchLimits,
+      )) {
+        const chunks = retryBatch.map(({ chunk }) => chunk);
+        const attemptCounts = new Map(retryBatch.map(({ chunk, attemptCount }) => [chunk.id, attemptCount]));
+        const batchResult = await this.processPendingChunkBatch(chunks, {
+          store,
+          provider,
+          invertedIndex,
+          database,
+          configuredProviderInfo,
+          queue,
+          providerRateLimits,
+          rateLimitState,
+          failedState: failedProcessing.state,
+          attemptCounts,
+          forceReembed: false,
+          reuseCachedEmbeddings: false,
+          incrementRepeatedFailures: false,
+          onSucceeded: (succeededChunks) => {
+            database.addChunksToBranchBatch(
+              this.getBranchCatalogKey(),
+              succeededChunks.map((chunk) => chunk.id),
             );
-
-            const touchedChunkIds = new Set<string>();
-            requestBatch.forEach((request, idx) => {
-              if (failedChunkIds.has(request.chunk.id) || completedChunkIds.has(request.chunk.id)) {
-                return;
-              }
-
-              const vector = result.embeddings[idx];
-              if (!vector) {
-                throw new Error(`Embedding API returned too few vectors for chunk ${request.chunk.id}`);
-              }
-
-              const parts = embeddingPartsByChunk.get(request.chunk.id) ?? [];
-              parts[request.partIndex] = {
-                vector,
-                tokenCount: request.tokenCount,
-              };
-              embeddingPartsByChunk.set(request.chunk.id, parts);
-              touchedChunkIds.add(request.chunk.id);
-            });
-
-            for (const chunkId of touchedChunkIds) {
-              if (failedChunkIds.has(chunkId) || completedChunkIds.has(chunkId)) {
-                continue;
-              }
-
-              const chunk = batchChunksById.get(chunkId);
-              if (!chunk) {
-                continue;
-              }
-
-              const parts = embeddingPartsByChunk.get(chunk.id) ?? [];
-              if (!hasAllEmbeddingParts(parts, chunk.texts.length)) {
-                continue;
-              }
-
-              const orderedParts = parts as Array<{ vector: number[]; tokenCount: number }>;
-              pooledResults.push({
-                chunk,
-                vector: poolEmbeddingVectors(
-                  orderedParts.map((part) => part.vector),
-                  orderedParts.map((part) => part.tokenCount)
-                ),
-              });
-            }
-
-            this.logger.recordEmbeddingApiCall(result.totalTokensUsed);
-          } catch (error) {
-            const failureMessage = String(error);
-            const failureTimestamp = new Date().toISOString();
-            const failedChunks = getUniquePendingChunksFromRequests(requestBatch)
-              .filter((chunk) => !completedChunkIds.has(chunk.id) && !failedChunkIds.has(chunk.id));
-
-            for (const chunk of failedChunks) {
-              failedChunkIds.add(chunk.id);
-              embeddingPartsByChunk.delete(chunk.id);
-              failedChunksForBatch.set(chunk.id, {
-                chunks: [chunk],
-                attemptCount: batch.attemptCount + 1,
-                lastAttempt: failureTimestamp,
-                error: failureMessage,
-              });
-            }
-
-            failed += failedChunks.length;
-            this.logger.recordEmbeddingError();
-          }
-        }
-
-        const successfulResults = pooledResults.filter(({ chunk }) => !failedChunkIds.has(chunk.id));
-
-        const items = successfulResults.map(({ chunk, vector }) => ({
-          id: chunk.id,
-          vector,
-          metadata: chunk.metadata,
-        }));
-
-        if (items.length > 0) {
-          store.addBatch(items);
-        }
-
-        if (successfulResults.length > 0) {
-          try {
-            database.upsertEmbeddingsBatch(
-              successfulResults.map(({ chunk, vector }) => ({
-                contentHash: chunk.contentHash,
-                embedding: float32ArrayToBuffer(vector),
-                chunkText: chunk.storageText,
-                model: configuredProviderInfo.modelInfo.model,
-              }))
-            );
-          } catch (dbError) {
-            this.rebuildVectorStoreExcludingChunkIds(
-              store,
-              database,
-              successfulResults.map(({ chunk }) => chunk.id)
-            );
-            throw dbError;
-          }
-        }
-
-        for (const { chunk } of successfulResults) {
-          invertedIndex.removeChunk(chunk.id);
-          invertedIndex.addChunk(chunk.id, chunk.content);
-          completedChunkIds.add(chunk.id);
-          embeddingPartsByChunk.delete(chunk.id);
-        }
-
-        database.addChunksToBranchBatch(
-          this.getBranchCatalogKey(),
-          successfulResults.map(({ chunk }) => chunk.id)
-        );
-
-        this.logger.recordChunksEmbedded(successfulResults.length);
-
-        succeeded += successfulResults.length;
-        stillFailing.push(...failedChunksForBatch.values());
-      } catch (error) {
-        const failureMessage = getErrorMessage(error);
-        const failureTimestamp = new Date().toISOString();
-        const unaccountedChunks = batch.chunks.filter(
-          (chunk) => !failedChunksForBatch.has(chunk.id) && !completedChunkIds.has(chunk.id)
-        );
-
-        for (const chunk of unaccountedChunks) {
-          failedChunksForBatch.set(chunk.id, {
-            chunks: [chunk],
-            attemptCount: batch.attemptCount + 1,
-            lastAttempt: failureTimestamp,
-            error: failureMessage,
-          });
-        }
-
-        failed += unaccountedChunks.length;
-        this.logger.recordEmbeddingError();
-        stillFailing.push(...coalesceFailedBatches(Array.from(failedChunksForBatch.values())));
+          },
+        });
+        succeeded += batchResult.indexedChunks;
+        failed += batchResult.failedChunks;
       }
+
+      this.finalizeFailedBatchWriteState(failedProcessing.state);
+    } catch (error) {
+      failedProcessing.state.writer.cleanup();
+      throw error;
     }
 
-    const persistedStillFailing = coalesceFailedBatches(stillFailing);
-
-    if (roots) {
-      this.saveFailedBatches([...retainedFailedBatches, ...persistedStillFailing]);
-    } else {
-      this.saveFailedBatches(persistedStillFailing);
-    }
-
+    const remaining = this.getFailedBatchesCount();
     if (succeeded > 0) {
       store.save();
       this.saveInvertedIndex(invertedIndex);
     }
 
-    if (roots && succeeded > 0 && persistedStillFailing.length === 0 && this.hasProjectForceReembedPending()) {
+    if (roots && succeeded > 0 && remaining === 0 && this.hasProjectForceReembedPending()) {
       database.deleteMetadata(this.getProjectForceReembedMetadataKey());
       this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
     }
 
-    return { succeeded, failed, remaining: persistedStillFailing.length };
+    return { succeeded, failed, remaining };
   }
 
   getFailedBatchesCount(): number {
-    if (this.config.scope === "global") {
-      return this.partitionFailedBatches(this.getScopedRoots()).scoped.length;
+    const roots = this.config.scope === "global" ? this.getScopedRoots() : null;
+    const latestById = new Map<string, FailedChunkRecordMetadata>();
+    for (const batch of this.loadSerializedFailedBatches()) {
+      for (const rawChunk of batch.chunks) {
+        const filePath = getPendingChunkFilePath(rawChunk);
+        if (roots && (filePath === null || !this.isFileInCurrentScope(filePath, roots))) {
+          continue;
+        }
+        const chunkId = getPendingChunkId(rawChunk);
+        if (!chunkId) {
+          continue;
+        }
+        const existing = latestById.get(chunkId);
+        if (!existing || batch.attemptCount >= existing.attemptCount) {
+          latestById.set(chunkId, {
+            attemptCount: batch.attemptCount,
+            error: batch.error,
+            lastAttempt: batch.lastAttempt,
+          });
+        }
+      }
     }
-    return this.loadFailedBatches().length;
+    return new Set(Array.from(latestById.values(), getFailedBatchGroupKey)).size;
   }
 
   getCurrentBranch(): string {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3608,9 +3608,13 @@ export class Indexer {
       }
     }
 
-    if (chunkDataBatch.length > 0) {
-      database.upsertChunksBatch(chunkDataBatch);
-    }
+    database.beginWriteTransaction();
+    let writeTransactionActive = true;
+
+    try {
+      if (chunkDataBatch.length > 0) {
+        database.upsertChunksBatch(chunkDataBatch);
+      }
 
     const allSymbolIds = new Set<string>();
     const symbolsByFile = new Map<string, SymbolData[]>();
@@ -3792,6 +3796,8 @@ export class Indexer {
       this.saveBranchCommit(database, indexedCommit);
       this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
+      database.commitWriteTransaction();
+      writeTransactionActive = false;
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -3830,6 +3836,8 @@ export class Indexer {
       this.saveBranchCommit(database, indexedCommit);
       this.saveIndexMetadata(configuredProviderInfo);
       this.indexCompatibility = { compatible: true };
+      database.commitWriteTransaction();
+      writeTransactionActive = false;
       stats.durationMs = Date.now() - startTime;
       onProgress?.({
         phase: "complete",
@@ -4123,6 +4131,9 @@ export class Indexer {
       this.saveFileHashCache();
     }
 
+    database.commitWriteTransaction();
+    writeTransactionActive = false;
+
     if (this.config.indexing.autoGc && stats.removedChunks > 0) {
       const gcReset = await this.maybeRunOrphanGc();
       if (gcReset) {
@@ -4181,6 +4192,18 @@ export class Indexer {
     });
 
     return stats;
+    } catch (error) {
+      if (writeTransactionActive) {
+        try {
+          database.rollbackWriteTransaction();
+        } catch (rollbackError) {
+          this.logger.error("Failed to roll back indexing database transaction", {
+            error: getErrorMessage(rollbackError),
+          });
+        }
+      }
+      throw error;
+    }
   }
 
   private async getQueryEmbedding(query: string, provider: EmbeddingProviderInterface): Promise<number[]> {

--- a/src/native/database.ts
+++ b/src/native/database.ts
@@ -52,6 +52,21 @@ export class Database {
     this.closed = true;
   }
 
+  beginWriteTransaction(): void {
+    this.throwIfClosed();
+    this.inner.beginWriteTransaction();
+  }
+
+  commitWriteTransaction(): void {
+    this.throwIfClosed();
+    this.inner.commitWriteTransaction();
+  }
+
+  rollbackWriteTransaction(): void {
+    this.throwIfClosed();
+    this.inner.rollbackWriteTransaction();
+  }
+
   embeddingExists(contentHash: string): boolean {
     this.throwIfClosed();
     return this.inner.embeddingExists(contentHash);

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { Database, ChunkData, SymbolData } from "../src/native/index.js";
+import { Database, CallEdgeData, ChunkData, SymbolData } from "../src/native/index.js";
 
 describe("Database", () => {
   let tempDir: string;
@@ -112,6 +112,98 @@ describe("Database", () => {
       } finally {
         reader.close();
       }
+    });
+  });
+
+  describe("write transactions", () => {
+    const chunk: ChunkData = {
+      chunkId: "transaction-chunk",
+      contentHash: "transaction-hash",
+      filePath: "/transaction.ts",
+      startLine: 1,
+      endLine: 3,
+      nodeType: "function",
+      name: "transactionFunction",
+      language: "typescript",
+    };
+    const symbol: SymbolData = {
+      id: "transaction-symbol",
+      filePath: "/transaction.ts",
+      name: "transactionFunction",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 3,
+      endCol: 1,
+      language: "typescript",
+    };
+    const edge: CallEdgeData = {
+      id: "transaction-edge",
+      fromSymbolId: symbol.id,
+      targetName: "dependency",
+      callType: "call",
+      confidence: "high",
+      line: 2,
+      col: 2,
+      isResolved: false,
+    };
+
+    function writeBatchRows(database: Database): void {
+      database.upsertChunksBatch([chunk]);
+      database.addChunksToBranchBatch("main", [chunk.chunkId]);
+      database.upsertSymbolsBatch([symbol]);
+      database.addSymbolsToBranchBatch("main", [symbol.id]);
+      database.upsertCallEdgesBatch([edge]);
+    }
+
+    it("keeps batch writes private until commit", () => {
+      const reader = Database.openReadOnly(path.join(tempDir, "test.db"));
+
+      try {
+        db.beginWriteTransaction();
+        writeBatchRows(db);
+
+        expect(db.getStats()).toMatchObject({ chunkCount: 1, symbolCount: 1, callEdgeCount: 1 });
+        expect(db.getBranchChunkIds("main")).toEqual([chunk.chunkId]);
+        expect(db.getBranchSymbolIds("main")).toEqual([symbol.id]);
+        expect(reader.getStats()).toMatchObject({ chunkCount: 0, symbolCount: 0, callEdgeCount: 0 });
+        expect(reader.getBranchChunkIds("main")).toEqual([]);
+        expect(reader.getBranchSymbolIds("main")).toEqual([]);
+
+        db.commitWriteTransaction();
+
+        expect(reader.getStats()).toMatchObject({ chunkCount: 1, symbolCount: 1, callEdgeCount: 1 });
+        expect(reader.getBranchChunkIds("main")).toEqual([chunk.chunkId]);
+        expect(reader.getBranchSymbolIds("main")).toEqual([symbol.id]);
+      } finally {
+        reader.close();
+      }
+    });
+
+    it("rolls back all batch writes", () => {
+      const reader = Database.openReadOnly(path.join(tempDir, "test.db"));
+
+      try {
+        db.beginWriteTransaction();
+        writeBatchRows(db);
+        db.rollbackWriteTransaction();
+
+        expect(db.getStats()).toMatchObject({ chunkCount: 0, symbolCount: 0, callEdgeCount: 0 });
+        expect(reader.getStats()).toMatchObject({ chunkCount: 0, symbolCount: 0, callEdgeCount: 0 });
+        expect(db.getBranchChunkIds("main")).toEqual([]);
+        expect(db.getBranchSymbolIds("main")).toEqual([]);
+      } finally {
+        reader.close();
+      }
+    });
+
+    it("rejects invalid transaction state transitions", () => {
+      expect(() => db.commitWriteTransaction()).toThrow(/no active transaction/i);
+      expect(() => db.rollbackWriteTransaction()).toThrow(/no active transaction/i);
+
+      db.beginWriteTransaction();
+      expect(() => db.beginWriteTransaction()).toThrow(/already active/i);
+      db.rollbackWriteTransaction();
     });
   });
 

--- a/tests/file-batches.test.ts
+++ b/tests/file-batches.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { INDEX_FILE_BATCH_LIMITS, iterateOrderedFileBatches } from "../src/indexer/file-batches.js";
+
+describe("iterateOrderedFileBatches", () => {
+  it("preserves discovery order while enforcing file and byte limits", () => {
+    const files = [
+      { path: "a", bytes: 3 },
+      { path: "b", bytes: 4 },
+      { path: "c", bytes: 5 },
+      { path: "d", bytes: 1 },
+    ];
+
+    const batches = Array.from(iterateOrderedFileBatches(files, (file) => file.bytes, {
+      maxFiles: 2,
+      maxBytes: 7,
+    }));
+
+    expect(batches.map((batch) => batch.map((file) => file.path))).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("places a single oversized file in its own batch", () => {
+    const batches = Array.from(iterateOrderedFileBatches(
+      [{ path: "large", bytes: 12 }, { path: "small", bytes: 1 }],
+      (file) => file.bytes,
+      { maxFiles: 4, maxBytes: 8 },
+    ));
+
+    expect(batches.map((batch) => batch.map((file) => file.path))).toEqual([
+      ["large"],
+      ["small"],
+    ]);
+  });
+
+  it("normalizes invalid limits to one", () => {
+    const batches = Array.from(iterateOrderedFileBatches([1, 2, 3], () => 0, {
+      maxFiles: 0,
+      maxBytes: 0,
+    }));
+
+    expect(batches).toEqual([[1], [2], [3]]);
+  });
+
+  it("uses fixed internal production limits", () => {
+    expect(INDEX_FILE_BATCH_LIMITS).toEqual({
+      maxFiles: 64,
+      maxBytes: 8 * 1024 * 1024,
+    });
+  });
+});

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { loadMergedConfig } from "../src/config/merger.js";
 import { parseConfig } from "../src/config/schema.js";
+import { readFailedBatchRecords } from "../src/indexer/failed-state-persistence.js";
 import { Indexer } from "../src/indexer/index.js";
 import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
 import { hashContent } from "../src/native/index.js";
@@ -1669,7 +1670,9 @@ describe("indexer clearIndex force rebuild", () => {
     const fileHashCache = JSON.parse(fs.readFileSync(fileHashCachePath, "utf-8")) as Record<string, string>;
     expect(fileHashCache[projectBFile]).toBe("foreign-hash");
 
-    const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{ chunks: Array<{ metadata: { filePath: string } }> }>;
+    const failedBatches = Array.from(
+      readFailedBatchRecords<{ metadata: { filePath: string } }>(failedBatchesPath),
+    );
     expect(failedBatches.some((batch) => batch.chunks.some((chunk) => chunk.metadata.filePath === projectBFile))).toBe(true);
   });
 

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -5,12 +5,64 @@ import * as path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { parseConfig } from "../src/config/schema.js";
+import { readFailedBatchRecords } from "../src/indexer/failed-state-persistence.js";
 import { Indexer } from "../src/indexer/index.js";
 import { Database, VectorStore, hashContent } from "../src/native/index.js";
 import { formatStatus } from "../src/tools/utils.js";
 
 function projectIdentityHash(projectRoot: string): string {
   return hashContent(fs.realpathSync.native(projectRoot)).slice(0, 16);
+}
+
+function readLogicalFailedBatches(filePath: string): unknown {
+  // Preserve the legacy tests' logical batch assertions. Raw JSONL shape is
+  // covered separately by failed-state persistence and file-batching tests.
+  const latestById = new Map<string, {
+    chunk: unknown;
+    error: string;
+    attemptCount: number;
+    lastAttempt: string;
+  }>();
+  let anonymousId = 0;
+
+  for (const record of readFailedBatchRecords<unknown>(filePath)) {
+    for (const chunk of record.chunks) {
+      const id = chunk && typeof chunk === "object" && typeof (chunk as { id?: unknown }).id === "string"
+        ? (chunk as { id: string }).id
+        : `anonymous-${anonymousId++}`;
+      const existing = latestById.get(id);
+      if (!existing || record.attemptCount >= existing.attemptCount) {
+        latestById.set(id, {
+          chunk,
+          error: record.error,
+          attemptCount: record.attemptCount,
+          lastAttempt: record.lastAttempt,
+        });
+      }
+    }
+  }
+
+  const grouped = new Map<string, {
+    chunks: unknown[];
+    error: string;
+    attemptCount: number;
+    lastAttempt: string;
+  }>();
+  for (const latest of latestById.values()) {
+    const key = `${latest.attemptCount}:${latest.lastAttempt}:${latest.error}`;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.chunks.push(latest.chunk);
+    } else {
+      grouped.set(key, {
+        chunks: [latest.chunk],
+        error: latest.error,
+        attemptCount: latest.attemptCount,
+        lastAttempt: latest.lastAttempt,
+      });
+    }
+  }
+  return Array.from(grouped.values());
 }
 
 describe("indexer failed batch recovery", () => {
@@ -802,7 +854,7 @@ describe("indexer failed batch recovery", () => {
     expect(embedPrompts.every((prompt) => prompt.includes("Part "))).toBe(true);
 
     const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
-    const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+    const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
       chunks: Array<{ id: string }>;
       attemptCount: number;
       error: string;
@@ -827,7 +879,7 @@ describe("indexer failed batch recovery", () => {
       expect(failedStats.indexedChunks).toBe(0);
 
       const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
-      const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+      const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
         chunks: Array<{ id: string }>;
         error: string;
         attemptCount: number;
@@ -902,7 +954,7 @@ describe("indexer failed batch recovery", () => {
       expect(retry.remaining).toBe(1);
 
       const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
-      const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+      const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
         chunks: Array<{ id: string }>;
         error: string;
         attemptCount: number;
@@ -968,7 +1020,7 @@ describe("indexer failed batch recovery", () => {
       expect(retry.failed).toBe(1);
       expect(retry.remaining).toBe(1);
 
-      const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+      const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
         chunks: Array<{ id: string }>;
         error: string;
         attemptCount: number;
@@ -1032,7 +1084,7 @@ describe("indexer failed batch recovery", () => {
     expect(failedStats.indexedChunks).toBe(0);
 
     const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
-    const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+    const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
       chunks: Array<{ id: string }>;
       error: string;
       attemptCount: number;
@@ -1120,7 +1172,7 @@ describe("indexer failed batch recovery", () => {
 
     const retry = await indexer.retryFailedBatches();
     const status = await indexer.getStatus();
-    const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+    const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
       chunks: Array<{ id: string }>;
       error: string;
       attemptCount: number;
@@ -1195,7 +1247,7 @@ describe("indexer failed batch recovery", () => {
     const stats = await indexer.index();
     expect(stats.failedChunks).toBe(0);
 
-    const persistedBatches = JSON.parse(fs.readFileSync(globalFailedBatchesPath, "utf-8")) as Array<{
+    const persistedBatches = readLogicalFailedBatches(globalFailedBatchesPath) as Array<{
       chunks: Array<{ metadata: { filePath: string }; text?: string; texts?: unknown[] }>;
     }>;
     const foreignChunk = persistedBatches
@@ -1286,7 +1338,7 @@ describe("indexer failed batch recovery", () => {
     expect(retry.failed).toBe(1);
     expect(retry.remaining).toBe(1);
 
-    const persistedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+    const persistedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
       attemptCount: number;
       error: string;
     }>;
@@ -1453,7 +1505,7 @@ describe("indexer failed batch recovery", () => {
     // Step 5: Assert the failed batch persists AND the branch catalog still contains that chunk id
     expect(retryStats.failedChunks).toBeGreaterThan(0);
 
-    const failedBatchesAfter = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+    const failedBatchesAfter = readLogicalFailedBatches(failedBatchesPath) as Array<{
       chunks: Array<{ id: string }>;
       error: string;
     }>;
@@ -1535,7 +1587,7 @@ describe("indexer failed batch recovery", () => {
 
       const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
       if (fs.existsSync(failedBatchesPath)) {
-        const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+        const failedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
           error: string;
         }>;
         expect(failedBatches.length).toBeGreaterThan(0);
@@ -1594,7 +1646,7 @@ describe("indexer failed batch recovery", () => {
 
       const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
       if (fs.existsSync(failedBatchesPath)) {
-        const failedBatches = JSON.parse(fs.readFileSync(failedBatchesPath, "utf-8")) as Array<{
+        const failedBatches = readLogicalFailedBatches(failedBatchesPath) as Array<{
           error: string;
         }>;
         expect(failedBatches.length).toBeGreaterThan(0);

--- a/tests/indexer-failed-state-persistence.test.ts
+++ b/tests/indexer-failed-state-persistence.test.ts
@@ -1,0 +1,256 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createFailedBatchWriter,
+  readFailedBatchRecords,
+  type FailedBatchReadOptions,
+  type FailedBatchRecord,
+  type FailedBatchRecordInput,
+  writeFailedBatchRecords,
+} from "../src/indexer/failed-state-persistence.js";
+
+interface FixtureChunk {
+  id: string;
+  text: string;
+}
+
+function makeChunk(id: string, text = `chunk-${id}`): FixtureChunk {
+  return { id, text };
+}
+
+function nowIso(): string {
+  return "2026-07-31T00:00:00.000Z";
+}
+
+async function collectFailedBatches<TChunk>(
+  filePath: string,
+  options?: FailedBatchReadOptions,
+): Promise<FailedBatchRecord<TChunk>[]> {
+  const result: FailedBatchRecord<TChunk>[] = [];
+  for await (const batch of readFailedBatchRecords<TChunk>(filePath, options)) {
+    result.push(batch);
+  }
+  return result;
+}
+
+describe("failed state persistence utility", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "failed-state-persistence-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("round-trips failed batches through versioned JSONL", async () => {
+    const failedBatchesPath = path.join(tempDir, "failed-batches.json");
+    const writer = createFailedBatchWriter<FixtureChunk>(failedBatchesPath);
+
+    const recordA: FailedBatchRecordInput<FixtureChunk> = {
+      chunks: [makeChunk("a", "alpha")],
+      error: "rate limited",
+      attemptCount: 1,
+      lastAttempt: nowIso(),
+    };
+    const recordB: FailedBatchRecordInput<FixtureChunk> = {
+      chunks: [makeChunk("b", "beta"), makeChunk("c", "gamma")],
+      error: "overloaded",
+      attemptCount: 2,
+      lastAttempt: nowIso(),
+    };
+
+    writer.write(recordA);
+    writer.write(recordB);
+    writer.commit();
+
+    const records = await collectFailedBatches<FixtureChunk>(failedBatchesPath);
+
+    expect(records).toHaveLength(3);
+    expect(records).toEqual([
+      {
+        version: 1,
+        chunks: [makeChunk("a", "alpha")],
+        error: "rate limited",
+        attemptCount: 1,
+        lastAttempt: nowIso(),
+      },
+      {
+        version: 1,
+        chunks: [makeChunk("b", "beta")],
+        error: "overloaded",
+        attemptCount: 2,
+        lastAttempt: nowIso(),
+      },
+      {
+        version: 1,
+        chunks: [makeChunk("c", "gamma")],
+        error: "overloaded",
+        attemptCount: 2,
+        lastAttempt: nowIso(),
+      },
+    ]);
+  });
+
+  it("reads legacy failed-batch JSON arrays with backward compatibility", async () => {
+    const failedBatchesPath = path.join(tempDir, "failed-batches.json");
+    fs.writeFileSync(
+      failedBatchesPath,
+      JSON.stringify([
+        {
+          chunks: [makeChunk("legacy", "legacy")],
+          error: "legacy failure",
+          attemptCount: 4,
+          lastAttempt: "2010-01-01T00:00:00.000Z",
+        },
+      ]),
+      "utf-8",
+    );
+
+    const records = await collectFailedBatches<FixtureChunk>(failedBatchesPath);
+
+    expect(records).toEqual([
+      {
+        version: 1,
+        chunks: [makeChunk("legacy", "legacy")],
+        error: "legacy failure",
+        attemptCount: 4,
+        lastAttempt: "2010-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("supports malformed-line handling policies", async () => {
+    const failedBatchesPath = path.join(tempDir, "failed-batches.json");
+    const validLine = JSON.stringify({
+      version: 1,
+      chunks: [makeChunk("valid")],
+      error: "retryable",
+      attemptCount: 1,
+      lastAttempt: nowIso(),
+    });
+
+    fs.writeFileSync(
+      failedBatchesPath,
+      [validLine, "{ nope", validLine].join("\n"),
+      "utf-8",
+    );
+
+    const callbacks: string[] = [];
+    const skipped = await collectFailedBatches<FixtureChunk>(failedBatchesPath, {
+      malformedLineAction: "skip",
+      onMalformedLine: (error) => {
+        callbacks.push(error.message);
+      },
+    });
+    expect(skipped).toHaveLength(2);
+    expect(callbacks).toHaveLength(1);
+
+    await expect(
+      collectFailedBatches<FixtureChunk>(failedBatchesPath, {
+        malformedLineAction: "fail",
+      }),
+    ).rejects.toBeInstanceOf(Error);
+
+    const fatalCallbacks: string[] = [];
+    await expect(
+      collectFailedBatches<FixtureChunk>(failedBatchesPath, {
+        malformedLineAction: "fail",
+        onMalformedLine: (error) => {
+          fatalCallbacks.push(error.message);
+        },
+      }),
+    ).rejects.toBeInstanceOf(Error);
+    expect(fatalCallbacks).toHaveLength(1);
+  });
+
+  it("uses atomic temp-file replacement with cleanup helpers", async () => {
+    const failedBatchesPath = path.join(tempDir, "failed-batches.json");
+    fs.writeFileSync(failedBatchesPath, JSON.stringify({ stale: true }), "utf-8");
+
+    const writer = createFailedBatchWriter<FixtureChunk>(failedBatchesPath);
+    writer.write({
+      chunks: [makeChunk("committed", "committed")],
+      error: "replace me",
+      attemptCount: 1,
+      lastAttempt: nowIso(),
+    });
+    writer.commit();
+
+    expect(writer.temporaryPath).not.toBe(failedBatchesPath);
+    expect(fs.existsSync(writer.temporaryPath)).toBe(false);
+
+    const committedText = fs.readFileSync(failedBatchesPath, "utf-8");
+    expect(committedText).toContain("\"replace me\"");
+    expect(committedText).toContain("\"version\":1");
+
+    const abortedWriter = createFailedBatchWriter<FixtureChunk>(failedBatchesPath);
+    abortedWriter.write({
+      chunks: [makeChunk("aborted", "aborted")],
+      error: "aborted",
+      attemptCount: 1,
+      lastAttempt: nowIso(),
+    });
+    const snapshot = fs.readFileSync(failedBatchesPath, "utf-8");
+    abortedWriter.cleanup();
+
+    expect(fs.existsSync(abortedWriter.temporaryPath)).toBe(false);
+    expect(fs.readFileSync(failedBatchesPath, "utf-8")).toBe(snapshot);
+  });
+
+  it("streams a large fixture without materializing an array result", async () => {
+    const failedBatchesPath = path.join(tempDir, "failed-batches.json");
+    const largeText = "payload".repeat(200_000);
+
+    const writer = createFailedBatchWriter<FixtureChunk>(failedBatchesPath);
+    writer.write({
+      chunks: [makeChunk("large", largeText)],
+      error: "large payload",
+      attemptCount: 1,
+      lastAttempt: nowIso(),
+    });
+    writer.write({
+      chunks: [makeChunk("small", "small")],
+      error: "small payload",
+      attemptCount: 1,
+      lastAttempt: nowIso(),
+    });
+    writer.commit();
+
+    const iterator = readFailedBatchRecords<FixtureChunk>(failedBatchesPath);
+    expect(Symbol.iterator in iterator).toBe(true);
+
+    let seen = 0;
+    for await (const batch of iterator) {
+      expect((batch.chunks[0] as FixtureChunk).text).toBe(largeText);
+      seen += 1;
+      break;
+    }
+
+    expect(seen).toBe(1);
+
+    const all = await collectFailedBatches<FixtureChunk>(failedBatchesPath);
+    expect(all).toHaveLength(2);
+  });
+
+  it("replaces an entire file from an iterable of batches", async () => {
+    const failedBatchesPath = path.join(tempDir, "failed-batches.json");
+    writeFailedBatchRecords(failedBatchesPath, [
+      {
+        chunks: [makeChunk("iter", "iter")],
+        error: "iterative",
+        attemptCount: 1,
+        lastAttempt: nowIso(),
+      },
+    ]);
+
+    const all = await collectFailedBatches<FixtureChunk>(failedBatchesPath);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.chunks[0]?.id).toBe("iter");
+  });
+});

--- a/tests/indexer-file-batching.test.ts
+++ b/tests/indexer-file-batching.test.ts
@@ -1,0 +1,182 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { readFailedBatchRecords } from "../src/indexer/failed-state-persistence.js";
+import { Indexer, type IndexProgress } from "../src/indexer/index.js";
+
+function writeMultiBatchFixture(projectDir: string): void {
+  const sourceDir = path.join(projectDir, "src");
+  fs.mkdirSync(sourceDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(sourceDir, "shared-early.ts"),
+    "export function sharedAcrossBatches() { return 7; }\n",
+    "utf-8",
+  );
+
+  for (let index = 0; index < 63; index++) {
+    fs.writeFileSync(
+      path.join(sourceDir, `filler-${index.toString().padStart(2, "0")}.ts`),
+      `export function filler${index}() { return ${index}; }\n// ${"x".repeat(100 + index)}\n`,
+      "utf-8",
+    );
+  }
+
+  const lateFile = path.join(sourceDir, "shared-late.ts");
+  fs.writeFileSync(
+    lateFile,
+    [
+      "export function sharedAcrossBatches() { return 7; }",
+      "export function lateOnlyMarker() { return 99; }",
+      `// ${"z".repeat(10_000)}`,
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+function expectMonotonic(values: number[]): void {
+  for (let index = 1; index < values.length; index++) {
+    expect(values[index]).toBeGreaterThanOrEqual(values[index - 1] ?? 0);
+  }
+}
+
+describe("bounded file-level indexing integration", () => {
+  let projectDir: string;
+  let indexDir: string;
+  let indexer: Indexer;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "index-file-batches-project-"));
+    indexDir = fs.mkdtempSync(path.join(os.tmpdir(), "index-file-batches-index-"));
+  });
+
+  afterEach(async () => {
+    await indexer?.close();
+    fetchSpy?.mockRestore();
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(indexDir, { recursive: true, force: true });
+  });
+
+  function createIndexer(): Indexer {
+    return new Indexer(projectDir, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "bounded-batch-test-model",
+        dimensions: 8,
+        maxBatchSize: 128,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+        autoGc: false,
+      },
+    }), "opencode", { indexPath: indexDir });
+  }
+
+  it("keeps progress cumulative and reuses duplicate embeddings across file batches", async () => {
+    writeMultiBatchFixture(projectDir);
+    const embeddedTexts: string[] = [];
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = body.input ?? [];
+      embeddedTexts.push(...texts);
+      return new Response(JSON.stringify({
+        data: texts.map((_text, itemIndex) => ({
+          embedding: Array.from({ length: 8 }, (_, dimension) => (itemIndex + dimension + 1) / 10),
+        })),
+        usage: { total_tokens: Math.max(1, texts.length) },
+      }), { status: 200 });
+    });
+    indexer = createIndexer();
+
+    const progress: IndexProgress[] = [];
+    const stats = await indexer.index((entry) => progress.push({ ...entry }));
+
+    const parsingFiles = progress
+      .filter((entry) => entry.phase === "parsing" && entry.filesProcessed > 0)
+      .map((entry) => entry.filesProcessed);
+    expect(parsingFiles).toContain(64);
+    expect(parsingFiles.at(-1)).toBe(65);
+
+    const embeddingProgress = progress.filter((entry) => entry.phase === "embedding");
+    expect(embeddingProgress.length).toBeGreaterThan(1);
+    expectMonotonic(embeddingProgress.map((entry) => entry.chunksProcessed));
+    expectMonotonic(embeddingProgress.map((entry) => entry.totalChunks));
+    expect(progress.at(-1)).toMatchObject({
+      phase: "complete",
+      chunksProcessed: stats.indexedChunks,
+      totalChunks: stats.totalChunks,
+    });
+
+    expect(embeddedTexts.filter((text) => text.includes("sharedAcrossBatches"))).toHaveLength(1);
+    expect(stats.failedChunks).toBe(0);
+    expect(stats.indexedChunks).toBe(stats.totalChunks);
+  });
+
+  it("flushes outage failures before the next file batch and streams them through retry", async () => {
+    writeMultiBatchFixture(projectDir);
+    let outage = true;
+    let failedRecordsBeforeLateBatch = 0;
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = body.input ?? [];
+      if (outage) {
+        if (texts.some((text) => text.includes("shared-late.ts"))) {
+          const temporaryState = fs.readdirSync(indexDir)
+            .find((entry) => entry.startsWith(".failed-batches") && entry.endsWith(".tmp"));
+          if (temporaryState) {
+            failedRecordsBeforeLateBatch = fs.readFileSync(path.join(indexDir, temporaryState), "utf-8")
+              .split("\n")
+              .filter((line) => line.length > 0)
+              .length;
+          }
+        }
+        return new Response(JSON.stringify({ error: "provider unavailable" }), { status: 503 });
+      }
+
+      return new Response(JSON.stringify({
+        data: texts.map((_text, itemIndex) => ({
+          embedding: Array.from({ length: 8 }, (_, dimension) => (itemIndex + dimension + 1) / 10),
+        })),
+        usage: { total_tokens: Math.max(1, texts.length) },
+      }), { status: 200 });
+    });
+    indexer = createIndexer();
+
+    const failedStats = await indexer.index();
+    const failedBatchesPath = path.join(indexDir, "failed-batches.json");
+    const records = Array.from(readFailedBatchRecords<{ id: string }>(failedBatchesPath));
+    const failedChunkIds = new Set(records.flatMap((record) => record.chunks.map((chunk) => chunk.id)));
+
+    expect(failedRecordsBeforeLateBatch).toBeGreaterThan(0);
+    expect(records.length).toBeGreaterThan(64);
+    expect(records.every((record) => record.chunks.length === 1)).toBe(true);
+    expect(failedChunkIds.size).toBe(failedStats.failedChunks);
+    expect(fs.readFileSync(failedBatchesPath, "utf-8").trimStart().startsWith("[")).toBe(false);
+
+    outage = false;
+    const retry = await indexer.retryFailedBatches();
+
+    expect(retry).toEqual({
+      succeeded: failedChunkIds.size,
+      failed: 0,
+      remaining: 0,
+    });
+    expect(fs.existsSync(failedBatchesPath)).toBe(false);
+  });
+});

--- a/tests/indexing-transaction.test.ts
+++ b/tests/indexing-transaction.test.ts
@@ -1,0 +1,105 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
+import { Database } from "../src/native/index.js";
+
+describe("indexing database transaction", () => {
+  let projectDir: string;
+  let indexDir: string;
+  let indexer: Indexer;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "indexing-transaction-project-"));
+    indexDir = fs.mkdtempSync(path.join(os.tmpdir(), "indexing-transaction-index-"));
+    fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (
+      _url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = body.input ?? [];
+      return new Response(JSON.stringify({
+        data: texts.map((_text, index) => ({
+          embedding: Array.from({ length: 8 }, (_, dimension) => (index + dimension + 1) / 10),
+        })),
+        usage: { total_tokens: Math.max(1, texts.length) },
+      }), { status: 200 });
+    });
+
+    indexer = new Indexer(projectDir, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "transaction-test-model",
+        dimensions: 8,
+        maxBatchSize: 8,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        autoGc: false,
+      },
+    }), "opencode", { indexPath: indexDir });
+  });
+
+  afterEach(async () => {
+    await indexer.close();
+    fetchSpy.mockRestore();
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(indexDir, { recursive: true, force: true });
+  });
+
+  it("does not expose parsed rows when indexing aborts before publication", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "src", "stable.ts"),
+      "export function stable() { return 'stable'; }\n",
+      "utf8",
+    );
+    await indexer.index();
+
+    const databasePath = path.join(indexDir, "codebase.db");
+    const before = Database.openReadOnly(databasePath);
+    const beforeStats = before.getStats();
+    const beforeBranches = before.getAllBranches().map((branch) => ({
+      branch,
+      chunks: before.getBranchChunkIds(branch),
+      symbols: before.getBranchSymbolIds(branch),
+    }));
+    before.close();
+
+    fs.writeFileSync(
+      path.join(projectDir, "src", "transient.ts"),
+      "export function transient() { return 'transient'; }\n",
+      "utf8",
+    );
+
+    await expect(indexer.index((progress) => {
+      if (progress.phase === "embedding") {
+        throw new Error("simulated interruption after database staging");
+      }
+    })).rejects.toThrow("simulated interruption");
+
+    const after = Database.openReadOnly(databasePath);
+    try {
+      expect(after.getStats()).toEqual(beforeStats);
+      expect(after.getChunksByFile(path.join(projectDir, "src", "transient.ts"))).toEqual([]);
+      expect(after.getSymbolsByFile(path.join(projectDir, "src", "transient.ts"))).toEqual([]);
+      expect(after.getAllBranches().map((branch) => ({
+        branch,
+        chunks: after.getBranchChunkIds(branch),
+        symbols: after.getBranchSymbolIds(branch),
+      }))).toEqual(beforeBranches);
+    } finally {
+      after.close();
+    }
+  });
+});

--- a/tests/indexing-transaction.test.ts
+++ b/tests/indexing-transaction.test.ts
@@ -102,4 +102,61 @@ describe("indexing database transaction", () => {
       after.close();
     }
   });
+
+  it("keeps the previous SQLite and branch catalog generation after a late file-batch interruption", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "src", "stable.ts"),
+      "export function stable() { return 'stable'; }\n",
+      "utf8",
+    );
+    await indexer.index();
+
+    const databasePath = path.join(indexDir, "codebase.db");
+    const fileHashesPath = path.join(indexDir, "file-hashes.json");
+    const failedBatchesPath = path.join(indexDir, "failed-batches.json");
+    const previousFileHashes = fs.readFileSync(fileHashesPath, "utf-8");
+    const before = Database.openReadOnly(databasePath);
+    const beforeStats = before.getStats();
+    const beforeBranches = before.getAllBranches().map((branch) => ({
+      branch,
+      chunks: before.getBranchChunkIds(branch),
+      symbols: before.getBranchSymbolIds(branch),
+    }));
+    before.close();
+
+    for (let fileIndex = 0; fileIndex < 65; fileIndex++) {
+      fs.writeFileSync(
+        path.join(projectDir, "src", `late-${fileIndex.toString().padStart(2, "0")}.ts`),
+        `export function late${fileIndex}() { return ${fileIndex}; }\n// ${"x".repeat(100 + fileIndex)}\n`,
+        "utf8",
+      );
+    }
+
+    await expect(indexer.index((progress) => {
+      if (progress.phase === "parsing" && progress.totalFiles === 66 && progress.filesProcessed === 66) {
+        throw new Error("simulated interruption in the final file batch");
+      }
+    })).rejects.toThrow("simulated interruption in the final file batch");
+
+    const after = Database.openReadOnly(databasePath);
+    try {
+      expect(after.getStats()).toEqual(beforeStats);
+      expect(after.getChunksByFile("src/late-00.ts")).toEqual([]);
+      expect(after.getChunksByFile("src/late-64.ts")).toEqual([]);
+      expect(after.getSymbolsByFile("src/late-00.ts")).toEqual([]);
+      expect(after.getSymbolsByFile("src/late-64.ts")).toEqual([]);
+      expect(after.getAllBranches().map((branch) => ({
+        branch,
+        chunks: after.getBranchChunkIds(branch),
+        symbols: after.getBranchSymbolIds(branch),
+      }))).toEqual(beforeBranches);
+      expect(fs.readFileSync(fileHashesPath, "utf-8")).toBe(previousFileHashes);
+      expect(fs.existsSync(failedBatchesPath)).toBe(false);
+      expect(fs.readdirSync(indexDir).some((entry) => (
+        entry.startsWith(".failed-batches.json.") && entry.endsWith(".tmp")
+      ))).toBe(false);
+    } finally {
+      after.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- process changed files in deterministic internal batches bounded by file count and source bytes
- stream failed embedding state and retry records without retaining all failed chunk text
- coordinate SQLite writes so interrupted indexing does not expose partial rows
- preserve provider batching, duplicate embedding reuse, call graphs, Git blame, and final artifact publication semantics
- add integration coverage and a reproducible memory benchmark

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run --no-file-parallelism` (1,301 tests)
- `npm run smoke:package`
- `npm run benchmark:indexing-memory` twice
- `git diff --check`

The normal parallel full suite reached 1,300/1,301 twice but hit the known watcher timing test. That watcher test passed alone, and the complete serial suite passed.

Closes #224
