### PR TITLE
fix: prevent invalid CodeGraph definition comparisons

### DIFF
--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -97,7 +97,7 @@ npx tsx scripts/cross-repo-benchmark.ts \
   --reindex --repeats 3 --codegraph
 ```
 
-The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for every repeat. It excludes existing `.codegraph`, `.codebase-index`, build outputs, dependencies, and benchmark results. It initializes CodeGraph in that copy, then runs only generated queries that include `expected.symbol`.
+The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for every repeat. It excludes existing `.codegraph`, `.codebase-index`, build outputs, dependencies, and benchmark results. It initializes CodeGraph in that copy, then runs only generated queries that include `expected.symbol`. Exact-definition candidates from known unsupported paths, currently `.github/workflows/`, are excluded. If no supported definition candidates remain, the runner fails instead of publishing an invalid comparison.
 
 The report places this result in a standalone **Fair CodeGraph Comparator** section. Plugin metrics are recomputed from exactly the same query IDs. A failed CodeGraph initialization, query, or strict-output parse disqualifies that repeat and prevents it from being presented as a comparable result. Raw commands, per-query results, scope IDs, and errors are written under `<run>/codegraph/<repo>/repeat-*.json`.
 

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -63,6 +63,8 @@ const EXCLUDED_DIRS = new Set([
   "temp",
 ]);
 
+const CODEGRAPH_UNSUPPORTED_DEFINITION_PATHS = [".github/workflows/"];
+
 export const MAX_FILE_SIZE_BYTES = 1_000_000;
 const MAX_PARSE_FILES = 2500;
 const CODEGRAPH_PACKAGE = "@colbymchenry/codegraph@1.5.0";
@@ -573,6 +575,14 @@ function getCanonicalChunkType(chunkType: string): CanonicalChunkType {
   return undefined;
 }
 
+function isCodeGraphUnsupportedDefinitionPath(filePath: string): boolean {
+  const normalizedPath = normalizePathForMatch(filePath).toLowerCase();
+  return CODEGRAPH_UNSUPPORTED_DEFINITION_PATHS.some((unsupportedPrefix) =>
+    normalizedPath === unsupportedPrefix.slice(0, -1)
+    || normalizedPath.startsWith(unsupportedPrefix)
+  );
+}
+
 function isFunctionOrClass(chunk: CodeChunk): chunk is CodeChunk & { name: string } {
   if (!chunk.name) return false;
   return getCanonicalChunkType(chunk.chunkType) !== undefined;
@@ -730,10 +740,15 @@ export function buildGoldenDataset(repoName: string, repoPath: string, parsedFil
     throw new Error(`No function/class candidates discovered in ${repoName}`);
   }
 
-  const definitions = pickDistinctFiles(candidates, 3);
+  const definitionCandidates = candidates.filter((candidate) => !isCodeGraphUnsupportedDefinitionPath(candidate.filePath));
+  if (definitionCandidates.length === 0) {
+    throw new Error(`No definition candidates outside unsupported CodeGraph source paths in ${repoName}`);
+  }
+
   const implementation = pickDistinctFiles(candidates.slice(3).length > 0 ? candidates.slice(3) : candidates, 3);
   const similarities = pickDistinctFiles(candidates.slice(6).length > 0 ? candidates.slice(6) : candidates, 2);
   const keywordHeavy = pickDistinctFiles(candidates.slice(8).length > 0 ? candidates.slice(8) : candidates, 2);
+  const definitions = pickDistinctFiles(definitionCandidates, 3);
 
   const queries: GoldenQuery[] = [];
   let counter = 1;

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -122,6 +122,81 @@ describe("cross-repo CodeGraph comparator", () => {
     }
   });
 
+  it("prefers definition candidates from non-workflow paths", () => {
+    const repoPath = "/repo";
+    const sourceFile = (name: string): ParsedFile => {
+      const symbol = path.basename(name).replace(/\.[^.]+$/, "").replace(/[^a-z]/gi, "");
+      return {
+        path: path.join(repoPath, name),
+        hash: name,
+        symbols: [],
+        chunks: [{
+          content: `export function ${symbol}() { return 1; }`,
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: symbol,
+          language: "typescript",
+        }],
+      };
+    };
+
+    const parsedFiles = [
+      sourceFile(".github/workflows/release.sh"),
+      sourceFile("src/alpha.ts"),
+      sourceFile("src/beta.ts"),
+      sourceFile("src/gamma.ts"),
+      sourceFile("src/delta.ts"),
+      sourceFile("src/epsilon.ts"),
+      sourceFile("src/zeta.ts"),
+      sourceFile("src/eta.ts"),
+      sourceFile("src/theta.ts"),
+      sourceFile("src/iota.ts"),
+    ];
+
+    const dataset = buildGoldenDataset("fixture", repoPath, parsedFiles);
+    const definitionQueries = dataset.queries.filter((query) => query.queryType === "definition");
+
+    expect(definitionQueries).toHaveLength(3);
+    expect(definitionQueries.every((query) => !query.expected.filePath.startsWith(".github/workflows/"))).toBe(true);
+  });
+
+  it("fails when all definition candidates are in unsupported workflow paths", () => {
+    const repoPath = "/repo";
+    const parsedFiles = [
+      {
+        path: path.join(repoPath, ".github/workflows/release.sh"),
+        hash: "release.sh",
+        symbols: [],
+        chunks: [{
+          content: "export function workflowonly() { return 1; }",
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: "workflowonly",
+          language: "typescript",
+        }],
+      },
+      {
+        path: path.join(repoPath, ".github/workflows/check.sh"),
+        hash: "check.sh",
+        symbols: [],
+        chunks: [{
+          content: "export function workflowsubonly() { return 1; }",
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: "workflowsubonly",
+          language: "typescript",
+        }],
+      },
+    ];
+
+    expect(() => buildGoldenDataset("fixture", repoPath, parsedFiles)).toThrow(
+      "No definition candidates outside unsupported CodeGraph source paths in fixture"
+    );
+  });
+
   it("uses a fresh isolated repo per repeat, exact pinned commands, strict scoped metrics, and raw artifacts", async () => {
     const repoPath = tempDir("cross-repo-cg-source-");
     const artifactRoot = tempDir("cross-repo-cg-artifacts-");


### PR DESCRIPTION
## Summary
- exclude known CodeGraph-unsupported workflow paths from generated exact-definition candidates
- fail closed when no supported definition candidates remain
- document the supported-source constraint and add regression coverage

## Validation
- 
> opencode-codebase-index@0.22.3 build
> npm run build:ts && npm run build:native


> opencode-codebase-index@0.22.3 build:ts
> tsup && node scripts/smoke-test-built-cli.mjs

CLI Building entry: src/cli.ts, src/index.ts, src/pi-extension.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/kenneth/dev/git/opencode-codebase-index/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
ESM dist/pi-extension.js     614.08 KB
ESM dist/index.js            745.63 KB
ESM dist/cli.js              823.05 KB
ESM dist/pi-extension.js.map 1.16 MB
ESM dist/index.js.map        1.38 MB
ESM dist/cli.js.map          1.52 MB
ESM ⚡️ Build success in 155ms
CJS dist/pi-extension.cjs     619.73 KB
CJS dist/cli.cjs              827.09 KB
CJS dist/index.cjs            748.62 KB
CJS dist/pi-extension.cjs.map 1.16 MB
CJS dist/cli.cjs.map          1.52 MB
CJS dist/index.cjs.map        1.38 MB
CJS ⚡️ Build success in 156ms

> opencode-codebase-index@0.22.3 build:native
> cd native && cargo build --release && napi build --release --platform


> opencode-codebase-index@0.22.3 typecheck
> tsc --noEmit


> opencode-codebase-index@0.22.3 lint
> eslint src/


> opencode-codebase-index@0.22.3 pretest:run
> node scripts/run-build-native-with-rustflags.mjs && npm run build:ts


> opencode-codebase-index@0.22.3 build:native
> cd native && cargo build --release && napi build --release --platform


> opencode-codebase-index@0.22.3 build:ts
> tsup && node scripts/smoke-test-built-cli.mjs

CLI Building entry: src/cli.ts, src/index.ts, src/pi-extension.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/kenneth/dev/git/opencode-codebase-index/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
CJS dist/cli.cjs              827.09 KB
CJS dist/pi-extension.cjs     619.73 KB
CJS dist/index.cjs            748.62 KB
CJS dist/index.cjs.map        1.38 MB
CJS dist/cli.cjs.map          1.52 MB
CJS dist/pi-extension.cjs.map 1.16 MB
CJS ⚡️ Build success in 176ms
ESM dist/index.js            745.63 KB
ESM dist/pi-extension.js     614.08 KB
ESM dist/cli.js              823.05 KB
ESM dist/pi-extension.js.map 1.16 MB
ESM dist/index.js.map        1.38 MB
ESM dist/cli.js.map          1.52 MB
ESM ⚡️ Build success in 176ms

> opencode-codebase-index@0.22.3 test:run
> vitest run


[1m[46m RUN [49m[22m [36mv4.1.2 [39m[90m/Users/kenneth/dev/git/opencode-codebase-index[39m

 [32m✓[39m tests/search-integration.test.ts [2m([22m[2m18 tests[22m[2m)[22m[33m 2743[2mms[22m[39m
     [33m[2m✓[22m[39m annotates indexed chunks with git blame and filters by blame author [33m 325[2mms[22m[39m
     [33m[2m✓[22m[39m applies directory, file type, and blame scopes before sending candidates to an external reranker [33m 482[2mms[22m[39m
 [32m✓[39m tests/eval-runner.test.ts [2m([22m[2m23 tests[22m[2m)[22m[33m 3075[2mms[22m[39m
     [33m[2m✓[22m[39m fails fast in sweep mode when reindexing produces no searchable vectors [33m 1080[2mms[22m[39m
 [32m✓[39m tests/indexer-file-batching.test.ts [2m([22m[2m2 tests[22m[2m)[22m[33m 3517[2mms[22m[39m
     [33m[2m✓[22m[39m keeps progress cumulative and reuses duplicate embeddings across file batches [33m 1832[2mms[22m[39m
     [33m[2m✓[22m[39m flushes outage failures before the next file batch and streams them through retry [33m 1681[2mms[22m[39m
 [32m✓[39m tests/call-graph.test.ts [2m([22m[2m97 tests[22m[2m)[22m[33m 4204[2mms[22m[39m
       [33m[2m✓[22m[39m should resolve Swift calls, preserve overloads and reparse cached files after upgrade [33m 684[2mms[22m[39m
 [32m✓[39m tests/indexer-clear-index.test.ts [2m([22m[2m43 tests[22m[2m)[22m[33m 4324[2mms[22m[39m
 [32m✓[39m tests/indexing-transaction.test.ts [2m([22m[2m2 tests[22m[2m)[22m[33m 1920[2mms[22m[39m
     [33m[2m✓[22m[39m keeps the previous SQLite and branch catalog generation after a late file-batch interruption [33m 1803[2mms[22m[39m
 [32m✓[39m tests/branch-materialization-multiprocess.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 1519[2mms[22m[39m
     [33m[2m✓[22m[39m returns each invocation-local OID during real overlapping fetches and cleans temporary refs [33m 1518[2mms[22m[39m
 [32m✓[39m tests/indexer-failed-batches.test.ts [2m([22m[2m27 tests[22m[2m)[22m[33m 1676[2mms[22m[39m
 [32m✓[39m tests/pr-impact.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 594[2mms[22m[39m
 [32m✓[39m tests/startup-regression.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 805[2mms[22m[39m
 [32m✓[39m tests/effectiveness-watcher-lifetime.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 1560[2mms[22m[39m
     [33m[2m✓[22m[39m preserves the process collector when a config change replaces the cached Indexer [33m 1559[2mms[22m[39m
 [32m✓[39m tests/database.test.ts [2m([22m[2m48 tests[22m[2m)[22m[33m 471[2mms[22m[39m
 [32m✓[39m tests/worktree-fallback.test.ts [2m([22m[2m14 tests[22m[2m)[22m[33m 858[2mms[22m[39m
     [33m[2m✓[22m[39m keeps shared project search results strictly scoped to the active branch [33m 359[2mms[22m[39m
 [32m✓[39m tests/branch-materialization.test.ts [2m([22m[2m14 tests[22m[2m)[22m[33m 6721[2mms[22m[39m
     [33m[2m✓[22m[39m materializes a local branch without mutating the caller worktree and cleans up [33m 495[2mms[22m[39m
     [33m[2m✓[22m[39m supports detached commit refs [33m 423[2mms[22m[39m
     [33m[2m✓[22m[39m uses an existing local PR head only when it matches the authoritative OID [33m 374[2mms[22m[39m
     [33m[2m✓[22m[39m fetches a missing remote-qualified branch without reading or overwriting FETCH_HEAD [33m 781[2mms[22m[39m
     [33m[2m✓[22m[39m prefers an independently configured remote over a shadowing local branch name [33m 827[2mms[22m[39m
     [33m[2m✓[22m[39m fetches an exact missing PR OID without gh checkout and removes the temporary ref [33m 925[2mms[22m[39m
     [33m[2m✓[22m[39m rejects a dangerous remote name before Git can interpret it as an option [33m 394[2mms[22m[39m
     [33m[2m✓[22m[39m suppresses configured repository post-checkout hooks while adding the worktree [33m 357[2mms[22m[39m
     [33m[2m✓[22m[39m cleans up the temporary worktree when indexing fails [33m 365[2mms[22m[39m
     [33m[2m✓[22m[39m removes only the exact stale registration when the materialized directory disappears [33m 346[2mms[22m[39m
     [33m[2m✓[22m[39m removes a missing temporary worktree registered through a symlinked temp path [33m 390[2mms[22m[39m
     [33m[2m✓[22m[39m preserves the temporary path and primary error when deregistration cannot be verified [33m 423[2mms[22m[39m
     [33m[2m✓[22m[39m rejects invalid refs before creating a worktree [33m 326[2mms[22m[39m
 [32m✓[39m tests/mcp-server.test.ts [2m([22m[2m53 tests[22m[2m)[22m[33m 626[2mms[22m[39m
 [32m✓[39m tests/index-lock.test.ts [2m([22m[2m18 tests[22m[2m)[22m[33m 597[2mms[22m[39m
 [32m✓[39m tests/pi-communities.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 424[2mms[22m[39m
     [33m[2m✓[22m[39m executes through the shared community operation and returns structured details [33m 423[2mms[22m[39m
 [32m✓[39m tests/communities.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 602[2mms[22m[39m
 [32m✓[39m tests/auto-index.test.ts [2m([22m[2m23 tests[22m[2m)[22m[33m 591[2mms[22m[39m
 [32m✓[39m tests/retrieval-benchmark.test.ts [2m([22m[2m2 tests[22m[2m)[22m[33m 490[2mms[22m[39m
     [33m[2m✓[22m[39m meets Hit@5 and latency budgets and emits candidate artifact [33m 340[2mms[22m[39m
 [32m✓[39m tests/host-mode-paths.test.ts [2m([22m[2m39 tests[22m[2m)[22m[32m 254[2mms[22m[39m
 [32m✓[39m tests/git.test.ts [2m([22m[2m36 tests[22m[2m)[22m[32m 60[2mms[22m[39m
 [32m✓[39m tests/effectiveness-ci.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 137[2mms[22m[39m
 [32m✓[39m tests/community-ranking-integration.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 143[2mms[22m[39m
 [32m✓[39m tests/pi-conformance.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 297[2mms[22m[39m
 [32m✓[39m tests/tools-utils.test.ts [2m([22m[2m76 tests[22m[2m)[22m[32m 126[2mms[22m[39m
 [32m✓[39m tests/effectiveness-metrics.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 206[2mms[22m[39m
 [32m✓[39m tests/native.test.ts [2m([22m[2m71 tests[22m[2m)[22m[32m 91[2mms[22m[39m
 [32m✓[39m tests/effectiveness-report.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 90[2mms[22m[39m
 [32m✓[39m tests/retrieval-ranking.test.ts [2m([22m[2m37 tests[22m[2m)[22m[32m 73[2mms[22m[39m
 [32m✓[39m tests/files.test.ts [2m([22m[2m26 tests[22m[2m)[22m[32m 47[2mms[22m[39m
 [32m✓[39m tests/custom-provider.test.ts [2m([22m[2m36 tests[22m[2m)[22m[32m 98[2mms[22m[39m
 [32m✓[39m tests/tools-knowledge-bases.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 91[2mms[22m[39m
 [32m✓[39m tests/cross-repo-codegraph.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m tests/auto-gc.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 42[2mms[22m[39m
 [32m✓[39m tests/visualize.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 35[2mms[22m[39m
 [32m✓[39m tests/plugin-hooks.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 69[2mms[22m[39m
 [32m✓[39m tests/claude-plugin.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m tests/watcher-emfile.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m tests/indexer-failed-state-persistence.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 25[2mms[22m[39m
 [32m✓[39m tests/embeddings.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m tests/tools-context.test.ts [2m([22m[2m21 tests[22m[2m)[22m[32m 54[2mms[22m[39m
 [32m✓[39m tests/mcp-lifecycle.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 74[2mms[22m[39m
 [32m✓[39m tests/logger.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m tests/config.test.ts [2m([22m[2m102 tests[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m tests/canonical-path.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m tests/cost.test.ts [2m([22m[2m32 tests[22m[2m)[22m[32m 24[2mms[22m[39m
 [32m✓[39m tests/automatic-branch-index.test.ts [2m([22m[2m9 tests[22m[2m)[22m[33m 8797[2mms[22m[39m
     [33m[2m✓[22m[39m prepares a missing local branch once, reports progress, and keeps canonical external knowledge bases external [33m 946[2mms[22m[39m
     [33m[2m✓[22m[39m keeps alternate-branch data intact while health check removes stale active-branch data [33m 854[2mms[22m[39m
     [33m[2m✓[22m[39m reparses a cached alternate branch when its symbol extractor metadata is stale [33m 971[2mms[22m[39m
     [33m[2m✓[22m[39m reparses only the cached branch whose parser migration marker is stale [33m 1359[2mms[22m[39m
     [33m[2m✓[22m[39m reindexes a moved branch OID, replaces stale catalog data, and preserves primary data [33m 961[2mms[22m[39m
     [33m[2m✓[22m[39m treats catalogs without commit metadata as legacy-stale and restores metadata [33m 959[2mms[22m[39m
     [33m[2m✓[22m[39m uses an authoritative local PR merge ref and a repository-specific catalog identity [33m 767[2mms[22m[39m
     [33m[2m✓[22m[39m keeps same-number, same-display PRs from different forks in distinct verified catalogs [33m 1407[2mms[22m[39m
     [33m[2m✓[22m[39m honors index lock contention and cleans up the temporary worktree on failure [33m 571[2mms[22m[39m
 [32m✓[39m tests/changed-files.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m tests/codegraph-baseline.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 64[2mms[22m[39m
 [32m✓[39m tests/git-refs.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 59[2mms[22m[39m
 [32m✓[39m tests/crash-recovery.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m tests/eval-schema.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m tests/inverted-index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m tests/edit-context.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m tests/commands.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m tests/routing-hints.test.ts [2m([22m[2m39 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m tests/definition-ranking.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 13[2mms[22m[39m
[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mreturns non-zero for --ci sweep when any run fails gate
[22m[39mEval sweep complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-kTEN77/out
Sweep runs: 2

[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mreturns zero for --ci sweep when all runs pass gate
[22m[39mEval sweep complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-uQcIOJ/out
Sweep runs: 2

[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mruns eval diff with explicit --current summary path
[22m[39mEval diff complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-L4ZRC8/benchmarks/results/2026-08-04T14-12-50-927Z

[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mallows eval diff to read legacy summaries missing diversity metrics
[22m[39mEval diff complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-yGEv0v/benchmarks/results/2026-08-04T14-12-50-931Z

 [32m✓[39m tests/eval-cli.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m tests/intent-aware-ranking-eval.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m tests/host-paths.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/power-source.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/eval-metrics.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m tests/symbol-inference.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m tests/embedding-batches.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 30[2mms[22m[39m
 [32m✓[39m tests/eval-budget.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m tests/eval-reports.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m tests/codex-plugin.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/cli.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/community-ranking.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/eval-compare.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m tests/mcp-cli-index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m tests/paths.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/config-rebase.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/file-batches.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/community-ranking-eval.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/pi-package.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/identity-phase0.test.ts [2m([22m[2m9 tests[22m[2m)[22m[33m 10513[2mms[22m[39m
     [33m[2m✓[22m[39m stages current metadata with only the legacy binary [33m 4071[2mms[22m[39m
     [33m[2m✓[22m[39m stages future metadata with both MCP binary aliases [33m 3232[2mms[22m[39m
     [33m[2m✓[22m[39m stages metadata with an explicit repository override [33m 3040[2mms[22m[39m
 [32m✓[39m tests/multiprocess-indexing.test.ts [2m([22m[2m34 tests[22m[2m)[22m[33m 21036[2mms[22m[39m
     [33m[2m✓[22m[39m allows only one normal indexer to embed [33m 801[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the same cold reader after the first writer publishes the index [33m 408[2mms[22m[39m
     [33m[2m✓[22m[39m keeps an unreadable BM25 artifact untouched under a live writer lease [33m 447[2mms[22m[39m
     [33m[2m✓[22m[39m falls back to semantic-only ranking when weighted BM25 is unavailable [33m 472[2mms[22m[39m
     [33m[2m✓[22m[39m reports an unreadable vector store without replacing it [33m 434[2mms[22m[39m
     [33m[2m✓[22m[39m rejects a valid vector metadata file from a different publication [33m 363[2mms[22m[39m
     [33m[2m✓[22m[39m requires a writer to fingerprint a structurally valid legacy vector pair [33m 803[2mms[22m[39m
     [33m[2m✓[22m[39m fingerprints an empty legacy vector pair after a successful writer publication [33m 773[2mms[22m[39m
     [33m[2m✓[22m[39m reports an incomplete vector publication when vectors is missing [33m 364[2mms[22m[39m
     [33m[2m✓[22m[39m reports an incomplete vector publication when vectors.meta.json is missing [33m 374[2mms[22m[39m
     [33m[2m✓[22m[39m rejects an incomplete vector publication during fresh writer initialization when vectors is missing [33m 826[2mms[22m[39m
     [33m[2m✓[22m[39m rejects an incomplete vector publication during fresh writer initialization when vectors.meta.json is missing [33m 850[2mms[22m[39m
     [33m[2m✓[22m[39m reports an unreadable database without resetting published artifacts [33m 482[2mms[22m[39m
     [33m[2m✓[22m[39m degrades the same healthy reader when its database becomes unreadable [33m 506[2mms[22m[39m
     [33m[2m✓[22m[39m keeps a degraded reader snapshot blocked while the same Indexer upgrades to writer [33m 502[2mms[22m[39m
     [33m[2m✓[22m[39m requires a forced rebuild when only legacy vector artifacts remain [33m 519[2mms[22m[39m
     [33m[2m✓[22m[39m publishes BM25 atomically while a cold reader overlaps the writer save [33m 916[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a first-publication BM25 reader after the atomic rename [33m 337[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a stale writer instance after another writer publishes [33m 383[2mms[22m[39m
     [33m[2m✓[22m[39m clears a lost local lease before refreshing a later external publication [33m 358[2mms[22m[39m
     [33m[2m✓[22m[39m leaves crashed-writer recovery to the next writer [33m 673[2mms[22m[39m
     [33m[2m✓[22m[39m allows only one of two real MCP stdio servers to index [33m 898[2mms[22m[39m
     [33m[2m✓[22m[39m supports first-use, healthy-skip, stale-refresh, and disabled auto-indexing over Jcode stdio [33m 2029[2mms[22m[39m
     [33m[2m✓[22m[39m keeps force against index under one lease [33m 897[2mms[22m[39m
     [33m[2m✓[22m[39m keeps index against force under one lease [33m 909[2mms[22m[39m
     [33m[2m✓[22m[39m recovers a crashed owner safely with two concurrent reclaimers [33m 1169[2mms[22m[39m
     [33m[2m✓[22m[39m recovers every pending owner after the recovery process also crashes [33m 1271[2mms[22m[39m
     [33m[2m✓[22m[39m coalesces two watcher processes without duplicate embeddings [33m 2025[2mms[22m[39m
 [32m✓[39m tests/watcher-config-refresh.test.ts [2m([22m[2m10 tests[22m[2m)[22m[33m 23490[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the codex indexer cache before reindexing when codex config changes [33m 3861[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the jcode indexer cache before reindexing when jcode config changes [33m 3964[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the codex indexer cache before reindexing when legacy OpenCode config changes [33m 3945[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the jcode indexer cache before reindexing when legacy OpenCode config changes [33m 1326[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree when its inherited project config changes [33m 1327[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree when its inherited project config is removed [33m 1135[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree when a local project override file appears after watcher ready [33m 1330[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree across inherited config creation, deletion, and recreation [33m 3772[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes from explicit config path when configured [33m 1324[2mms[22m[39m
     [33m[2m✓[22m[39m does not refresh from project config when explicit config path is configured [33m 1504[2mms[22m[39m
 [32m✓[39m tests/watcher.test.ts [2m([22m[2m23 tests[22m[2m)[22m[33m 27548[2mms[22m[39m
       [33m[2m✓[22m[39m captures only matching include-pattern changes after watcher ready [33m 1422[2mms[22m[39m
       [33m[2m✓[22m[39m includes matching root-level files without missed events [33m 3862[2mms[22m[39m
       [33m[2m✓[22m[39m should watch codex-native config without watching codex index files [33m 3990[2mms[22m[39m
       [33m[2m✓[22m[39m should watch legacy OpenCode config in codex mode without watching legacy index files [33m 3932[2mms[22m[39m
       [33m[2m✓[22m[39m handles file-triggered reindexing in the background [33m 1326[2mms[22m[39m
       [33m[2m✓[22m[39m coalesces file-triggered reindex requests while one is running [33m 2876[2mms[22m[39m
       [33m[2m✓[22m[39m keeps one pending request and retries after INDEX_BUSY [33m 3935[2mms[22m[39m
       [33m[2m✓[22m[39m logs a non-transient lock state without retrying forever [33m 4430[2mms[22m[39m
       [33m[2m✓[22m[39m uses the latest indexer instance for file-triggered reindexing [33m 1329[2mms[22m[39m

[2m Test Files [22m [1m[32m81 passed[39m[22m[90m (81)[39m
[2m      Tests [22m [1m[32m1353 passed[39m[22m[90m (1353)[39m
[2m   Start at [22m 16:12:40
[2m   Duration [22m 28.38s[2m (transform 5.59s, setup 0ms, import 14.96s, tests 131.31s, environment 7ms)[22m
- pinned two-repeat kcov C++ rerun: plugin Hit@1 100% vs CodeGraph 66.67%, both Hit@3+ 100%, p50 89.64 ms vs 2410.23 ms on 3 scoped exact-definition queries

The comparison is a narrow, pinned C++ cohort and not a broad superiority claim.