### PR TITLE
chore: prepare v0.22.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.21.0"
+      "version": "0.22.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ Prefer existing batch database methods for bulk indexing. Do not replace them w/
 
 ## Package Identity and Compatibility
 
- checked-in package remains `opencode-codebase-index@0.21.0`while release workflow publishes both:
+ checked-in package remains `opencode-codebase-index@0.22.0`while release workflow publishes both:
 
 - `open-codebase-index`preferred host-neutral package; exports `open-codebase-index-mcp` and legacy binary alias
 - `opencode-codebase-index`synchronized compatibility package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-01
+
 ### Added
 
-- **Direct index CLI subcommand for MCP binary**: Added `index` command support to the shared MCP CLI entrypoint with `--project`, `--host`, `--config`, `--force`, `--estimate-only`, and `--verbose` flags. The command uses shared indexing execution and lock/callback semantics, prints diagnostics to `stderr`, exits non-zero on usage and runtime errors, and preserves existing MCP/eval/visualize modes.
-- **Portable `code_communities` tool**: Added a new graph analysis tool that exposes community detection and hub node analysis across OpenCode, MCP, and Pi. Clusters symbols by call-graph connectivity using label propagation, reports deterministic community summaries with member listings, and identifies hub symbols from exact distinct cross-community neighbors. Supports `branch`, `minSize`, `limit`, and `hubThreshold` parameters. Recomputes on-demand from current branch data for freshness without persisted state, with a checked-in 10k-node sub-second performance regression.
-- **Community coupling options for `code_communities`**: Added parity support for `minCoupling` and `couplingLimit` across OpenCode, MCP, and Pi, including representative coupling formatting and expanded host-parity executable tests.
-- **Opt-in community-aware retrieval ranking**: Exact, unambiguous symbol queries can optionally boost already in-scope candidates from the same call-graph community. The feature is disabled by default, deterministic, branch-aware, and falls back to existing ranking when graph context is unavailable.
+- **Direct index CLI subcommand for MCP binary**: Added an `index` command to the shared MCP CLI entrypoint with `--project`, `--host`, `--config`, `--force`, `--estimate-only`, and `--verbose` options. The command shares indexing execution and lock handling with existing flows, writes diagnostics to `stderr`, fails on usage and runtime errors, and keeps MCP/eval/visualize modes intact.
+- **Portable `code_communities` tool**: Added a graph-analysis tool across OpenCode, MCP, and Pi to expose call-graph communities and hub symbols. It performs label-propagation clustering, reports deterministic member summaries, and identifies hubs using distinct cross-community neighbors. It supports `branch`, `minSize`, `limit`, and `hubThreshold` and recomputes on demand from branch-local data.
+- **Community coupling options for `code_communities`**: Added parity support for `minCoupling` and `couplingLimit` across OpenCode, MCP, and Pi, including representative coupling rendering and expanded host-parity test coverage.
+- **Community-aware retrieval ranking**: Added deterministic, opt-in ranking that boosts exact symbol matches within the same in-scope call-graph community. The feature is branch-aware, disabled by default, and falls back to existing ranking when graph context is unavailable.
 
 ### Changed
 
-- **Bounded file-level indexing batches** (#224): Changed-file scans now retain only path, hash, and byte-size descriptors, then parse, chunk, extract call-graph data, and admit embeddings in fixed internal file batches with queue backpressure. Failed embedding state is incrementally written as versioned JSONL and retried as a bounded stream while preserving legacy JSON-array reads, branch catalogs, Git blame, duplicate embedding reuse, and prior-generation SQLite visibility after interrupted runs.
+- **Bounded file-level indexing batches** (#224): Changed-file scans now store only path, hash, and byte size before parsing and chunking. Embedding, call-graph extraction, and storage are processed in bounded batches with queue backpressure. Failed embeddings are persisted as versioned JSONL and retried from a bounded stream while preserving legacy JSON-array reads, branch catalogs, Git blame, duplicate-embedding reuse, and index visibility after interrupted runs.
 
 ## [0.21.0] - 2026-07-30
 
@@ -571,7 +573,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.0...v0.19.1

--- a/docs/benchmarks/v0.22.0-vs-v0.21.0.md
+++ b/docs/benchmarks/v0.22.0-vs-v0.21.0.md
@@ -1,0 +1,59 @@
+# v0.22.0 benchmark comparison
+
+This report compares the `v0.22.0` release candidate (`68cb977`, before metadata-only release changes) with `v0.21.0` (`022af30`). Lower times are better.
+
+## Environment
+
+- macOS 26.6, Apple silicon (`arm64`)
+- 96 GiB RAM
+- Node.js 26.5.0, npm 11.17.0
+- Rust 1.97.1
+- Release-mode native modules built separately from each revision
+
+## Method
+
+The general native benchmark (`npx tsx benchmarks/run.ts`) ran three times per revision in interleaved order. Values below are medians. Category changes are geometric means across operations of at least 0.05 ms to avoid magnifying timer-resolution noise.
+
+The indexing-memory fixture ran three additional sequential samples on the release candidate. Its `unbounded` mode disables the new file-batch limits to model the previous all-files retention strategy, while `bounded` uses the v0.22.0 defaults. Both modes process the same 512 files, 3,072 chunks, and 14.8 MiB of source. Published-output and embedding-request digests must match.
+
+## General benchmark
+
+| Category | Operations | v0.22.0 change |
+|---|---:|---:|
+| Parsing (tree-sitter) | 4 | 5.7% faster |
+| Vector store (usearch) | 20 | unchanged (0.0%) |
+| Inverted index (BM25) | 16 | 0.1% slower |
+| Database (SQLite) | 28 | 1.3% slower |
+
+Representative large-workload medians:
+
+| Operation | v0.21.0 | v0.22.0 | Change |
+|---|---:|---:|---:|
+| Parse 500 files | 58.63 ms | 59.51 ms | 1.5% slower |
+| Add 10,000 vectors, batch | 36,374.19 ms | 36,408.92 ms | 0.1% slower |
+| Search 10,000 vectors, top 20 | 1.27 ms | 1.41 ms | 11.0% slower (+0.14 ms) |
+| Search 10,000 BM25 documents | 4.71 ms | 4.56 ms | 3.2% faster |
+| Insert 10,000 embeddings, batch | 399.31 ms | 404.15 ms | 1.2% slower |
+| Insert 10,000 chunks, batch | 63.05 ms | 62.31 ms | 1.2% faster |
+| Add 10,000 chunks to branch, batch | 22.46 ms | 21.99 ms | 2.1% faster |
+| Find missing embeddings, batch of 100 | 0.10 ms | 0.10 ms | unchanged |
+
+The broad native benchmark is effectively flat. The largest percentage movement in a representative retrieval operation is the 10,000-vector search, but the absolute median difference is only 0.14 ms and should be treated as local benchmark noise unless reproduced on other machines.
+
+## Bounded indexing memory
+
+Median of three sequential samples:
+
+| Mode | Peak RSS | Duration |
+|---|---:|---:|
+| Unbounded | 387.3 MiB | 13,111 ms |
+| Bounded | 328.3 MiB | 12,873 ms |
+
+- Peak RSS decreased by **15.2%** (59.0 MiB).
+- Duration improved by **1.8%**.
+- All three runs produced the same published-output digest: `aad68adb5b2df5a1224164111c2115bed9cc65b18d4611619ba9a0f8e7d7fba0`.
+- Bounded and unbounded request digests matched in every run.
+
+## Conclusion
+
+v0.22.0 materially reduces indexing peak memory for the checked-in workload without changing published output or embedding requests. General parsing, vector, BM25, and SQLite performance remains broadly consistent with v0.21.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- prepare the v0.22.0 minor release
- reconcile the complete v0.21.0-to-main changelog delta
- synchronize npm, Claude, marketplace, Codex, and contributor metadata
- include a checked-in benchmark comparison against v0.21.0

## Highlights

- bounded-memory file-level indexing with transactional publication and streaming failed-embedding state
- direct `index` subcommand for both MCP binary identities
- portable `code_communities` across OpenCode, MCP, and Pi
- deterministic community-aware retrieval ranking and cross-community coupling diagnostics

## Benchmark comparison

Three interleaved general benchmark samples per revision show effectively flat native performance:

- tree-sitter category: 5.7% faster
- usearch category: unchanged
- BM25 category: 0.1% slower
- SQLite category: 1.3% slower

Three sequential indexing-memory samples on the 512-file, 3,072-chunk fixture show:

- peak RSS: 387.3 MiB unbounded to 328.3 MiB bounded, **15.2% lower**
- duration: 13,111 ms to 12,873 ms, **1.8% faster**
- identical published-output and embedding-request digests

Full methodology and representative operations: [`docs/benchmarks/v0.22.0-vs-v0.21.0.md`](https://github.com/Helweg/opencode-codebase-index/blob/release/v0.22.0/docs/benchmarks/v0.22.0-vs-v0.21.0.md)

## Compatibility

- `open-codebase-index` remains the preferred package identity
- `opencode-codebase-index` and the legacy MCP binary remain supported
- native artifact names, public tool names, storage paths, and persisted formats remain compatible
- both package identities are staged from the same implementation

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (78 files, 1,322 tests)
- `npm run smoke:package` for clean packed installs and both MCP binary identities
- focused Claude, Codex, and identity tests (12 tests)
- `npm run benchmark:indexing-memory` (three sequential samples)
- `npx tsx benchmarks/run.ts` on v0.21.0 and v0.22.0 (three interleaved samples each)
- `git diff --check`

Publication remains handled by the trusted-publishing workflow after this PR is merged and `v0.22.0` is tagged.
