### PR TITLE
feat: add opt-in community-aware retrieval ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Direct index CLI subcommand for MCP binary**: Added `index` command support to the shared MCP CLI entrypoint with `--project`, `--host`, `--config`, `--force`, `--estimate-only`, and `--verbose` flags. The command uses shared indexing execution and lock/callback semantics, prints diagnostics to `stderr`, exits non-zero on usage and runtime errors, and preserves existing MCP/eval/visualize modes.
 - **Portable `code_communities` tool**: Added a new graph analysis tool that exposes community detection and hub node analysis across OpenCode, MCP, and Pi. Clusters symbols by call-graph connectivity using label propagation, reports deterministic community summaries with member listings, and identifies hub symbols from exact distinct cross-community neighbors. Supports `branch`, `minSize`, `limit`, and `hubThreshold` parameters. Recomputes on-demand from current branch data for freshness without persisted state, with a checked-in 10k-node sub-second performance regression.
+- **Opt-in community-aware retrieval ranking**: Exact, unambiguous symbol queries can optionally boost already in-scope candidates from the same call-graph community. The feature is disabled by default, deterministic, branch-aware, and falls back to existing ranking when graph context is unavailable.
 
 ### Changed
 

--- a/benchmarks/baselines/community-aware-ranking.json
+++ b/benchmarks/baselines/community-aware-ranking.json
@@ -1,0 +1,11 @@
+{
+  "fixtureVersion": "1.0.0",
+  "queryCount": 3,
+  "baselineMrr": 0.833333,
+  "communityAwareMrr": 1,
+  "perQuery": [
+    { "id": "promotes-related-candidate", "baselineReciprocalRank": 0.5, "communityAwareReciprocalRank": 1 },
+    { "id": "preserves-already-correct-order", "baselineReciprocalRank": 1, "communityAwareReciprocalRank": 1 },
+    { "id": "no-context-guardrail", "baselineReciprocalRank": 1, "communityAwareReciprocalRank": 1 }
+  ]
+}

--- a/benchmarks/fixtures/community-aware-ranking.json
+++ b/benchmarks/fixtures/community-aware-ranking.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0.0",
+  "name": "community-aware-ranking",
+  "methodology": {
+    "baseline": "Candidates are sorted only by their supplied retrieval score and id.",
+    "candidatePools": "Hand-labeled fixed candidate pools isolate post-retrieval ordering.",
+    "metrics": "Mean reciprocal rank over one relevant same-community candidate per query.",
+    "limitations": "This does not measure embedding recall, community detection quality, indexing latency, or end-to-end agent success."
+  },
+  "boost": 0.25,
+  "queries": [
+    {
+      "id": "promotes-related-candidate",
+      "relevantId": "auth-helper",
+      "sameCommunityIds": ["auth-helper"],
+      "candidates": [
+        { "id": "generic-helper", "score": 0.9 },
+        { "id": "auth-helper", "score": 0.8 }
+      ]
+    },
+    {
+      "id": "preserves-already-correct-order",
+      "relevantId": "session-loader",
+      "sameCommunityIds": ["session-loader"],
+      "candidates": [
+        { "id": "session-loader", "score": 0.95 },
+        { "id": "unrelated-loader", "score": 0.8 }
+      ]
+    },
+    {
+      "id": "no-context-guardrail",
+      "relevantId": "query-builder",
+      "sameCommunityIds": [],
+      "candidates": [
+        { "id": "query-builder", "score": 0.92 },
+        { "id": "other", "score": 0.7 }
+      ]
+    }
+  ]
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,9 @@ Example:
 | `routingHints` | `true` | Inject host routing guidance |
 | `routingGraphHandoffHints` | `false` | Include graph handoff guidance |
 | `routingHintRole` | `system` | `system` or `developer` |
+| `communityBoost` | `0` | Opt-in multiplicative boost (`0` to `1`) for candidates in an exact query symbol's call-graph community |
+
+`communityBoost` is experimental and disabled by default. It activates only when the query contains one unambiguous exact symbol already present in the active branch catalog. Existing branch, directory, file-type, chunk-type, blame, and score filters run first, so community context can reorder only candidates that already passed normal search scope. Missing or ambiguous symbols and unavailable graph data fall back to the existing ranking.
 
 ## Include and exclude patterns
 
@@ -280,7 +283,8 @@ Debug defaults:
     "fusionStrategy": "rrf",
     "rrfK": 60,
     "rerankTopN": 20,
-    "contextLines": 0
+    "contextLines": 0,
+    "communityBoost": 0
   },
   "knowledgeBases": [],
   "debug": {

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -76,6 +76,14 @@ npx vitest run tests/intent-aware-ranking-eval.test.ts
 
 `benchmarks/fixtures/intent-aware-ranking.json` contains eight representative coding-agent queries for exact and Unicode-normalized definitions, test/docs/config/call-flow intent, evidence diversity, and a conceptual-search guardrail. The baseline sorts the supplied candidates by retrieval score and id, while the candidate run applies only the local intent-aware ranker. `benchmarks/baselines/intent-aware-ranking.json` records evidence recall@3 and MRR plus per-query values. The candidate pools and relevance ids are hand-labeled and fixed, so this comparison isolates post-retrieval ordering. It does not measure embedding recall, candidate generation, indexing quality, latency, external rerankers, production repositories, or end-to-end agent success.
 
+The opt-in community signal has a separate transparent comparison:
+
+```bash
+npx vitest run tests/community-ranking-eval.test.ts
+```
+
+`benchmarks/fixtures/community-aware-ranking.json` compares supplied-score ordering with the local community boost on three fixed pools, including an improvement case and no-regression guardrails. `benchmarks/baselines/community-aware-ranking.json` records aggregate and per-query MRR. This isolates ordering only; it does not measure embedding recall, community-detection quality, indexing latency, or end-to-end agent success.
+
 Opt-in runtime effectiveness counters complement these synthetic reports. `index_metrics` exposes fixed aggregate counters plus bounded per-route outcome, result-count, latency, and returned-token histograms. These route-specific views can reveal that one route has a higher no-result rate or larger response buckets, but they remain process-memory-only and contain no queries, paths, symbols, source, repository identity, or raw measurements. They cannot establish causal end-to-end agent success or compare trends across process restarts.
 
 Evaluation comparisons require the same dataset name, version, query count, and dataset

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -42,6 +42,7 @@ export function getDefaultSearchConfig(): SearchConfig {
     routingHints: true,
     routingGraphHandoffHints: false,
     routingHintRole: "system",
+    communityBoost: 0,
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -82,6 +82,8 @@ export interface SearchConfig {
   routingHints: boolean;
   routingGraphHandoffHints: boolean;
   routingHintRole: "system" | "developer";
+  /** Multiplicative boost for candidates in an exact query symbol's call-graph community. Default: 0 (disabled). */
+  communityBoost: number;
 }
 
 export type RerankerProvider = "cohere" | "jina" | "custom";
@@ -238,6 +240,9 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     routingHintRole: rawSearch.routingHintRole === "developer" || rawSearch.routingHintRole === "system"
       ? rawSearch.routingHintRole
       : defaultSearch.routingHintRole,
+    communityBoost: typeof rawSearch.communityBoost === "number" && Number.isFinite(rawSearch.communityBoost)
+      ? Math.min(1, Math.max(0, rawSearch.communityBoost))
+      : defaultSearch.communityBoost,
   };
 
   const rawDebug = (input.debug && typeof input.debug === "object" ? input.debug : {}) as Record<string, unknown>;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -43,6 +43,7 @@ import type { PrImpactResult } from "./pr-impact-types.js";
 import { getChunkGitBlame, type GitBlameMetadata } from "./git-blame.js";
 import { analyzeQueryIntent } from "./intent-aware-ranking.js";
 import {
+  applyCommunityBoost,
   classifyQueryIntentRaw,
   diversifyCandidatesByFile,
   rankHybridResults,
@@ -50,12 +51,14 @@ import {
   type RankedCandidate,
 } from "./search-ranking.js";
 export {
+  applyCommunityBoost,
   fuseResultsRrf,
   fuseResultsWeighted,
   rankHybridResults,
   rankSemanticOnlyResults,
   rerankResults,
 } from "./search-ranking.js";
+import { inferExactSymbolFromQuery } from "../tools/symbol-inference.js";
 import { CALL_GRAPH_SYMBOL_CHUNK_TYPES } from "./call-graph-constants.js";
 export { CALL_GRAPH_SYMBOL_CHUNK_TYPES } from "./call-graph-constants.js";
 import {
@@ -113,6 +116,66 @@ export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", 
 // the same normalization when looking up symbols by name. Keep this set in
 // sync with the matching branch in native/src/call_extractor.rs.
 export const CASE_INSENSITIVE_LANGUAGES = new Set(["apex", "php"]);
+
+function candidateOverlapsSymbol(candidate: RankedCandidate, symbol: SymbolData): boolean {
+  return candidate.metadata.filePath === symbol.filePath &&
+    candidate.metadata.startLine <= symbol.endLine &&
+    candidate.metadata.endLine >= symbol.startLine;
+}
+
+function resolveSameCommunityCandidateIds(
+  query: string,
+  candidates: RankedCandidate[],
+  database: Database,
+  branchCatalogKeys: string[],
+): Set<string> {
+  const anchorName = inferExactSymbolFromQuery(query);
+  if (!anchorName || candidates.length === 0) {
+    return new Set();
+  }
+
+  const catalogs = branchCatalogKeys.map((branchKey) => ({
+    branchKey,
+    symbols: database.getSymbolsForBranch(branchKey),
+  }));
+  const exactAnchors = catalogs.flatMap(({ branchKey, symbols }) => symbols
+    .filter((symbol) => symbol.name === anchorName)
+    .map((symbol) => ({ branchKey, symbol })));
+  const anchors = exactAnchors.length > 0
+    ? exactAnchors
+    : catalogs.flatMap(({ branchKey, symbols }) => symbols
+      .filter((symbol) => symbol.name.toLowerCase() === anchorName.toLowerCase())
+      .map((symbol) => ({ branchKey, symbol })));
+
+  const uniqueAnchors = new Map(anchors.map((anchor) => [anchor.symbol.id, anchor]));
+  if (uniqueAnchors.size !== 1) {
+    return new Set();
+  }
+
+  const anchor = uniqueAnchors.values().next().value as { branchKey: string; symbol: SymbolData };
+  const branchSymbols = catalogs.find((catalog) => catalog.branchKey === anchor.branchKey)?.symbols ?? [];
+  const candidateSymbols = branchSymbols.filter((symbol) =>
+    candidates.some((candidate) => candidateOverlapsSymbol(candidate, symbol))
+  );
+  const assignments = database.detectCommunities(
+    anchor.branchKey,
+    [anchor.symbol.id, ...candidateSymbols.map((symbol) => symbol.id)],
+  );
+  const anchorCommunity = assignments.find((assignment) => assignment.symbolId === anchor.symbol.id)?.communityId;
+  if (anchorCommunity === undefined) {
+    return new Set();
+  }
+
+  const sameCommunitySymbolIds = new Set(assignments
+    .filter((assignment) => assignment.communityId === anchorCommunity)
+    .map((assignment) => assignment.symbolId));
+
+  return new Set(candidates
+    .filter((candidate) => candidateSymbols.some((symbol) =>
+      sameCommunitySymbolIds.has(symbol.id) && candidateOverlapsSymbol(candidate, symbol)
+    ))
+    .map((candidate) => candidate.id));
+}
 // Existing indexes without this metadata are the implicit version 1.
 const CALL_GRAPH_RESOLUTION_VERSION = "4";
 const PHP_FUNCTION_SYMBOL_CHUNK_TYPES = new Set([
@@ -4749,14 +4812,36 @@ export class Indexer {
       matchesSearchFilters(r, options, this.config.search.minScore, this.projectRoot)
     );
 
-    const implementationOnly = baseFiltered.filter((r) =>
+    let communityRanked = baseFiltered;
+    if (this.config.search.communityBoost > 0) {
+      try {
+        const sameCommunityCandidateIds = resolveSameCommunityCandidateIds(
+          query,
+          baseFiltered,
+          database,
+          this.getBranchCatalogKeys(),
+        );
+        communityRanked = applyCommunityBoost(
+          baseFiltered,
+          sameCommunityCandidateIds,
+          this.config.search.communityBoost,
+        );
+      } catch (error) {
+        this.logger.search("debug", "Community-aware ranking unavailable; using existing ranking", {
+          query,
+          error: getErrorMessage(error),
+        });
+      }
+    }
+
+    const implementationOnly = communityRanked.filter((r) =>
       isLikelyImplementationPath(r.metadata.filePath) &&
       isImplementationChunkType(r.metadata.chunkType)
     );
 
     const filtered = (sourceIntent && hasCodeHints && implementationOnly.length > 0
       ? implementationOnly
-      : baseFiltered
+      : communityRanked
     ).slice(0, maxResults);
 
     const identifierFallback = (!options?.definitionIntent && filtered.length === 0 && identifierHints.length > 0)

--- a/src/indexer/search-ranking.ts
+++ b/src/indexer/search-ranking.ts
@@ -12,11 +12,25 @@ export function applyCommunityBoost(
     return candidates;
   }
 
-  return candidates
-    .map((candidate) => sameCommunityCandidateIds.has(candidate.id)
-      ? { ...candidate, score: candidate.score * (1 + boost) }
-      : candidate)
-    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+  const result = candidates.map((candidate) => sameCommunityCandidateIds.has(candidate.id)
+    ? { ...candidate, score: candidate.score * (1 + boost) }
+    : candidate);
+
+  for (let index = 1; index < result.length; index += 1) {
+    const candidate = result[index];
+    const previous = result[index - 1];
+    if (
+      candidate && previous &&
+      sameCommunityCandidateIds.has(candidate.id) &&
+      !sameCommunityCandidateIds.has(previous.id) &&
+      candidate.score > previous.score
+    ) {
+      result[index - 1] = candidate;
+      result[index] = previous;
+    }
+  }
+
+  return result;
 }
 
 interface HybridRankOptions {

--- a/src/indexer/search-ranking.ts
+++ b/src/indexer/search-ranking.ts
@@ -3,6 +3,22 @@ import { analyzeQueryIntent, rankIntentAwareCandidates } from "./intent-aware-ra
 
 export type RankedCandidate = { id: string; score: number; metadata: ChunkMetadata };
 
+export function applyCommunityBoost(
+  candidates: RankedCandidate[],
+  sameCommunityCandidateIds: ReadonlySet<string>,
+  boost: number,
+): RankedCandidate[] {
+  if (boost <= 0 || sameCommunityCandidateIds.size === 0 || candidates.length <= 1) {
+    return candidates;
+  }
+
+  return candidates
+    .map((candidate) => sameCommunityCandidateIds.has(candidate.id)
+      ? { ...candidate, score: candidate.score * (1 + boost) }
+      : candidate)
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+}
+
 interface HybridRankOptions {
   fusionStrategy: "weighted" | "rrf";
   rrfK: number;

--- a/tests/community-ranking-eval.test.ts
+++ b/tests/community-ranking-eval.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { ChunkMetadata } from "../src/native/index.js";
+import { applyCommunityBoost } from "../src/indexer/index.js";
+
+interface FixtureCandidate { id: string; score: number }
+interface FixtureQuery {
+  id: string;
+  relevantId: string;
+  sameCommunityIds: string[];
+  candidates: FixtureCandidate[];
+}
+interface Fixture {
+  version: string;
+  methodology: { baseline: string; limitations: string };
+  boost: number;
+  queries: FixtureQuery[];
+}
+
+const fixturePath = path.join(process.cwd(), "benchmarks", "fixtures", "community-aware-ranking.json");
+const baselinePath = path.join(process.cwd(), "benchmarks", "baselines", "community-aware-ranking.json");
+
+function metadata(id: string): ChunkMetadata {
+  return {
+    filePath: `src/${id}.ts`,
+    startLine: 1,
+    endLine: 10,
+    chunkType: "function",
+    language: "typescript",
+    hash: id,
+    name: id,
+  };
+}
+
+function reciprocalRank(ids: string[], relevantId: string): number {
+  const index = ids.indexOf(relevantId);
+  return index < 0 ? 0 : 1 / (index + 1);
+}
+
+function rounded(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+describe("community-aware ranking evaluation", () => {
+  it("matches the checked-in comparison and improves aggregate MRR without guardrail regressions", () => {
+    const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as Fixture;
+    const expected = JSON.parse(readFileSync(baselinePath, "utf-8")) as unknown;
+    const perQuery = fixture.queries.map((query) => {
+      const candidates = query.candidates.map((candidate) => ({
+        ...candidate,
+        metadata: metadata(candidate.id),
+      }));
+      const baselineIds = [...candidates]
+        .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+        .map((candidate) => candidate.id);
+      const enabledIds = applyCommunityBoost(candidates, new Set(query.sameCommunityIds), fixture.boost)
+        .map((candidate) => candidate.id);
+      const baselineReciprocalRank = reciprocalRank(baselineIds, query.relevantId);
+      const communityAwareReciprocalRank = reciprocalRank(enabledIds, query.relevantId);
+      expect(communityAwareReciprocalRank).toBeGreaterThanOrEqual(baselineReciprocalRank);
+      return {
+        id: query.id,
+        baselineReciprocalRank,
+        communityAwareReciprocalRank,
+      };
+    });
+    const mean = (values: number[]): number => rounded(values.reduce((sum, value) => sum + value, 0) / values.length);
+    const actual = {
+      fixtureVersion: fixture.version,
+      queryCount: fixture.queries.length,
+      baselineMrr: mean(perQuery.map((query) => query.baselineReciprocalRank)),
+      communityAwareMrr: mean(perQuery.map((query) => query.communityAwareReciprocalRank)),
+      perQuery,
+    };
+
+    expect(fixture.methodology.baseline).toContain("supplied retrieval score");
+    expect(fixture.methodology.limitations).toContain("does not measure embedding recall");
+    expect(actual).toEqual(expected);
+    expect(actual.communityAwareMrr).toBeGreaterThan(actual.baselineMrr);
+  });
+});

--- a/tests/community-ranking-integration.test.ts
+++ b/tests/community-ranking-integration.test.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { Indexer } from "../src/indexer/index.js";
+
+function config(communityBoost: number) {
+  return parseConfig({
+    embeddingProvider: "custom",
+    customProvider: {
+      baseUrl: "http://localhost:11434/v1",
+      model: "mock-model",
+      dimensions: 8,
+    },
+    indexing: { watchFiles: false },
+    search: { communityBoost, minScore: 0 },
+  });
+}
+
+describe("community-aware search integration", () => {
+  let tempDir: string;
+  let indexers: Indexer[];
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "community-ranking-search-"));
+    indexers = [];
+    fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, "src", "auth.ts"), [
+      "export function validateToken() { return refreshToken(); }",
+      "export function refreshToken() { return authHelper(); }",
+      "export function authHelper() { return true; }",
+    ].join("\n"));
+    fs.writeFileSync(path.join(tempDir, "src", "database.ts"), [
+      "export function openDatabase() { return runQuery(); }",
+      "export function runQuery() { return true; }",
+    ].join("\n"));
+
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init?) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[] };
+      const texts = Array.isArray(body.input) ? body.input : [];
+      return new Response(JSON.stringify({
+        data: texts.map((text) => ({
+          embedding: Array.from({ length: 8 }, (_, index) => ((text.length + index * 13) % 101) / 101),
+        })),
+        usage: { total_tokens: Math.max(1, texts.length * 4) },
+      }), { status: 200 });
+    });
+  });
+
+  afterEach(async () => {
+    await Promise.all(indexers.map((indexer) => indexer.close()));
+    fetchSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("boosts same-community results only when enabled and preserves filtered scope", async () => {
+    const indexPath = path.join(tempDir, ".index");
+    const baselineIndexer = new Indexer(tempDir, config(0), "opencode", { indexPath });
+    indexers.push(baselineIndexer);
+    await baselineIndexer.index();
+
+    const baseline = await baselineIndexer.search("validateToken", 20, { metadataOnly: true });
+    await baselineIndexer.close();
+    indexers = [];
+
+    const enabledIndexer = new Indexer(tempDir, config(0.5), "opencode", { indexPath });
+    indexers.push(enabledIndexer);
+    const enabled = await enabledIndexer.search("validateToken", 20, { metadataOnly: true });
+    const filtered = await enabledIndexer.search("validateToken", 20, {
+      metadataOnly: true,
+      directory: "src/database",
+    });
+
+    const baselineAuth = baseline.find((result) => result.filePath.endsWith("src/auth.ts"));
+    const enabledAuth = enabled.find((result) => result.filePath.endsWith("src/auth.ts"));
+    expect(baselineAuth).toBeDefined();
+    expect(enabledAuth).toBeDefined();
+    expect(enabledAuth!.score).toBeGreaterThan(baselineAuth!.score);
+    expect(filtered).toEqual([]);
+  });
+});

--- a/tests/community-ranking.test.ts
+++ b/tests/community-ranking.test.ts
@@ -48,6 +48,29 @@ describe("community-aware local ranking", () => {
     expect(applyCommunityBoost(candidates, new Set(), 0.5)).toBe(candidates);
   });
 
+  it("preserves the existing relative order of unaffected tiered candidates", () => {
+    const candidates = [
+      candidate("definition-lane", 0.4),
+      candidate("high-score-unaffected", 0.95),
+      candidate("related", 0.8),
+      candidate("low-score-unaffected", 0.3),
+    ];
+
+    const ranked = applyCommunityBoost(candidates, new Set(["related"]), 0.25);
+
+    expect(ranked.map((entry) => entry.id)).toEqual([
+      "definition-lane",
+      "related",
+      "high-score-unaffected",
+      "low-score-unaffected",
+    ]);
+    expect(ranked.filter((entry) => entry.id !== "related").map((entry) => entry.id)).toEqual([
+      "definition-lane",
+      "high-score-unaffected",
+      "low-score-unaffected",
+    ]);
+  });
+
   it("improves reciprocal rank on a transparent fixed candidate pool", () => {
     const candidates = [candidate("unrelated", 0.9), candidate("same-community", 0.8)];
     const baseline = candidates.map((entry) => entry.id);

--- a/tests/community-ranking.test.ts
+++ b/tests/community-ranking.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChunkMetadata } from "../src/native/index.js";
+import { applyCommunityBoost } from "../src/indexer/index.js";
+
+type Candidate = { id: string; score: number; metadata: ChunkMetadata };
+
+function candidate(id: string, score: number): Candidate {
+  return {
+    id,
+    score,
+    metadata: {
+      filePath: `src/${id}.ts`,
+      startLine: 1,
+      endLine: 10,
+      chunkType: "function",
+      language: "typescript",
+      hash: id,
+      name: id,
+    },
+  };
+}
+
+describe("community-aware local ranking", () => {
+  it("is byte-for-byte unchanged when disabled", () => {
+    const candidates = [candidate("outside", 0.9), candidate("related", 0.8)];
+    expect(applyCommunityBoost(candidates, new Set(["related"]), 0)).toBe(candidates);
+  });
+
+  it("deterministically promotes only supplied same-community candidates", () => {
+    const candidates = [
+      candidate("outside", 0.9),
+      candidate("related", 0.8),
+      candidate("excluded-before-ranking", 0.99),
+    ];
+    const scopedCandidates = candidates.slice(0, 2);
+
+    const first = applyCommunityBoost(scopedCandidates, new Set(["related", "excluded-before-ranking"]), 0.25);
+    const second = applyCommunityBoost(scopedCandidates, new Set(["related", "excluded-before-ranking"]), 0.25);
+
+    expect(first.map((entry) => entry.id)).toEqual(["related", "outside"]);
+    expect(second).toEqual(first);
+    expect(first.some((entry) => entry.id === "excluded-before-ranking")).toBe(false);
+  });
+
+  it("falls back without copying or reordering when no community context exists", () => {
+    const candidates = [candidate("a", 0.9), candidate("b", 0.8)];
+    expect(applyCommunityBoost(candidates, new Set(), 0.5)).toBe(candidates);
+  });
+
+  it("improves reciprocal rank on a transparent fixed candidate pool", () => {
+    const candidates = [candidate("unrelated", 0.9), candidate("same-community", 0.8)];
+    const baseline = candidates.map((entry) => entry.id);
+    const enabled = applyCommunityBoost(candidates, new Set(["same-community"]), 0.25)
+      .map((entry) => entry.id);
+    const reciprocalRank = (ids: string[], relevant: string): number => 1 / (ids.indexOf(relevant) + 1);
+
+    expect(reciprocalRank(enabled, "same-community")).toBeGreaterThan(
+      reciprocalRank(baseline, "same-community"),
+    );
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -88,6 +88,14 @@ describe("config schema", () => {
       expect(config.include).toHaveLength(DEFAULT_INCLUDE.length);
       expect(config.exclude).toHaveLength(DEFAULT_EXCLUDE.length);
       expect(config.indexing.pauseBackgroundIndexingOnBattery).toBe(false);
+      expect(config.search.communityBoost).toBe(0);
+    });
+
+    it("parses and clamps the opt-in community ranking boost", () => {
+      expect(parseConfig({ search: { communityBoost: 0.25 } }).search.communityBoost).toBe(0.25);
+      expect(parseConfig({ search: { communityBoost: -1 } }).search.communityBoost).toBe(0);
+      expect(parseConfig({ search: { communityBoost: 2 } }).search.communityBoost).toBe(1);
+      expect(parseConfig({ search: { communityBoost: "0.25" } }).search.communityBoost).toBe(0);
     });
 
     it("should return defaults for null input", () => {


### PR DESCRIPTION
## Summary

- add `search.communityBoost` as an opt-in, clamped `0..1` multiplicative ranking signal
- infer only an exact, unambiguous query symbol and resolve its active branch catalog community
- boost only candidates that already passed normal branch, path, type, blame, and score filters
- fall back unchanged when disabled, ambiguous, missing graph data, or community detection fails
- add deterministic unit and end-to-end integration coverage
- add a checked-in fixed-candidate baseline comparison and configuration/evaluation documentation

## Evaluation

The transparent fixed-candidate comparison improves aggregate MRR from `0.833333` to `1.0`, with no per-query regression. This isolates local post-retrieval ordering and does not claim improved embedding recall or end-to-end agent success.

## Validation

- `158/158` focused tests passed
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run build:ts` passed
- full suite: `1319/1320` passed; the sole failure is the pre-existing, unrelated `watcher-config-refresh` local override timing test, and this PR does not modify watcher/config-refresh paths

Closes #230
