### PR TITLE
fix: restore evaluation quality gate

### DIFF
--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  models: read
 
 jobs:
   eval-quality:
@@ -48,14 +47,10 @@ jobs:
           EVAL_EMBED_API_KEY: ${{ secrets.EVAL_EMBED_API_KEY }}
           EVAL_EMBED_MODEL: ${{ secrets.EVAL_EMBED_MODEL }}
           EVAL_EMBED_DIMENSIONS: ${{ secrets.EVAL_EMBED_DIMENSIONS }}
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          MODEL="${EVAL_EMBED_MODEL:-text-embedding-3-small}"
-          DIMS="${EVAL_EMBED_DIMENSIONS:-1536}"
-
           if [ -n "$EVAL_EMBED_BASE_URL" ] || [ -n "$EVAL_EMBED_API_KEY" ]; then
             if [ -z "$EVAL_EMBED_BASE_URL" ] || [ -z "$EVAL_EMBED_API_KEY" ]; then
-              echo "If overriding the default GitHub Models provider, both EVAL_EMBED_BASE_URL and EVAL_EMBED_API_KEY must be set."
+              echo "If overriding the default Ollama provider, both EVAL_EMBED_BASE_URL and EVAL_EMBED_API_KEY must be set."
               exit 1
             fi
 
@@ -64,22 +59,39 @@ jobs:
             echo "against_path=benchmarks/baselines/eval-baseline-summary.json" >> "$GITHUB_OUTPUT"
             echo "base_url=$EVAL_EMBED_BASE_URL" >> "$GITHUB_OUTPUT"
             echo "api_key=$EVAL_EMBED_API_KEY" >> "$GITHUB_OUTPUT"
+            echo "model=${EVAL_EMBED_MODEL:-text-embedding-3-small}" >> "$GITHUB_OUTPUT"
+            echo "dimensions=${EVAL_EMBED_DIMENSIONS:-1536}" >> "$GITHUB_OUTPUT"
           else
-            if [ -z "$GITHUB_TOKEN" ]; then
-              echo "Missing GitHub Actions token for GitHub Models fallback."
-              exit 1
-            fi
-
-            echo "provider_source=github-models" >> "$GITHUB_OUTPUT"
-            echo "budget_path=benchmarks/budgets/github-models.json" >> "$GITHUB_OUTPUT"
+            echo "provider_source=ollama" >> "$GITHUB_OUTPUT"
+            echo "budget_path=benchmarks/budgets/ollama.json" >> "$GITHUB_OUTPUT"
             echo "against_path=" >> "$GITHUB_OUTPUT"
-            echo "base_url=https://models.inference.ai.azure.com" >> "$GITHUB_OUTPUT"
-            echo "api_key=$GITHUB_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Eval quality gate provider::Using GitHub Models via GITHUB_TOKEN with the GitHub Models CI budget."
+            echo "model=nomic-embed-text" >> "$GITHUB_OUTPUT"
+            echo "dimensions=768" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Eval quality gate provider::Using local Ollama because no custom embedding provider secrets are configured."
           fi
 
-          echo "model=$MODEL" >> "$GITHUB_OUTPUT"
-          echo "dimensions=$DIMS" >> "$GITHUB_OUTPUT"
+      - name: Start local Ollama evaluation provider
+        if: steps.eval-provider.outputs.provider_source == 'ollama'
+        run: |
+          OLLAMA_VERSION=0.32.5
+          INSTALLER="$RUNNER_TEMP/ollama-install.sh"
+          curl --fail --show-error --silent --location \
+            "https://github.com/ollama/ollama/releases/download/v${OLLAMA_VERSION}/install.sh" \
+            --output "$INSTALLER"
+          echo "25f64b810b947145095956533e1bdf56eacea2673c55a7e586be4515fc882c9f  $INSTALLER" | sha256sum --check
+          OLLAMA_VERSION="$OLLAMA_VERSION" sh "$INSTALLER"
+          ollama serve > "$RUNNER_TEMP/ollama.log" 2>&1 &
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:11434/api/tags >/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              cat "$RUNNER_TEMP/ollama.log"
+              exit 1
+            fi
+            sleep 2
+          done
+          ollama pull "${{ steps.eval-provider.outputs.model }}"
 
       - name: Ensure baseline exists for baseline-driven budget
         if: steps.eval-provider.outputs.against_path != ''
@@ -89,21 +101,16 @@ jobs:
             exit 1
           fi
 
-      - name: Create eval quality config from secrets
+      - name: Create eval quality config
         run: |
-          if [ "${{ steps.eval-provider.outputs.provider_source }}" = "github-models" ]; then
-            EMBED_CONCURRENCY=1
-            EMBED_REQUEST_INTERVAL_MS=5000
-            EMBED_RETRIES=5
-            EMBED_RETRY_DELAY_MS=15000
+          if [ "${{ steps.eval-provider.outputs.provider_source }}" = "ollama" ]; then
+            cp .github/eval-ollama-config.json .github/eval-quality-config.json
           else
             EMBED_CONCURRENCY=3
             EMBED_REQUEST_INTERVAL_MS=1000
             EMBED_RETRIES=3
             EMBED_RETRY_DELAY_MS=1000
-          fi
-
-          cat > .github/eval-quality-config.json <<EOF
+            cat > .github/eval-quality-config.json <<EOF
           {
             "embeddingProvider": "custom",
             "customProvider": {
@@ -140,10 +147,11 @@ jobs:
             }
           }
           EOF
+          fi
 
       - name: Run eval quality gate (real provider config required)
         run: |
-          ARGS=(eval run --config .github/eval-quality-config.json --output eval-results --reindex --ci --budget "${{ steps.eval-provider.outputs.budget_path }}")
+          ARGS=(eval run --dataset benchmarks/golden/small.json --config .github/eval-quality-config.json --output eval-results --reindex --ci --budget "${{ steps.eval-provider.outputs.budget_path }}")
           if [ -n "${{ steps.eval-provider.outputs.against_path }}" ]; then
             ARGS+=(--against "${{ steps.eval-provider.outputs.against_path }}")
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Evaluation quality gate**: Replaced the retired GitHub Models fallback with a pinned local Ollama provider, refreshed stale smoke-dataset paths after the adapter and ranking refactors, explicitly scoped scheduled runs to the smoke dataset, and fail fast when CI reindexing produces no searchable vectors instead of reporting a misleading zero-quality score.
+
 ## [0.22.0] - 2026-08-01
 
 ### Added

--- a/benchmarks/budgets/ollama.json
+++ b/benchmarks/budgets/ollama.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-models-eval-budget",
+  "name": "ollama-eval-budget",
   "failOnMissingBaseline": false,
   "thresholds": {
     "minHitAt5": 0.75,

--- a/benchmarks/golden/small.json
+++ b/benchmarks/golden/small.json
@@ -8,7 +8,7 @@
       "query": "where is rankHybridResults implementation",
       "queryType": "definition",
       "expected": {
-        "filePath": "src/indexer/index.ts",
+        "filePath": "src/indexer/search-ranking.ts",
         "symbol": "rankHybridResults"
       }
     },
@@ -17,7 +17,7 @@
       "query": "find implementation of codebase_search tool",
       "queryType": "implementation-intent",
       "expected": {
-        "filePath": "src/tools/index.ts",
+        "filePath": "src/adapters/opencode/tools.ts",
         "symbol": "codebase_search"
       }
     },
@@ -26,7 +26,7 @@
       "query": "find similar code feature and duplicates",
       "queryType": "similarity",
       "expected": {
-        "filePath": "src/tools/index.ts",
+        "filePath": "src/adapters/opencode/tools.ts",
         "symbol": "find_similar"
       }
     },
@@ -37,7 +37,8 @@
       "expected": {
         "acceptableFiles": [
           "src/config/schema.ts",
-          "src/indexer/index.ts"
+          "src/indexer/index.ts",
+          "src/indexer/search-ranking.ts"
         ]
       }
     }

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -143,15 +143,15 @@ If the referenced baseline summary file contains malformed JSON, compare mode no
 npm run eval:ci
 ```
 
-The scheduled/manual `Eval Quality Gate` uses real embeddings and uploads the generated `summary.json`, `summary.md`, and `per-query.json` diagnostics for 14 days even when a budget fails. Its GitHub Models budget rejects Hit@5 below 0.75 or MRR@10 below 0.65, which catches sustained quality step-downs while leaving room for provider variance. The workflow also writes the latest summary to the GitHub Actions job summary. These artifacts contain the repository's checked-in evaluation dataset and result paths, not runtime effectiveness telemetry or user repository data.
+The scheduled/manual `Eval Quality Gate` uses real embeddings and uploads the generated `summary.json`, `summary.md`, and `per-query.json` diagnostics for 14 days even when a budget fails. Its default Ollama budget rejects Hit@5 below 0.75 or MRR@10 below 0.65. The workflow also writes the latest summary to the GitHub Actions job summary. These artifacts contain the repository's checked-in evaluation dataset and result paths, not runtime effectiveness telemetry or user repository data.
 
-Default script:
+Default script (explicitly scoped to the smoke dataset):
 
 ```bash
-npx tsx src/cli.ts eval run --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json
+npx tsx src/cli.ts eval run --dataset benchmarks/golden/small.json --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json
 ```
 
-CI mode fails when configured thresholds regress beyond tolerance.
+CI mode fails fast when a reindex run produces no searchable vectors, and the command exits non-zero when configured thresholds regress beyond tolerance.
 
 ### CI integration in GitHub Actions
 
@@ -161,27 +161,24 @@ There are two CI levels:
    - Purpose: verify eval harness integrity (CLI, schema validation, artifact writing, report generation) without external dependencies.
    - This is **not** a retrieval-quality signal.
 
-2. **Quality gate workflow (`eval-quality.yml`)** runs `npm run eval:ci` with your real provider config/authentication context.
+2. **Quality gate workflow (`eval-quality.yml`)** runs the real retrieval evaluation with a local Ollama provider or explicit provider secrets.
    - Purpose: enforce actual quality/latency regressions against baselines/budgets.
    - Triggered on schedule (`cron`) and manually (`workflow_dispatch`).
-   - By default, it uses GitHub Models embeddings with the workflow `GITHUB_TOKEN` and `models: read` permission.
-   - GitHub Models runs use `benchmarks/budgets/github-models.json`, which enforces stable absolute quality floors (`minHitAt5`, `minMrrAt10`, `p95LatencyMaxAbsoluteMs`) instead of comparing to the provider-specific regression baseline.
-   - If `EVAL_EMBED_BASE_URL` and `EVAL_EMBED_API_KEY` are both set, those explicit provider credentials override the GitHub Models default and the workflow switches back to the stricter baseline-driven budget in `benchmarks/budgets/default.json`.
+   - By default, it installs Ollama on the runner, pulls `nomic-embed-text`, and uses `benchmarks/budgets/ollama.json` with stable absolute quality floors.
+   - If `EVAL_EMBED_BASE_URL` and `EVAL_EMBED_API_KEY` are both set, those explicit provider credentials override Ollama and the workflow switches back to the stricter baseline-driven budget in `benchmarks/budgets/default.json`.
 
 This split keeps regular CI stable while preserving meaningful retrieval-quality gating.
 
 ### Authentication for `eval-quality.yml`
 
-Default path (no extra API key required):
+Default path (no API key required):
 
-- The workflow uses `GITHUB_TOKEN` with `models: read`
-- Base URL: `https://models.inference.ai.azure.com`
-- Default model: `text-embedding-3-small`
-- Default dimensions: `1536`
+- The workflow installs and starts Ollama on the GitHub-hosted runner.
+- Model: `nomic-embed-text`
+- Dimensions: `768`
+- Budget: `benchmarks/budgets/ollama.json`
 
-This uses GitHub Models from GitHub Actions. It is separate from your local OpenCode/Copilot OAuth session, but it avoids provisioning a separate OpenAI key for the scheduled/manual gate.
-
-Because GitHub Models in Actions has higher latency/ranking variance than a dedicated provider setup, the default GitHub Models path uses an absolute-floor CI budget instead of relative baseline regression checks.
+GitHub Models was retired on July 30, 2026. The local Ollama path replaces that retired service and keeps the scheduled gate independent of external embedding credentials. It uses an absolute-floor budget instead of a provider-specific relative baseline.
 
 Optional override for another OpenAI-compatible provider:
 
@@ -194,19 +191,18 @@ Configure these GitHub repository secrets:
 
 If you set one of `EVAL_EMBED_BASE_URL` or `EVAL_EMBED_API_KEY`, you must set both. Partial override configuration fails fast.
 
-The workflow generates `.github/eval-quality-config.json` from secrets and runs:
+The workflow materializes `.github/eval-quality-config.json` for the selected provider and runs:
 
 ```bash
-npx tsx src/cli.ts eval run --config .github/eval-quality-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json
+npx tsx src/cli.ts eval run --dataset benchmarks/golden/small.json --config .github/eval-quality-config.json --reindex --ci --budget benchmarks/budgets/default.json --against benchmarks/baselines/eval-baseline-summary.json
 ```
 
 #### Example values
 
-- GitHub Models in Actions (default):
-  - `baseUrl=https://models.inference.ai.azure.com`
-  - `apiKey=${{ github.token }}`
-  - requires workflow permission `models: read`
-  - uses `benchmarks/budgets/github-models.json`
+- Ollama in Actions (default):
+  - installed and started by the workflow
+  - model `nomic-embed-text`
+  - uses `benchmarks/budgets/ollama.json`
 
 - OpenAI direct:
   - `EVAL_EMBED_BASE_URL=https://api.openai.com/v1`
@@ -222,7 +218,7 @@ npx tsx src/cli.ts eval run --config .github/eval-quality-config.json --reindex 
 
 If dimensions do not match returned vectors, eval fails fast with a clear mismatch error.
 
-### Ollama quality gate (manual/local, not CI)
+### Ollama quality gate (manual/local)
 
 If you do not have OpenAI API access, run the quality gate locally with Ollama:
 

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -95,6 +95,18 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
   try {
     await indexer.index();
 
+    if (options.ciMode) {
+      const indexStatus = await indexer.getStatus();
+      if (!indexStatus.indexed || indexStatus.vectorCount === 0) {
+        const failedBatchDetails = indexStatus.failedBatchesCount > 0
+          ? ` ${indexStatus.failedBatchesCount} embedding batch(es) failed; diagnostics: ${indexStatus.failedBatchesPath ?? "unavailable"}.`
+          : "";
+        throw new Error(
+          `Evaluation reindex produced no searchable vectors.${failedBatchDetails} Check the embedding provider and indexing diagnostics before evaluating retrieval quality.`
+        );
+      }
+    }
+
     const perQuery: PerQueryEvalResult[] = [];
 
     for (const query of dataset.queries) {

--- a/tests/effectiveness-ci.test.ts
+++ b/tests/effectiveness-ci.test.ts
@@ -52,7 +52,7 @@ function summary(hitAt5: number, mrrAt10: number): EvalSummary {
 
 describe("effectiveness quality CI", () => {
   const budget = JSON.parse(
-    readFileSync("benchmarks/budgets/github-models.json", "utf8"),
+    readFileSync("benchmarks/budgets/ollama.json", "utf8"),
   ) as EvalBudget;
 
   it("rejects the observed retrieval step-down and accepts the healthy result", () => {

--- a/tests/eval-runner.test.ts
+++ b/tests/eval-runner.test.ts
@@ -149,6 +149,72 @@ describe("eval runner", () => {
     expect(repeatRun.summary.datasetFingerprint).toBe(result.summary.datasetFingerprint);
   });
 
+  it("fails fast when reindexing produces no searchable vectors", async () => {
+    fetchSpy.mockResolvedValue(new Response(
+      JSON.stringify({ data: [], usage: { total_tokens: 0 } }),
+      { status: 200 },
+    ));
+
+    const configPath = path.join(tempDir, ".opencode", "codebase-index.json");
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    config.indexing = {
+      watchFiles: false,
+      retries: 0,
+      retryDelayMs: 0,
+    };
+    writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
+    writeFileSync(
+      path.join(tempDir, "benchmarks", "budgets", "empty-index.json"),
+      JSON.stringify({
+        name: "empty-index",
+        failOnMissingBaseline: false,
+        thresholds: {},
+      }),
+      "utf-8",
+    );
+
+    await expect(runEvaluation({
+      projectRoot: tempDir,
+      datasetPath: "benchmarks/golden/small.json",
+      outputRoot: "benchmarks/results",
+      ciMode: true,
+      reindex: true,
+      budgetPath: "benchmarks/budgets/empty-index.json",
+    })).rejects.toThrow(/Evaluation reindex produced no searchable vectors/);
+  });
+
+  it("fails fast in sweep mode when reindexing produces no searchable vectors", async () => {
+    fetchSpy.mockResolvedValue(new Response(
+      JSON.stringify({ data: [], usage: { total_tokens: 0 } }),
+      { status: 200 },
+    ));
+
+    const configPath = path.join(tempDir, "benchmarks", "budgets", "empty-index-sweep.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        name: "empty-index-sweep",
+        failOnMissingBaseline: false,
+        thresholds: {},
+      }, null, 2),
+      "utf-8",
+    );
+
+    await expect(runSweep(
+      {
+        projectRoot: tempDir,
+        datasetPath: "benchmarks/golden/small.json",
+        outputRoot: "benchmarks/results",
+        ciMode: true,
+        budgetPath: "benchmarks/budgets/empty-index-sweep.json",
+        reindex: true,
+      },
+      {
+        fusionStrategy: ["rrf", "weighted"],
+      }
+    )).rejects.toThrow(/Evaluation reindex produced no searchable vectors/);
+  });
+
   it("applies query args as search filters in search mode", async () => {
     const datasetPath = path.join(tempDir, "benchmarks", "golden", "args-search.json");
     writeFileSync(


### PR DESCRIPTION
## Summary
- replace the retired GitHub Models fallback with pinned, checksum-verified Ollama and `nomic-embed-text`
- refresh stale smoke-dataset ground truth after ranking and adapter refactors
- fail CI evaluations early when reindexing produces no searchable vectors
- document the provider change and retain custom-provider secret overrides

## Root cause
GitHub Models was fully retired on July 30, 2026. The scheduled workflow continued sending embedding requests to the retired endpoint. Failed batches were persisted rather than aborting indexing, so the gate misleadingly reported Hit@5 and MRR@10 as zero. The smoke dataset also referenced implementation files removed during the v0.20.1 refactor.

## Validation
- local repaired gate: Hit@5 100%, MRR@10 1.0000, p95 65.172 ms
- `npx vitest run tests/eval-runner.test.ts`: 22 passed
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run build`: passed
- workflow YAML and budget/dataset JSON parsed successfully
- isolated watcher test: 10 passed

The full suite passed 1,323 tests but repeatedly exposed one unrelated parallel-only watcher timing failure that passes in isolation. No retrieval baselines were changed.
