### PR TITLE
chore: complete repository rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Kenneth",
     "email": "kenneth@example.com",
-    "url": "https://github.com/Helweg/opencode-codebase-index"
+    "url": "https://github.com/Helweg/open-codebase-index"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,10 +6,10 @@
   "author": {
     "name": "Kenneth",
     "email": "kenneth@example.com",
-    "url": "https://github.com/Helweg/opencode-codebase-index"
+    "url": "https://github.com/Helweg/open-codebase-index"
   },
-  "homepage": "https://github.com/Helweg/opencode-codebase-index",
-  "repository": "https://github.com/Helweg/opencode-codebase-index",
+  "homepage": "https://github.com/Helweg/open-codebase-index",
+  "repository": "https://github.com/Helweg/open-codebase-index",
   "license": "MIT",
   "keywords": [
     "codebase-index",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,10 +5,10 @@
   "author": {
     "name": "Kenneth",
     "email": "kenneth@example.com",
-    "url": "https://github.com/Helweg/opencode-codebase-index"
+    "url": "https://github.com/Helweg/open-codebase-index"
   },
-  "homepage": "https://github.com/Helweg/opencode-codebase-index",
-  "repository": "https://github.com/Helweg/opencode-codebase-index",
+  "homepage": "https://github.com/Helweg/open-codebase-index",
+  "repository": "https://github.com/Helweg/open-codebase-index",
   "license": "MIT",
   "keywords": [
     "codebase-index",
@@ -32,9 +32,9 @@
       "MCP Tools",
       "Search"
     ],
-    "websiteURL": "https://github.com/Helweg/opencode-codebase-index",
-    "privacyPolicyURL": "https://github.com/Helweg/opencode-codebase-index/blob/main/SECURITY.md",
-    "termsOfServiceURL": "https://github.com/Helweg/opencode-codebase-index/blob/main/LICENSE",
+    "websiteURL": "https://github.com/Helweg/open-codebase-index",
+    "privacyPolicyURL": "https://github.com/Helweg/open-codebase-index/blob/main/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/Helweg/open-codebase-index/blob/main/LICENSE",
     "brandColor": "#3B82F6",
     "defaultPrompt": [
       "For repository questions, use index_status when readiness is unknown, then call codebase_context before shell search or broad file reads."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Repository rename preparation**: Added validated repository URL overrides for staged package and host metadata, including package, Claude, and Codex repository fields, and made release metadata follow `GITHUB_REPOSITORY` before and after the planned GitHub rename.
+- **Canonical repository identity**: Renamed the GitHub repository to `Helweg/open-codebase-index` and updated package metadata, host manifests, badges, installation commands, security links, troubleshooting links, and changelog comparisons while preserving legacy package, binary, storage, and tool compatibility.
 
 ## [0.22.1] - 2026-08-01
 
@@ -591,46 +592,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/opencode-codebase-index/compare/v0.22.0...HEAD
-[0.22.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.21.0...v0.22.0
-[0.21.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.1...v0.21.0
-[0.20.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.20.0...v0.20.1
-[0.20.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.1...v0.20.0
-[0.19.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.19.0...v0.19.1
-[0.19.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.1...v0.19.0
-[0.18.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.18.0...v0.18.1
-[0.18.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.1...v0.18.0
-[0.17.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.17.0...v0.17.1
-[0.17.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.16.0...v0.17.0
-[0.16.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.14.0...v0.15.0
-[0.14.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.2...v0.14.0
-[0.13.2]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.1...v0.13.2
-[0.13.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.13.0...v0.13.1
-[0.13.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.11.0...v0.12.0
-[0.11.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.10.0...v0.11.0
-[0.10.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.1...v0.9.0
-[0.8.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.8.0...v0.8.1
-[0.8.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.6.1...v0.7.0
-[0.6.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.5.2...v0.6.0
-[0.5.2]: https://github.com/Helweg/opencode-codebase-index/compare/v0.5.1...v0.5.2
-[0.5.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.5.0...v0.5.1
-[0.5.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.4.1...v0.5.0
-[0.4.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.3.2...v0.4.0
-[0.3.2]: https://github.com/Helweg/opencode-codebase-index/compare/v0.3.1...v0.3.2
-[0.3.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.11...v0.2.0
-[0.1.11]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.10...v0.1.11
-[0.1.10]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.9...v0.1.10
-[0.1.9]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.8...v0.1.9
-[0.1.8]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.3...v0.1.8
-[0.1.3]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.1...v0.1.3
-[0.1.1]: https://github.com/Helweg/opencode-codebase-index/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/Helweg/opencode-codebase-index/releases/tag/v0.1.0
+[Unreleased]: https://github.com/Helweg/open-codebase-index/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/Helweg/open-codebase-index/compare/v0.21.0...v0.22.0
+[0.21.0]: https://github.com/Helweg/open-codebase-index/compare/v0.20.1...v0.21.0
+[0.20.1]: https://github.com/Helweg/open-codebase-index/compare/v0.20.0...v0.20.1
+[0.20.0]: https://github.com/Helweg/open-codebase-index/compare/v0.19.1...v0.20.0
+[0.19.1]: https://github.com/Helweg/open-codebase-index/compare/v0.19.0...v0.19.1
+[0.19.0]: https://github.com/Helweg/open-codebase-index/compare/v0.18.1...v0.19.0
+[0.18.1]: https://github.com/Helweg/open-codebase-index/compare/v0.18.0...v0.18.1
+[0.18.0]: https://github.com/Helweg/open-codebase-index/compare/v0.17.1...v0.18.0
+[0.17.1]: https://github.com/Helweg/open-codebase-index/compare/v0.17.0...v0.17.1
+[0.17.0]: https://github.com/Helweg/open-codebase-index/compare/v0.16.0...v0.17.0
+[0.16.0]: https://github.com/Helweg/open-codebase-index/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/Helweg/open-codebase-index/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/Helweg/open-codebase-index/compare/v0.13.2...v0.14.0
+[0.13.2]: https://github.com/Helweg/open-codebase-index/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/Helweg/open-codebase-index/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/Helweg/open-codebase-index/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/Helweg/open-codebase-index/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/Helweg/open-codebase-index/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/Helweg/open-codebase-index/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/Helweg/open-codebase-index/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/Helweg/open-codebase-index/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/Helweg/open-codebase-index/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/Helweg/open-codebase-index/compare/v0.6.1...v0.7.0
+[0.6.1]: https://github.com/Helweg/open-codebase-index/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/Helweg/open-codebase-index/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/Helweg/open-codebase-index/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/Helweg/open-codebase-index/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/Helweg/open-codebase-index/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/Helweg/open-codebase-index/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/Helweg/open-codebase-index/compare/v0.3.2...v0.4.0
+[0.3.2]: https://github.com/Helweg/open-codebase-index/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/Helweg/open-codebase-index/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/Helweg/open-codebase-index/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/Helweg/open-codebase-index/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/Helweg/open-codebase-index/compare/v0.1.11...v0.2.0
+[0.1.11]: https://github.com/Helweg/open-codebase-index/compare/v0.1.10...v0.1.11
+[0.1.10]: https://github.com/Helweg/open-codebase-index/compare/v0.1.9...v0.1.10
+[0.1.9]: https://github.com/Helweg/open-codebase-index/compare/v0.1.8...v0.1.9
+[0.1.8]: https://github.com/Helweg/open-codebase-index/compare/v0.1.3...v0.1.8
+[0.1.3]: https://github.com/Helweg/open-codebase-index/compare/v0.1.1...v0.1.3
+[0.1.1]: https://github.com/Helweg/open-codebase-index/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Helweg/open-codebase-index/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/open-codebase-index.svg)](https://www.npmjs.com/package/open-codebase-index)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://img.shields.io/npm/dm/open-codebase-index.svg)](https://www.npmjs.com/package/open-codebase-index)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/Helweg/opencode-codebase-index/ci.yml?branch=main)](https://github.com/Helweg/opencode-codebase-index/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/Helweg/open-codebase-index/ci.yml?branch=main)](https://github.com/Helweg/open-codebase-index/actions)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
 
 > Search a codebase by meaning, then follow the result into definitions, callers, and dependency paths.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ If you discover a security vulnerability, please report it responsibly:
 
 1. **Do not** open a public issue
 2. Use GitHub's private vulnerability reporting for this repository:
-   - https://github.com/Helweg/opencode-codebase-index/security/advisories/new
+   - https://github.com/Helweg/open-codebase-index/security/advisories/new
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -452,7 +452,7 @@ If none of these solutions work:
 
 1. **Check logs:** Look for error messages in the OpenCode output
 2. **Verbose indexing:** Run with verbose mode to see detailed progress
-3. **GitHub Issues:** [Open an issue](https://github.com/Helweg/opencode-codebase-index/issues) with:
+3. **GitHub Issues:** [Open an issue](https://github.com/Helweg/open-codebase-index/issues) with:
    - Error message
    - OS and Node.js version
    - Provider being used

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,7 +92,7 @@ The package provides native tools and the `codebase-search` skill. Pi uses `.cod
 Add the marketplace and install the plugin:
 
 ```text
-codex plugin marketplace add Helweg/opencode-codebase-index
+codex plugin marketplace add Helweg/open-codebase-index
 codex plugin add codebase-index@helweg-plugins
 ```
 
@@ -112,7 +112,7 @@ Codex uses `.codebase-index/` project storage.
 From Claude Code, add the marketplace and install the plugin:
 
 ```text
-/plugin marketplace add Helweg/opencode-codebase-index
+/plugin marketplace add Helweg/open-codebase-index
 /plugin install codebase-index@helweg-plugins
 ```
 

--- a/docs/rename-to-open-codebase-index.md
+++ b/docs/rename-to-open-codebase-index.md
@@ -1,8 +1,8 @@
 # Migration plan: `open-codebase-index`
 
-This document describes how to evolve the project from `opencode-codebase-index` to the host-neutral name `open-codebase-index` without breaking existing installations or losing indexes.
+This document describes the compatibility plan used to evolve the project from `opencode-codebase-index` to the host-neutral name `open-codebase-index` without breaking existing installations or losing indexes.
 
-It is a plan, not an active rename. Repository renames, npm publication, tags, releases, storage migrations, and removal of compatibility aliases require separate approval.
+The GitHub repository and preferred npm package now use `open-codebase-index`. Legacy package, binary, configuration, storage, and tool contracts remain supported as documented below.
 
 ## Why the rename is now feasible
 
@@ -39,7 +39,7 @@ The rename touches several independently versioned identities. Treat each as a s
 
 | Surface | Current identity | Proposed identity | Initial compatibility action |
 |---|---|---|---|
-| GitHub repository | `Helweg/opencode-codebase-index` | `Helweg/open-codebase-index` | Rename only after docs and automation accept both URLs; rely on GitHub redirect temporarily |
+| GitHub repository | `Helweg/opencode-codebase-index` | `Helweg/open-codebase-index` | Renamed; GitHub redirects the legacy URL |
 | npm package | `opencode-codebase-index` | `open-codebase-index` | Publish a new package; keep the old package as a compatibility wrapper or deprecation bridge |
 | MCP binary | `opencode-codebase-index-mcp` | `open-codebase-index-mcp` | Ship both bin names from the new package during the transition |
 | MCP server name | `opencode-codebase-index` | `open-codebase-index` | Change only after client snapshots and integration tests accept the new display identity |
@@ -97,19 +97,18 @@ The old package can initially remain a synchronized publication of the same code
   - explicit override updates package, Claude, and Codex staged metadata.
 - [x] Ensure invalid or unknown repository URLs fail fast with clear errors.
 - [x] Keep checked-in links on the live repository until the rename is approved. The release workflow is already rename-safe because it derives staged metadata from `GITHUB_REPOSITORY`.
-- [ ] Rename the GitHub repository only after explicit maintainer approval.
-- [ ] Immediately after the rename, update checked-in public links and verify redirects, provenance, and marketplace installation.
+- [x] Rename the GitHub repository only after explicit maintainer approval.
+- [x] Immediately after the rename, update checked-in public links and verify redirects, provenance, and marketplace installation.
 
-Intentional pre-rename references to `Helweg/opencode-codebase-index` are classified as follows:
+Legacy references to `Helweg/opencode-codebase-index` are now limited to migration history and compatibility documentation:
 
 | Location | Why it remains | When to update |
 |---|---|---|
-| `package.json`, `src/identity-catalog.json` current identity, and checked-in host manifests | Describe the currently live repository and legacy compatibility identity | Immediately after the GitHub rename; retain the catalog's current identity as the documented compatibility value |
-| `README.md`, `SECURITY.md`, `TROUBLESHOOTING.md`, and `docs/installation.md` | Must resolve before the new repository URL exists | In the rename commit or immediately after the rename |
-| Historical `CHANGELOG.md` comparison links | Release history currently resolves through the live repository | After the rename, relying on GitHub redirects for old external links |
-| This migration document | Explicitly documents both old and future identities | Keep both identities for historical and operational context |
+| Checked-in package and host metadata | Uses the canonical `Helweg/open-codebase-index` repository | Complete |
+| Public documentation and changelog comparison links | Uses the canonical repository directly | Complete |
+| This migration document | Explicitly records the old identity and redirect contract | Retain for historical and operational context |
 
-Phase 2 rename changes require explicit maintainer approval and are not to be executed during this repository-rename preparation pass.
+Phase 2 was completed after explicit maintainer approval. Storage locations, native artifacts, legacy package and binary names, and public tool contracts were intentionally unchanged.
 
 **Exit criteria:** fresh clones, pull requests, release automation, package provenance, source links, and documentation links resolve through the new repository identity.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Kenneth",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Helweg/opencode-codebase-index"
+    "url": "https://github.com/Helweg/open-codebase-index"
   },
   "keywords": [
     "semantic-search",

--- a/src/identity-catalog.json
+++ b/src/identity-catalog.json
@@ -3,7 +3,7 @@
     "current": {
       "productName": "opencode-codebase-index",
       "packageName": "opencode-codebase-index",
-      "repository": "https://github.com/Helweg/opencode-codebase-index",
+      "repository": "https://github.com/Helweg/open-codebase-index",
       "mcpBinary": "opencode-codebase-index-mcp",
       "mcpServerName": "opencode-codebase-index"
     },

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -68,6 +68,34 @@ function prepareMetadata(packageName: string, outputDir: string, repositoryUrl?:
 }
 
 describe("Phase 1 product identity compatibility", () => {
+  it("uses the canonical repository in public metadata while retaining migration history", () => {
+    const canonicalRepository = IDENTITY_CATALOG.product.future.repository;
+    const legacyRepository = "https://github.com/Helweg/opencode-codebase-index";
+    const publicUrlFiles = [
+      "package.json",
+      "README.md",
+      "SECURITY.md",
+      "TROUBLESHOOTING.md",
+      "CHANGELOG.md",
+      ".claude-plugin/plugin.json",
+      ".claude-plugin/marketplace.json",
+      ".codex-plugin/plugin.json",
+    ];
+
+    expect(IDENTITY_CATALOG.product.current.repository).toBe(canonicalRepository);
+    for (const filePath of publicUrlFiles) {
+      const contents = readText(filePath);
+      expect(contents, filePath).toContain(canonicalRepository);
+      expect(contents, filePath).not.toContain(legacyRepository);
+    }
+
+    const installation = readText("docs/installation.md");
+    expect(installation).toContain("Helweg/open-codebase-index");
+    expect(installation).not.toContain("Helweg/opencode-codebase-index");
+
+    expect(readText("docs/rename-to-open-codebase-index.md")).toContain("Helweg/opencode-codebase-index");
+  });
+
   it("keeps the checked-in legacy package and host manifests unchanged", () => {
     const current = IDENTITY_CATALOG.product.current;
     const packageJson = readJson<PackageMetadata>("package.json");


### PR DESCRIPTION
## Summary
- switch checked-in package, host, documentation, badge, security, and changelog links to `Helweg/open-codebase-index`
- preserve legacy package, binary, storage, native artifact, and tool contracts
- mark the approved repository rename complete and add stale-identity coverage

## Validation
- identity tests: 8 passed
- build, typecheck, and lint passed
- legacy GitHub URL redirects to the canonical repository
- watcher suites pass independently; two full-suite local runs encountered unrelated watcher timing flakes under load, which CI will verify