### PR TITLE
perf: bound real-provider smoke evaluation

### DIFF
--- a/.github/eval-ollama-config.json
+++ b/.github/eval-ollama-config.json
@@ -1,6 +1,11 @@
 {
   "embeddingProvider": "ollama",
   "embeddingModel": "nomic-embed-text",
+  "include": [
+    "src/indexer/*.ts",
+    "src/adapters/opencode/*.ts",
+    "src/config/*.ts"
+  ],
   "indexing": {
     "autoIndex": false,
     "watchFiles": false,

--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -122,6 +122,11 @@ jobs:
               "concurrency": $EMBED_CONCURRENCY,
               "requestIntervalMs": $EMBED_REQUEST_INTERVAL_MS
             },
+            "include": [
+              "src/indexer/*.ts",
+              "src/adapters/opencode/*.ts",
+              "src/config/*.ts"
+            ],
             "indexing": {
               "autoIndex": false,
               "watchFiles": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Faster real-provider evaluation**: Scoped the four-query scheduled Ollama smoke gate to the relevant indexer, OpenCode adapter, and configuration source areas, retaining real semantic competition and all expected files while avoiding full-repository embedding on CPU-only GitHub runners.
+
 ### Fixed
 
 - **Evaluation quality gate**: Replaced the retired GitHub Models fallback with a pinned local Ollama provider, refreshed stale smoke-dataset paths after the adapter and ranking refactors, explicitly scoped scheduled runs to the smoke dataset, and fail fast when CI reindexing produces no searchable vectors instead of reporting a misleading zero-quality score.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -143,7 +143,7 @@ If the referenced baseline summary file contains malformed JSON, compare mode no
 npm run eval:ci
 ```
 
-The scheduled/manual `Eval Quality Gate` uses real embeddings and uploads the generated `summary.json`, `summary.md`, and `per-query.json` diagnostics for 14 days even when a budget fails. Its default Ollama budget rejects Hit@5 below 0.75 or MRR@10 below 0.65. The workflow also writes the latest summary to the GitHub Actions job summary. These artifacts contain the repository's checked-in evaluation dataset and result paths, not runtime effectiveness telemetry or user repository data.
+The scheduled/manual `Eval Quality Gate` uses real embeddings and uploads the generated `summary.json`, `summary.md`, and `per-query.json` diagnostics for 14 days even when a budget fails. Its default Ollama budget rejects Hit@5 below 0.75 or MRR@10 below 0.65. The workflow also writes the latest summary to the GitHub Actions job summary. To keep CPU-only Ollama runs bounded, this four-query smoke gate indexes the relevant `src/indexer`, `src/adapters/opencode`, and `src/config` TypeScript source areas rather than the entire repository. A contract test ensures every expected result remains inside that corpus. These artifacts contain the repository's checked-in evaluation dataset and result paths, not runtime effectiveness telemetry or user repository data.
 
 Default script (explicitly scoped to the smoke dataset):
 

--- a/tests/effectiveness-ci.test.ts
+++ b/tests/effectiveness-ci.test.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from "fs";
+import * as path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import { evaluateBudgetGate } from "../src/eval/budget.js";
+import { collectFiles } from "../src/utils/files.js";
 import type { EvalBudget, EvalSummary } from "../src/eval/types.js";
 
 function summary(hitAt5: number, mrrAt10: number): EvalSummary {
@@ -77,5 +79,31 @@ describe("effectiveness quality CI", () => {
     expect(workflow).toContain("if-no-files-found: warn");
     expect(workflow).toContain("retention-days: 14");
     expect(workflow).not.toContain(".codebase-index");
+  });
+
+  it("keeps the smoke evaluation corpus focused while covering every expected file", async () => {
+    const config = JSON.parse(
+      readFileSync(".github/eval-ollama-config.json", "utf8"),
+    ) as { include: string[] };
+    const dataset = JSON.parse(
+      readFileSync("benchmarks/golden/small.json", "utf8"),
+    ) as {
+      queries: Array<{
+        expected: { filePath?: string; acceptableFiles?: string[] };
+      }>;
+    };
+    const collected = await collectFiles(process.cwd(), config.include, [], 1_048_576);
+    const relativeFiles = new Set(
+      collected.files.map((file) => path.relative(process.cwd(), file.path)),
+    );
+
+    expect(relativeFiles.size).toBeGreaterThan(10);
+    expect(relativeFiles.size).toBeLessThanOrEqual(40);
+    for (const query of dataset.queries) {
+      const expectedFiles = query.expected.filePath
+        ? [query.expected.filePath]
+        : query.expected.acceptableFiles ?? [];
+      expect(expectedFiles.some((file) => relativeFiles.has(file))).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- scope the four-query real-provider smoke eval to 24 relevant TypeScript implementation/configuration files instead of embedding the whole repository
- apply the same corpus to both the default Ollama path and custom-provider override
- add a contract test that bounds corpus growth and verifies every golden expectation remains covered
- document the scope and runtime rationale

## Why

The restored GitHub Actions Ollama evaluation spent 33m30s embedding the entire repository for four smoke queries. The smoke dataset only targets `src/indexer`, `src/adapters/opencode`, and `src/config`; indexing tests, docs, Rust, and unrelated adapters added CPU work without contributing expected results.

This keeps real semantic retrieval with 24 competing source files and does not weaken the quality budget.

## Measurements

- GitHub Actions baseline eval step: **33m30s**
- Local focused eval: **10.99s**
- Local quality: **Hit@5 100%**, **MRR@10 0.8750**, **p95 60.207ms**
- Quality floors unchanged: Hit@5 >= 75%, MRR@10 >= 0.65

A new GitHub Actions run will provide the runner-to-runner comparison.

## Validation

- `npm run build && npm run typecheck && npm run lint && npm run test:run` ✅
- 78 files, 1,325 tests passed
- focused real Ollama eval ✅
- workflow YAML and JSON parsed successfully
