### PR TITLE
chore: prepare v0.22.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.22.1"
+      "version": "0.22.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {
@@ -22,7 +22,14 @@
   "mcpServers": {
     "codebase-index": {
       "command": "npx",
-      "args": ["-y", "--package", "opencode-codebase-index", "opencode-codebase-index-mcp", "--host", "claude"]
+      "args": [
+        "-y",
+        "--package",
+        "opencode-codebase-index",
+        "opencode-codebase-index-mcp",
+        "--host",
+        "claude"
+      ]
     }
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-08-02
+
 ### Changed
 
 - **Repository rename preparation**: Added validated repository URL overrides for staged package and host metadata, including package, Claude, and Codex repository fields, and made release metadata follow `GITHUB_REPOSITORY` before and after the planned GitHub rename.
@@ -592,7 +594,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/open-codebase-index/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/Helweg/open-codebase-index/compare/v0.22.2...HEAD
+[0.22.2]: https://github.com/Helweg/open-codebase-index/compare/v0.22.1...v0.22.2
+[0.22.1]: https://github.com/Helweg/open-codebase-index/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Helweg/open-codebase-index/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/Helweg/open-codebase-index/compare/v0.20.1...v0.21.0
 [0.20.1]: https://github.com/Helweg/open-codebase-index/compare/v0.20.0...v0.20.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.22.1",
+      "version": "0.22.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- release repository rename preparation and canonical identity updates as v0.22.2
- synchronize package lock and Claude/Codex manifest versions
- finalize changelog entries and comparison links

## Validation
- identity and host manifest tests: 17 passed
- typecheck and lint passed
- post-rename PR CI passed the full repository gate