### PR TITLE
chore: prepare v0.22.3 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.22.2"
+      "version": "0.22.3"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - AI Agent Guidelines for open-codebase-index
 
-**Updated:** 2026-08-02 | **Commit:** c33c88b | **Branch:** main | **Version:** 0.22.2
+**Updated:** 2026-08-02 | **Commit:** 32160f8 | **Branch:** main | **Version:** 0.22.3
 
 Semantic codebase indexing for OpenCode, MCP hosts, Pi, Claude, Codex, and Jcode. repo uses hybrid TypeScript/Rust architecture:
 
@@ -173,7 +173,7 @@ Prefer existing batch database methods for bulk indexing. Do not replace them w/
 
 ## Package Identity and Compatibility
 
- checked-in package remains `opencode-codebase-index@0.22.2`while release workflow publishes both:
+ checked-in package remains `opencode-codebase-index@0.22.3`while release workflow publishes both:
 
 - `open-codebase-index`preferred host-neutral package; exports `open-codebase-index-mcp` and legacy binary alias
 - `opencode-codebase-index`synchronized compatibility package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3] - 2026-08-02
+
+### Changed
+
+- **Canonical identity cleanup**: Standardized remaining user-facing defaults and development example copy to prefer `open-codebase-index` in docs and build artifacts, including architecture, contributor and troubleshooting guidance, native crate description, benchmark defaults, and host-neutral bundle banners. Legacy package, binary, manifest, storage, and dual-publication compatibility remains unchanged.
+
 ### Fixed
 
 - **CI timing reliability**: Added explicit Git watcher readiness, replaced watcher startup sleeps with readiness synchronization, stopped forcing polling in config-refresh integration tests, retried file writes only when an event was not observed, and changed the 10k-node community performance gate to enforce a sub-second warm median plus a two-second cold/outlier ceiling.
-- **Canonical identity cleanup**: Standardized remaining user-facing defaults and development example copy to prefer `open-codebase-index` in docs and build artifacts (including architecture/contributing/troubleshooting guidance, native crate description, benchmark defaults, and bundle banners) while preserving all legacy compatibility surfaces and keeping checked-in manifests unchanged. Added identity regressions that assert these canonical defaults and banner text so they cannot silently regress.
 
 ## [0.22.2] - 2026-08-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.22.2",
+      "version": "0.22.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -109,7 +109,7 @@ describe("Phase 1 product identity compatibility", () => {
     };
 
     expect(docsAndArtifacts.agentGuidance).toContain("AI Agent Guidelines for open-codebase-index");
-    expect(docsAndArtifacts.agentGuidance).toContain("opencode-codebase-index@0.22.2");
+    expect(docsAndArtifacts.agentGuidance).toContain("opencode-codebase-index@0.22.3");
     expect(docsAndArtifacts.agentGuidance).not.toContain("AI Agent Guidelines for opencode-codebase-index");
 
     expect(docsAndArtifacts.architecture).toContain("open-codebase-index");


### PR DESCRIPTION
## Release v0.22.3

### Changed
- complete canonical host-neutral identity cleanup across user-facing defaults and build artifacts while preserving legacy compatibility

### Fixed
- harden watcher readiness and filesystem integration tests against CI timing variance
- stabilize the 10k-node community performance budget with warm median and bounded outlier checks

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (78 files, 1331 tests)