### PR TITLE
docs: complete canonical identity cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# AGENTS.md - AI Agent Guidelines for opencode-codebase-index
+# AGENTS.md - AI Agent Guidelines for open-codebase-index
 
-**Updated:** 2026-07-30 | **Commit:** 022af30 | **Branch:** main | **Version:** 0.21.0
+**Updated:** 2026-08-02 | **Commit:** c33c88b | **Branch:** main | **Version:** 0.22.2
 
 Semantic codebase indexing for OpenCode, MCP hosts, Pi, Claude, Codex, and Jcode. repo uses hybrid TypeScript/Rust architecture:
 
@@ -173,7 +173,7 @@ Prefer existing batch database methods for bulk indexing. Do not replace them w/
 
 ## Package Identity and Compatibility
 
- checked-in package remains `opencode-codebase-index@0.22.0`while release workflow publishes both:
+ checked-in package remains `opencode-codebase-index@0.22.2`while release workflow publishes both:
 
 - `open-codebase-index`preferred host-neutral package; exports `open-codebase-index-mcp` and legacy binary alias
 - `opencode-codebase-index`synchronized compatibility package

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-This document explains the architecture of opencode-codebase-index, including data flow, component interactions, and key design decisions.
+This document explains the architecture of open-codebase-index, including data flow, component interactions, and key design decisions.
 
 ## Table of Contents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CI timing reliability**: Added explicit Git watcher readiness, replaced watcher startup sleeps with readiness synchronization, stopped forcing polling in config-refresh integration tests, retried file writes only when an event was not observed, and changed the 10k-node community performance gate to enforce a sub-second warm median plus a two-second cold/outlier ceiling.
+- **Canonical identity cleanup**: Standardized remaining user-facing defaults and development example copy to prefer `open-codebase-index` in docs and build artifacts (including architecture/contributing/troubleshooting guidance, native crate description, benchmark defaults, and bundle banners) while preserving all legacy compatibility surfaces and keeping checked-in manifests unchanged. Added identity regressions that assert these canonical defaults and banner text so they cannot silently regress.
 
 ## [0.22.2] - 2026-08-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to opencode-codebase-index
+# Contributing to open-codebase-index
 
 Thank you for your interest in contributing! This document provides guidelines and information for contributors.
 
@@ -26,8 +26,8 @@ Use this when you just want the shortest path to a good PR:
 1. **Fork the repository** on GitHub
 2. **Clone your fork** locally:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/opencode-codebase-index.git
-   cd opencode-codebase-index
+   git clone https://github.com/YOUR_USERNAME/open-codebase-index.git
+   cd open-codebase-index
    ```
 3. **Install dependencies**:
    ```bash

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide
 
-Common issues and solutions for opencode-codebase-index.
+Common issues and solutions for open-codebase-index.
 
 ## 🚑 Quick Triage (fastest path)
 

--- a/benchmarks/run.ts
+++ b/benchmarks/run.ts
@@ -1,5 +1,5 @@
 /**
- * Synthetic benchmark for opencode-codebase-index
+ * Synthetic benchmark for open-codebase-index
  * 
  * Measures performance of:
  * - File parsing (tree-sitter)

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -3,7 +3,7 @@ name = "codebase-index-native"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-description = "Native Rust core for opencode-codebase-index: tree-sitter parsing and vector search"
+description = "Native Rust core for open-codebase-index: tree-sitter parsing and vector search"
 
 [features]
 default = []

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Token Usage Benchmark Script for opencode-codebase-index
+# Token Usage Benchmark Script for open-codebase-index
 # Compares token usage with and without the plugin across different codebase sizes
 
 set -e
@@ -43,7 +43,8 @@ run_test() {
     
     # Configure opencode.json based on with_plugin flag
     if [ "$with_plugin" = "true" ]; then
-        echo '{"plugin": ["opencode-codebase-index"]}' > "$repo_path/opencode.json"
+        # Use canonical package name; opencode-codebase-index remains a legacy alias.
+        echo '{"plugin": ["open-codebase-index"]}' > "$repo_path/opencode.json"
         
         # First, index the codebase if not already indexed
         echo "  Indexing codebase..."

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -96,6 +96,46 @@ describe("Phase 1 product identity compatibility", () => {
     expect(readText("docs/rename-to-open-codebase-index.md")).toContain("Helweg/opencode-codebase-index");
   });
 
+  it("uses canonical user-facing defaults for docs, tool banners, and benchmark scaffolding", () => {
+    const docsAndArtifacts = {
+      agentGuidance: readText("AGENTS.md"),
+      architecture: readText("ARCHITECTURE.md"),
+      contributing: readText("CONTRIBUTING.md"),
+      troubleshooting: readText("TROUBLESHOOTING.md"),
+      benchmarkRun: readText("benchmarks/run.ts"),
+      benchmarkShell: readText("scripts/benchmark.sh"),
+      nativeManifest: readText("native/Cargo.toml"),
+      tsupConfig: readText("tsup.config.ts"),
+    };
+
+    expect(docsAndArtifacts.agentGuidance).toContain("AI Agent Guidelines for open-codebase-index");
+    expect(docsAndArtifacts.agentGuidance).toContain("opencode-codebase-index@0.22.2");
+    expect(docsAndArtifacts.agentGuidance).not.toContain("AI Agent Guidelines for opencode-codebase-index");
+
+    expect(docsAndArtifacts.architecture).toContain("open-codebase-index");
+    expect(docsAndArtifacts.architecture).not.toContain("opencode-codebase-index");
+
+    expect(docsAndArtifacts.contributing).toContain("Contributing to open-codebase-index");
+    expect(docsAndArtifacts.contributing).not.toContain("Contributing to opencode-codebase-index");
+    expect(docsAndArtifacts.contributing).toContain("github.com/YOUR_USERNAME/open-codebase-index.git");
+
+    expect(docsAndArtifacts.troubleshooting).toContain("open-codebase-index");
+    expect(docsAndArtifacts.troubleshooting).not.toContain("opencode-codebase-index");
+
+    expect(docsAndArtifacts.benchmarkRun).toContain("Synthetic benchmark for open-codebase-index");
+    expect(docsAndArtifacts.benchmarkRun).not.toContain("Synthetic benchmark for opencode-codebase-index");
+
+    expect(docsAndArtifacts.benchmarkShell).toContain("Token Usage Benchmark Script for open-codebase-index");
+    expect(docsAndArtifacts.benchmarkShell).toContain('"plugin": ["open-codebase-index"]');
+    expect(docsAndArtifacts.benchmarkShell).toContain("opencode-codebase-index remains a legacy alias");
+
+    expect(docsAndArtifacts.nativeManifest).toContain("Native Rust core for open-codebase-index");
+    expect(docsAndArtifacts.nativeManifest).not.toContain("Native Rust core for opencode-codebase-index");
+
+    expect(docsAndArtifacts.tsupConfig).toContain("// open-codebase-index - Semantic codebase indexing and search");
+    expect(docsAndArtifacts.tsupConfig).not.toContain("// opencode-codebase-index - Semantic codebase search for OpenCode");
+  });
+
   it("keeps the checked-in legacy package and host manifests unchanged", () => {
     const current = IDENTITY_CATALOG.product.current;
     const packageJson = readJson<PackageMetadata>("package.json");

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -44,13 +44,13 @@ export default defineConfig({
     if (context.format === "esm") {
       options.banner = {
         js: [
-          "// opencode-codebase-index - Semantic codebase search for OpenCode",
+          "// open-codebase-index - Semantic codebase indexing and search",
           "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
         ].join("\n"),
       };
     } else {
       options.banner = {
-        js: "// opencode-codebase-index - Semantic codebase search for OpenCode",
+        js: "// open-codebase-index - Semantic codebase indexing and search",
       };
     }
     if (context.format === "cjs") {


### PR DESCRIPTION
## Summary
- update remaining stale repository, contributor, troubleshooting, benchmark, native metadata, and bundle banner copy to the canonical host-neutral identity
- preserve checked-in legacy package/manifests, binary aliases, release dual-publishing, storage paths, and historical migration references
- add regression coverage for canonical user-facing defaults

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (78 files, 1331 tests)