### PR TITLE
chore: release v0.22.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.22.0"
+      "version": "0.22.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-08-01
+
 ### Added
 
 - **Two-tier retrieval quality gates**: Added a daily focused Ollama smoke evaluation and a weekly full-repository representative evaluation spanning TypeScript, Rust, Swift, and PHP, with manual tier selection, separate artifacts, and dataset-specific absolute budgets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -241,7 +241,7 @@ describe("watcher config refresh", () => {
           undefined,
         );
         expect(indexer.index).toHaveBeenCalledTimes(1);
-      }, { timeout: 5000 });
+      }, { timeout: 10000 });
     } finally {
       await watcher.stop();
     }


### PR DESCRIPTION
## v0.22.1

Patch release containing the evaluation quality work merged since v0.22.0:

### Added
- daily focused Ollama smoke evaluation plus weekly full-repository representative evaluation
- manual smoke/full tier selection, tier-specific artifacts, and measured absolute budgets

### Changed
- bounded the real-provider smoke corpus, reducing GitHub evaluation runtime while retaining all expected evidence

### Fixed
- replaced the retired GitHub Models fallback with pinned local Ollama
- refreshed stale eval evidence after adapter/ranking refactors
- fail fast when CI reindexing produces no searchable vectors
- widened one asynchronous watcher test deadline to avoid full-suite CPU-contention flakes

## Validation
- `npm run build` passed
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run test:run` passed: 78 files, 1,328 tests
- `npm run smoke:package` passed for both `open-codebase-index` and `opencode-codebase-index`, including both MCP binary aliases
- real GitHub full-tier eval passed: Hit@5 84.62%, MRR@10 0.5987, p95 105.778 ms
