### PR TITLE
test: add two-tier retrieval quality gates

### DIFF
--- a/.github/eval-ollama-full-config.json
+++ b/.github/eval-ollama-full-config.json
@@ -1,0 +1,25 @@
+{
+  "embeddingProvider": "ollama",
+  "embeddingModel": "nomic-embed-text",
+  "indexing": {
+    "autoIndex": false,
+    "watchFiles": false,
+    "respectGitignore": true,
+    "semanticOnly": false,
+    "requireProjectMarker": false
+  },
+  "search": {
+    "maxResults": 10,
+    "minScore": 0,
+    "hybridWeight": 0.4,
+    "fusionStrategy": "rrf",
+    "rrfK": 60,
+    "rerankTopN": 20,
+    "enableCrossLanguage": true
+  },
+  "debug": {
+    "enabled": false,
+    "logLevel": "info",
+    "metrics": true
+  }
+}

--- a/.github/workflows/eval-quality.yml
+++ b/.github/workflows/eval-quality.yml
@@ -2,15 +2,25 @@ name: Eval Quality Gate
 
 on:
   workflow_dispatch:
+    inputs:
+      tier:
+        description: Evaluation tier to run
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - full
   schedule:
     - cron: "0 3 * * *"
+    - cron: "0 4 * * 0"
 
 permissions:
   contents: read
 
 jobs:
   eval-quality:
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -40,6 +50,24 @@ jobs:
           cargo build --release
           npx napi build --release --platform
 
+      - name: Resolve evaluation tier
+        id: eval-tier
+        env:
+          DISPATCH_TIER: ${{ inputs.tier }}
+          SCHEDULE: ${{ github.event.schedule }}
+        run: |
+          if [ "$DISPATCH_TIER" = "full" ] || [ "$SCHEDULE" = "0 4 * * 0" ]; then
+            echo "name=full" >> "$GITHUB_OUTPUT"
+            echo "dataset_path=benchmarks/golden/representative.json" >> "$GITHUB_OUTPUT"
+            echo "ollama_config=.github/eval-ollama-full-config.json" >> "$GITHUB_OUTPUT"
+            echo "absolute_budget=benchmarks/budgets/representative.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=smoke" >> "$GITHUB_OUTPUT"
+            echo "dataset_path=benchmarks/golden/small.json" >> "$GITHUB_OUTPUT"
+            echo "ollama_config=.github/eval-ollama-config.json" >> "$GITHUB_OUTPUT"
+            echo "absolute_budget=benchmarks/budgets/ollama.json" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve eval provider config
         id: eval-provider
         env:
@@ -47,6 +75,7 @@ jobs:
           EVAL_EMBED_API_KEY: ${{ secrets.EVAL_EMBED_API_KEY }}
           EVAL_EMBED_MODEL: ${{ secrets.EVAL_EMBED_MODEL }}
           EVAL_EMBED_DIMENSIONS: ${{ secrets.EVAL_EMBED_DIMENSIONS }}
+          EVAL_TIER: ${{ steps.eval-tier.outputs.name }}
         run: |
           if [ -n "$EVAL_EMBED_BASE_URL" ] || [ -n "$EVAL_EMBED_API_KEY" ]; then
             if [ -z "$EVAL_EMBED_BASE_URL" ] || [ -z "$EVAL_EMBED_API_KEY" ]; then
@@ -55,15 +84,20 @@ jobs:
             fi
 
             echo "provider_source=custom-secrets" >> "$GITHUB_OUTPUT"
-            echo "budget_path=benchmarks/budgets/default.json" >> "$GITHUB_OUTPUT"
-            echo "against_path=benchmarks/baselines/eval-baseline-summary.json" >> "$GITHUB_OUTPUT"
+            if [ "$EVAL_TIER" = "full" ]; then
+              echo "budget_path=${{ steps.eval-tier.outputs.absolute_budget }}" >> "$GITHUB_OUTPUT"
+              echo "against_path=" >> "$GITHUB_OUTPUT"
+            else
+              echo "budget_path=benchmarks/budgets/default.json" >> "$GITHUB_OUTPUT"
+              echo "against_path=benchmarks/baselines/eval-baseline-summary.json" >> "$GITHUB_OUTPUT"
+            fi
             echo "base_url=$EVAL_EMBED_BASE_URL" >> "$GITHUB_OUTPUT"
             echo "api_key=$EVAL_EMBED_API_KEY" >> "$GITHUB_OUTPUT"
             echo "model=${EVAL_EMBED_MODEL:-text-embedding-3-small}" >> "$GITHUB_OUTPUT"
             echo "dimensions=${EVAL_EMBED_DIMENSIONS:-1536}" >> "$GITHUB_OUTPUT"
           else
             echo "provider_source=ollama" >> "$GITHUB_OUTPUT"
-            echo "budget_path=benchmarks/budgets/ollama.json" >> "$GITHUB_OUTPUT"
+            echo "budget_path=${{ steps.eval-tier.outputs.absolute_budget }}" >> "$GITHUB_OUTPUT"
             echo "against_path=" >> "$GITHUB_OUTPUT"
             echo "model=nomic-embed-text" >> "$GITHUB_OUTPUT"
             echo "dimensions=768" >> "$GITHUB_OUTPUT"
@@ -104,7 +138,7 @@ jobs:
       - name: Create eval quality config
         run: |
           if [ "${{ steps.eval-provider.outputs.provider_source }}" = "ollama" ]; then
-            cp .github/eval-ollama-config.json .github/eval-quality-config.json
+            cp "${{ steps.eval-tier.outputs.ollama_config }}" .github/eval-quality-config.json
           else
             EMBED_CONCURRENCY=3
             EMBED_REQUEST_INTERVAL_MS=1000
@@ -122,11 +156,6 @@ jobs:
               "concurrency": $EMBED_CONCURRENCY,
               "requestIntervalMs": $EMBED_REQUEST_INTERVAL_MS
             },
-            "include": [
-              "src/indexer/*.ts",
-              "src/adapters/opencode/*.ts",
-              "src/config/*.ts"
-            ],
             "indexing": {
               "autoIndex": false,
               "watchFiles": false,
@@ -152,11 +181,16 @@ jobs:
             }
           }
           EOF
+            if [ "${{ steps.eval-tier.outputs.name }}" = "smoke" ]; then
+              jq '.include = ["src/indexer/*.ts", "src/adapters/opencode/*.ts", "src/config/*.ts"]' \
+                .github/eval-quality-config.json > .github/eval-quality-config.tmp.json
+              mv .github/eval-quality-config.tmp.json .github/eval-quality-config.json
+            fi
           fi
 
       - name: Run eval quality gate (real provider config required)
         run: |
-          ARGS=(eval run --dataset benchmarks/golden/small.json --config .github/eval-quality-config.json --output eval-results --reindex --ci --budget "${{ steps.eval-provider.outputs.budget_path }}")
+          ARGS=(eval run --dataset "${{ steps.eval-tier.outputs.dataset_path }}" --config .github/eval-quality-config.json --output "eval-results/${{ steps.eval-tier.outputs.name }}" --reindex --ci --budget "${{ steps.eval-provider.outputs.budget_path }}")
           if [ -n "${{ steps.eval-provider.outputs.against_path }}" ]; then
             ARGS+=(--against "${{ steps.eval-provider.outputs.against_path }}")
           fi
@@ -176,7 +210,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: eval-quality-${{ github.run_id }}
+          name: eval-quality-${{ steps.eval-tier.outputs.name }}-${{ github.run_id }}
           path: eval-results
           if-no-files-found: warn
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Two-tier retrieval quality gates**: Added a daily focused Ollama smoke evaluation and a weekly full-repository representative evaluation spanning TypeScript, Rust, Swift, and PHP, with manual tier selection, separate artifacts, and dataset-specific absolute budgets.
+
 ### Changed
 
 - **Faster real-provider evaluation**: Scoped the four-query scheduled Ollama smoke gate to the relevant indexer, OpenCode adapter, and configuration source areas, retaining real semantic competition and all expected files while avoiding full-repository embedding on CPU-only GitHub runners.

--- a/benchmarks/budgets/representative.json
+++ b/benchmarks/budgets/representative.json
@@ -1,0 +1,17 @@
+{
+  "name": "representative-eval-budget",
+  "failOnMissingBaseline": false,
+  "thresholds": {
+    "minHitAt5": 0.75,
+    "minMrrAt10": 0.55,
+    "minRawDistinctTop3Ratio": 0.5,
+    "p95LatencyMaxAbsoluteMs": 500,
+    "maxContextResponseTokensAverage": 1000,
+    "maxContextResponseTokensP95": 1200,
+    "maxContextResponseTokensMax": 1200,
+    "maxContextDuplicateCandidateRatio": 0.5,
+    "minContextSelectedFileRatio": 0.5,
+    "minContextHitAt5Per1kResponseTokens": 0.5,
+    "minContextMrrAt10Per1kResponseTokens": 0.25
+  }
+}

--- a/benchmarks/golden/representative.json
+++ b/benchmarks/golden/representative.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "name": "representative-retrieval",
   "description": "Hand-labeled retrieval kernel covering exact and nested definitions, conceptual source discovery, language and path filters, scoped recovery, graded multi-file evidence, similarity, keywords, and a negative filtered search.",
   "queries": [
@@ -15,7 +15,7 @@
         "expectedRoute": "definition",
         "expectedOutcome": "results",
         "gradedEvidence": [
-          { "path": "src/indexer/index.ts", "symbol": "fuseResultsRrf", "relevance": 3 }
+          { "path": "src/indexer/search-ranking.ts", "symbol": "fuseResultsRrf", "relevance": 3 }
         ]
       }
     },
@@ -48,7 +48,8 @@
         "expectedRoute": "search",
         "expectedOutcome": "results",
         "gradedEvidence": [
-          { "path": "native/src/call_extractor.rs", "symbol": "extract_calls", "relevance": 3 }
+          { "path": "native/src/lib.rs", "symbol": "extract_calls", "relevance": 3 },
+          { "path": "native/src/call_extractor.rs", "relevance": 2 }
         ]
       }
     },
@@ -83,7 +84,7 @@
         "expectedRoute": "search",
         "expectedOutcome": "results",
         "gradedEvidence": [
-          { "path": "src/indexer/index-lock.ts", "symbol": "acquireIndexLock", "relevance": 3 }
+          { "path": "src/indexer/index-lock.ts", "relevance": 3 }
         ]
       }
     },
@@ -99,8 +100,8 @@
         "expectedRoute": "search",
         "expectedOutcome": "results",
         "gradedEvidence": [
-          { "path": "src/mcp-server/register-tools.ts", "symbol": "registerMcpTools", "relevance": 3 },
-          { "path": "src/mcp-server.ts", "symbol": "createMcpServer", "relevance": 2 }
+          { "path": "src/adapters/mcp/register-tools.ts", "symbol": "registerMcpTools", "relevance": 3 },
+          { "path": "src/adapters/mcp/server.ts", "symbol": "createMcpServer", "relevance": 2 }
         ]
       }
     },
@@ -215,8 +216,8 @@
       "expected": {
         "expectedOutcome": "results",
         "gradedEvidence": [
-          { "path": "src/indexer/index.ts", "symbol": "fuseResultsRrf", "relevance": 3 },
-          { "path": "src/indexer/index.ts", "symbol": "rankHybridResults", "relevance": 2 }
+          { "path": "src/indexer/search-ranking.ts", "symbol": "fuseResultsRrf", "relevance": 3 },
+          { "path": "src/indexer/search-ranking.ts", "symbol": "rankHybridResults", "relevance": 2 }
         ]
       }
     },
@@ -232,7 +233,7 @@
         "expectedOutcome": "results",
         "gradedEvidence": [
           { "path": "src/config/schema.ts", "relevance": 3 },
-          { "path": "src/indexer/index.ts", "relevance": 2 },
+          { "path": "src/indexer/search-ranking.ts", "relevance": 2 },
           { "path": "src/eval/runner-config.ts", "symbol": "resolveSearchConfig", "relevance": 2 },
           { "path": "src/eval/runner.ts", "symbol": "runSweep", "relevance": 1 },
           { "path": "src/eval/cli-parser.ts", "symbol": "hasSweepOptions", "relevance": 1 }

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -143,7 +143,7 @@ If the referenced baseline summary file contains malformed JSON, compare mode no
 npm run eval:ci
 ```
 
-The scheduled/manual `Eval Quality Gate` uses real embeddings and uploads the generated `summary.json`, `summary.md`, and `per-query.json` diagnostics for 14 days even when a budget fails. Its default Ollama budget rejects Hit@5 below 0.75 or MRR@10 below 0.65. The workflow also writes the latest summary to the GitHub Actions job summary. To keep CPU-only Ollama runs bounded, this four-query smoke gate indexes the relevant `src/indexer`, `src/adapters/opencode`, and `src/config` TypeScript source areas rather than the entire repository. A contract test ensures every expected result remains inside that corpus. These artifacts contain the repository's checked-in evaluation dataset and result paths, not runtime effectiveness telemetry or user repository data.
+The scheduled/manual `Eval Quality Gate` uses real embeddings and uploads the generated `summary.json`, `summary.md`, and `per-query.json` diagnostics for 14 days even when a budget fails. The daily smoke tier rejects Hit@5 below 0.75 or MRR@10 below 0.65. To keep CPU-only Ollama runs bounded, it indexes the relevant `src/indexer`, `src/adapters/opencode`, and `src/config` TypeScript source areas for four queries. A weekly full tier indexes the entire repository and runs the 14-query representative dataset across TypeScript, Rust, Swift, and PHP. Its separate measured budget keeps the same 0.75 Hit@5 floor and uses a 0.55 MRR@10 floor for the harder query mix. Contract tests ensure the smoke corpus covers its expectations and every representative evidence path and symbol remains current. The workflow also writes the latest summary to the GitHub Actions job summary. These artifacts contain the repository's checked-in evaluation dataset and result paths, not runtime effectiveness telemetry or user repository data.
 
 Default script (explicitly scoped to the smoke dataset):
 
@@ -163,9 +163,11 @@ There are two CI levels:
 
 2. **Quality gate workflow (`eval-quality.yml`)** runs the real retrieval evaluation with a local Ollama provider or explicit provider secrets.
    - Purpose: enforce actual quality/latency regressions against baselines/budgets.
-   - Triggered on schedule (`cron`) and manually (`workflow_dispatch`).
-   - By default, it installs Ollama on the runner, pulls `nomic-embed-text`, and uses `benchmarks/budgets/ollama.json` with stable absolute quality floors.
-   - If `EVAL_EMBED_BASE_URL` and `EVAL_EMBED_API_KEY` are both set, those explicit provider credentials override Ollama and the workflow switches back to the stricter baseline-driven budget in `benchmarks/budgets/default.json`.
+   - The focused smoke tier runs daily at 03:00 UTC.
+   - The full-repository representative tier runs Sundays at 04:00 UTC.
+   - Manual runs expose a required `smoke` or `full` tier selector.
+   - By default, both tiers install Ollama on the runner and pull `nomic-embed-text`. Smoke uses `benchmarks/budgets/ollama.json`; full uses `benchmarks/budgets/representative.json`.
+   - If `EVAL_EMBED_BASE_URL` and `EVAL_EMBED_API_KEY` are both set, those explicit provider credentials override Ollama. Smoke uses the stricter baseline-driven budget in `benchmarks/budgets/default.json`; full retains its representative absolute budget because the checked-in baseline targets the smoke dataset.
 
 This split keeps regular CI stable while preserving meaningful retrieval-quality gating.
 
@@ -176,7 +178,7 @@ Default path (no API key required):
 - The workflow installs and starts Ollama on the GitHub-hosted runner.
 - Model: `nomic-embed-text`
 - Dimensions: `768`
-- Budget: `benchmarks/budgets/ollama.json`
+- Budgets: `benchmarks/budgets/ollama.json` for smoke and `benchmarks/budgets/representative.json` for full
 
 GitHub Models was retired on July 30, 2026. The local Ollama path replaces that retired service and keeps the scheduled gate independent of external embedding credentials. It uses an absolute-floor budget instead of a provider-specific relative baseline.
 

--- a/tests/effectiveness-ci.test.ts
+++ b/tests/effectiveness-ci.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import * as path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -56,6 +56,9 @@ describe("effectiveness quality CI", () => {
   const budget = JSON.parse(
     readFileSync("benchmarks/budgets/ollama.json", "utf8"),
   ) as EvalBudget;
+  const representativeBudget = JSON.parse(
+    readFileSync("benchmarks/budgets/representative.json", "utf8"),
+  ) as EvalBudget;
 
   it("rejects the observed retrieval step-down and accepts the healthy result", () => {
     const regressed = evaluateBudgetGate(budget, summary(0.5, 0.54));
@@ -73,12 +76,55 @@ describe("effectiveness quality CI", () => {
 
     expect(workflow).toContain("- name: Add evaluation summary\n        if: always()");
     expect(workflow).toContain("- name: Upload evaluation diagnostics\n        if: always()");
-    expect(workflow).toContain("--output eval-results");
+    expect(workflow).toContain('--output "eval-results/${{ steps.eval-tier.outputs.name }}"');
     expect(workflow).toContain("path: eval-results");
     expect(workflow).not.toContain(".eval-results");
     expect(workflow).toContain("if-no-files-found: warn");
     expect(workflow).toContain("retention-days: 14");
     expect(workflow).not.toContain(".codebase-index");
+  });
+
+  it("schedules a fast daily smoke tier and a weekly full-repository tier", () => {
+    const workflow = readFileSync(".github/workflows/eval-quality.yml", "utf8");
+    const fullConfig = JSON.parse(
+      readFileSync(".github/eval-ollama-full-config.json", "utf8"),
+    ) as { include?: string[] };
+
+    expect(workflow).toContain('cron: "0 3 * * *"');
+    expect(workflow).toContain('cron: "0 4 * * 0"');
+    expect(workflow).toContain("benchmarks/golden/small.json");
+    expect(workflow).toContain("benchmarks/golden/representative.json");
+    expect(workflow).toContain("benchmarks/budgets/representative.json");
+    expect(workflow).toContain("timeout-minutes: 60");
+    expect(workflow).toContain("eval-quality-${{ steps.eval-tier.outputs.name }}-${{ github.run_id }}");
+    expect(fullConfig.include).toBeUndefined();
+  });
+
+  it("uses a measured representative budget without weakening the smoke budget", () => {
+    expect(evaluateBudgetGate(representativeBudget, summary(0.8462, 0.5987)).passed).toBe(true);
+    expect(evaluateBudgetGate(representativeBudget, summary(0.7, 0.5)).passed).toBe(false);
+    expect(representativeBudget.thresholds.minHitAt5).toBe(budget.thresholds.minHitAt5);
+    expect(budget.thresholds.minMrrAt10).toBe(0.65);
+  });
+
+  it("keeps representative evidence aligned with current source paths and symbols", () => {
+    const dataset = JSON.parse(
+      readFileSync("benchmarks/golden/representative.json", "utf8"),
+    ) as {
+      queries: Array<{
+        expected: { gradedEvidence?: Array<{ path: string; symbol?: string }> };
+      }>;
+    };
+
+    for (const query of dataset.queries) {
+      for (const evidence of query.expected.gradedEvidence ?? []) {
+        expect(existsSync(evidence.path), evidence.path).toBe(true);
+        if (evidence.symbol) {
+          expect(readFileSync(evidence.path, "utf8"), `${evidence.path}:${evidence.symbol}`)
+            .toContain(evidence.symbol);
+        }
+      }
+    }
   });
 
   it("keeps the smoke evaluation corpus focused while covering every expected file", async () => {


### PR DESCRIPTION
## Summary
- keep the focused four-query real-provider smoke gate running daily
- add a weekly full-repository representative gate spanning TypeScript, Rust, Swift, and PHP
- add manual smoke/full selection, tier-specific configurations, budgets, artifacts, tests, and documentation
- refresh stale representative evidence labels after repository refactors

## Measured results
- focused smoke: Hit@5 100%, MRR@10 0.875, local runtime 11s
- representative full repository: Hit@5 84.62%, MRR@10 0.5987, local runtime 125s on Apple M4
- smoke floors remain unchanged at Hit@5 0.75 and MRR@10 0.65
- representative floor is Hit@5 0.75 and MRR@10 0.55 for the harder 14-query multilingual mix

## Validation
- `npm run build` passed
- `npm run typecheck` passed
- `npm run lint` passed
- focused effectiveness/eval tests passed
- representative evaluation passed its new absolute budget
- full Vitest run passed 1,327 of 1,328 tests; the known watcher timing test failed under suite load but passed all 10 tests in isolation immediately before the run

A real GitHub Actions full-tier run will be attached before merge.
