### PR TITLE
fix: exclude documentation definition candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cross-repo comparison eligibility**: Exclude documentation-only symbols from the CodeGraph exact-definition cohort, keeping the comparator aligned to source-intent definition retrieval.
 - **Exact definition context**: Preserve exact definition lookup ordering when assembling `codebase_context` evidence, so diversification cannot displace the requested definition.
 
 ## [0.22.3] - 2026-08-02

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -97,7 +97,7 @@ npx tsx scripts/cross-repo-benchmark.ts \
   --reindex --repeats 3 --codegraph
 ```
 
-The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for every repeat. It excludes existing `.codegraph`, `.codebase-index`, build outputs, dependencies, and benchmark results. It initializes CodeGraph in that copy, then runs only generated queries that include `expected.symbol`. Exact-definition candidates from known unsupported paths, currently `.github/workflows/`, and test or fixture paths are excluded because the comparison uses the plugin's source-intent definition route. If no supported definition candidates remain, the runner fails instead of publishing an invalid comparison.
+The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for every repeat. It excludes existing `.codegraph`, `.codebase-index`, build outputs, dependencies, and benchmark results. It initializes CodeGraph in that copy, then runs only generated queries that include `expected.symbol`. Exact-definition candidates from known unsupported paths, currently `.github/workflows/`, plus test, fixture, and documentation paths are excluded because the comparison uses the plugin's source-intent definition route. If no supported definition candidates remain, the runner fails instead of publishing an invalid comparison.
 
 The report places this result in a standalone **Fair CodeGraph Comparator** section. Plugin metrics are recomputed from exactly the same query IDs. A failed CodeGraph initialization, query, or strict-output parse disqualifies that repeat and prevents it from being presented as a comparable result. Raw commands, per-query results, scope IDs, and errors are written under `<run>/codegraph/<repo>/repeat-*.json`.
 

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -11,7 +11,7 @@ import { createIsolatedSourceCopy, parseCodeGraphOutput, type CodeGraphResult } 
 import { buildPerQueryResult, computeEvalMetrics } from "../src/eval/metrics.js";
 import { runEvaluation } from "../src/eval/runner.js";
 import { parseGoldenDataset } from "../src/eval/schema.js";
-import { isFixturePath, isTestPath } from "../src/indexer/intent-aware-ranking.js";
+import { isDocumentationPath, isFixturePath, isTestPath } from "../src/indexer/intent-aware-ranking.js";
 import type {
   EvalMetrics,
   EvalRunOptions,
@@ -66,7 +66,7 @@ const EXCLUDED_DIRS = new Set([
 
 const CODEGRAPH_UNSUPPORTED_DEFINITION_PATHS = [".github/workflows/"];
 
-const CODEGRAPH_SOURCE_EXCLUDED_PATHS = [isTestPath, isFixturePath];
+const CODEGRAPH_SOURCE_EXCLUDED_PATHS = [isTestPath, isFixturePath, isDocumentationPath];
 
 export const MAX_FILE_SIZE_BYTES = 1_000_000;
 const MAX_PARSE_FILES = 2500;

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -165,6 +165,45 @@ describe("cross-repo CodeGraph comparator", () => {
     expect(definitionQueries.every((query) => !query.expected.filePath.includes("/fixtures/"))).toBe(true);
     });
 
+  it("excludes documentation candidates from source definition set and keeps source candidates", () => {
+    const repoPath = "/repo";
+    const sourceFile = (name: string): ParsedFile => {
+      const symbol = path.basename(name).replace(/\.[^.]+$/, "");
+      return {
+        path: path.join(repoPath, name),
+        hash: name,
+        symbols: [],
+        chunks: [{
+          content: `export function ${symbol}() { return 1; }`,
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: symbol,
+          language: name.endsWith(".py") ? "python" : "typescript",
+        }],
+      };
+    };
+
+    const parsedFiles = [
+      sourceFile("src/alpha.ts"),
+      sourceFile("src/beta.ts"),
+      sourceFile("src/gamma.ts"),
+      sourceFile("docs/_themes/flask_theme_support.py"),
+      sourceFile("src/delta.ts"),
+    ];
+
+    const dataset = buildGoldenDataset("fixture", repoPath, parsedFiles);
+    const definitionQueries = dataset.queries.filter((query) => query.queryType === "definition");
+
+    expect(definitionQueries).toHaveLength(3);
+    expect(
+      definitionQueries.some((query) => query.expected.filePath === "docs/_themes/flask_theme_support.py")
+    ).toBe(false);
+    expect(
+      definitionQueries.every((query) => query.expected.filePath.startsWith("src/") && !query.expected.filePath.includes("docs/"))
+    ).toBe(true);
+  });
+
   it("fails when all definition candidates are in test or fixture paths", () => {
     const repoPath = "/repo";
     const parsedFiles = [


### PR DESCRIPTION
## Summary
- exclude documentation paths from source-only CodeGraph exact-definition candidates
- add regression coverage for candidate eligibility
- document the fair-comparison scope and record the correction in the changelog

## Validation
- focused comparator tests: 10 passed
- typecheck and lint passed
- pinned `psf/requests` revision `1f6589ec3a1ee910f9a65cc3ceac60b26677bc0e`, 2-repeat rerun: both tools 100% Hit@1 through Hit@10 across the valid 3-query source definition cohort
- full validation is running locally
