### PR TITLE
fix: preserve exact definition context order

### DIFF
--- a/src/tools/context-pack.ts
+++ b/src/tools/context-pack.ts
@@ -20,6 +20,7 @@ export interface ContextPackOptions {
   maxResults?: number;
   includeExactSearchHandoff?: boolean;
   preferImplementationPaths?: boolean;
+  preserveInputOrder?: boolean;
 }
 
 export interface ContextPackResult {
@@ -227,13 +228,12 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const maxResults = Math.max(0, Math.floor(options.maxResults ?? results.length));
   const includeExactSearchHandoff = options.includeExactSearchHandoff ?? false;
   const candidateCount = results.length;
-  const deduplicated = deduplicateContextCandidates(
-    rankContextCandidates(
-      results,
-      options.preferImplementationPaths ?? false,
-    ),
-  );
-  const diversified = diversifyContextCandidates(deduplicated);
+  const preserveInputOrder = options.preserveInputOrder ?? false;
+  const ranked = preserveInputOrder
+    ? results.map((result, originalIndex) => ({ result, originalIndex }))
+    : rankContextCandidates(results, options.preferImplementationPaths ?? false);
+  const deduplicated = deduplicateContextCandidates(ranked);
+  const diversified = preserveInputOrder ? deduplicated : diversifyContextCandidates(deduplicated);
   const duplicateCount = candidateCount - deduplicated.length;
   const selectable = diversified.slice(0, maxResults);
   const limitOmittedCount = deduplicated.length - selectable.length;

--- a/src/tools/context-search.ts
+++ b/src/tools/context-search.ts
@@ -378,6 +378,7 @@ export async function resolveSearchContext(
           tokenBudget,
           maxResults: limit,
           heading,
+          preserveInputOrder: true,
         }),
       );
     }
@@ -394,12 +395,13 @@ export async function resolveSearchContext(
           return toResult(
             "definition",
             definitionSymbol,
-            buildContextPack(unscopedDefinitionResults, {
-              tokenBudget,
-              maxResults: limit,
-              heading,
-            }),
-          );
+          buildContextPack(unscopedDefinitionResults, {
+            tokenBudget,
+            maxResults: limit,
+            heading,
+            preserveInputOrder: true,
+          }),
+        );
         }
       }
 

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -361,6 +361,62 @@ describe("native OpenCode codebase_context", () => {
     expect(countContextTokens(result)).toBeLessThanOrEqual(128);
   });
 
+  it("preserves lookup order for definition evidence so the exact-symbol result stays first", async () => {
+    const lookup = vi.fn().mockResolvedValue([
+      {
+        filePath: "src/exact-result.ts",
+        startLine: 10,
+        endLine: 12,
+        name: "exactMatch",
+        chunkType: "function",
+        content: "exact",
+        score: 0.10,
+      },
+      {
+        filePath: "src/other-source.ts",
+        startLine: 1,
+        endLine: 4,
+        name: "otherMatch",
+        chunkType: "function",
+        content: "high score",
+        score: 0.99,
+      },
+      {
+        filePath: "README.md",
+        startLine: 1,
+        endLine: 8,
+        name: "overlap",
+        chunkType: "other",
+        content: "docs",
+        score: 0.98,
+      },
+    ]);
+
+    const result = await resolveSearchContext(
+      {
+        query: "find exactMatch",
+        symbol: "exactMatch",
+        limit: 10,
+        tokenBudget: 2048,
+        fileType: undefined,
+        directory: undefined,
+      },
+      {
+        lookup,
+        search: vi.fn(),
+      },
+    );
+
+    expect(result.details?.route).toBe("definition");
+    expect(result.details?.results?.[0]).toMatchObject({
+      filePath: "src/exact-result.ts",
+      startLine: 10,
+      endLine: 12,
+      score: 0.10,
+    });
+    expect(result.text.indexOf("src/exact-result.ts:10-12")).toBeLessThan(result.text.indexOf("src/other-source.ts:1-4"));
+  });
+
   it("routes dependency endpoints through bounded call-path output", async () => {
     operationMocks.getCallGraphPath.mockResolvedValue({
       from: { status: "resolved", name: "start", symbolId: "start-id", filePath: "src/start.ts", startLine: 1, kind: "function", matchedBy: "name" },


### PR DESCRIPTION
## Summary
- preserve ranked lookup order only for exact definition context packs
- prevent context diversification from displacing an exact definition
- add regression coverage

## Validation
- focused context tests: 98 passed
- typecheck and lint passed
- pinned external TypeScript two-repeat comparator: plugin and CodeGraph both 100% Hit@1 through Hit@10; plugin p50 89.66 ms vs CodeGraph 2489.85 ms

This stacked PR targets #247, which establishes the aligned source-only comparator scope.