### PR TITLE
chore: prepare repository rename metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
             node scripts/prepare-package-metadata.mjs \
               --package-name "${packageName}" \
               --project-root "${GITHUB_WORKSPACE}" \
-              --output-dir "${RUNNER_TEMP}/package-metadata/${packageName}"
+              --output-dir "${RUNNER_TEMP}/package-metadata/${packageName}" \
+              --repository-url "https://github.com/${GITHUB_REPOSITORY}"
           done
 
   build:
@@ -130,7 +131,8 @@ jobs:
             node scripts/prepare-package-metadata.mjs \
               --package-name "${packageName}" \
               --project-root "${GITHUB_WORKSPACE}" \
-              --output-dir "${stagingDir}"
+              --output-dir "${stagingDir}" \
+              --repository-url "https://github.com/${GITHUB_REPOSITORY}"
 
             if npm view "${packageName}@${PACKAGE_VERSION}" --json >/dev/null 2>&1; then
               echo "Skipping ${packageName} because version already exists."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Repository rename preparation**: Added validated repository URL overrides for staged package and host metadata, including package, Claude, and Codex repository fields, and made release metadata follow `GITHUB_REPOSITORY` before and after the planned GitHub rename.
+
 ## [0.22.1] - 2026-08-01
 
 ### Added

--- a/docs/rename-to-open-codebase-index.md
+++ b/docs/rename-to-open-codebase-index.md
@@ -89,6 +89,28 @@ The old package can initially remain a synchronized publication of the same code
 4. Keep explicit tests for old GitHub URLs only where compatibility documentation intentionally mentions the redirect.
 5. Announce that storage locations and tool names are intentionally unchanged.
 
+### Phase 2 readiness checklist
+
+- [x] Publish and CI use the workflow repository URL override from `GITHUB_REPOSITORY` so metadata stages follow the active host URL.
+- [x] Add targeted identity test coverage for:
+  - checked-in defaults remain unchanged without overrides,
+  - explicit override updates package, Claude, and Codex staged metadata.
+- [x] Ensure invalid or unknown repository URLs fail fast with clear errors.
+- [x] Keep checked-in links on the live repository until the rename is approved. The release workflow is already rename-safe because it derives staged metadata from `GITHUB_REPOSITORY`.
+- [ ] Rename the GitHub repository only after explicit maintainer approval.
+- [ ] Immediately after the rename, update checked-in public links and verify redirects, provenance, and marketplace installation.
+
+Intentional pre-rename references to `Helweg/opencode-codebase-index` are classified as follows:
+
+| Location | Why it remains | When to update |
+|---|---|---|
+| `package.json`, `src/identity-catalog.json` current identity, and checked-in host manifests | Describe the currently live repository and legacy compatibility identity | Immediately after the GitHub rename; retain the catalog's current identity as the documented compatibility value |
+| `README.md`, `SECURITY.md`, `TROUBLESHOOTING.md`, and `docs/installation.md` | Must resolve before the new repository URL exists | In the rename commit or immediately after the rename |
+| Historical `CHANGELOG.md` comparison links | Release history currently resolves through the live repository | After the rename, relying on GitHub redirects for old external links |
+| This migration document | Explicitly documents both old and future identities | Keep both identities for historical and operational context |
+
+Phase 2 rename changes require explicit maintainer approval and are not to be executed during this repository-rename preparation pass.
+
 **Exit criteria:** fresh clones, pull requests, release automation, package provenance, source links, and documentation links resolve through the new repository identity.
 
 ### Phase 3: deprecate legacy entrypoints

--- a/scripts/prepare-package-metadata.mjs
+++ b/scripts/prepare-package-metadata.mjs
@@ -28,6 +28,34 @@ function parseArgs(argv) {
   return args;
 }
 
+function normalizeRepositoryUrl(value) {
+  const url = new URL(value);
+  url.hash = "";
+  url.search = "";
+  if (url.pathname.length > 1) {
+    url.pathname = url.pathname.replace(/\/+$/, "");
+  }
+  return url.toString();
+}
+
+function parseRepositoryUrlOverride(catalog, value, rawArg) {
+  if (value === null || value === undefined) return null;
+  try {
+    const candidate = normalizeRepositoryUrl(value);
+    const catalogUrls = [catalog.product.current.repository, catalog.product.future.repository]
+      .map((it) => normalizeRepositoryUrl(it));
+
+    if (!catalogUrls.includes(candidate)) {
+      fail(`Unsupported repository URL: ${rawArg}`);
+    }
+
+    return candidate;
+  } catch {
+    fail(`Invalid repository URL: ${rawArg}`);
+    return null;
+  }
+}
+
 function fail(message) {
   console.error(message);
   process.exit(1);
@@ -38,9 +66,17 @@ const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 const catalog = JSON.parse(readFileSync(path.join(repositoryRoot, "src", "identity-catalog.json"), "utf-8"));
 const args = parseArgs(process.argv.slice(2));
 const packageName = args.get("--package-name");
+const repositoryUrlArg = args.has("--repository-url") ? args.get("--repository-url") : null;
+const repositoryUrl = parseRepositoryUrlOverride(
+  catalog,
+  repositoryUrlArg,
+  repositoryUrlArg || "",
+);
 
 if (!packageName) {
-  fail("Usage: node scripts/prepare-package-metadata.mjs --package-name <known-name> [--project-root <path>] [--output-dir <path>]");
+  fail(
+    "Usage: node scripts/prepare-package-metadata.mjs --package-name <known-name> [--project-root <path>] [--output-dir <path>] [--repository-url <url>]",
+  );
 }
 
 const selectedIdentity = [catalog.product.current, catalog.product.future]
@@ -82,9 +118,15 @@ function copyProject() {
   });
 }
 
+if (repositoryUrl && outputDir === projectRoot) {
+  fail("Repository override staging requires --output-dir because this operation preserves checked-in metadata.");
+}
+
 if (!isCurrentIdentity() && outputDir === projectRoot) {
   fail("Future identity staging requires --output-dir because this operation preserves checked-in metadata.");
 }
+
+const appliedRepositoryUrl = repositoryUrl || catalog.product.current.repository;
 
 function isCurrentIdentity() {
   return selectedIdentity.packageName === catalog.product.current.packageName;
@@ -98,6 +140,76 @@ function prepareManifest(manifestPath, host) {
     fail(`Missing codebase-index MCP server in ${manifestPath}`);
   }
   server.args = ["-y", "--package", selectedIdentity.packageName, selectedIdentity.mcpBinary, "--host", host];
+  if (manifest.author?.url) {
+    manifest.author.url = appliedRepositoryUrl;
+  }
+  if (manifest.homepage) {
+    manifest.homepage = appliedRepositoryUrl;
+  }
+  if (manifest.repository) {
+    manifest.repository = appliedRepositoryUrl;
+  }
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+function prepareClaudePluginManifest(manifestPath) {
+  if (!existsSync(manifestPath)) fail(`Missing Claude plugin manifest at ${manifestPath}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const server = manifest.mcpServers?.["codebase-index"];
+  if (!server?.command || !Array.isArray(server.args)) {
+    fail(`Missing codebase-index MCP server in ${manifestPath}`);
+  }
+  server.args = ["-y", "--package", selectedIdentity.packageName, selectedIdentity.mcpBinary, "--host", "claude"];
+
+  if (manifest.homepage) {
+    manifest.homepage = appliedRepositoryUrl;
+  }
+  if (manifest.repository) {
+    manifest.repository = appliedRepositoryUrl;
+  }
+  if (manifest.author?.url) {
+    manifest.author.url = appliedRepositoryUrl;
+  }
+
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+function prepareCodexManifest(manifestPath) {
+  if (!existsSync(manifestPath)) fail(`Missing Codex manifest at ${manifestPath}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+
+  if (manifest.homepage) {
+    manifest.homepage = appliedRepositoryUrl;
+  }
+  if (manifest.repository) {
+    manifest.repository = appliedRepositoryUrl;
+  }
+  if (manifest.author?.url) {
+    manifest.author.url = appliedRepositoryUrl;
+  }
+  if (manifest.interface?.websiteURL) {
+    manifest.interface.websiteURL = appliedRepositoryUrl;
+  }
+  if (manifest.interface?.privacyPolicyURL) {
+    manifest.interface.privacyPolicyURL = `${appliedRepositoryUrl}/blob/main/SECURITY.md`;
+  }
+  if (manifest.interface?.termsOfServiceURL) {
+    manifest.interface.termsOfServiceURL = `${appliedRepositoryUrl}/blob/main/LICENSE`;
+  }
+
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+function prepareClaudeMarketplace(manifestPath) {
+  if (!existsSync(manifestPath)) fail(`Missing marketplace manifest at ${manifestPath}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  if (!manifest.owner?.url) {
+    fail(`Missing marketplace owner URL in ${manifestPath}`);
+  }
+  if (typeof manifest.name !== "string") {
+    fail(`Invalid marketplace manifest at ${manifestPath}`);
+  }
+  manifest.owner.url = appliedRepositoryUrl;
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
 }
 
@@ -122,12 +234,33 @@ if (!isCurrentIdentity()) {
   }
   packageLock.packages[""].name = selectedIdentity.packageName;
   packageLock.packages[""].bin = preparedBins;
+}
 
-  writeFileSync(targetPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf-8");
-  writeFileSync(targetPackageLockPath, `${JSON.stringify(packageLock, null, 2)}\n`, "utf-8");
+const shouldWritePackageJson = !isCurrentIdentity() || !!repositoryUrl;
+const shouldWritePackageLock = !isCurrentIdentity();
 
+if (shouldWritePackageJson || shouldWritePackageLock) {
+  if (repositoryUrl) {
+    packageJson.repository = {
+      ...packageJson.repository,
+      url: appliedRepositoryUrl,
+    };
+  }
+
+  if (shouldWritePackageJson) {
+    writeFileSync(targetPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf-8");
+  }
+
+  if (shouldWritePackageLock) {
+    writeFileSync(targetPackageLockPath, `${JSON.stringify(packageLock, null, 2)}\n`, "utf-8");
+  }
+}
+
+if (!isCurrentIdentity() || repositoryUrl) {
   prepareManifest(path.join(outputDir, ".mcp.json"), "codex");
-  prepareManifest(path.join(outputDir, ".claude-plugin", "plugin.json"), "claude");
+  prepareClaudePluginManifest(path.join(outputDir, ".claude-plugin", "plugin.json"));
+  prepareCodexManifest(path.join(outputDir, ".codex-plugin", "plugin.json"));
+  prepareClaudeMarketplace(path.join(outputDir, ".claude-plugin", "marketplace.json"));
 }
 
 console.log(`Prepared metadata for ${selectedIdentity.packageName}`);

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -15,6 +15,29 @@ interface PackageMetadata {
   napi: { binaryName: string };
 }
 
+interface CodexManifestMetadata {
+  author?: { url?: string };
+  homepage: string;
+  repository: string;
+  interface: {
+    websiteURL: string;
+    privacyPolicyURL: string;
+    termsOfServiceURL: string;
+  };
+}
+
+interface ClaudeManifestMetadata {
+  homepage: string;
+  repository: string;
+  author?: { url?: string };
+}
+
+interface ClaudeMarketplaceMetadata {
+  owner: {
+    url: string;
+  };
+}
+
 interface PackageLockMetadata {
   name: string;
   packages: Record<string, { name?: string; bin?: Record<string, string> }>;
@@ -28,16 +51,20 @@ function readText(filePath: string): string {
   return readFileSync(filePath, "utf-8");
 }
 
-function prepareMetadata(packageName: string, outputDir: string): void {
-  execFileSync(process.execPath, [
-    path.join(process.cwd(), "scripts", "prepare-package-metadata.mjs"),
+function prepareMetadata(packageName: string, outputDir: string, repositoryUrl?: string): void {
+  const args = [
     "--package-name",
     packageName,
     "--project-root",
     process.cwd(),
     "--output-dir",
     outputDir,
-  ]);
+  ];
+  if (repositoryUrl) {
+    args.push("--repository-url", repositoryUrl);
+  }
+
+  execFileSync(process.execPath, [path.join(process.cwd(), "scripts", "prepare-package-metadata.mjs"), ...args]);
 }
 
 describe("Phase 1 product identity compatibility", () => {
@@ -48,18 +75,11 @@ describe("Phase 1 product identity compatibility", () => {
     const mcpManifest = readJson<{
       mcpServers: Record<string, { command: string; args: string[] }>;
     }>(".mcp.json");
-    const claudeManifest = readJson<{
-      homepage: string;
-      repository: string;
+    const claudeManifest = readJson<ClaudeManifestMetadata & {
       mcpServers: Record<string, { command: string; args: string[] }>;
     }>(".claude-plugin/plugin.json");
     const claudeMarketplace = readJson<{ owner: { url: string } }>(".claude-plugin/marketplace.json");
-    const codexManifest = readJson<{
-      homepage: string;
-      repository: string;
-      mcpServers: string;
-      interface: { websiteURL: string };
-    }>(".codex-plugin/plugin.json");
+    const codexManifest = readJson<CodexManifestMetadata>(".codex-plugin/plugin.json");
 
     const expectedBin = { [current.mcpBinary]: "dist/cli.js" };
     expect(packageJson.name).toBe(current.packageName);
@@ -81,10 +101,12 @@ describe("Phase 1 product identity compatibility", () => {
     expect(claudeManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedClaudeArgs });
     expect(claudeManifest.homepage).toBe(current.repository);
     expect(claudeManifest.repository).toBe(current.repository);
+    expect(claudeManifest.author?.url).toBe(current.repository);
     expect(claudeMarketplace.owner.url).toBe(current.repository);
     expect(codexManifest.homepage).toBe(current.repository);
     expect(codexManifest.repository).toBe(current.repository);
     expect(codexManifest.interface.websiteURL).toBe(current.repository);
+    expect(codexManifest.author?.url).toBe(current.repository);
   });
 
   it("stages current metadata with only the legacy binary", () => {
@@ -124,11 +146,15 @@ describe("Phase 1 product identity compatibility", () => {
       const stagedMcpManifest = readJson<{
         mcpServers: Record<string, { command: string; args: string[] }>;
       }>(path.join(tempDir, ".mcp.json"));
-      const stagedClaudeManifest = readJson<{
-        homepage: string;
-        repository: string;
+      const stagedClaudeManifest = readJson<ClaudeManifestMetadata & {
         mcpServers: Record<string, { command: string; args: string[] }>;
       }>(path.join(tempDir, ".claude-plugin", "plugin.json"));
+      const stagedCodexManifest = readJson<CodexManifestMetadata>(
+        path.join(tempDir, ".codex-plugin", "plugin.json"),
+      );
+      const stagedClaudeMarketplace = readJson<ClaudeMarketplaceMetadata>(
+        path.join(tempDir, ".claude-plugin", "marketplace.json"),
+      );
       const expectedBin = {
         [IDENTITY_CATALOG.product.future.mcpBinary]: "dist/cli.js",
         [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js",
@@ -160,6 +186,53 @@ describe("Phase 1 product identity compatibility", () => {
       expect(stagedClaudeManifest.mcpServers["codebase-index"]).toEqual({ command: "npx", args: expectedClaudeArgs });
       expect(stagedClaudeManifest.homepage).toBe(IDENTITY_CATALOG.product.current.repository);
       expect(stagedClaudeManifest.repository).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedClaudeManifest.author?.url).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedCodexManifest.homepage).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedCodexManifest.repository).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedCodexManifest.author?.url).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedCodexManifest.interface.websiteURL).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(stagedClaudeMarketplace.owner.url).toBe(IDENTITY_CATALOG.product.current.repository);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stages metadata with an explicit repository override", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-repo-override-metadata-"));
+    const repositoryUrl = "https://github.com/Helweg/open-codebase-index";
+    try {
+      prepareMetadata(IDENTITY_CATALOG.product.future.packageName, tempDir, repositoryUrl);
+      const packageJson = readJson<PackageMetadata>(path.join(tempDir, "package.json"));
+      const packageLock = readJson<PackageLockMetadata>(path.join(tempDir, "package-lock.json"));
+      const stagedMcpManifest = readJson<{
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      }>(path.join(tempDir, ".mcp.json"));
+      const stagedClaudeManifest = readJson<ClaudeManifestMetadata & {
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      }>(path.join(tempDir, ".claude-plugin", "plugin.json"));
+      const stagedCodexManifest = readJson<CodexManifestMetadata>(
+        path.join(tempDir, ".codex-plugin", "plugin.json"),
+      );
+      const stagedClaudeMarketplace = readJson<ClaudeMarketplaceMetadata>(
+        path.join(tempDir, ".claude-plugin", "marketplace.json"),
+      );
+
+      expect(packageJson.name).toBe(IDENTITY_CATALOG.product.future.packageName);
+      expect(packageJson.repository.url).toBe(repositoryUrl);
+      expect(packageLock.name).toBe(IDENTITY_CATALOG.product.future.packageName);
+      expect(packageJson.bin[IDENTITY_CATALOG.product.future.mcpBinary]).toBe("dist/cli.js");
+      expect(packageJson.bin[IDENTITY_CATALOG.product.current.mcpBinary]).toBe("dist/cli.js");
+      expect(stagedClaudeManifest.homepage).toBe(repositoryUrl);
+      expect(stagedClaudeManifest.repository).toBe(repositoryUrl);
+      expect(stagedClaudeManifest.author?.url).toBe(repositoryUrl);
+      expect(stagedCodexManifest.homepage).toBe(repositoryUrl);
+      expect(stagedCodexManifest.repository).toBe(repositoryUrl);
+      expect(stagedCodexManifest.author?.url).toBe(repositoryUrl);
+      expect(stagedCodexManifest.interface.websiteURL).toBe(repositoryUrl);
+      expect(stagedCodexManifest.interface.privacyPolicyURL).toBe(`${repositoryUrl}/blob/main/SECURITY.md`);
+      expect(stagedCodexManifest.interface.termsOfServiceURL).toBe(`${repositoryUrl}/blob/main/LICENSE`);
+      expect(stagedClaudeMarketplace.owner.url).toBe(repositoryUrl);
+      expect(stagedMcpManifest.mcpServers["codebase-index"].args[2]).toBe(IDENTITY_CATALOG.product.future.packageName);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -169,6 +242,14 @@ describe("Phase 1 product identity compatibility", () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-invalid-metadata-"));
     try {
       expect(() => prepareMetadata("unknown-codebase-index", tempDir)).toThrow();
+      expect(() =>
+        prepareMetadata(
+          IDENTITY_CATALOG.product.current.packageName,
+          tempDir,
+          "https://invalid.example.com/opencode-codebase-index",
+        ),
+      ).toThrow();
+      expect(() => prepareMetadata(IDENTITY_CATALOG.product.current.packageName, tempDir, "not-a-url")).toThrow();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -200,6 +281,7 @@ describe("Phase 1 product identity compatibility", () => {
     expect(workflow).toContain("npm publish --ignore-scripts --access public");
     expect(workflow).toContain("npm view \"${packageName}@${PACKAGE_VERSION}\" --json");
     expect(workflow).toContain("stagingDir=\"${RUNNER_TEMP}/package-metadata/${packageName}\"");
+    expect(workflow).toContain("--repository-url \"https://github.com/${GITHUB_REPOSITORY}\"");
 
     const openFirst = workflow.indexOf("open-codebase-index");
     const legacyAfter = workflow.indexOf("opencode-codebase-index", openFirst + 1);


### PR DESCRIPTION
## Summary
- add validated repository URL overrides for staged package and host metadata
- make release metadata follow `GITHUB_REPOSITORY` before and after the repository rename
- document the Phase 2 readiness checklist and intentional legacy references

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (1,329 tests)
- `npx vitest run tests/identity-phase0.test.ts`