### PR TITLE
fix: omit non-comparable CodeGraph latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cross-repo comparison latency**: Omit non-comparable CodeGraph CLI startup time from fair quality tables while retaining raw timing artifacts for diagnostics.
 - **Cross-repo comparison eligibility**: Exclude documentation-only symbols from the CodeGraph exact-definition cohort, keeping the comparator aligned to source-intent definition retrieval.
 - **Exact definition context**: Preserve exact definition lookup ordering when assembling `codebase_context` evidence, so diversification cannot displace the requested definition.
 

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -101,6 +101,8 @@ The runner uses `@colbymchenry/codegraph@1.5.0` in a fresh temporary copy for ev
 
 The report places this result in a standalone **Fair CodeGraph Comparator** section. Plugin metrics are recomputed from exactly the same query IDs. A failed CodeGraph initialization, query, or strict-output parse disqualifies that repeat and prevents it from being presented as a comparable result. Raw commands, per-query results, scope IDs, and errors are written under `<run>/codegraph/<repo>/repeat-*.json`.
 
+The comparator intentionally omits latency in the CodeGraph row because each `codegraph query` invocation is measured through `npx`, which includes one-shot CLI process startup. This makes the timing comparable only to plugin-side warm eval timings and is not a fair latency comparison without additional normalization.
+
 ## Output artifacts
 
 Each run writes to:

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -1344,7 +1344,8 @@ function ms(value: number): string {
 function appendCodeGraphMetricTable(
   lines: string[],
   pluginMetrics: EvalMetrics,
-  codeGraphMetrics: EvalMetrics
+  codeGraphMetrics: EvalMetrics,
+  includeLatency = true
 ): void {
   lines.push("| Metric | Plugin | CodeGraph |");
   lines.push("|---|---:|---:|");
@@ -1354,9 +1355,11 @@ function appendCodeGraphMetricTable(
   lines.push(`| Hit@10 | ${pct(pluginMetrics.hitAt10)} | ${pct(codeGraphMetrics.hitAt10)} |`);
   lines.push(`| MRR@10 | ${num(pluginMetrics.mrrAt10)} | ${num(codeGraphMetrics.mrrAt10)} |`);
   lines.push(`| nDCG@10 | ${num(pluginMetrics.ndcgAt10)} | ${num(codeGraphMetrics.ndcgAt10)} |`);
-  lines.push(`| Latency p50 (ms) | ${ms(pluginMetrics.latencyMs.p50)} | ${ms(codeGraphMetrics.latencyMs.p50)} |`);
-  lines.push(`| Latency p95 (ms) | ${ms(pluginMetrics.latencyMs.p95)} | ${ms(codeGraphMetrics.latencyMs.p95)} |`);
-  lines.push(`| Latency p99 (ms) | ${ms(pluginMetrics.latencyMs.p99)} | ${ms(codeGraphMetrics.latencyMs.p99)} |`);
+  if (includeLatency) {
+    lines.push(`| Latency p50 (ms) | ${ms(pluginMetrics.latencyMs.p50)} | ${ms(codeGraphMetrics.latencyMs.p50)} |`);
+    lines.push(`| Latency p95 (ms) | ${ms(pluginMetrics.latencyMs.p95)} | ${ms(codeGraphMetrics.latencyMs.p95)} |`);
+    lines.push(`| Latency p99 (ms) | ${ms(pluginMetrics.latencyMs.p99)} | ${ms(codeGraphMetrics.latencyMs.p99)} |`);
+  }
   lines.push("");
 }
 
@@ -1472,6 +1475,7 @@ export function buildReportMarkdown(
     lines.push("## Fair CodeGraph Comparator");
     lines.push("");
     lines.push("Plugin metrics are recomputed per repeat from exactly the same query IDs with `expected.symbol` that CodeGraph receives.");
+    lines.push("Latency is omitted in this comparator because each `codegraph query` timing includes one-shot CLI process startup.");
     lines.push("");
 
     for (const result of successful) {
@@ -1494,7 +1498,7 @@ export function buildReportMarkdown(
 
       if (comparison.metrics) {
         lines.push("");
-        appendCodeGraphMetricTable(lines, comparison.metrics.plugin, comparison.metrics.codegraph);
+        appendCodeGraphMetricTable(lines, comparison.metrics.plugin, comparison.metrics.codegraph, false);
       } else {
         lines.push("");
         lines.push("No comparison result: no CodeGraph repeat completed successfully.");
@@ -1511,7 +1515,8 @@ export function buildReportMarkdown(
       appendCodeGraphMetricTable(
         lines,
         averageMetrics(comparable.map((metrics) => metrics.plugin)),
-        averageMetrics(comparable.map((metrics) => metrics.codegraph))
+        averageMetrics(comparable.map((metrics) => metrics.codegraph)),
+        false
       );
     } else {
       lines.push("No comparison result: no repository had a successful CodeGraph repeat.");

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -384,6 +384,10 @@ describe("cross-repo CodeGraph comparator", () => {
     expect(fairSection).toContain("| Metric | Plugin | CodeGraph |");
     expect(fairSection).not.toContain("| Ripgrep |");
     expect(fairSection).not.toContain("ast-grep");
+    expect(fairSection).toContain("Latency is omitted in this comparator because each `codegraph query` timing includes one-shot CLI process startup.");
+    expect(fairSection).not.toContain("| Latency p50 (ms) |");
+    expect(fairSection).not.toContain("| Latency p95 (ms) |");
+    expect(fairSection).not.toContain("| Latency p99 (ms) |");
   });
 
   it("disqualifies invocation failures without zero-scoring and keeps CodeGraph out of general tables", async () => {


### PR DESCRIPTION
## Summary
- omit CodeGraph latency rows from the fair quality comparator
- retain raw command timings as diagnostic artifacts
- document the one-shot CLI startup caveat and add regression coverage

## Evidence
CodeGraph timing wraps a fresh `npx @colbymchenry/codegraph query` invocation, whereas plugin timing is warmed in-process evaluation. The former includes process startup and is not lifecycle-comparable.

## Validation
- `npx vitest run tests/cross-repo-codegraph.test.ts`
- `npm run typecheck`
- `npm run lint`
- full repository validation is running locally
