### PR TITLE
fix: align definition benchmark scope with source intent

### DIFF
--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -97,7 +97,7 @@ npx tsx scripts/cross-repo-benchmark.ts \
   --reindex --repeats 3 --codegraph
 ```
 
-The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for every repeat. It excludes existing `.codegraph`, `.codebase-index`, build outputs, dependencies, and benchmark results. It initializes CodeGraph in that copy, then runs only generated queries that include `expected.symbol`. Exact-definition candidates from known unsupported paths, currently `.github/workflows/`, are excluded. If no supported definition candidates remain, the runner fails instead of publishing an invalid comparison.
+The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for every repeat. It excludes existing `.codegraph`, `.codebase-index`, build outputs, dependencies, and benchmark results. It initializes CodeGraph in that copy, then runs only generated queries that include `expected.symbol`. Exact-definition candidates from known unsupported paths, currently `.github/workflows/`, and test or fixture paths are excluded because the comparison uses the plugin's source-intent definition route. If no supported definition candidates remain, the runner fails instead of publishing an invalid comparison.
 
 The report places this result in a standalone **Fair CodeGraph Comparator** section. Plugin metrics are recomputed from exactly the same query IDs. A failed CodeGraph initialization, query, or strict-output parse disqualifies that repeat and prevents it from being presented as a comparable result. Raw commands, per-query results, scope IDs, and errors are written under `<run>/codegraph/<repo>/repeat-*.json`.
 

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -11,6 +11,7 @@ import { createIsolatedSourceCopy, parseCodeGraphOutput, type CodeGraphResult } 
 import { buildPerQueryResult, computeEvalMetrics } from "../src/eval/metrics.js";
 import { runEvaluation } from "../src/eval/runner.js";
 import { parseGoldenDataset } from "../src/eval/schema.js";
+import { isFixturePath, isTestPath } from "../src/indexer/intent-aware-ranking.js";
 import type {
   EvalMetrics,
   EvalRunOptions,
@@ -64,6 +65,8 @@ const EXCLUDED_DIRS = new Set([
 ]);
 
 const CODEGRAPH_UNSUPPORTED_DEFINITION_PATHS = [".github/workflows/"];
+
+const CODEGRAPH_SOURCE_EXCLUDED_PATHS = [isTestPath, isFixturePath];
 
 export const MAX_FILE_SIZE_BYTES = 1_000_000;
 const MAX_PARSE_FILES = 2500;
@@ -583,6 +586,11 @@ function isCodeGraphUnsupportedDefinitionPath(filePath: string): boolean {
   );
 }
 
+function isCodeGraphSourceExcludedDefinitionPath(filePath: string): boolean {
+  const normalizedPath = normalizePathForMatch(filePath).toLowerCase();
+  return CODEGRAPH_SOURCE_EXCLUDED_PATHS.some((predicate) => predicate(normalizedPath));
+}
+
 function isFunctionOrClass(chunk: CodeChunk): chunk is CodeChunk & { name: string } {
   if (!chunk.name) return false;
   return getCanonicalChunkType(chunk.chunkType) !== undefined;
@@ -740,7 +748,10 @@ export function buildGoldenDataset(repoName: string, repoPath: string, parsedFil
     throw new Error(`No function/class candidates discovered in ${repoName}`);
   }
 
-  const definitionCandidates = candidates.filter((candidate) => !isCodeGraphUnsupportedDefinitionPath(candidate.filePath));
+  const definitionCandidates = candidates.filter((candidate) =>
+    !isCodeGraphUnsupportedDefinitionPath(candidate.filePath) &&
+    !isCodeGraphSourceExcludedDefinitionPath(candidate.filePath)
+  );
   if (definitionCandidates.length === 0) {
     throw new Error(`No definition candidates outside unsupported CodeGraph source paths in ${repoName}`);
   }

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -152,6 +152,8 @@ describe("cross-repo CodeGraph comparator", () => {
       sourceFile("src/eta.ts"),
       sourceFile("src/theta.ts"),
       sourceFile("src/iota.ts"),
+      sourceFile("src/__tests__/test-helper.ts"),
+      sourceFile("src/fixtures/sample-fixture.ts"),
     ];
 
     const dataset = buildGoldenDataset("fixture", repoPath, parsedFiles);
@@ -159,6 +161,44 @@ describe("cross-repo CodeGraph comparator", () => {
 
     expect(definitionQueries).toHaveLength(3);
     expect(definitionQueries.every((query) => !query.expected.filePath.startsWith(".github/workflows/"))).toBe(true);
+    expect(definitionQueries.every((query) => !query.expected.filePath.includes("/__tests__/"))).toBe(true);
+    expect(definitionQueries.every((query) => !query.expected.filePath.includes("/fixtures/"))).toBe(true);
+    });
+
+  it("fails when all definition candidates are in test or fixture paths", () => {
+    const repoPath = "/repo";
+    const parsedFiles = [
+      {
+        path: path.join(repoPath, "src/__tests__/alpha.test.ts"),
+        hash: "alpha.test.ts",
+        symbols: [],
+        chunks: [{
+          content: "export function testAlpha() { return 1; }",
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: "testAlpha",
+          language: "typescript",
+        }],
+      },
+      {
+        path: path.join(repoPath, "src/fixtures/beta.fixture.ts"),
+        hash: "beta.fixture.ts",
+        symbols: [],
+        chunks: [{
+          content: "export function fixtureBeta() { return 1; }",
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: "fixtureBeta",
+          language: "typescript",
+        }],
+      },
+    ];
+
+    expect(() => buildGoldenDataset("fixture", repoPath, parsedFiles)).toThrow(
+      "No definition candidates outside unsupported CodeGraph source paths in fixture"
+    );
   });
 
   it("fails when all definition candidates are in unsupported workflow paths", () => {


### PR DESCRIPTION
## Summary
- exclude test and fixture definition candidates from the source-intent CodeGraph comparator
- retain explicit failure when no comparable source candidates remain
- document the comparator scope and add regression coverage

## Validation
- 
> opencode-codebase-index@0.22.3 build
> npm run build:ts && npm run build:native


> opencode-codebase-index@0.22.3 build:ts
> tsup && node scripts/smoke-test-built-cli.mjs

CLI Building entry: src/cli.ts, src/index.ts, src/pi-extension.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/kenneth/dev/git/opencode-codebase-index/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
ESM dist/cli.js              823.05 KB
ESM dist/pi-extension.js     614.08 KB
ESM dist/index.js            745.63 KB
ESM dist/index.js.map        1.38 MB
ESM dist/pi-extension.js.map 1.16 MB
ESM dist/cli.js.map          1.52 MB
ESM ⚡️ Build success in 173ms
CJS dist/index.cjs            748.62 KB
CJS dist/pi-extension.cjs     619.73 KB
CJS dist/cli.cjs              827.09 KB
CJS dist/pi-extension.cjs.map 1.16 MB
CJS dist/index.cjs.map        1.38 MB
CJS dist/cli.cjs.map          1.52 MB
CJS ⚡️ Build success in 173ms

> opencode-codebase-index@0.22.3 build:native
> cd native && cargo build --release && napi build --release --platform


> opencode-codebase-index@0.22.3 typecheck
> tsc --noEmit


> opencode-codebase-index@0.22.3 lint
> eslint src/


> opencode-codebase-index@0.22.3 pretest:run
> node scripts/run-build-native-with-rustflags.mjs && npm run build:ts


> opencode-codebase-index@0.22.3 build:native
> cd native && cargo build --release && napi build --release --platform


> opencode-codebase-index@0.22.3 build:ts
> tsup && node scripts/smoke-test-built-cli.mjs

CLI Building entry: src/cli.ts, src/index.ts, src/pi-extension.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/kenneth/dev/git/opencode-codebase-index/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
ESM dist/pi-extension.js     614.08 KB
ESM dist/cli.js              823.05 KB
ESM dist/index.js            745.63 KB
ESM dist/pi-extension.js.map 1.16 MB
ESM dist/index.js.map        1.38 MB
ESM dist/cli.js.map          1.52 MB
ESM ⚡️ Build success in 160ms
CJS dist/cli.cjs              827.09 KB
CJS dist/index.cjs            748.62 KB
CJS dist/pi-extension.cjs     619.73 KB
CJS dist/pi-extension.cjs.map 1.16 MB
CJS dist/index.cjs.map        1.38 MB
CJS dist/cli.cjs.map          1.52 MB
CJS ⚡️ Build success in 192ms

> opencode-codebase-index@0.22.3 test:run
> vitest run


[1m[46m RUN [49m[22m [36mv4.1.2 [39m[90m/Users/kenneth/dev/git/opencode-codebase-index[39m

 [32m✓[39m tests/search-integration.test.ts [2m([22m[2m18 tests[22m[2m)[22m[33m 2891[2mms[22m[39m
     [33m[2m✓[22m[39m annotates indexed chunks with git blame and filters by blame author [33m 356[2mms[22m[39m
     [33m[2m✓[22m[39m applies directory, file type, and blame scopes before sending candidates to an external reranker [33m 457[2mms[22m[39m
 [32m✓[39m tests/eval-runner.test.ts [2m([22m[2m23 tests[22m[2m)[22m[33m 3473[2mms[22m[39m
     [33m[2m✓[22m[39m fails fast in sweep mode when reindexing produces no searchable vectors [33m 1107[2mms[22m[39m
 [32m✓[39m tests/indexer-file-batching.test.ts [2m([22m[2m2 tests[22m[2m)[22m[33m 4370[2mms[22m[39m
     [33m[2m✓[22m[39m keeps progress cumulative and reuses duplicate embeddings across file batches [33m 2072[2mms[22m[39m
     [33m[2m✓[22m[39m flushes outage failures before the next file batch and streams them through retry [33m 2297[2mms[22m[39m
 [32m✓[39m tests/call-graph.test.ts [2m([22m[2m97 tests[22m[2m)[22m[33m 4942[2mms[22m[39m
       [33m[2m✓[22m[39m should not attach a preceding top-level call to a documented Swift symbol [33m 320[2mms[22m[39m
       [33m[2m✓[22m[39m should resolve Swift calls, preserve overloads and reparse cached files after upgrade [33m 942[2mms[22m[39m
 [32m✓[39m tests/indexer-clear-index.test.ts [2m([22m[2m43 tests[22m[2m)[22m[33m 5190[2mms[22m[39m
     [33m[2m✓[22m[39m re-embeds shared knowledge-base chunks after a global embedding strategy reset [33m 344[2mms[22m[39m
     [33m[2m✓[22m[39m keeps forced re-embed pending across restart until a failed shared chunk is re-embedded [33m 306[2mms[22m[39m
 [32m✓[39m tests/indexing-transaction.test.ts [2m([22m[2m2 tests[22m[2m)[22m[33m 2153[2mms[22m[39m
     [33m[2m✓[22m[39m keeps the previous SQLite and branch catalog generation after a late file-batch interruption [33m 2022[2mms[22m[39m
 [32m✓[39m tests/indexer-failed-batches.test.ts [2m([22m[2m27 tests[22m[2m)[22m[33m 2136[2mms[22m[39m
     [33m[2m✓[22m[39m clears pending global force re-embed metadata after retryFailedBatches() recovers all remaining chunks [33m 453[2mms[22m[39m
 [32m✓[39m tests/branch-materialization-multiprocess.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 1822[2mms[22m[39m
     [33m[2m✓[22m[39m returns each invocation-local OID during real overlapping fetches and cleans temporary refs [33m 1820[2mms[22m[39m
 [32m✓[39m tests/startup-regression.test.ts [2m([22m[2m3 tests[22m[2m)[22m[33m 1077[2mms[22m[39m
     [33m[2m✓[22m[39m starts in an empty non-git directory [33m 332[2mms[22m[39m
     [33m[2m✓[22m[39m starts in a package-marked non-git directory [33m 392[2mms[22m[39m
     [33m[2m✓[22m[39m starts with only runtime state in a non-git directory [33m 352[2mms[22m[39m
 [32m✓[39m tests/effectiveness-watcher-lifetime.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 1482[2mms[22m[39m
     [33m[2m✓[22m[39m preserves the process collector when a config change replaces the cached Indexer [33m 1481[2mms[22m[39m
 [32m✓[39m tests/pr-impact.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 841[2mms[22m[39m
 [32m✓[39m tests/branch-materialization.test.ts [2m([22m[2m14 tests[22m[2m)[22m[33m 7377[2mms[22m[39m
     [33m[2m✓[22m[39m materializes a local branch without mutating the caller worktree and cleans up [33m 409[2mms[22m[39m
     [33m[2m✓[22m[39m supports detached commit refs [33m 409[2mms[22m[39m
     [33m[2m✓[22m[39m uses an existing local PR head only when it matches the authoritative OID [33m 468[2mms[22m[39m
     [33m[2m✓[22m[39m fetches a missing remote-qualified branch without reading or overwriting FETCH_HEAD [33m 766[2mms[22m[39m
     [33m[2m✓[22m[39m prefers an independently configured remote over a shadowing local branch name [33m 842[2mms[22m[39m
     [33m[2m✓[22m[39m fetches an exact missing PR OID without gh checkout and removes the temporary ref [33m 1058[2mms[22m[39m
     [33m[2m✓[22m[39m rejects a dangerous remote name before Git can interpret it as an option [33m 407[2mms[22m[39m
     [33m[2m✓[22m[39m suppresses configured repository post-checkout hooks while adding the worktree [33m 488[2mms[22m[39m
     [33m[2m✓[22m[39m cleans up the temporary worktree when indexing fails [33m 479[2mms[22m[39m
     [33m[2m✓[22m[39m removes only the exact stale registration when the materialized directory disappears [33m 451[2mms[22m[39m
     [33m[2m✓[22m[39m removes a missing temporary worktree registered through a symlinked temp path [33m 508[2mms[22m[39m
     [33m[2m✓[22m[39m preserves the temporary path and primary error when deregistration cannot be verified [33m 358[2mms[22m[39m
     [33m[2m✓[22m[39m rejects invalid refs before creating a worktree [33m 458[2mms[22m[39m
 [32m✓[39m tests/pi-communities.test.ts [2m([22m[2m1 test[22m[2m)[22m[33m 499[2mms[22m[39m
     [33m[2m✓[22m[39m executes through the shared community operation and returns structured details [33m 497[2mms[22m[39m
 [32m✓[39m tests/worktree-fallback.test.ts [2m([22m[2m14 tests[22m[2m)[22m[33m 1087[2mms[22m[39m
     [33m[2m✓[22m[39m rebinds branch-scoped runtime caches when one Indexer switches branches [33m 347[2mms[22m[39m
     [33m[2m✓[22m[39m keeps shared project search results strictly scoped to the active branch [33m 429[2mms[22m[39m
 [32m✓[39m tests/communities.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 896[2mms[22m[39m
 [32m✓[39m tests/mcp-server.test.ts [2m([22m[2m53 tests[22m[2m)[22m[33m 729[2mms[22m[39m
 [32m✓[39m tests/auto-index.test.ts [2m([22m[2m23 tests[22m[2m)[22m[33m 625[2mms[22m[39m
 [32m✓[39m tests/index-lock.test.ts [2m([22m[2m18 tests[22m[2m)[22m[33m 778[2mms[22m[39m
 [32m✓[39m tests/host-mode-paths.test.ts [2m([22m[2m39 tests[22m[2m)[22m[33m 435[2mms[22m[39m
 [32m✓[39m tests/retrieval-benchmark.test.ts [2m([22m[2m2 tests[22m[2m)[22m[33m 733[2mms[22m[39m
     [33m[2m✓[22m[39m meets Hit@5 and latency budgets and emits candidate artifact [33m 532[2mms[22m[39m
 [32m✓[39m tests/pi-conformance.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 255[2mms[22m[39m
 [32m✓[39m tests/community-ranking-integration.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 239[2mms[22m[39m
 [32m✓[39m tests/database.test.ts [2m([22m[2m48 tests[22m[2m)[22m[33m 689[2mms[22m[39m
 [32m✓[39m tests/effectiveness-metrics.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 264[2mms[22m[39m
 [32m✓[39m tests/native.test.ts [2m([22m[2m71 tests[22m[2m)[22m[32m 177[2mms[22m[39m
 [32m✓[39m tests/tools-knowledge-bases.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 105[2mms[22m[39m
 [32m✓[39m tests/effectiveness-ci.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 152[2mms[22m[39m
 [32m✓[39m tests/retrieval-ranking.test.ts [2m([22m[2m37 tests[22m[2m)[22m[32m 134[2mms[22m[39m
 [32m✓[39m tests/custom-provider.test.ts [2m([22m[2m36 tests[22m[2m)[22m[32m 173[2mms[22m[39m
 [32m✓[39m tests/tools-utils.test.ts [2m([22m[2m76 tests[22m[2m)[22m[32m 205[2mms[22m[39m
 [32m✓[39m tests/files.test.ts [2m([22m[2m26 tests[22m[2m)[22m[32m 69[2mms[22m[39m
 [32m✓[39m tests/plugin-hooks.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 74[2mms[22m[39m
 [32m✓[39m tests/git.test.ts [2m([22m[2m36 tests[22m[2m)[22m[32m 129[2mms[22m[39m
 [32m✓[39m tests/indexer-failed-state-persistence.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 41[2mms[22m[39m
 [32m✓[39m tests/config.test.ts [2m([22m[2m102 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m tests/effectiveness-report.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 146[2mms[22m[39m
 [32m✓[39m tests/visualize.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 53[2mms[22m[39m
 [32m✓[39m tests/tools-context.test.ts [2m([22m[2m21 tests[22m[2m)[22m[32m 77[2mms[22m[39m
 [32m✓[39m tests/logger.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m tests/mcp-lifecycle.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 58[2mms[22m[39m
 [32m✓[39m tests/auto-gc.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 67[2mms[22m[39m
 [32m✓[39m tests/edit-context.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 31[2mms[22m[39m
 [32m✓[39m tests/automatic-branch-index.test.ts [2m([22m[2m9 tests[22m[2m)[22m[33m 10392[2mms[22m[39m
     [33m[2m✓[22m[39m prepares a missing local branch once, reports progress, and keeps canonical external knowledge bases external [33m 990[2mms[22m[39m
     [33m[2m✓[22m[39m keeps alternate-branch data intact while health check removes stale active-branch data [33m 936[2mms[22m[39m
     [33m[2m✓[22m[39m reparses a cached alternate branch when its symbol extractor metadata is stale [33m 989[2mms[22m[39m
     [33m[2m✓[22m[39m reparses only the cached branch whose parser migration marker is stale [33m 1663[2mms[22m[39m
     [33m[2m✓[22m[39m reindexes a moved branch OID, replaces stale catalog data, and preserves primary data [33m 1254[2mms[22m[39m
     [33m[2m✓[22m[39m treats catalogs without commit metadata as legacy-stale and restores metadata [33m 1074[2mms[22m[39m
     [33m[2m✓[22m[39m uses an authoritative local PR merge ref and a repository-specific catalog identity [33m 997[2mms[22m[39m
     [33m[2m✓[22m[39m keeps same-number, same-display PRs from different forks in distinct verified catalogs [33m 1603[2mms[22m[39m
     [33m[2m✓[22m[39m honors index lock contention and cleans up the temporary worktree on failure [33m 884[2mms[22m[39m
 [32m✓[39m tests/codegraph-baseline.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m tests/definition-ranking.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m tests/commands.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m tests/embeddings.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 72[2mms[22m[39m
 [32m✓[39m tests/crash-recovery.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m tests/routing-hints.test.ts [2m([22m[2m39 tests[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m tests/canonical-path.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 32[2mms[22m[39m
 [32m✓[39m tests/cross-repo-codegraph.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 88[2mms[22m[39m
 [32m✓[39m tests/cost.test.ts [2m([22m[2m32 tests[22m[2m)[22m[32m 94[2mms[22m[39m
[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mreturns non-zero for --ci sweep when any run fails gate
[22m[39mEval sweep complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-m6CJfL/out
Sweep runs: 2

[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mreturns zero for --ci sweep when all runs pass gate
[22m[39mEval sweep complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-4fkesl/out
Sweep runs: 2

[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mruns eval diff with explicit --current summary path
[22m[39mEval diff complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-BaB9lj/benchmarks/results/2026-08-04T14-45-14-678Z

 [32m✓[39m tests/git-refs.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
[90mstdout[2m | tests/eval-cli.test.ts[2m > [22m[2meval cli[2m > [22m[2mallows eval diff to read legacy summaries missing diversity metrics
[22m[39mEval diff complete. Artifacts: /Users/kenneth/.jcode/scratch/eval-cli-lRZHEp/benchmarks/results/2026-08-04T14-45-14-682Z

 [32m✓[39m tests/eval-cli.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m tests/power-source.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m tests/changed-files.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 28[2mms[22m[39m
 [32m✓[39m tests/watcher-emfile.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 63[2mms[22m[39m
 [32m✓[39m tests/intent-aware-ranking-eval.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m tests/eval-schema.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m tests/symbol-inference.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/inverted-index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m tests/eval-metrics.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m tests/eval-budget.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m tests/host-paths.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/codex-plugin.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m tests/mcp-cli-index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m tests/eval-compare.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/embedding-batches.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/eval-reports.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m tests/cli.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m tests/claude-plugin.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/paths.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/community-ranking.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m tests/community-ranking-eval.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m tests/file-batches.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m tests/config-rebase.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m tests/pi-package.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m tests/identity-phase0.test.ts [2m([22m[2m9 tests[22m[2m)[22m[33m 12264[2mms[22m[39m
     [33m[2m✓[22m[39m stages current metadata with only the legacy binary [33m 3674[2mms[22m[39m
     [33m[2m✓[22m[39m stages future metadata with both MCP binary aliases [33m 4094[2mms[22m[39m
     [33m[2m✓[22m[39m stages metadata with an explicit repository override [33m 4317[2mms[22m[39m
 [32m✓[39m tests/watcher.test.ts [2m([22m[2m23 tests[22m[2m)[22m[33m 22394[2mms[22m[39m
       [33m[2m✓[22m[39m captures only matching include-pattern changes after watcher ready [33m 3884[2mms[22m[39m
       [33m[2m✓[22m[39m includes matching root-level files without missed events [33m 3872[2mms[22m[39m
       [33m[2m✓[22m[39m should watch codex-native config without watching codex index files [33m 1381[2mms[22m[39m
       [33m[2m✓[22m[39m should watch legacy OpenCode config in codex mode without watching legacy index files [33m 3934[2mms[22m[39m
       [33m[2m✓[22m[39m handles file-triggered reindexing in the background [33m 1328[2mms[22m[39m
       [33m[2m✓[22m[39m coalesces file-triggered reindex requests while one is running [33m 2882[2mms[22m[39m
       [33m[2m✓[22m[39m keeps one pending request and retries after INDEX_BUSY [33m 1430[2mms[22m[39m
       [33m[2m✓[22m[39m logs a non-transient lock state without retrying forever [33m 1927[2mms[22m[39m
       [33m[2m✓[22m[39m uses the latest indexer instance for file-triggered reindexing [33m 1325[2mms[22m[39m
 [32m✓[39m tests/multiprocess-indexing.test.ts [2m([22m[2m34 tests[22m[2m)[22m[33m 22941[2mms[22m[39m
     [33m[2m✓[22m[39m allows only one normal indexer to embed [33m 864[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the same cold reader after the first writer publishes the index [33m 387[2mms[22m[39m
     [33m[2m✓[22m[39m keeps an unreadable BM25 artifact untouched under a live writer lease [33m 492[2mms[22m[39m
     [33m[2m✓[22m[39m falls back to semantic-only ranking when weighted BM25 is unavailable [33m 470[2mms[22m[39m
     [33m[2m✓[22m[39m reports an unreadable vector store without replacing it [33m 525[2mms[22m[39m
     [33m[2m✓[22m[39m rejects a valid vector metadata file from a different publication [33m 420[2mms[22m[39m
     [33m[2m✓[22m[39m requires a writer to fingerprint a structurally valid legacy vector pair [33m 976[2mms[22m[39m
     [33m[2m✓[22m[39m fingerprints an empty legacy vector pair after a successful writer publication [33m 895[2mms[22m[39m
     [33m[2m✓[22m[39m reports an incomplete vector publication when vectors is missing [33m 390[2mms[22m[39m
     [33m[2m✓[22m[39m reports an incomplete vector publication when vectors.meta.json is missing [33m 676[2mms[22m[39m
     [33m[2m✓[22m[39m rejects an incomplete vector publication during fresh writer initialization when vectors is missing [33m 1001[2mms[22m[39m
     [33m[2m✓[22m[39m rejects an incomplete vector publication during fresh writer initialization when vectors.meta.json is missing [33m 1054[2mms[22m[39m
     [33m[2m✓[22m[39m reports an unreadable database without resetting published artifacts [33m 625[2mms[22m[39m
     [33m[2m✓[22m[39m degrades the same healthy reader when its database becomes unreadable [33m 603[2mms[22m[39m
     [33m[2m✓[22m[39m keeps a degraded reader snapshot blocked while the same Indexer upgrades to writer [33m 673[2mms[22m[39m
     [33m[2m✓[22m[39m requires a forced rebuild when only legacy vector artifacts remain [33m 733[2mms[22m[39m
     [33m[2m✓[22m[39m publishes BM25 atomically while a cold reader overlaps the writer save [33m 1085[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a first-publication BM25 reader after the atomic rename [33m 348[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a stale writer instance after another writer publishes [33m 387[2mms[22m[39m
     [33m[2m✓[22m[39m clears a lost local lease before refreshing a later external publication [33m 351[2mms[22m[39m
     [33m[2m✓[22m[39m leaves crashed-writer recovery to the next writer [33m 655[2mms[22m[39m
     [33m[2m✓[22m[39m allows only one of two real MCP stdio servers to index [33m 882[2mms[22m[39m
     [33m[2m✓[22m[39m supports first-use, healthy-skip, stale-refresh, and disabled auto-indexing over Jcode stdio [33m 2091[2mms[22m[39m
     [33m[2m✓[22m[39m keeps force against index under one lease [33m 866[2mms[22m[39m
     [33m[2m✓[22m[39m keeps index against force under one lease [33m 920[2mms[22m[39m
     [33m[2m✓[22m[39m recovers a crashed owner safely with two concurrent reclaimers [33m 1156[2mms[22m[39m
     [33m[2m✓[22m[39m recovers every pending owner after the recovery process also crashes [33m 1269[2mms[22m[39m
     [33m[2m✓[22m[39m coalesces two watcher processes without duplicate embeddings [33m 1901[2mms[22m[39m
 [31m❯[39m tests/watcher-config-refresh.test.ts [2m([22m[2m10 tests[22m[2m | [22m[31m1 failed[39m[2m)[22m[33m 27176[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the codex indexer cache before reindexing when codex config changes [33m 1356[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the jcode indexer cache before reindexing when jcode config changes [33m 3871[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the codex indexer cache before reindexing when legacy OpenCode config changes [33m 1395[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes the jcode indexer cache before reindexing when legacy OpenCode config changes [33m 1411[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree when its inherited project config changes [33m 1364[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree when its inherited project config is removed [33m 1160[2mms[22m[39m
[31m     [31m×[31m refreshes a linked worktree when a local project override file appears after watcher ready[39m[33m 10020[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes a linked worktree across inherited config creation, deletion, and recreation [33m 3769[2mms[22m[39m
     [33m[2m✓[22m[39m refreshes from explicit config path when configured [33m 1325[2mms[22m[39m
     [33m[2m✓[22m[39m does not refresh from project config when explicit config path is configured [33m 1504[2mms[22m[39m

[2m Test Files [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m80 passed[39m[22m[90m (81)[39m
[2m      Tests [22m [1m[31m1 failed[39m[22m[2m | [22m[1m[32m1353 passed[39m[22m[90m (1354)[39m
[2m   Start at [22m 16:45:03
[2m   Duration [22m 27.86s[2m (transform 6.32s, setup 0ms, import 17.31s, tests 142.60s, environment 9ms)[22m (81 files, 1,354 tests)
- pinned two-repeat external TypeScript rerun completed with aligned source-only scope

The remaining TypeScript exact-definition recall gap is intentionally tracked separately from this benchmark-validity correction.