### PR TITLE
feat: expose codebase context diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ test-*.mjs
 benchmark-results/
 benchmarks/results/
 
+# Local checkouts used by the checked-in cross-repo benchmark manifest
+demo-repos/
+
 # Local agent/session artifacts
 .sisyphus/
 .superset/

--- a/benchmarks/codegraph-official-agent.json
+++ b/benchmarks/codegraph-official-agent.json
@@ -1,0 +1,85 @@
+{
+  "version": 1,
+  "source": {
+    "name": "CodeGraph README agent benchmark",
+    "methodologyRepository": "https://github.com/colbymchenry/codegraph",
+    "methodologyCommit": "a7db24d0c08cbedcd1b0aff100bc0079f666ee14",
+    "codegraphPackage": "@colbymchenry/codegraph@1.5.0",
+    "defaultRuns": 4,
+    "defaultTurns": 3,
+    "model": "sonnet",
+    "effort": "high"
+  },
+  "repositories": [
+    {
+      "id": "vscode",
+      "url": "https://github.com/microsoft/vscode.git",
+      "commit": "13c6ffb35d0f706d16d8d58f6b48f72f76be5882",
+      "questions": [
+        "How does the extension host communicate with the main process?",
+        "Where in that path would a message be dropped if the extension host crashes?",
+        "What would I need to change to add a new message type to that protocol?"
+      ]
+    },
+    {
+      "id": "excalidraw",
+      "url": "https://github.com/excalidraw/excalidraw.git",
+      "commit": "e4ab626739f5f163c5eca56190f615643218b61c",
+      "questions": [
+        "How does Excalidraw render and update canvas elements?",
+        "Which part of that path decides whether a full re-render happens or an incremental one?",
+        "If I added a new element type, what in that render path would need to change?"
+      ]
+    },
+    {
+      "id": "django",
+      "url": "https://github.com/django/django.git",
+      "commit": "dfc52e53f1d19a2730854d68b602fb4dba8bf0c5",
+      "questions": [
+        "How does Django's ORM build and execute a query from a QuerySet?",
+        "Where in that path is the SQL actually compiled into a string?",
+        "What would I change to add a new lookup type to that pipeline?"
+      ]
+    },
+    {
+      "id": "tokio",
+      "url": "https://github.com/tokio-rs/tokio.git",
+      "commit": "108d6d3dc038332af2af83957748333091e35b3f",
+      "questions": [
+        "How does tokio schedule and run async tasks on its runtime?",
+        "Where does a task move between the local and the global queue in that path?",
+        "What in that path would I touch to add a per-task instrumentation hook?"
+      ]
+    },
+    {
+      "id": "okhttp",
+      "url": "https://github.com/square/okhttp.git",
+      "commit": "4fc083138014aba3d0078f5c26d1ce84815fa984",
+      "questions": [
+        "How does OkHttp process a request through its interceptor chain?",
+        "Where in that chain is the connection actually acquired?",
+        "What would I change to add a new interceptor stage before the cache?"
+      ]
+    },
+    {
+      "id": "gin",
+      "url": "https://github.com/gin-gonic/gin.git",
+      "commit": "34dac209ffb6ef85cc78c5d217bbb7ad001d68fd",
+      "questions": [
+        "How does gin route requests through its middleware chain?",
+        "Where is the 404 / no-route case handled in that same chain?",
+        "What would I change to add a per-route middleware that runs before the global ones?"
+      ]
+    },
+    {
+      "id": "alamofire",
+      "url": "https://github.com/Alamofire/Alamofire.git",
+      "commit": "0455bfb650893e86ad07ace16e5f2d36dadf46f4",
+      "questions": [
+        "How does Alamofire build, send, and validate a request?",
+        "Where does retry / interceptor logic hook into that path?",
+        "What would I change to add a new validation step to it?"
+      ]
+    }
+  ]
+}

--- a/benchmarks/cross-repo-manifest.json
+++ b/benchmarks/cross-repo-manifest.json
@@ -10,11 +10,5 @@
     "repositoryUrl": "https://github.com/expressjs/express",
     "commitSha": "1faf228935aa0a13111f92c28ee795be64ce3f0f",
     "path": "../demo-repos/express"
-  },
-  {
-    "name": "typescript",
-    "repositoryUrl": "https://github.com/microsoft/TypeScript",
-    "commitSha": "a5e123d9e0690fcea92878ea8a0a382922009fc9",
-    "path": "../demo-repos/typescript"
   }
 ]

--- a/benchmarks/cross-repo-manifest.json
+++ b/benchmarks/cross-repo-manifest.json
@@ -16,5 +16,11 @@
     "repositoryUrl": "https://github.com/sindresorhus/got",
     "commitSha": "b855688f0e520c82aff7a1dd913f9f95a4a05337",
     "path": "../demo-repos/got"
+  },
+  {
+    "name": "bytes",
+    "repositoryUrl": "https://github.com/tokio-rs/bytes",
+    "commitSha": "76c0fbb54ed4336caf9d2311658a2f4a5627c21d",
+    "path": "../demo-repos/bytes"
   }
 ]

--- a/benchmarks/cross-repo-manifest.json
+++ b/benchmarks/cross-repo-manifest.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "axios",
+    "repositoryUrl": "https://github.com/axios/axios",
+    "commitSha": "5b8a826771b77ab30081d033fdba9ef3b90e439a",
+    "path": "../demo-repos/axios"
+  },
+  {
+    "name": "express",
+    "repositoryUrl": "https://github.com/expressjs/express",
+    "commitSha": "1faf228935aa0a13111f92c28ee795be64ce3f0f",
+    "path": "../demo-repos/express"
+  }
+]

--- a/benchmarks/cross-repo-manifest.json
+++ b/benchmarks/cross-repo-manifest.json
@@ -10,5 +10,11 @@
     "repositoryUrl": "https://github.com/expressjs/express",
     "commitSha": "1faf228935aa0a13111f92c28ee795be64ce3f0f",
     "path": "../demo-repos/express"
+  },
+  {
+    "name": "got",
+    "repositoryUrl": "https://github.com/sindresorhus/got",
+    "commitSha": "b855688f0e520c82aff7a1dd913f9f95a4a05337",
+    "path": "../demo-repos/got"
   }
 ]

--- a/benchmarks/cross-repo-manifest.json
+++ b/benchmarks/cross-repo-manifest.json
@@ -10,5 +10,11 @@
     "repositoryUrl": "https://github.com/expressjs/express",
     "commitSha": "1faf228935aa0a13111f92c28ee795be64ce3f0f",
     "path": "../demo-repos/express"
+  },
+  {
+    "name": "typescript",
+    "repositoryUrl": "https://github.com/microsoft/TypeScript",
+    "commitSha": "a5e123d9e0690fcea92878ea8a0a382922009fc9",
+    "path": "../demo-repos/typescript"
   }
 ]

--- a/benchmarks/golden/cross-repo-behavior/axios.json
+++ b/benchmarks/golden/cross-repo-behavior/axios.json
@@ -1,0 +1,147 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-behavior-axios",
+  "description": "Hand-labeled behavior and task queries grounded in axios source at pinned commit 5b8a826771b77ab30081d033fdba9ef3b90e439a.",
+  "queries": [
+    {
+      "id": "axios-behavior-configuration-01",
+      "query": "How are instance defaults and per-request options merged when fields require request-only values, fallback values, deep object merging, or case-insensitive header merging?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": ["configuration", "defaults", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/core/mergeConfig.js",
+          "lib/core/Axios.js",
+          "lib/defaults/index.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/core/mergeConfig.js", "relevance": 3},
+          {"path": "lib/core/Axios.js", "relevance": 2},
+          {"path": "lib/defaults/index.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "axios-behavior-request-flow-02",
+      "query": "Trace how request data is transformed before a transport adapter runs and how response data is transformed on both successful and rejected adapter results.",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["request-flow", "data-transform", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/core/dispatchRequest.js",
+          "lib/core/transformData.js",
+          "lib/defaults/index.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/core/dispatchRequest.js", "relevance": 3},
+          {"path": "lib/core/transformData.js", "relevance": 3},
+          {"path": "lib/defaults/index.js", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "axios-behavior-error-handling-03",
+      "query": "How does Axios decide whether an HTTP response resolves or rejects, and how is a rejected status converted into a structured request error?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": ["error-handling", "status", "response"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/core/settle.js",
+          "lib/core/AxiosError.js",
+          "lib/defaults/index.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/core/settle.js", "relevance": 3},
+          {"path": "lib/core/AxiosError.js", "relevance": 2},
+          {"path": "lib/defaults/index.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "axios-behavior-interceptors-04",
+      "query": "How are request and response interceptors ordered, conditionally skipped, and executed around the core request dispatch step?",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["extension", "interceptors", "request-flow"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/core/Axios.js",
+          "lib/core/InterceptorManager.js",
+          "lib/core/dispatchRequest.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/core/Axios.js", "relevance": 3},
+          {"path": "lib/core/InterceptorManager.js", "relevance": 2},
+          {"path": "lib/core/dispatchRequest.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "axios-behavior-adapters-05",
+      "query": "How does Axios select among named or custom transport adapters and explain why none of the configured adapters can run in the current environment?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": ["configuration", "adapters", "extension"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/adapters/adapters.js",
+          "lib/defaults/index.js",
+          "lib/core/dispatchRequest.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/adapters/adapters.js", "relevance": 3},
+          {"path": "lib/defaults/index.js", "relevance": 2},
+          {"path": "lib/core/dispatchRequest.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "axios-behavior-cancellation-06",
+      "query": "Trace how legacy cancel tokens and abort signals become cancellation errors and are checked before and after transport execution, including combined timeout signals.",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["error-handling", "cancellation", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/cancel/CancelToken.js",
+          "lib/cancel/CanceledError.js",
+          "lib/core/dispatchRequest.js",
+          "lib/helpers/composeSignals.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/cancel/CancelToken.js", "relevance": 3},
+          {"path": "lib/core/dispatchRequest.js", "relevance": 3},
+          {"path": "lib/helpers/composeSignals.js", "relevance": 2},
+          {"path": "lib/cancel/CanceledError.js", "relevance": 2}
+        ]
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-behavior/axios.json
+++ b/benchmarks/golden/cross-repo-behavior/axios.json
@@ -133,11 +133,13 @@
           "lib/cancel/CancelToken.js",
           "lib/cancel/CanceledError.js",
           "lib/core/dispatchRequest.js",
+          "lib/adapters/fetch.js",
           "lib/helpers/composeSignals.js"
         ],
         "gradedEvidence": [
           {"path": "lib/cancel/CancelToken.js", "relevance": 3},
           {"path": "lib/core/dispatchRequest.js", "relevance": 3},
+          {"path": "lib/adapters/fetch.js", "relevance": 3},
           {"path": "lib/helpers/composeSignals.js", "relevance": 2},
           {"path": "lib/cancel/CanceledError.js", "relevance": 2}
         ]

--- a/benchmarks/golden/cross-repo-behavior/bytes.json
+++ b/benchmarks/golden/cross-repo-behavior/bytes.json
@@ -1,0 +1,141 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-behavior-bytes",
+  "description": "Hand-labeled behavior and task queries grounded in bytes source at pinned commit 76c0fbb54ed4336caf9d2311658a2f4a5627c21d.",
+  "queries": [
+    {
+      "id": "bytes-behavior-capacity-01",
+      "query": "How does BytesMut reserve capacity by choosing among existing spare space, shifting consumed bytes, reclaiming uniquely owned shared storage, or allocating a larger vector?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "hard",
+      "tags": ["configuration", "capacity", "allocation"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "src/bytes_mut.rs"
+        ],
+        "gradedEvidence": [
+          {"path": "src/bytes_mut.rs", "relevance": 3}
+        ]
+      }
+    },
+    {
+      "id": "bytes-behavior-numeric-flow-02",
+      "query": "How are fixed-width and variable-width integers encoded and decoded in different byte orders while advancing readable and writable buffer cursors?",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "hard",
+      "tags": ["data-flow", "endianness", "buffer-cursors"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "src/buf/buf_impl.rs",
+          "src/buf/buf_mut.rs"
+        ],
+        "gradedEvidence": [
+          {"path": "src/buf/buf_impl.rs", "relevance": 3},
+          {"path": "src/buf/buf_mut.rs", "relevance": 3}
+        ]
+      }
+    },
+    {
+      "id": "bytes-behavior-bounds-errors-03",
+      "query": "What bounds checks and error values protect buffer reads and cursor movement when a caller requests more bytes than remain, including fallible reads that must not consume data?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "medium",
+      "tags": ["error-handling", "bounds", "fallible-read"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "src/buf/buf_impl.rs",
+          "src/lib.rs",
+          "src/bytes.rs",
+          "src/buf/take.rs"
+        ],
+        "gradedEvidence": [
+          {"path": "src/buf/buf_impl.rs", "relevance": 3},
+          {"path": "src/lib.rs", "relevance": 3},
+          {"path": "src/bytes.rs", "relevance": 1},
+          {"path": "src/buf/take.rs", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "bytes-behavior-buffer-adapters-04",
+      "query": "How do the chain and take adapters expose multiple buffers as one continuous but bounded readable view, including advancing across the first buffer and limiting vectored chunks?",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "hard",
+      "tags": ["extension", "adapters", "composition"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "src/buf/buf_impl.rs",
+          "src/buf/chain.rs",
+          "src/buf/take.rs"
+        ],
+        "gradedEvidence": [
+          {"path": "src/buf/chain.rs", "relevance": 3},
+          {"path": "src/buf/take.rs", "relevance": 3},
+          {"path": "src/buf/buf_impl.rs", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "bytes-behavior-io-bridges-05",
+      "query": "How are Buf and BufMut adapted to standard Read, BufRead, and Write interfaces while limiting each operation to remaining data or capacity and advancing the underlying buffer?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "medium",
+      "tags": ["extension", "io", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "src/buf/reader.rs",
+          "src/buf/writer.rs",
+          "src/buf/buf_impl.rs",
+          "src/buf/buf_mut.rs"
+        ],
+        "gradedEvidence": [
+          {"path": "src/buf/reader.rs", "relevance": 3},
+          {"path": "src/buf/writer.rs", "relevance": 3},
+          {"path": "src/buf/buf_impl.rs", "relevance": 1},
+          {"path": "src/buf/buf_mut.rs", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "bytes-behavior-shared-storage-06",
+      "query": "How do freezing, slicing, and splitting share byte storage without copying, and when can immutable Bytes be converted back into BytesMut using the original allocation?",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "hard",
+      "tags": ["cross-file", "shared-storage", "copy-on-write"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "src/bytes.rs",
+          "src/bytes_mut.rs"
+        ],
+        "gradedEvidence": [
+          {"path": "src/bytes.rs", "relevance": 3},
+          {"path": "src/bytes_mut.rs", "relevance": 3}
+        ]
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-behavior/express.json
+++ b/benchmarks/golden/cross-repo-behavior/express.json
@@ -1,0 +1,147 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-behavior-express",
+  "description": "Hand-labeled behavior and task queries grounded in Express source at pinned commit 1faf228935aa0a13111f92c28ee795be64ce3f0f.",
+  "queries": [
+    {
+      "id": "express-behavior-configuration-01",
+      "query": "How are default application settings initialized and converted into derived functions for ETags, query parsing, and trust proxy behavior?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": ["configuration", "defaults", "application"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/application.js",
+          "lib/utils.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/application.js", "relevance": 3},
+          {"path": "lib/utils.js", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "express-behavior-request-flow-02",
+      "query": "Trace an incoming request from the application handler through router layer matching, parameter processing, route dispatch, and final-handler fallback.",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["request-flow", "routing", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/application.js",
+          "lib/router/index.js",
+          "lib/router/layer.js",
+          "lib/router/route.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/router/index.js", "relevance": 3},
+          {"path": "lib/application.js", "relevance": 2},
+          {"path": "lib/router/layer.js", "relevance": 2},
+          {"path": "lib/router/route.js", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "express-behavior-error-handling-03",
+      "query": "How does next with an error skip normal routes and select four-argument error middleware while preserving errors thrown by handlers?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["error-handling", "middleware", "routing"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/router/index.js",
+          "lib/router/layer.js",
+          "lib/router/route.js",
+          "lib/application.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/router/index.js", "relevance": 3},
+          {"path": "lib/router/layer.js", "relevance": 3},
+          {"path": "lib/router/route.js", "relevance": 2},
+          {"path": "lib/application.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "express-behavior-mounted-apps-04",
+      "query": "How does app.use distinguish ordinary middleware from a mounted sub-application, wire it into the router, and restore request and response prototypes after child handling?",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["extension", "middleware", "sub-app"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/application.js",
+          "lib/router/index.js",
+          "lib/middleware/init.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/application.js", "relevance": 3},
+          {"path": "lib/router/index.js", "relevance": 2},
+          {"path": "lib/middleware/init.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "express-behavior-prototypes-05",
+      "query": "How are application-specific request and response prototypes installed for each request, including request-response links, response locals, and the X-Powered-By header?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": ["extension", "prototype", "middleware"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/middleware/init.js",
+          "lib/express.js",
+          "lib/application.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/middleware/init.js", "relevance": 3},
+          {"path": "lib/express.js", "relevance": 2},
+          {"path": "lib/application.js", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "express-behavior-rendering-06",
+      "query": "Trace response rendering from merging response and application locals through view lookup, engine loading, caching, and either sending output or forwarding render errors.",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": ["data-flow", "views", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "lib/response.js",
+          "lib/application.js",
+          "lib/view.js"
+        ],
+        "gradedEvidence": [
+          {"path": "lib/response.js", "relevance": 3},
+          {"path": "lib/application.js", "relevance": 3},
+          {"path": "lib/view.js", "relevance": 3}
+        ]
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-behavior/got.json
+++ b/benchmarks/golden/cross-repo-behavior/got.json
@@ -1,0 +1,149 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-behavior-got",
+  "description": "Hand-labeled behavior and task queries grounded in Got source at pinned commit b855688f0e520c82aff7a1dd913f9f95a4a05337.",
+  "queries": [
+    {
+      "id": "got-behavior-configuration-01",
+      "query": "How are Got defaults cloned and user options merged while init hooks run, unknown or non-mergeable keys are handled, and the request URL is applied last?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["configuration", "options", "hooks"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "source/core/options.ts",
+          "source/create.ts"
+        ],
+        "gradedEvidence": [
+          {"path": "source/core/options.ts", "relevance": 3},
+          {"path": "source/create.ts", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "got-behavior-request-body-02",
+      "query": "Trace how body, form, and JSON options are kept mutually exclusive, serialized with content headers and length, and written for streams, buffers, typed arrays, or iterables.",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["request-flow", "body", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "source/core/options.ts",
+          "source/core/index.ts",
+          "source/core/utils/get-body-size.ts"
+        ],
+        "gradedEvidence": [
+          {"path": "source/core/options.ts", "relevance": 3},
+          {"path": "source/core/index.ts", "relevance": 3},
+          {"path": "source/core/utils/get-body-size.ts", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "got-behavior-retries-03",
+      "query": "How does Got decide whether and when to retry a failed request, honor Retry-After and backoff rules, run before-retry hooks, and reject retries for consumed body streams?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["error-handling", "retry", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "source/core/calculate-retry-delay.ts",
+          "source/core/index.ts",
+          "source/as-promise/index.ts",
+          "source/core/options.ts"
+        ],
+        "gradedEvidence": [
+          {"path": "source/core/calculate-retry-delay.ts", "relevance": 3},
+          {"path": "source/core/index.ts", "relevance": 3},
+          {"path": "source/as-promise/index.ts", "relevance": 2},
+          {"path": "source/core/options.ts", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "got-behavior-extension-04",
+      "query": "How do extended Got instances compose default options and custom handlers, then run lifecycle hooks that can modify requests, responses, retries, and errors?",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["extension", "handlers", "hooks"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "source/create.ts",
+          "source/core/options.ts",
+          "source/core/index.ts",
+          "source/as-promise/index.ts"
+        ],
+        "gradedEvidence": [
+          {"path": "source/create.ts", "relevance": 3},
+          {"path": "source/core/options.ts", "relevance": 3},
+          {"path": "source/core/index.ts", "relevance": 2},
+          {"path": "source/as-promise/index.ts", "relevance": 2}
+        ]
+      }
+    },
+    {
+      "id": "got-behavior-redirects-05",
+      "query": "How are redirects followed while enforcing redirect limits, rewriting methods or dropping bodies when required, and stripping credentials or sensitive headers across origins?",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["request-flow", "redirect", "security"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "source/core/index.ts",
+          "source/core/options.ts",
+          "source/core/errors.ts"
+        ],
+        "gradedEvidence": [
+          {"path": "source/core/index.ts", "relevance": 3},
+          {"path": "source/core/options.ts", "relevance": 2},
+          {"path": "source/core/errors.ts", "relevance": 1}
+        ]
+      }
+    },
+    {
+      "id": "got-behavior-response-errors-06",
+      "query": "Trace how Promise responses are decoded and parsed, converted into HTTP or parse errors, passed through before-error hooks, or returned when HTTP errors are disabled.",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "typescript",
+      "difficulty": "hard",
+      "tags": ["error-handling", "response", "cross-file"],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "acceptableFiles": [
+          "source/as-promise/index.ts",
+          "source/core/response.ts",
+          "source/core/errors.ts",
+          "source/core/index.ts"
+        ],
+        "gradedEvidence": [
+          {"path": "source/as-promise/index.ts", "relevance": 3},
+          {"path": "source/core/response.ts", "relevance": 3},
+          {"path": "source/core/errors.ts", "relevance": 2},
+          {"path": "source/core/index.ts", "relevance": 2}
+        ]
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-hand-labeled/axios.json
+++ b/benchmarks/golden/cross-repo-hand-labeled/axios.json
@@ -1,0 +1,119 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-hand-labeled-axios",
+  "description": "Hand-labeled definition-only benchmark dataset for the pinned axios repository",
+  "queries": [
+    {
+      "id": "axios-definition-01",
+      "query": "where is createInstance defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "createInstance"
+      },
+      "expected": {
+        "filePath": "lib/axios.js",
+        "symbol": "createInstance",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-02",
+      "query": "where is CancelToken defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "CancelToken"
+      },
+      "expected": {
+        "filePath": "lib/cancel/CancelToken.js",
+        "symbol": "CancelToken",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-03",
+      "query": "where is Axios defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "Axios"
+      },
+      "expected": {
+        "filePath": "lib/core/Axios.js",
+        "symbol": "Axios",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-04",
+      "query": "where is AxiosError defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "AxiosError"
+      },
+      "expected": {
+        "filePath": "lib/core/AxiosError.js",
+        "symbol": "AxiosError",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-05",
+      "query": "where is InterceptorManager defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "InterceptorManager"
+      },
+      "expected": {
+        "filePath": "lib/core/InterceptorManager.js",
+        "symbol": "InterceptorManager",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-06",
+      "query": "where is AxiosTransformStream defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "AxiosTransformStream"
+      },
+      "expected": {
+        "filePath": "lib/helpers/AxiosTransformStream.js",
+        "symbol": "AxiosTransformStream",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-07",
+      "query": "where is AxiosURLSearchParams defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "AxiosURLSearchParams"
+      },
+      "expected": {
+        "filePath": "lib/helpers/AxiosURLSearchParams.js",
+        "symbol": "AxiosURLSearchParams",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-definition-08",
+      "query": "where is speedometer defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "speedometer"
+      },
+      "expected": {
+        "filePath": "lib/helpers/speedometer.js",
+        "symbol": "speedometer",
+        "expectedRoute": "definition"
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-hand-labeled/bytes.json
+++ b/benchmarks/golden/cross-repo-hand-labeled/bytes.json
@@ -1,0 +1,119 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-hand-labeled-bytes",
+  "description": "Hand-labeled definition-only benchmark dataset for the pinned bytes repository",
+  "queries": [
+    {
+      "id": "bytes-definition-01",
+      "query": "where is sign_extend defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "sign_extend"
+      },
+      "expected": {
+        "filePath": "src/buf/buf_impl.rs",
+        "symbol": "sign_extend",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-02",
+      "query": "where is increment_shared defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "increment_shared"
+      },
+      "expected": {
+        "filePath": "src/bytes_mut.rs",
+        "symbol": "increment_shared",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-03",
+      "query": "where is original_capacity_to_repr defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "original_capacity_to_repr"
+      },
+      "expected": {
+        "filePath": "src/bytes_mut.rs",
+        "symbol": "original_capacity_to_repr",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-04",
+      "query": "where is rebuild_vec defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "rebuild_vec"
+      },
+      "expected": {
+        "filePath": "src/bytes_mut.rs",
+        "symbol": "rebuild_vec",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-05",
+      "query": "where is shared_v_clone defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "shared_v_clone"
+      },
+      "expected": {
+        "filePath": "src/bytes_mut.rs",
+        "symbol": "shared_v_clone",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-06",
+      "query": "where is static_clone defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "static_clone"
+      },
+      "expected": {
+        "filePath": "src/bytes.rs",
+        "symbol": "static_clone",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-07",
+      "query": "where is owned_to_vec defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "owned_to_vec"
+      },
+      "expected": {
+        "filePath": "src/bytes.rs",
+        "symbol": "owned_to_vec",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "bytes-definition-08",
+      "query": "where is free_boxed_slice defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "free_boxed_slice"
+      },
+      "expected": {
+        "filePath": "src/bytes.rs",
+        "symbol": "free_boxed_slice",
+        "expectedRoute": "definition"
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-hand-labeled/express.json
+++ b/benchmarks/golden/cross-repo-hand-labeled/express.json
@@ -1,0 +1,119 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-hand-labeled-express",
+  "description": "Hand-labeled definition-only benchmark dataset for the pinned express repository",
+  "queries": [
+    {
+      "id": "express-definition-01",
+      "query": "where is createApplication defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "createApplication"
+      },
+      "expected": {
+        "filePath": "lib/express.js",
+        "symbol": "createApplication",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-02",
+      "query": "where is logerror defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "logerror"
+      },
+      "expected": {
+        "filePath": "lib/application.js",
+        "symbol": "logerror",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-03",
+      "query": "where is tryRender defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "tryRender"
+      },
+      "expected": {
+        "filePath": "lib/application.js",
+        "symbol": "tryRender",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-04",
+      "query": "where is defineGetter defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "defineGetter"
+      },
+      "expected": {
+        "filePath": "lib/request.js",
+        "symbol": "defineGetter",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-05",
+      "query": "where is sendfile defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "sendfile"
+      },
+      "expected": {
+        "filePath": "lib/response.js",
+        "symbol": "sendfile",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-06",
+      "query": "where is appendMethods defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "appendMethods"
+      },
+      "expected": {
+        "filePath": "lib/router/index.js",
+        "symbol": "appendMethods",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-07",
+      "query": "where is Layer defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "Layer"
+      },
+      "expected": {
+        "filePath": "lib/router/layer.js",
+        "symbol": "Layer",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-definition-08",
+      "query": "where is Route defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "Route"
+      },
+      "expected": {
+        "filePath": "lib/router/route.js",
+        "symbol": "Route",
+        "expectedRoute": "definition"
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/cross-repo-hand-labeled/got.json
+++ b/benchmarks/golden/cross-repo-hand-labeled/got.json
@@ -1,0 +1,119 @@
+{
+  "version": "1.0.0",
+  "name": "cross-repo-hand-labeled-got",
+  "description": "Hand-labeled definition-only benchmark dataset for the pinned got repository",
+  "queries": [
+    {
+      "id": "got-definition-01",
+      "query": "where is isRequest defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "isRequest"
+      },
+      "expected": {
+        "filePath": "source/core/errors.ts",
+        "symbol": "isRequest",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-02",
+      "query": "where is wrapAssertionWithContext defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "wrapAssertionWithContext"
+      },
+      "expected": {
+        "filePath": "source/core/options.ts",
+        "symbol": "wrapAssertionWithContext",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-03",
+      "query": "where is assertAny defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "assertAny"
+      },
+      "expected": {
+        "filePath": "source/core/options.ts",
+        "symbol": "assertAny",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-04",
+      "query": "where is assertPlainObject defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "assertPlainObject"
+      },
+      "expected": {
+        "filePath": "source/core/options.ts",
+        "symbol": "assertPlainObject",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-05",
+      "query": "where is usesUnixSocket defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "usesUnixSocket"
+      },
+      "expected": {
+        "filePath": "source/core/options.ts",
+        "symbol": "usesUnixSocket",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-06",
+      "query": "where is hasCredentialInUrl defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "hasCredentialInUrl"
+      },
+      "expected": {
+        "filePath": "source/core/options.ts",
+        "symbol": "hasCredentialInUrl",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-07",
+      "query": "where is isTlsSocket defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "isTlsSocket"
+      },
+      "expected": {
+        "filePath": "source/core/utils/defer-to-connect.ts",
+        "symbol": "isTlsSocket",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "got-definition-08",
+      "query": "where is isClientRequest defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "isClientRequest"
+      },
+      "expected": {
+        "filePath": "source/core/utils/is-client-request.ts",
+        "symbol": "isClientRequest",
+        "expectedRoute": "definition"
+      }
+    }
+  ]
+}

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -74,6 +74,8 @@ git clone https://github.com/axios/axios.git demo-repos/axios
 git -C demo-repos/axios checkout --detach 5b8a826771b77ab30081d033fdba9ef3b90e439a
 git clone https://github.com/expressjs/express.git demo-repos/express
 git -C demo-repos/express checkout --detach 1faf228935aa0a13111f92c28ee795be64ce3f0f
+git clone https://github.com/sindresorhus/got.git demo-repos/got
+git -C demo-repos/got checkout --detach b855688f0e520c82aff7a1dd913f9f95a4a05337
 
 npx tsx scripts/cross-repo-benchmark.ts \
   --manifest benchmarks/cross-repo-manifest.json \

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -54,18 +54,6 @@ Manifest entries support checked-in repository metadata:
     "repositoryUrl": "https://github.com/axios/axios",
     "commitSha": "5b8a826771b77ab30081d033fdba9ef3b90e439a",
     "path": "../demo-repos/axios"
-  },
-  {
-    "name": "express",
-    "repositoryUrl": "https://github.com/expressjs/express",
-    "commitSha": "1faf228935aa0a13111f92c28ee795be64ce3f0f",
-    "path": "../demo-repos/express"
-  },
-  {
-    "name": "typescript",
-    "repositoryUrl": "https://github.com/microsoft/TypeScript",
-    "commitSha": "a5e123d9e0690fcea92878ea8a0a382922009fc9",
-    "path": "../demo-repos/typescript"
   }
 ]
 ```
@@ -86,8 +74,6 @@ git clone https://github.com/axios/axios.git demo-repos/axios
 git -C demo-repos/axios checkout --detach 5b8a826771b77ab30081d033fdba9ef3b90e439a
 git clone https://github.com/expressjs/express.git demo-repos/express
 git -C demo-repos/express checkout --detach 1faf228935aa0a13111f92c28ee795be64ce3f0f
-git clone https://github.com/microsoft/TypeScript.git demo-repos/typescript
-git -C demo-repos/typescript checkout --detach a5e123d9e0690fcea92878ea8a0a382922009fc9
 
 npx tsx scripts/cross-repo-benchmark.ts \
   --manifest benchmarks/cross-repo-manifest.json \

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -88,11 +88,27 @@ git clone https://github.com/expressjs/express.git demo-repos/express
 git -C demo-repos/express checkout --detach 1faf228935aa0a13111f92c28ee795be64ce3f0f
 git clone https://github.com/sindresorhus/got.git demo-repos/got
 git -C demo-repos/got checkout --detach b855688f0e520c82aff7a1dd913f9f95a4a05337
+git clone https://github.com/tokio-rs/bytes.git demo-repos/bytes
+git -C demo-repos/bytes checkout --detach 76c0fbb54ed4336caf9d2311658a2f4a5627c21d
 
 npx tsx scripts/cross-repo-benchmark.ts \
   --manifest benchmarks/cross-repo-manifest.json \
   --reindex --repeats 2 --codegraph
 ```
+
+## Behavior corpus run
+
+For the checked-in behavior-query corpus, run this command instead:
+
+```bash
+npx tsx scripts/cross-repo-benchmark.ts \
+  --manifest benchmarks/cross-repo-manifest.json \
+  --dataset-dir benchmarks/golden/cross-repo-behavior \
+  --reindex --repeats 2
+```
+
+This command is intentionally run **without** `--codegraph` because the CodeGraph
+CLI is symbol-only and does not benchmark natural-language behavior queries.
 
 `demo-repos/` is ignored by Git. The runner aborts before evaluating if either
 checkout is not at its pinned revision.

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -54,6 +54,18 @@ Manifest entries support checked-in repository metadata:
     "repositoryUrl": "https://github.com/axios/axios",
     "commitSha": "5b8a826771b77ab30081d033fdba9ef3b90e439a",
     "path": "../demo-repos/axios"
+  },
+  {
+    "name": "express",
+    "repositoryUrl": "https://github.com/expressjs/express",
+    "commitSha": "1faf228935aa0a13111f92c28ee795be64ce3f0f",
+    "path": "../demo-repos/express"
+  },
+  {
+    "name": "typescript",
+    "repositoryUrl": "https://github.com/microsoft/TypeScript",
+    "commitSha": "a5e123d9e0690fcea92878ea8a0a382922009fc9",
+    "path": "../demo-repos/typescript"
   }
 ]
 ```
@@ -74,6 +86,8 @@ git clone https://github.com/axios/axios.git demo-repos/axios
 git -C demo-repos/axios checkout --detach 5b8a826771b77ab30081d033fdba9ef3b90e439a
 git clone https://github.com/expressjs/express.git demo-repos/express
 git -C demo-repos/express checkout --detach 1faf228935aa0a13111f92c28ee795be64ce3f0f
+git clone https://github.com/microsoft/TypeScript.git demo-repos/typescript
+git -C demo-repos/typescript checkout --detach a5e123d9e0690fcea92878ea8a0a382922009fc9
 
 npx tsx scripts/cross-repo-benchmark.ts \
   --manifest benchmarks/cross-repo-manifest.json \

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -45,6 +45,18 @@ Option C: manifest file
 npx tsx scripts/cross-repo-benchmark.ts --manifest /path/to/cross-repo-manifest.json
 ```
 
+Option D: prebuilt dataset directory
+
+```bash
+npx tsx scripts/cross-repo-benchmark.ts \
+  --repos /path/to/repo1,/path/to/repo2 \
+  --dataset-dir benchmarks/golden/cross-repo
+```
+
+With `--dataset-dir`, each repository requires `<dataset-dir>/<repo-name>.json`.
+The runner validates each file via `parseGoldenDataset`, then copies that exact file into `<run>/datasets/`.
+If any required dataset file is missing or invalid, the run fails before evaluations begin.
+
 Manifest entries support checked-in repository metadata:
 
 ```json
@@ -113,6 +125,9 @@ npx tsx scripts/cross-repo-benchmark.ts --manifest benchmarks/cross-repo-manifes
 ```bash
 npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --persist-datasets
 ```
+
+`--persist-datasets` is respected when `--dataset-dir` is used too.
+The loaded dataset file is copied unchanged into `benchmarks/golden/cross-repo/`.
 
 - File parsing is capped (`--max-parse-files`, default `2500`). Reports include whether truncation occurred.
 

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -39,6 +39,50 @@ export BENCHMARK_REPOS=/path/to/repo1,/path/to/repo2
 npx tsx scripts/cross-repo-benchmark.ts
 ```
 
+Option C: manifest file
+
+```bash
+npx tsx scripts/cross-repo-benchmark.ts --manifest /path/to/cross-repo-manifest.json
+```
+
+Manifest entries support checked-in repository metadata:
+
+```json
+[
+  {
+    "name": "axios",
+    "repositoryUrl": "https://github.com/axios/axios",
+    "commitSha": "5b8a826771b77ab30081d033fdba9ef3b90e439a",
+    "path": "../demo-repos/axios"
+  }
+]
+```
+
+Path values are resolved relative to the manifest location. Before any benchmark run, manifest mode validates each entry:
+
+- Repository path exists
+- `git rev-parse HEAD` is exactly the listed `commitSha`
+
+This mode enforces immutable revision provenance for reproducible benchmarking.
+
+The checked-in smoke manifest expects local clones under `demo-repos/`. Prepare
+the pinned revisions once, then run the matrix without editing the manifest:
+
+```bash
+mkdir -p demo-repos
+git clone https://github.com/axios/axios.git demo-repos/axios
+git -C demo-repos/axios checkout --detach 5b8a826771b77ab30081d033fdba9ef3b90e439a
+git clone https://github.com/expressjs/express.git demo-repos/express
+git -C demo-repos/express checkout --detach 1faf228935aa0a13111f92c28ee795be64ce3f0f
+
+npx tsx scripts/cross-repo-benchmark.ts \
+  --manifest benchmarks/cross-repo-manifest.json \
+  --reindex --repeats 2 --codegraph
+```
+
+`demo-repos/` is ignored by Git. The runner aborts before evaluating if either
+checkout is not at its pinned revision.
+
 ## Reindex modes
 
 - Default: `--no-reindex` behavior (fast iteration, reuses existing index)
@@ -55,6 +99,8 @@ npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --
 
 # Repeat runs for stable medians (recommended)
 npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --repeats 20
+
+npx tsx scripts/cross-repo-benchmark.ts --manifest benchmarks/cross-repo-manifest.json --repeats 20
 ```
 
 ## Sampling and mutability notes

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 
 import { execFile, execFileSync } from "child_process";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
 import { promisify } from "util";
@@ -90,6 +97,7 @@ interface ManifestEntry {
 export interface CliOptions {
   repos: RepoDescriptor[];
   manifestPath?: string;
+  datasetDir?: string;
   outputRoot: string;
   reindex: boolean;
   repeats: number;
@@ -107,7 +115,7 @@ export interface RepoRepositoryMetadata {
   path: string;
 }
 
-interface FileCollectionResult {
+export interface FileCollectionResult {
   files: string[];
   truncated: boolean;
   maxParseFiles: number;
@@ -250,7 +258,7 @@ interface RipgrepJsonEvent {
 
 function printUsage(): void {
   console.log(`Usage:
-	npx tsx scripts/cross-repo-benchmark.ts [--repos /path/a,/path/b] [--manifest /path/to/manifest.json] [--output benchmarks/results/cross-repo] [--reindex|--no-reindex] [--repeats N] [--max-parse-files N] [--persist-datasets] [--skip-ripgrep] [--skip-sg] [--codegraph]
+	npx tsx scripts/cross-repo-benchmark.ts [--repos /path/a,/path/b] [--manifest /path/to/manifest.json] [--dataset-dir /path/to/datasets] [--output benchmarks/results/cross-repo] [--reindex|--no-reindex] [--repeats N] [--max-parse-files N] [--persist-datasets] [--skip-ripgrep] [--skip-sg] [--codegraph]
 
 	Defaults:
 	  repos: none (required via --repos, --manifest, or BENCHMARK_REPOS)
@@ -455,6 +463,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
   let repeats = 1;
   let maxParseFiles = MAX_PARSE_FILES;
   let persistDatasets = false;
+  let datasetDir: string | undefined;
   let skipRipgrep = false;
   let skipSg = false;
   let codegraph = false;
@@ -488,6 +497,16 @@ export function parseCliArgs(argv: string[]): CliOptions {
       }
       manifestPath = value;
       repos = repos.concat(parseManifest(value));
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--dataset-dir") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--dataset-dir requires a path");
+      }
+      datasetDir = path.resolve(expandHome(value));
       i += 1;
       continue;
     }
@@ -570,6 +589,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
   return {
     repos,
     manifestPath,
+    datasetDir,
     outputRoot,
     reindex,
     repeats,
@@ -1011,6 +1031,73 @@ function writeDataset(datasetPath: string, dataset: GoldenDataset): void {
   ensureDir(path.dirname(datasetPath));
   parseGoldenDataset(dataset, datasetPath);
   writeFileSync(datasetPath, JSON.stringify(dataset, null, 2), "utf-8");
+}
+
+export interface ResolvedDataset {
+  dataset: GoldenDataset;
+  collection: FileCollectionResult;
+  datasetPath: string;
+}
+
+export function resolveBenchmarkDataset(
+  repo: RepoDescriptor,
+  options: Pick<CliOptions, "datasetDir" | "maxParseFiles" | "persistDatasets">,
+  datasetRoot: string,
+  persistentDatasetRoot: string,
+): ResolvedDataset {
+  const repoName = repo.name;
+  const datasetPath = path.join(datasetRoot, `${repoName}.json`);
+  const persistentDatasetPath = path.join(persistentDatasetRoot, `${repoName}.json`);
+
+  if (options.datasetDir) {
+    const sourcePath = path.join(options.datasetDir, `${repoName}.json`);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Missing dataset file for repository ${repoName}: ${sourcePath}`);
+    }
+
+    const raw = readFileSync(sourcePath, "utf-8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse dataset JSON from ${sourcePath}: ${message}`);
+    }
+
+    const dataset = parseGoldenDataset(parsed, sourcePath);
+
+    ensureDir(path.dirname(datasetPath));
+    copyFileSync(sourcePath, datasetPath);
+
+    if (options.persistDatasets) {
+      ensureDir(path.dirname(persistentDatasetPath));
+      copyFileSync(sourcePath, persistentDatasetPath);
+    }
+
+    return {
+      dataset,
+      collection: {
+        files: [],
+        truncated: false,
+        maxParseFiles: options.maxParseFiles,
+      },
+      datasetPath,
+    };
+  }
+
+  const { parsedFiles, collection } = collectParsedFiles(repo.path, options.maxParseFiles);
+  const dataset = buildGoldenDataset(repo.name, repo.path, parsedFiles);
+  writeDataset(datasetPath, dataset);
+
+  if (options.persistDatasets) {
+    writeDataset(persistentDatasetPath, dataset);
+  }
+
+  return {
+    dataset,
+    collection,
+    datasetPath,
+  };
 }
 
 function escapeRegexLiteral(input: string): string {
@@ -1710,15 +1797,18 @@ async function runForRepo(
   const repoPath = repo.path;
   const repositoryMetadata = repositoryMetadataFromDescriptor(repo);
   const datasetPath = path.join(datasetRoot, `${repoName}.json`);
-  const persistentDatasetPath = path.join(persistentDatasetRoot, `${repoName}.json`);
 
   try {
-    const { parsedFiles, collection } = collectParsedFiles(repoPath, options.maxParseFiles);
-    const dataset = buildGoldenDataset(repoName, repoPath, parsedFiles);
-    writeDataset(datasetPath, dataset);
-    if (options.persistDatasets) {
-      writeDataset(persistentDatasetPath, dataset);
-    }
+    const { dataset, collection, datasetPath } = resolveBenchmarkDataset(
+      repo,
+      {
+        datasetDir: options.datasetDir,
+        maxParseFiles: options.maxParseFiles,
+        persistDatasets: options.persistDatasets,
+      },
+      datasetRoot,
+      persistentDatasetRoot,
+    );
 
     const pluginOutputRoot = path.join(runDir, "plugin", repoName);
     const pluginRuns: EvalMetrics[] = [];
@@ -1919,7 +2009,7 @@ async function main(): Promise<void> {
 
   for (const repo of options.repos) {
     const repoName = repo.name;
-    console.log(`\n[${repoName}] generating dataset + running evaluations...`);
+    console.log(`\n[${repoName}] ${options.datasetDir ? "loading" : "generating"} dataset + running evaluations...`);
     const repoResult = await runForRepo(
       repo,
       options,
@@ -1949,6 +2039,7 @@ async function main(): Promise<void> {
     options: {
       repos: options.repos,
       manifestPath: options.manifestPath,
+      datasetDir: options.datasetDir,
       outputRoot: options.outputRoot,
       reindex: options.reindex,
       repeats: options.repeats,

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFile } from "child_process";
+import { execFile, execFileSync } from "child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import * as path from "path";
 import { performance } from "perf_hooks";
@@ -73,8 +73,23 @@ const MAX_PARSE_FILES = 2500;
 const CODEGRAPH_PACKAGE = "@colbymchenry/codegraph@1.5.0";
 const MAX_CHUNKS_PER_FILE = 100;
 
+export interface RepoDescriptor {
+  name: string;
+  path: string;
+  repositoryUrl?: string;
+  commitSha?: string;
+}
+
+interface ManifestEntry {
+  name: string;
+  repositoryUrl: string;
+  commitSha: string;
+  path: string;
+}
+
 export interface CliOptions {
-  repos: string[];
+  repos: RepoDescriptor[];
+  manifestPath?: string;
   outputRoot: string;
   reindex: boolean;
   repeats: number;
@@ -83,6 +98,13 @@ export interface CliOptions {
   skipRipgrep: boolean;
   skipSg: boolean;
   codegraph: boolean;
+}
+
+export interface RepoRepositoryMetadata {
+  name: string;
+  repositoryUrl: string;
+  commitSha: string;
+  path: string;
 }
 
 interface FileCollectionResult {
@@ -122,6 +144,7 @@ export interface ControlledEvalConfigArtifact {
 export interface RepoBenchmarkResult {
   repoName: string;
   repoPath: string;
+  repository?: RepoRepositoryMetadata;
   datasetPath: string;
   datasetQueryCount: number;
   fileSampling: {
@@ -227,10 +250,10 @@ interface RipgrepJsonEvent {
 
 function printUsage(): void {
   console.log(`Usage:
-npx tsx scripts/cross-repo-benchmark.ts [--repos /path/a,/path/b] [--output benchmarks/results/cross-repo] [--reindex|--no-reindex] [--repeats N] [--max-parse-files N] [--persist-datasets] [--skip-ripgrep] [--skip-sg] [--codegraph]
+	npx tsx scripts/cross-repo-benchmark.ts [--repos /path/a,/path/b] [--manifest /path/to/manifest.json] [--output benchmarks/results/cross-repo] [--reindex|--no-reindex] [--repeats N] [--max-parse-files N] [--persist-datasets] [--skip-ripgrep] [--skip-sg] [--codegraph]
 
-Defaults:
-  repos: none (required via --repos or BENCHMARK_REPOS)
+	Defaults:
+	  repos: none (required via --repos, --manifest, or BENCHMARK_REPOS)
   output: benchmarks/results/cross-repo
   reindex: false
   repeats: 1
@@ -258,6 +281,99 @@ function normalizePathForMatch(input: string): string {
 
 function ensureDir(dirPath: string): void {
   mkdirSync(dirPath, { recursive: true });
+}
+
+function parseGitHead(repoPath: string): string {
+  return execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], {
+    encoding: "utf-8",
+  }).trim();
+}
+
+function parseManifestEntry(entry: unknown, index: number): ManifestEntry {
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+    throw new Error(`Invalid manifest entry at index ${index}: expected an object`);
+  }
+
+  const candidate = entry as Partial<ManifestEntry>;
+
+  if (typeof candidate.name !== "string" || candidate.name.trim().length === 0) {
+    throw new Error(`Invalid manifest entry at index ${index}: name must be a non-empty string`);
+  }
+
+  if (typeof candidate.repositoryUrl !== "string" || candidate.repositoryUrl.trim().length === 0) {
+    throw new Error(`Invalid manifest entry at index ${index}: repositoryUrl must be a non-empty string`);
+  }
+
+  const canonicalRepositoryUrl = candidate.repositoryUrl.trim();
+  if (!/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(canonicalRepositoryUrl)) {
+    throw new Error(`Invalid manifest entry at index ${index}: repositoryUrl must be a canonical GitHub URL`);
+  }
+
+  if (typeof candidate.commitSha !== "string" || !/^[0-9a-fA-F]{40}$/.test(candidate.commitSha.trim())) {
+    throw new Error(`Invalid manifest entry at index ${index}: commitSha must be a 40-character hex SHA`);
+  }
+
+  if (typeof candidate.path !== "string" || candidate.path.trim().length === 0) {
+    throw new Error(`Invalid manifest entry at index ${index}: path must be a non-empty string`);
+  }
+
+  return {
+    name: candidate.name.trim(),
+    repositoryUrl: canonicalRepositoryUrl,
+    commitSha: candidate.commitSha.toLowerCase(),
+    path: candidate.path.trim(),
+  };
+}
+
+export function parseManifest(pathToManifest: string): RepoDescriptor[] {
+  const manifestPath = path.resolve(expandHome(pathToManifest));
+  const rawManifest = readFileSync(manifestPath, "utf-8");
+
+  let entries: unknown;
+  try {
+    entries = JSON.parse(rawManifest) as unknown;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON in manifest ${manifestPath}: ${message}`);
+  }
+
+  if (!Array.isArray(entries)) {
+    throw new Error(`Manifest ${manifestPath} must contain an array of entries`);
+  }
+
+  const baseDirectory = path.dirname(manifestPath);
+
+  return entries.map((entry, index) => {
+    const parsed = parseManifestEntry(entry, index);
+    const resolvedPath = path.resolve(baseDirectory, parsed.path);
+
+    if (!existsSync(resolvedPath)) {
+      throw new Error(`Manifest entry ${parsed.name} references missing path: ${resolvedPath}`);
+    }
+
+    let headSha = "";
+    try {
+      headSha = parseGitHead(resolvedPath);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Manifest entry ${parsed.name} failed HEAD lookup at ${resolvedPath}: ${message}`);
+    }
+
+    if (!/^[0-9a-fA-F]{40}$/.test(headSha)) {
+      throw new Error(`Manifest entry ${parsed.name} has invalid HEAD SHA '${headSha}' at ${resolvedPath}`);
+    }
+
+    if (headSha.toLowerCase() !== parsed.commitSha.toLowerCase()) {
+      throw new Error(`Manifest entry ${parsed.name} commit mismatch: ${parsed.commitSha} != ${headSha}`);
+    }
+
+    return {
+      name: parsed.name,
+      path: resolvedPath,
+      repositoryUrl: parsed.repositoryUrl,
+      commitSha: parsed.commitSha,
+    };
+  });
 }
 
 export function controlledEvalConfigPath(runDir: string, repoName: string): string {
@@ -304,8 +420,36 @@ function toRepoName(repoPath: string): string {
   return path.basename(repoPath.replace(/[\\/]+$/, ""));
 }
 
+function reposFromCommaSeparated(value: string): RepoDescriptor[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .map((item) => {
+      const resolvedPath = path.resolve(expandHome(item));
+      return {
+        name: toRepoName(resolvedPath),
+        path: resolvedPath,
+      };
+    });
+}
+
+function repositoryMetadataFromDescriptor(repo: RepoDescriptor): RepoRepositoryMetadata | undefined {
+  if (!repo.repositoryUrl || !repo.commitSha) {
+    return undefined;
+  }
+
+  return {
+    name: repo.name,
+    repositoryUrl: repo.repositoryUrl,
+    commitSha: repo.commitSha,
+    path: repo.path,
+  };
+}
+
 export function parseCliArgs(argv: string[]): CliOptions {
-  let repos: string[] = [];
+  let repos: RepoDescriptor[] = [];
+  let manifestPath: string | undefined;
   let outputRoot = path.resolve(process.cwd(), "benchmarks/results/cross-repo");
   let reindex = false;
   let repeats = 1;
@@ -317,11 +461,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
 
   const envRepos = process.env.BENCHMARK_REPOS;
   if (envRepos && envRepos.trim().length > 0) {
-    repos = envRepos
-      .split(",")
-      .map((item) => item.trim())
-      .filter((item) => item.length > 0)
-      .map((item) => path.resolve(expandHome(item)));
+    repos = reposFromCommaSeparated(envRepos);
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -336,11 +476,18 @@ export function parseCliArgs(argv: string[]): CliOptions {
       if (!value) {
         throw new Error("--repos requires a comma-separated value");
       }
-      repos = value
-        .split(",")
-        .map((item) => item.trim())
-        .filter((item) => item.length > 0)
-        .map((item) => path.resolve(expandHome(item)));
+      repos = repos.concat(reposFromCommaSeparated(value));
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--manifest") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--manifest requires a path");
+      }
+      manifestPath = value;
+      repos = repos.concat(parseManifest(value));
       i += 1;
       continue;
     }
@@ -417,11 +564,12 @@ export function parseCliArgs(argv: string[]): CliOptions {
   }
 
   if (repos.length === 0) {
-    throw new Error("No repositories configured. Pass --repos /path/a,/path/b or set BENCHMARK_REPOS");
+    throw new Error("No repositories configured. Pass --repos /path/a,/path/b, --manifest path, or set BENCHMARK_REPOS");
   }
 
   return {
     repos,
+    manifestPath,
     outputRoot,
     reindex,
     repeats,
@@ -1538,13 +1686,15 @@ export function buildReportMarkdown(
 }
 
 async function runForRepo(
-  repoPath: string,
+  repo: RepoDescriptor,
   options: CliOptions,
   runDir: string,
   datasetRoot: string,
   persistentDatasetRoot: string
 ): Promise<RepoBenchmarkResult> {
-  const repoName = toRepoName(repoPath);
+  const repoName = repo.name;
+  const repoPath = repo.path;
+  const repositoryMetadata = repositoryMetadataFromDescriptor(repo);
   const datasetPath = path.join(datasetRoot, `${repoName}.json`);
   const persistentDatasetPath = path.join(persistentDatasetRoot, `${repoName}.json`);
 
@@ -1634,6 +1784,7 @@ async function runForRepo(
     const result: RepoBenchmarkResult = {
       repoName,
       repoPath,
+      repository: repositoryMetadata,
       datasetPath,
       datasetQueryCount: dataset.queries.length,
       fileSampling: {
@@ -1700,6 +1851,7 @@ async function runForRepo(
     return {
       repoName,
       repoPath,
+      repository: repositoryMetadata,
       datasetPath,
       datasetQueryCount: 0,
       fileSampling: {
@@ -1722,7 +1874,7 @@ async function runForRepo(
 
 async function main(): Promise<void> {
   const options = parseCliArgs(process.argv.slice(2));
-  const resolvedRepos = options.repos.map((repo) => path.resolve(expandHome(repo)));
+  const resolvedRepos = options.repos.map((repo) => path.resolve(expandHome(repo.path)));
 
   if (resolvedRepos.length === 0) {
     throw new Error("No repositories configured");
@@ -1751,11 +1903,11 @@ async function main(): Promise<void> {
 
   const results: RepoBenchmarkResult[] = [];
 
-  for (const repoPath of resolvedRepos) {
-    const repoName = toRepoName(repoPath);
+  for (const repo of options.repos) {
+    const repoName = repo.name;
     console.log(`\n[${repoName}] generating dataset + running evaluations...`);
     const repoResult = await runForRepo(
-      repoPath,
+      repo,
       options,
       runDir,
       datasetRoot,
@@ -1781,7 +1933,8 @@ async function main(): Promise<void> {
   const reportJson = {
     generatedAt: new Date().toISOString(),
     options: {
-      repos: resolvedRepos,
+      repos: options.repos,
+      manifestPath: options.manifestPath,
       outputRoot: options.outputRoot,
       reindex: options.reindex,
       repeats: options.repeats,

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -900,6 +900,16 @@ export function buildGoldenDataset(repoName: string, repoPath: string, parsedFil
     !isCodeGraphUnsupportedDefinitionPath(candidate.filePath) &&
     !isCodeGraphSourceExcludedDefinitionPath(candidate.filePath)
   );
+
+  const definitionCounts = new Map<string, number>();
+  for (const candidate of definitionCandidates) {
+    definitionCounts.set(candidate.symbol, (definitionCounts.get(candidate.symbol) ?? 0) + 1);
+  }
+
+  const uniqueDefinitionCandidates = definitionCandidates.filter(
+    (candidate) => definitionCounts.get(candidate.symbol) === 1
+  );
+
   if (definitionCandidates.length === 0) {
     throw new Error(`No definition candidates outside unsupported CodeGraph source paths in ${repoName}`);
   }
@@ -907,7 +917,11 @@ export function buildGoldenDataset(repoName: string, repoPath: string, parsedFil
   const implementation = pickDistinctFiles(candidates.slice(3).length > 0 ? candidates.slice(3) : candidates, 3);
   const similarities = pickDistinctFiles(candidates.slice(6).length > 0 ? candidates.slice(6) : candidates, 2);
   const keywordHeavy = pickDistinctFiles(candidates.slice(8).length > 0 ? candidates.slice(8) : candidates, 2);
-  const definitions = pickDistinctFiles(definitionCandidates, 3);
+  if (uniqueDefinitionCandidates.length === 0) {
+    throw new Error(`No unique definition candidates outside unsupported CodeGraph source paths in ${repoName}`);
+  }
+
+  const definitions = pickDistinctFiles(uniqueDefinitionCandidates, 3);
 
   const queries: GoldenQuery[] = [];
   let counter = 1;

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -1799,7 +1799,7 @@ async function runForRepo(
   const datasetPath = path.join(datasetRoot, `${repoName}.json`);
 
   try {
-    const { dataset, collection, datasetPath } = resolveBenchmarkDataset(
+    const { dataset, collection, datasetPath: resolvedDatasetPath } = resolveBenchmarkDataset(
       repo,
       {
         datasetDir: options.datasetDir,
@@ -1837,7 +1837,7 @@ async function runForRepo(
       const reindexApplied = options.reindex && repeat === 0;
       const runOptions: EvalRunOptions = buildPluginEvalRunOptions({
         projectRoot: repoPath,
-        datasetPath,
+        datasetPath: resolvedDatasetPath,
         outputRoot: pluginOutputRoot,
         reindexApplied,
         configPath: controlledEvalConfigArtifactPath,
@@ -1889,7 +1889,7 @@ async function runForRepo(
       repoName,
       repoPath,
       repository: repositoryMetadata,
-      datasetPath,
+      datasetPath: resolvedDatasetPath,
       datasetQueryCount: dataset.queries.length,
       fileSampling: {
         parsedFileCount: collection.files.length,

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -18,7 +18,7 @@ import { createIsolatedSourceCopy, parseCodeGraphOutput, type CodeGraphResult } 
 import { buildPerQueryResult, computeEvalMetrics } from "../src/eval/metrics.js";
 import { runEvaluation } from "../src/eval/runner.js";
 import { parseGoldenDataset } from "../src/eval/schema.js";
-import { isDocumentationPath, isFixturePath, isTestPath } from "../src/indexer/intent-aware-ranking.js";
+import { isBenchmarkPath, isDocumentationPath, isFixturePath, isTestPath } from "../src/indexer/intent-aware-ranking.js";
 import type {
   EvalMetrics,
   EvalRunOptions,
@@ -73,7 +73,7 @@ const EXCLUDED_DIRS = new Set([
 
 const CODEGRAPH_UNSUPPORTED_DEFINITION_PATHS = [".github/workflows/"];
 
-const CODEGRAPH_SOURCE_EXCLUDED_PATHS = [isTestPath, isFixturePath, isDocumentationPath];
+const CODEGRAPH_SOURCE_EXCLUDED_PATHS = [isTestPath, isFixturePath, isDocumentationPath, isBenchmarkPath];
 
 export const MAX_FILE_SIZE_BYTES = 1_000_000;
 const MAX_PARSE_FILES = 2500;

--- a/scripts/prepare-package-metadata.mjs
+++ b/scripts/prepare-package-metadata.mjs
@@ -90,6 +90,13 @@ const outputDir = path.resolve(args.get("--output-dir") || projectRoot);
 const packageJsonPath = path.join(projectRoot, "package.json");
 const packageLockPath = path.join(projectRoot, "package-lock.json");
 
+const EXCLUDED_INDEX_PATHS = [
+  path.join(".opencode", "index"),
+  path.join(".claude", "index"),
+  path.join(".codebase-index", "index"),
+];
+const EXCLUDED_STAGING_DIRECTORIES = new Set([".git", "demo-repos"]);
+
 if (!existsSync(packageJsonPath)) fail(`Missing package.json at ${packageJsonPath}`);
 if (!existsSync(packageLockPath)) fail(`Missing package-lock.json at ${packageLockPath}`);
 
@@ -112,7 +119,16 @@ function copyProject() {
       if (relative === "") return true;
       const segments = relative.split(path.sep);
       const firstSegment = segments[0];
-      if (firstSegment === ".git" || firstSegment === "node_modules") return false;
+      if (segments.some((segment) => EXCLUDED_STAGING_DIRECTORIES.has(segment) || segment === "node_modules")) {
+        return false;
+      }
+      if (firstSegment === ".") return false;
+      if (segments.length >= 2) {
+        const pathPrefix = path.join(segments[0], segments[1]);
+        if (EXCLUDED_INDEX_PATHS.includes(pathPrefix)) {
+          return false;
+        }
+      }
       return !(firstSegment === "native" && segments[1] === "target");
     },
   });

--- a/scripts/run-codegraph-official-agent-benchmark.ts
+++ b/scripts/run-codegraph-official-agent-benchmark.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
 import * as path from "node:path";
 
 import { fileURLToPath } from "node:url";
@@ -71,8 +70,6 @@ interface CommandResult {
 }
 
 type CommandRunner = (command: string, args: string[], options?: { cwd?: string }) => Promise<CommandResult>;
-
-const execFileAsync = promisify(execFile);
 
 const DEFAULT_MANIFEST_PATH = path.join(process.cwd(), "benchmarks", "codegraph-official-agent.json");
 const DEFAULT_OUTPUT_ROOT = path.join(process.cwd(), "benchmarks", "results", "codegraph-official-agent");
@@ -150,26 +147,33 @@ function assertPathSafeId(value: unknown): string {
   return value;
 }
 
-function resolveCommandResult(command: string, result: unknown): CommandResult {
-  if (
-    isRecord(result) &&
-    "stdout" in result &&
-    "stderr" in result &&
-    typeof result.stdout === "string" &&
-    typeof result.stderr === "string"
-  ) {
-    return { stdout: result.stdout, stderr: result.stderr };
-  }
-  throw new Error(`Invalid command result from ${command}`);
-}
-
 export async function runCommand(command: string, args: string[], options?: { cwd?: string }): Promise<CommandResult> {
-  const result = await execFileAsync(command, args, {
-    encoding: "utf-8",
-    cwd: options?.cwd,
-    maxBuffer: 30 * 1024 * 1024,
+  return new Promise<CommandResult>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options?.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(`Command failed: ${command} ${args.join(" ")}\n${stderr}`));
+    });
+    child.stdin.end();
   });
-  return resolveCommandResult(command, result);
 }
 
 function parseSource(source: unknown): BenchmarkSourceManifest {

--- a/scripts/run-codegraph-official-agent-benchmark.ts
+++ b/scripts/run-codegraph-official-agent-benchmark.ts
@@ -625,7 +625,7 @@ function buildCodeGraphConfig(manifest: BenchmarkManifest, repoPath: string): Mc
     mcpServers: {
       codegraph: {
         command: "npx",
-        args: ["--yes", "--package", manifest.source.codegraphPackage, "mcp", "--path", repoPath],
+        args: ["--yes", manifest.source.codegraphPackage, "serve", "--mcp", "--path", repoPath],
       },
     },
   };
@@ -637,7 +637,7 @@ function buildOpenCodebaseIndexConfig(repoPath: string): McpConfig {
     mcpServers: {
       "open-codebase-index": {
         command: "node",
-        args: [cliPath, "mcp", "--host", "claude", "--project", repoPath],
+        args: [cliPath, "--host", "claude", "--project", repoPath],
       },
     },
   };
@@ -649,16 +649,54 @@ function configFileForArm(manifest: BenchmarkManifest, arm: (typeof ARMS)[number
   return buildOpenCodebaseIndexConfig(repoPath);
 }
 
+async function indexWorkspaceForArm(
+  manifest: BenchmarkManifest,
+  arm: (typeof ARMS)[number],
+  workspacePath: string,
+  commandRunner: CommandRunner,
+): Promise<void> {
+  if (arm === "baseline") return;
+
+  if (arm === "codegraph") {
+    await commandRunner("npx", ["--yes", manifest.source.codegraphPackage, "init", workspacePath]);
+    return;
+  }
+
+  const cliPath = path.resolve(process.cwd(), "dist", "cli.js");
+  if (!existsSync(cliPath)) {
+    throw new Error(`Local MCP CLI is missing: ${cliPath}. Run npm run build:ts before --execute.`);
+  }
+  await commandRunner("node", [cliPath, "index", "--host", "claude", "--project", workspacePath, "--force"]);
+}
+
 function writeConfig(configPath: string, config: McpConfig): void {
   mkdirSync(path.dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
 }
 
+function sessionIdFromStreamJson(output: string): string | undefined {
+  for (const line of output.split("\n").reverse()) {
+    if (!line.trim()) continue;
+    try {
+      const event: unknown = JSON.parse(line);
+      if (isRecord(event) && isNonEmptyString(event.session_id)) {
+        return event.session_id;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
 async function runClaudeSession(
   prompt: string,
   configPath: string,
+  workspacePath: string,
   model: string,
   effort: EffortLevel,
+  maxBudgetUsd: number,
+  sessionId: string | undefined,
   commandRunner: CommandRunner,
 ): Promise<string> {
   const args = [
@@ -670,11 +708,21 @@ async function runClaudeSession(
     effort,
     "--output-format",
     "stream-json",
+    "--verbose",
+    "--permission-mode",
+    "bypassPermissions",
+    "--max-budget-usd",
+    String(maxBudgetUsd),
+    "--strict-mcp-config",
     "--mcp-config",
     configPath,
   ];
 
-  const result = await commandRunner("claude", args);
+  if (sessionId) {
+    args.push("--resume", sessionId);
+  }
+
+  const result = await commandRunner("claude", args, { cwd: workspacePath });
   return result.stdout;
 }
 
@@ -716,10 +764,12 @@ export async function executeBenchmark(
         const armRunRoot = path.join(runRoot, repository.id, arm, `run-${run}`);
         const workspaceRoot = path.join(armRunRoot, "workspace");
         copyIsolatedRepo(preparedRepo.path, workspaceRoot);
+        await indexWorkspaceForArm(manifest, arm, workspaceRoot, commandRunner);
 
         const config = configFileForArm(manifest, arm, workspaceRoot);
         const configPath = path.join(armRunRoot, `mcp-config-${arm}.json`);
         writeConfig(configPath, config);
+        let sessionId: string | undefined;
 
         for (let turn = 0; turn < resolvedTurns; turn += 1) {
           const question = questionSet[turn];
@@ -731,11 +781,18 @@ export async function executeBenchmark(
           const raw = await runClaudeSession(
             question,
             configPath,
+            workspaceRoot,
             manifest.source.model,
             manifest.source.effort,
+            maxBudgetUsd,
+            sessionId,
             commandRunner,
           );
           writeFileSync(artifactPath, `${raw}\n`, { encoding: "utf-8" });
+          sessionId = sessionIdFromStreamJson(raw);
+          if (turn < resolvedTurns - 1 && !sessionId) {
+            throw new Error(`Claude did not return a session_id for ${repository.id}/${arm}/run-${run}/turn-${turn + 1}`);
+          }
         }
       }
     }

--- a/scripts/run-codegraph-official-agent-benchmark.ts
+++ b/scripts/run-codegraph-official-agent-benchmark.ts
@@ -455,7 +455,9 @@ export function planSummary(manifest: BenchmarkManifest, runs: number, turns: nu
   const resolvedRuns = runs || manifest.source.defaultRuns;
   const resolvedTurns = turns || manifest.source.defaultTurns;
   const repos = manifest.repositories.length;
-  const sessions = repos * resolvedRuns * resolvedTurns;
+  const armSessions = repos * resolvedRuns * ARMS.length;
+  const agentInvocations = armSessions * resolvedTurns;
+  const maxTotalBudgetUsd = agentInvocations * maxBudgetUsd;
 
   const armLabels = [
     "baseline",
@@ -468,8 +470,9 @@ export function planSummary(manifest: BenchmarkManifest, runs: number, turns: nu
     `Repos: ${repos}`,
     `Runs per repo: ${resolvedRuns}`,
     `Turns per run: ${resolvedTurns}`,
-    `Total planned agent sessions: ${sessions}`,
-    `Max budget ceiling: $${maxBudgetUsd.toFixed(2)} per session`,
+    `Total arm sessions: ${armSessions}`,
+    `Total Claude invocations: ${agentInvocations}`,
+    `Max budget ceiling: $${maxBudgetUsd.toFixed(2)} per invocation, $${maxTotalBudgetUsd.toFixed(2)} total`,
   ].join("\n");
 }
 

--- a/scripts/run-codegraph-official-agent-benchmark.ts
+++ b/scripts/run-codegraph-official-agent-benchmark.ts
@@ -39,6 +39,10 @@ export interface ParsedCliOptions {
   turns: number;
   maxBudgetUsd: number;
   mode: "dry-run" | "prepare" | "execute";
+  selectedRepo?: string;
+  selectedArm?: (typeof ARMS)[number];
+  selectedRun?: number;
+  selectedRunRoot?: string;
 }
 
 export interface PreparedRepository {
@@ -116,6 +120,10 @@ function isGitHubHttpsUrl(value: unknown): value is string {
 
 function isNpmPackage(value: unknown): value is string {
   return typeof value === "string" && /^@?[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[^\s]+$/.test(value);
+}
+
+function isKnownArm(value: unknown): value is (typeof ARMS)[number] {
+  return typeof value === "string" && (ARMS as readonly string[]).includes(value);
 }
 
 function expandHome(input: string): string {
@@ -344,6 +352,10 @@ export function parseCliArgs(argv: string[]): ParsedCliOptions {
   let turns = 0;
   let maxBudgetUsd = DEFAULT_MAX_BUDGET_USD;
   let mode: ParsedCliOptions["mode"] = "dry-run";
+  let selectedRepo: string | undefined;
+  let selectedArm: (typeof ARMS)[number] | undefined;
+  let selectedRun = 0;
+  let selectedRunRoot: string | undefined;
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -358,6 +370,53 @@ export function parseCliArgs(argv: string[]): ParsedCliOptions {
         throw new Error("--manifest requires a path value");
       }
       manifestPath = expandHome(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--run-root") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--run-root requires a path value");
+      }
+      selectedRunRoot = expandHome(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--repo") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--repo requires a repository id");
+      }
+      selectedRepo = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--run") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--run requires a positive integer");
+      }
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error("--run must be a positive integer");
+      }
+      selectedRun = parsed;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--arm") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--arm requires one of baseline, codegraph, or open-codebase-index");
+      }
+      if (!isKnownArm(value)) {
+        throw new Error("--arm must be baseline, codegraph, or open-codebase-index");
+      }
+      selectedArm = value;
       i += 1;
       continue;
     }
@@ -442,8 +501,29 @@ export function parseCliArgs(argv: string[]): ParsedCliOptions {
     throw new Error("Manifest path is required");
   }
 
+  const hasSelection =
+    selectedRepo !== undefined ||
+    selectedArm !== undefined ||
+    selectedRun !== 0 ||
+    selectedRunRoot !== undefined;
+
+  const hasIncompleteSelection =
+    selectedRepo === undefined ||
+    selectedArm === undefined ||
+    selectedRun === 0 ||
+    selectedRunRoot === undefined;
+
+  if (hasSelection && hasIncompleteSelection) {
+    throw new Error("Selection requires --run-root, --repo, --run, and --arm");
+  }
+
+  if (hasSelection && mode !== "execute") {
+    throw new Error("Single-session selection requires --execute");
+  }
+
   const resolvedManifestPath = path.resolve(expandHome(manifestPath));
   const resolvedOutputRoot = path.resolve(expandHome(outputRoot));
+  const resolvedSelectedRunRoot = selectedRunRoot ? path.resolve(expandHome(selectedRunRoot)) : undefined;
 
   return {
     manifestPath: resolvedManifestPath,
@@ -452,6 +532,10 @@ export function parseCliArgs(argv: string[]): ParsedCliOptions {
     turns,
     maxBudgetUsd,
     mode,
+    selectedRepo,
+    selectedArm,
+    selectedRun: hasSelection ? selectedRun : undefined,
+    selectedRunRoot: resolvedSelectedRunRoot,
   };
 }
 
@@ -696,6 +780,39 @@ function sessionIdFromStreamJson(output: string): string | undefined {
   return undefined;
 }
 
+function resolveArmSessionProgress(armRunRoot: string, turns: number): {
+  startTurn: number;
+  sessionId: string | undefined;
+  completed: boolean;
+} {
+  let startTurn = 0;
+  let sessionId: string | undefined;
+
+  for (let turn = 0; turn < turns; turn += 1) {
+    const artifactPath = path.join(armRunRoot, `turn-${turn + 1}.jsonl`);
+    if (!existsSync(artifactPath)) {
+      return { startTurn, sessionId, completed: false };
+    }
+
+    const raw = readFileSync(artifactPath, "utf-8").trim();
+    if (raw.length === 0) {
+      return { startTurn, sessionId, completed: false };
+    }
+
+    const found = sessionIdFromStreamJson(raw);
+    if (found) {
+      sessionId = found;
+    }
+    startTurn = turn + 1;
+  }
+
+  return {
+    startTurn,
+    sessionId,
+    completed: startTurn >= turns,
+  };
+}
+
 async function runClaudeSession(
   prompt: string,
   configPath: string,
@@ -744,21 +861,56 @@ export async function executeBenchmark(
   turns: number,
   maxBudgetUsd: number,
   commandRunner: CommandRunner = runCommand,
+  selectedSession?: {
+    runRoot: string;
+    repositoryId: string;
+    run: number;
+    arm: (typeof ARMS)[number];
+  },
 ): Promise<void> {
   if (maxBudgetUsd <= 0) {
     throw new Error("Max budget must be greater than 0");
   }
 
+  const runRoot = selectedSession ? selectedSession.runRoot : getRunRoot(outputRoot);
+  if (selectedSession && !existsSync(runRoot)) {
+    throw new Error(`Selected run root does not exist: ${runRoot}`);
+  }
+
   const state = await ensurePreparedWorkspace(manifest, outputRoot, commandRunner);
-  const runRoot = getRunRoot(outputRoot);
+
   const preparedById = new Map(state.repositories.map((entry) => [entry.id, entry] as const));
   const resolvedRuns = runs || manifest.source.defaultRuns;
   const resolvedTurns = turns || manifest.source.defaultTurns;
+  const selectedRepo = selectedSession ? preparedById.get(selectedSession.repositoryId) : undefined;
+  if (selectedSession) {
+    if (!selectedRepo) {
+      throw new Error(`Repository '${selectedSession.repositoryId}' is not in the manifest`);
+    }
 
-  for (const repository of manifest.repositories) {
-    const preparedRepo = preparedById.get(repository.id);
+    const selectedArmValid = ARMS.includes(selectedSession.arm);
+    if (!selectedArmValid) {
+      throw new Error(`Invalid arm '${selectedSession.arm}'`);
+    }
+  }
+
+  const selectedArm = selectedSession?.arm;
+  const selectedRun = selectedSession?.run;
+  const selectedRunNumber = selectedSession?.run ?? 0;
+
+  const repositoriesToRun = selectedSession ? [selectedRepo as PreparedRepository] : manifest.repositories.map((repo) => {
+    const preparedRepo = preparedById.get(repo.id);
     if (!preparedRepo) {
-      throw new Error(`Missing prepared repository '${repository.id}'`);
+      throw new Error(`Missing prepared repository '${repo.id}'`);
+    }
+    return preparedRepo;
+  });
+  const runList = selectedSession ? [selectedRun] : Array.from({ length: resolvedRuns }, (_, i) => i + 1);
+
+  for (const preparedRepo of repositoriesToRun) {
+    const repository = manifest.repositories.find((repo) => repo.id === preparedRepo.id);
+    if (!repository) {
+      throw new Error(`Prepared repository '${preparedRepo.id}' is not in manifest`);
     }
 
     const questionSet = sanitizeQuestions(repository, resolvedTurns);
@@ -766,9 +918,23 @@ export async function executeBenchmark(
       throw new Error(`Repository '${repository.id}' has only ${questionSet.length} questions, expected ${resolvedTurns}`);
     }
 
-    for (let run = 1; run <= resolvedRuns; run += 1) {
-      for (const arm of ARMS) {
+    const repositoryRunList = selectedSession
+      ? runList.filter((run) => run === selectedRunNumber)
+      : runList;
+
+    for (const run of repositoryRunList) {
+      const armList = selectedSession ? [selectedArm as (typeof ARMS)[number]] : ARMS;
+      for (const arm of armList) {
         const armRunRoot = path.join(runRoot, repository.id, arm, `run-${run}`);
+
+        const progress = selectedSession
+          ? resolveArmSessionProgress(armRunRoot, resolvedTurns)
+          : { startTurn: 0, sessionId: undefined, completed: false };
+
+        if (selectedSession && progress.completed) {
+          continue;
+        }
+
         const workspaceRoot = path.join(armRunRoot, "workspace");
         copyIsolatedRepo(preparedRepo.path, workspaceRoot);
         await indexWorkspaceForArm(manifest, arm, workspaceRoot, commandRunner);
@@ -776,9 +942,9 @@ export async function executeBenchmark(
         const config = configFileForArm(manifest, arm, workspaceRoot);
         const configPath = path.join(armRunRoot, `mcp-config-${arm}.json`);
         writeConfig(configPath, config);
-        let sessionId: string | undefined;
+        let sessionId: string | undefined = progress.sessionId;
 
-        for (let turn = 0; turn < resolvedTurns; turn += 1) {
+        for (let turn = progress.startTurn; turn < resolvedTurns; turn += 1) {
           const question = questionSet[turn];
           if (!question) {
             throw new Error(`Missing question ${turn} for repository '${repository.id}'`);
@@ -805,16 +971,24 @@ export async function executeBenchmark(
     }
   }
 
-  const planPath = path.join(runRoot, "plan.txt");
-  mkdirSync(runRoot, { recursive: true });
-  writeFileSync(planPath, [
-    planSummary(manifest, resolvedRuns, resolvedTurns, maxBudgetUsd),
-    `Execution output root: ${runRoot}`,
-  ].join("\n"), "utf-8");
+  if (!selectedSession) {
+    const planPath = path.join(runRoot, "plan.txt");
+    mkdirSync(runRoot, { recursive: true });
+    writeFileSync(planPath, [
+      planSummary(manifest, resolvedRuns, resolvedTurns, maxBudgetUsd),
+      `Execution output root: ${runRoot}`,
+    ].join("\n"), "utf-8");
+  }
 }
 
 function printUsage(): void {
-  console.log(`Usage: npx tsx scripts/run-codegraph-official-agent-benchmark.ts [--manifest path] [--output path] [--runs N] [--turns N] [--max-budget N] [--dry-run|--prepare|--execute]`);
+  console.log(
+    "Usage: npx tsx scripts/run-codegraph-official-agent-benchmark.ts [--manifest path] [--output path] [--runs N] [--turns N] [--max-budget N] [--dry-run|--prepare|--execute]",
+  );
+  console.log("Or run one session in an existing run root:");
+  console.log(
+    "  --execute --run-root <path> --repo <id> --run <N> --arm <baseline|codegraph|open-codebase-index>",
+  );
   console.log("Defaults:");
   console.log(`- manifest: ${DEFAULT_MANIFEST_PATH}`);
   console.log(`- output: ${DEFAULT_OUTPUT_ROOT}`);
@@ -855,8 +1029,21 @@ async function main(): Promise<void> {
   }
 
   if (options.mode === "execute") {
-    await executeBenchmark(manifest, options.outputRoot, runs, turns, options.maxBudgetUsd, runCommand);
-    console.log(`Execution artifacts written under ${options.outputRoot}/${RUNS_DIR}`);
+    const selectedSession = options.selectedRepo
+      ? {
+          runRoot: options.selectedRunRoot ?? "",
+          repositoryId: options.selectedRepo,
+          run: options.selectedRun ?? 0,
+          arm: options.selectedArm as (typeof ARMS)[number],
+        }
+      : undefined;
+
+    await executeBenchmark(manifest, options.outputRoot, runs, turns, options.maxBudgetUsd, runCommand, selectedSession);
+    if (selectedSession) {
+      console.log(`Execution artifacts written under ${selectedSession.runRoot}`);
+    } else {
+      console.log(`Execution artifacts written under ${options.outputRoot}/${RUNS_DIR}`);
+    }
   }
 }
 

--- a/scripts/run-codegraph-official-agent-benchmark.ts
+++ b/scripts/run-codegraph-official-agent-benchmark.ts
@@ -1,0 +1,805 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import * as path from "node:path";
+
+import { fileURLToPath } from "node:url";
+
+export interface BenchmarkSourceManifest {
+  name: string;
+  methodologyRepository: string;
+  methodologyCommit: string;
+  codegraphPackage: string;
+  defaultRuns: number;
+  defaultTurns: number;
+  model: string;
+  effort: EffortLevel;
+}
+
+export interface BenchmarkRepositoryManifest {
+  id: string;
+  url: string;
+  commit: string;
+  questions: string[];
+}
+
+export interface BenchmarkManifest {
+  version: number;
+  source: BenchmarkSourceManifest;
+  repositories: BenchmarkRepositoryManifest[];
+}
+
+export type EffortLevel = "low" | "medium" | "high" | "max";
+
+export interface ParsedCliOptions {
+  manifestPath: string;
+  outputRoot: string;
+  runs: number;
+  turns: number;
+  maxBudgetUsd: number;
+  mode: "dry-run" | "prepare" | "execute";
+}
+
+export interface PreparedRepository {
+  id: string;
+  path: string;
+  commit: string;
+}
+
+export interface PreparedState {
+  manifestPath: string;
+  source: BenchmarkSourceManifest;
+  repositories: PreparedRepository[];
+  preparedAt: string;
+}
+
+export interface McpServerSpec {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpConfig {
+  mcpServers: Record<string, McpServerSpec>;
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+type CommandRunner = (command: string, args: string[], options?: { cwd?: string }) => Promise<CommandResult>;
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_MANIFEST_PATH = path.join(process.cwd(), "benchmarks", "codegraph-official-agent.json");
+const DEFAULT_OUTPUT_ROOT = path.join(process.cwd(), "benchmarks", "results", "codegraph-official-agent");
+const PREPARED_MANIFEST_FILE = "prepared.json";
+const PREPARED_REPOS_DIR = "prepared";
+const RUNS_DIR = "runs";
+const DEFAULT_MAX_BUDGET_USD = 4;
+const ARMS = ["baseline", "codegraph", "open-codebase-index"] as const;
+const EXCLUDED_DIR_ENTRIES = new Set([
+  ".git",
+  ".codegraph",
+  ".codebase-index",
+  ".opencode",
+  ".claude",
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  "target",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isEffort(value: unknown): value is EffortLevel {
+  return value === "low" || value === "medium" || value === "high" || value === "max";
+}
+
+function isSha40(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-fA-F]{40}$/.test(value);
+}
+
+function isGitHubHttpsUrl(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(value)
+  );
+}
+
+function isNpmPackage(value: unknown): value is string {
+  return typeof value === "string" && /^@?[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[^\s]+$/.test(value);
+}
+
+function expandHome(input: string): string {
+  const home = process.env.HOME;
+  if (!home) return input;
+  if (input === "~") return home;
+  if (input.startsWith("~/")) {
+    return path.join(home, input.slice(2));
+  }
+  return input;
+}
+
+function assertFiniteInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`Expected ${label} to be a positive integer, got ${String(value)}`);
+  }
+  return value;
+}
+
+function assertPathSafeId(value: unknown): string {
+  if (!isNonEmptyString(value)) {
+    throw new Error("Repository id must be a non-empty string");
+  }
+
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    throw new Error(`Invalid repository id '${value}': must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/`);
+  }
+
+  return value;
+}
+
+function resolveCommandResult(command: string, result: unknown): CommandResult {
+  if (
+    isRecord(result) &&
+    "stdout" in result &&
+    "stderr" in result &&
+    typeof result.stdout === "string" &&
+    typeof result.stderr === "string"
+  ) {
+    return { stdout: result.stdout, stderr: result.stderr };
+  }
+  throw new Error(`Invalid command result from ${command}`);
+}
+
+export async function runCommand(command: string, args: string[], options?: { cwd?: string }): Promise<CommandResult> {
+  const result = await execFileAsync(command, args, {
+    encoding: "utf-8",
+    cwd: options?.cwd,
+    maxBuffer: 30 * 1024 * 1024,
+  });
+  return resolveCommandResult(command, result);
+}
+
+function parseSource(source: unknown): BenchmarkSourceManifest {
+  if (!isRecord(source)) {
+    throw new Error("Manifest source must be an object");
+  }
+
+  const keys = Object.keys(source);
+  const allowed = new Set([
+    "name",
+    "methodologyRepository",
+    "methodologyCommit",
+    "codegraphPackage",
+    "defaultRuns",
+    "defaultTurns",
+    "model",
+    "effort",
+  ]);
+
+  for (const key of keys) {
+    if (!allowed.has(key)) {
+      throw new Error(`Manifest source contains unexpected field '${key}'`);
+    }
+  }
+
+  if (!isNonEmptyString(source.name)) {
+    throw new Error("Manifest source.name must be a non-empty string");
+  }
+
+  if (!isGitHubHttpsUrl(source.methodologyRepository)) {
+    throw new Error("Manifest source.methodologyRepository must be a canonical github URL");
+  }
+
+  const methodologyCommit = String(source.methodologyCommit ?? "").trim().toLowerCase();
+  if (!isSha40(methodologyCommit)) {
+    throw new Error("Manifest source.methodologyCommit must be a full 40-character SHA");
+  }
+
+  if (!isNpmPackage(source.codegraphPackage)) {
+    throw new Error("Manifest source.codegraphPackage must be a pinned package reference");
+  }
+
+  const defaultRuns = assertFiniteInteger(source.defaultRuns, "source.defaultRuns");
+  const defaultTurns = assertFiniteInteger(source.defaultTurns, "source.defaultTurns");
+
+  if (!isNonEmptyString(source.model)) {
+    throw new Error("Manifest source.model must be a non-empty string");
+  }
+
+  if (!isEffort(source.effort)) {
+    throw new Error("Manifest source.effort must be 'low', 'medium', 'high', or 'max'");
+  }
+
+  return {
+    name: source.name,
+    methodologyRepository: source.methodologyRepository,
+    methodologyCommit,
+    codegraphPackage: source.codegraphPackage,
+    defaultRuns,
+    defaultTurns,
+    model: source.model,
+    effort: source.effort,
+  };
+}
+
+function parseRepository(
+  repo: unknown,
+  index: number,
+  defaultTurns: number,
+): BenchmarkRepositoryManifest {
+  if (!isRecord(repo)) {
+    throw new Error(`Manifest repository at index ${index} must be an object`);
+  }
+
+  const keys = Object.keys(repo);
+  const allowed = new Set(["id", "url", "commit", "questions"]);
+  for (const key of keys) {
+    if (!allowed.has(key)) {
+      throw new Error(`Manifest repository '${index}' contains unexpected field '${key}'`);
+    }
+  }
+
+  const id = assertPathSafeId(repo.id);
+
+  if (!isGitHubHttpsUrl(repo.url)) {
+    throw new Error(`Manifest repository '${id}' url must be a canonical github URL`);
+  }
+
+  const commit = String(repo.commit ?? "").trim().toLowerCase();
+  if (!isSha40(commit)) {
+    throw new Error(`Manifest repository '${id}' commit must be a full 40-character SHA`);
+  }
+
+  if (!Array.isArray(repo.questions)) {
+    throw new Error(`Manifest repository '${id}' questions must be an array`);
+  }
+
+  if (repo.questions.length < defaultTurns) {
+    throw new Error(`Manifest repository '${id}' has fewer questions (${repo.questions.length}) than defaultTurns (${defaultTurns})`);
+  }
+
+  const questions: string[] = [];
+  for (let q = 0; q < repo.questions.length; q += 1) {
+    const question = repo.questions[q];
+    if (!isNonEmptyString(question)) {
+      throw new Error(`Manifest repository '${id}' question ${q} must be a non-empty string`);
+    }
+    questions.push(question.trim());
+  }
+
+  return { id, url: repo.url, commit, questions };
+}
+
+export function parseManifest(manifestPath: string): BenchmarkManifest {
+  const resolvedPath = path.resolve(expandHome(manifestPath));
+  const raw = readFileSync(resolvedPath, "utf-8");
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw) as unknown;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Manifest file ${resolvedPath} is invalid JSON: ${message}`);
+  }
+
+  if (!isRecord(data)) {
+    throw new Error(`Manifest file ${resolvedPath} must contain a JSON object`);
+  }
+
+  const keys = Object.keys(data);
+  const allowedTopLevel = new Set(["version", "source", "repositories"]);
+  for (const key of keys) {
+    if (!allowedTopLevel.has(key)) {
+      throw new Error(`Manifest contains unexpected top-level field '${key}'`);
+    }
+  }
+
+  if (data.version !== 1) {
+    throw new Error(`Manifest version must be 1, got ${String(data.version)}`);
+  }
+
+  const source = parseSource(data.source);
+
+  if (!Array.isArray(data.repositories) || data.repositories.length === 0) {
+    throw new Error("Manifest repositories must be a non-empty array");
+  }
+
+  const repositories = data.repositories.map((repo, index) => parseRepository(repo, index, source.defaultTurns));
+  const ids = new Set<string>();
+  for (const repo of repositories) {
+    if (ids.has(repo.id)) {
+      throw new Error(`Manifest repository id '${repo.id}' is duplicated`);
+    }
+    ids.add(repo.id);
+  }
+
+  return {
+    version: 1,
+    source,
+    repositories,
+  };
+}
+
+export function parseCliArgs(argv: string[]): ParsedCliOptions {
+  let manifestPath = DEFAULT_MANIFEST_PATH;
+  let outputRoot = DEFAULT_OUTPUT_ROOT;
+  let runs = 0;
+  let turns = 0;
+  let maxBudgetUsd = DEFAULT_MAX_BUDGET_USD;
+  let mode: ParsedCliOptions["mode"] = "dry-run";
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === "--help" || arg === "-h") {
+      throw new Error("HELP_REQUESTED");
+    }
+
+    if (arg === "--manifest") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--manifest requires a path value");
+      }
+      manifestPath = expandHome(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--output requires a path value");
+      }
+      outputRoot = expandHome(value);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--runs") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--runs requires a number");
+      }
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error("--runs must be a positive integer");
+      }
+      runs = parsed;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--turns") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--turns requires a number");
+      }
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error("--turns must be a positive integer");
+      }
+      turns = parsed;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--max-budget") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--max-budget requires a number");
+      }
+      const parsed = Number.parseFloat(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error("--max-budget must be a positive number");
+      }
+      maxBudgetUsd = parsed;
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      mode = "dry-run";
+      continue;
+    }
+
+    if (arg === "--prepare") {
+      if (mode === "execute") {
+        throw new Error("Cannot combine --prepare and --execute");
+      }
+      mode = "prepare";
+      continue;
+    }
+
+    if (arg === "--execute") {
+      if (mode === "prepare") {
+        throw new Error("Cannot combine --prepare and --execute");
+      }
+      mode = "execute";
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (manifestPath.trim().length === 0) {
+    throw new Error("Manifest path is required");
+  }
+
+  const resolvedManifestPath = path.resolve(expandHome(manifestPath));
+  const resolvedOutputRoot = path.resolve(expandHome(outputRoot));
+
+  return {
+    manifestPath: resolvedManifestPath,
+    outputRoot: resolvedOutputRoot,
+    runs,
+    turns,
+    maxBudgetUsd,
+    mode,
+  };
+}
+
+export function planSummary(manifest: BenchmarkManifest, runs: number, turns: number, maxBudgetUsd: number): string {
+  const resolvedRuns = runs || manifest.source.defaultRuns;
+  const resolvedTurns = turns || manifest.source.defaultTurns;
+  const repos = manifest.repositories.length;
+  const sessions = repos * resolvedRuns * resolvedTurns;
+
+  const armLabels = [
+    "baseline",
+    `codegraph (${manifest.source.codegraphPackage})`,
+    "open-codebase-index (dist/cli.js --host claude)",
+  ];
+
+  return [
+    `Three-arm plan: ${armLabels.join(" | ")}`,
+    `Repos: ${repos}`,
+    `Runs per repo: ${resolvedRuns}`,
+    `Turns per run: ${resolvedTurns}`,
+    `Total planned agent sessions: ${sessions}`,
+    `Max budget ceiling: $${maxBudgetUsd.toFixed(2)} per session`,
+  ].join("\n");
+}
+
+function shouldExcludeFromCopy(entry: string, repoRoot: string): boolean {
+  const relative = path.relative(repoRoot, entry);
+  if (relative === "" || relative.startsWith("..")) {
+    return false;
+  }
+
+  const segments = relative.split(path.sep).filter((segment) => segment.length > 0);
+  return segments.some((segment, index) => {
+    const lowered = segment.toLowerCase();
+    if (EXCLUDED_DIR_ENTRIES.has(lowered)) return true;
+    return index === 0 && lowered === "benchmarks";
+  });
+}
+
+function copyIsolatedRepo(sourcePath: string, destinationPath: string): void {
+  rmSync(destinationPath, { recursive: true, force: true });
+  cpSync(sourcePath, destinationPath, {
+    recursive: true,
+    force: true,
+    filter: (source) => !shouldExcludeFromCopy(source, sourcePath),
+  });
+}
+
+function getPreparedStatePath(outputRoot: string): string {
+  return path.join(outputRoot, PREPARED_MANIFEST_FILE);
+}
+
+function getPreparedRepoRoot(outputRoot: string, repoId: string): string {
+  return path.join(outputRoot, PREPARED_REPOS_DIR, repoId);
+}
+
+function getRunRoot(outputRoot: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return path.join(outputRoot, RUNS_DIR, timestamp);
+}
+
+function readPreparedState(outputRoot: string): PreparedState {
+  const marker = getPreparedStatePath(outputRoot);
+  if (!existsSync(marker)) {
+    throw new Error(`No prepared repos found. Run with --prepare first.`);
+  }
+
+  const raw = readFileSync(marker, "utf-8");
+  try {
+    return JSON.parse(raw) as PreparedState;
+  } catch {
+    throw new Error(`Prepared state at ${marker} is invalid JSON`);
+  }
+}
+
+export async function ensurePreparedWorkspace(
+  manifest: BenchmarkManifest,
+  outputRoot: string,
+  commandRunner: CommandRunner = runCommand,
+): Promise<PreparedState> {
+  const state = readPreparedState(outputRoot);
+
+  if (state.source.codegraphPackage !== manifest.source.codegraphPackage) {
+    throw new Error("Prepared state does not match current manifest's CodeGraph package");
+  }
+
+  if (state.repositories.length !== manifest.repositories.length) {
+    throw new Error("Prepared repo count does not match manifest");
+  }
+
+  for (const repo of manifest.repositories) {
+    const preparedRepo = state.repositories.find((item) => item.id === repo.id);
+    if (!preparedRepo) {
+      throw new Error(`Prepared workspace missing for repository '${repo.id}'`);
+    }
+
+    if (preparedRepo.commit !== repo.commit) {
+      throw new Error(`Prepared repository '${repo.id}' commit mismatch: ${preparedRepo.commit} != ${repo.commit}`);
+    }
+
+    const output = await commandRunner("git", ["-C", preparedRepo.path, "rev-parse", "HEAD"]);
+    const head = output.stdout.trim().toLowerCase();
+    if (head !== repo.commit) {
+      throw new Error(`Prepared repository '${repo.id}' currently at ${head}; expected ${repo.commit}`);
+    }
+
+    if (!existsSync(preparedRepo.path)) {
+      throw new Error(`Prepared repository path missing for '${repo.id}': ${preparedRepo.path}`);
+    }
+  }
+
+  return state;
+}
+
+export async function prepareRepositories(
+  manifest: BenchmarkManifest,
+  outputRoot: string,
+  manifestPath?: string,
+  commandRunner: CommandRunner = runCommand,
+): Promise<void> {
+  mkdirSync(outputRoot, { recursive: true });
+  const preparedRepoEntries: PreparedRepository[] = [];
+  const preparedDir = path.join(outputRoot, PREPARED_REPOS_DIR);
+  mkdirSync(preparedDir, { recursive: true });
+
+  for (const repository of manifest.repositories) {
+    const destination = getPreparedRepoRoot(outputRoot, repository.id);
+
+    if (existsSync(destination)) {
+      const existsHead = await commandRunner("git", ["-C", destination, "rev-parse", "HEAD"]).then((result) =>
+        result.stdout.trim().toLowerCase(),
+      );
+      if (existsHead !== repository.commit) {
+        throw new Error(`Existing directory ${destination} for '${repository.id}' is at ${existsHead} (expected ${repository.commit})`);
+      }
+
+      await commandRunner("git", ["-C", destination, "checkout", "--detach", repository.commit]);
+      preparedRepoEntries.push({ id: repository.id, path: destination, commit: repository.commit });
+      continue;
+    }
+
+    await commandRunner("git", ["clone", "--filter=blob:none", "--depth", "1", repository.url, destination]);
+    await commandRunner("git", ["-C", destination, "fetch", "--depth", "1", "origin", repository.commit]);
+    await commandRunner("git", ["-C", destination, "checkout", "--detach", repository.commit]);
+    const head = await commandRunner("git", ["-C", destination, "rev-parse", "HEAD"]).then((result) =>
+      result.stdout.trim().toLowerCase(),
+    );
+
+    if (head !== repository.commit) {
+      throw new Error(`Prepared repository '${repository.id}' checkout failed (expected ${repository.commit}, got ${head})`);
+    }
+
+    preparedRepoEntries.push({ id: repository.id, path: destination, commit: repository.commit });
+  }
+
+  const state: PreparedState = {
+    manifestPath: manifestPath
+      ? path.resolve(expandHome(manifestPath))
+      : path.resolve(process.cwd(), "benchmarks", "codegraph-official-agent.json"),
+    source: manifest.source,
+    repositories: preparedRepoEntries,
+    preparedAt: new Date().toISOString(),
+  };
+
+  const markerPath = getPreparedStatePath(outputRoot);
+  writeFileSync(markerPath, JSON.stringify(state, null, 2), "utf-8");
+}
+
+function buildBaselineConfig(): McpConfig {
+  return { mcpServers: {} };
+}
+
+function buildCodeGraphConfig(manifest: BenchmarkManifest, repoPath: string): McpConfig {
+  return {
+    mcpServers: {
+      codegraph: {
+        command: "npx",
+        args: ["--yes", "--package", manifest.source.codegraphPackage, "mcp", "--path", repoPath],
+      },
+    },
+  };
+}
+
+function buildOpenCodebaseIndexConfig(repoPath: string): McpConfig {
+  const cliPath = path.resolve(process.cwd(), "dist", "cli.js");
+  return {
+    mcpServers: {
+      "open-codebase-index": {
+        command: "node",
+        args: [cliPath, "mcp", "--host", "claude", "--project", repoPath],
+      },
+    },
+  };
+}
+
+function configFileForArm(manifest: BenchmarkManifest, arm: (typeof ARMS)[number], repoPath: string): McpConfig {
+  if (arm === "baseline") return buildBaselineConfig();
+  if (arm === "codegraph") return buildCodeGraphConfig(manifest, repoPath);
+  return buildOpenCodebaseIndexConfig(repoPath);
+}
+
+function writeConfig(configPath: string, config: McpConfig): void {
+  mkdirSync(path.dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
+}
+
+async function runClaudeSession(
+  prompt: string,
+  configPath: string,
+  model: string,
+  effort: EffortLevel,
+  commandRunner: CommandRunner,
+): Promise<string> {
+  const args = [
+    "-p",
+    prompt,
+    "--model",
+    model,
+    "--effort",
+    effort,
+    "--output-format",
+    "stream-json",
+    "--mcp-config",
+    configPath,
+  ];
+
+  const result = await commandRunner("claude", args);
+  return result.stdout;
+}
+
+function sanitizeQuestions(repository: BenchmarkRepositoryManifest, turns: number): string[] {
+  return repository.questions.slice(0, turns);
+}
+
+export async function executeBenchmark(
+  manifest: BenchmarkManifest,
+  outputRoot: string,
+  runs: number,
+  turns: number,
+  maxBudgetUsd: number,
+  commandRunner: CommandRunner = runCommand,
+): Promise<void> {
+  if (maxBudgetUsd <= 0) {
+    throw new Error("Max budget must be greater than 0");
+  }
+
+  const state = await ensurePreparedWorkspace(manifest, outputRoot, commandRunner);
+  const runRoot = getRunRoot(outputRoot);
+  const preparedById = new Map(state.repositories.map((entry) => [entry.id, entry] as const));
+  const resolvedRuns = runs || manifest.source.defaultRuns;
+  const resolvedTurns = turns || manifest.source.defaultTurns;
+
+  for (const repository of manifest.repositories) {
+    const preparedRepo = preparedById.get(repository.id);
+    if (!preparedRepo) {
+      throw new Error(`Missing prepared repository '${repository.id}'`);
+    }
+
+    const questionSet = sanitizeQuestions(repository, resolvedTurns);
+    if (questionSet.length < resolvedTurns) {
+      throw new Error(`Repository '${repository.id}' has only ${questionSet.length} questions, expected ${resolvedTurns}`);
+    }
+
+    for (let run = 1; run <= resolvedRuns; run += 1) {
+      for (const arm of ARMS) {
+        const armRunRoot = path.join(runRoot, repository.id, arm, `run-${run}`);
+        const workspaceRoot = path.join(armRunRoot, "workspace");
+        copyIsolatedRepo(preparedRepo.path, workspaceRoot);
+
+        const config = configFileForArm(manifest, arm, workspaceRoot);
+        const configPath = path.join(armRunRoot, `mcp-config-${arm}.json`);
+        writeConfig(configPath, config);
+
+        for (let turn = 0; turn < resolvedTurns; turn += 1) {
+          const question = questionSet[turn];
+          if (!question) {
+            throw new Error(`Missing question ${turn} for repository '${repository.id}'`);
+          }
+
+          const artifactPath = path.join(armRunRoot, `turn-${turn + 1}.jsonl`);
+          const raw = await runClaudeSession(
+            question,
+            configPath,
+            manifest.source.model,
+            manifest.source.effort,
+            commandRunner,
+          );
+          writeFileSync(artifactPath, `${raw}\n`, { encoding: "utf-8" });
+        }
+      }
+    }
+  }
+
+  const planPath = path.join(runRoot, "plan.txt");
+  mkdirSync(runRoot, { recursive: true });
+  writeFileSync(planPath, [
+    planSummary(manifest, resolvedRuns, resolvedTurns, maxBudgetUsd),
+    `Execution output root: ${runRoot}`,
+  ].join("\n"), "utf-8");
+}
+
+function printUsage(): void {
+  console.log(`Usage: npx tsx scripts/run-codegraph-official-agent-benchmark.ts [--manifest path] [--output path] [--runs N] [--turns N] [--max-budget N] [--dry-run|--prepare|--execute]`);
+  console.log("Defaults:");
+  console.log(`- manifest: ${DEFAULT_MANIFEST_PATH}`);
+  console.log(`- output: ${DEFAULT_OUTPUT_ROOT}`);
+  console.log(`- dry-run: true`);
+  console.log(`- runs: manifest.source.defaultRuns`);
+  console.log(`- turns: manifest.source.defaultTurns`);
+  console.log(`- max budget: $${DEFAULT_MAX_BUDGET_USD}`);
+}
+
+async function main(): Promise<void> {
+  let options: ParsedCliOptions;
+  try {
+    options = parseCliArgs(process.argv.slice(2));
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message === "HELP_REQUESTED") {
+      printUsage();
+      return;
+    }
+    throw error;
+  }
+
+  const manifest = parseManifest(options.manifestPath);
+  const runs = options.runs || manifest.source.defaultRuns;
+  const turns = options.turns || manifest.source.defaultTurns;
+
+  console.log(planSummary(manifest, runs, turns, options.maxBudgetUsd));
+  console.log(`Output directory: ${options.outputRoot}`);
+
+  if (options.mode === "dry-run") {
+    console.log("Mode: dry-run (no clone, no indexing, no model calls)");
+    return;
+  }
+
+  if (options.mode === "prepare") {
+    await prepareRepositories(manifest, options.outputRoot, options.manifestPath, runCommand);
+    console.log(`Prepared ${manifest.repositories.length} repos under ${options.outputRoot}`);
+    return;
+  }
+
+  if (options.mode === "execute") {
+    await executeBenchmark(manifest, options.outputRoot, runs, turns, options.maxBudgetUsd, runCommand);
+    console.log(`Execution artifacts written under ${options.outputRoot}/${RUNS_DIR}`);
+  }
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  });
+}

--- a/scripts/run-codegraph-official-agent-benchmark.ts
+++ b/scripts/run-codegraph-official-agent-benchmark.ts
@@ -936,8 +936,11 @@ export async function executeBenchmark(
         }
 
         const workspaceRoot = path.join(armRunRoot, "workspace");
-        copyIsolatedRepo(preparedRepo.path, workspaceRoot);
-        await indexWorkspaceForArm(manifest, arm, workspaceRoot, commandRunner);
+        const reuseWorkspace = selectedSession && existsSync(workspaceRoot);
+        if (!reuseWorkspace) {
+          copyIsolatedRepo(preparedRepo.path, workspaceRoot);
+          await indexWorkspaceForArm(manifest, arm, workspaceRoot, commandRunner);
+        }
 
         const config = configFileForArm(manifest, arm, workspaceRoot);
         const configPath = path.join(armRunRoot, `mcp-config-${arm}.json`);

--- a/src/adapters/mcp/register-tools.ts
+++ b/src/adapters/mcp/register-tools.ts
@@ -80,10 +80,14 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET).optional()
           .default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET),
       ).describe(`Maximum response tokens for this context pack (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
+      diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
     },
     async (args) => {
       const result = await executeCodebaseContext(runtime.projectRoot, runtime.host, args);
-      return { content: [{ type: "text", text: result.text }] };
+      return {
+        content: [{ type: "text", text: result.text }],
+        ...(args.diagnostic ? { structuredContent: result.details } : {}),
+      };
     },
   );
 

--- a/src/adapters/opencode/tools.ts
+++ b/src/adapters/opencode/tools.ts
@@ -68,6 +68,31 @@ const DEFAULT_HOST: HostMode = "opencode";
 const CHUNK_TYPE_VALUES = CHUNK_TYPES;
 const RELATIONSHIP_TYPE_VALUES = RELATIONSHIP_TYPES;
 
+function stableSortedDiagnosticValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableSortedDiagnosticValue(item));
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const entries = Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const sorted: Record<string, unknown> = {};
+
+  for (const [key, item] of entries) {
+    sorted[key] = stableSortedDiagnosticValue(item);
+  }
+
+  return sorted;
+}
+
+function formatCodebaseContextDiagnostic(details: unknown): string {
+  const sorted = stableSortedDiagnosticValue(details);
+  return `\nDiagnostics:\n${JSON.stringify(sorted, null, 2)}`;
+}
+
 export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig): void {
   initializeToolOperations(projectRoot, config, DEFAULT_HOST);
 }
@@ -102,7 +127,12 @@ export const codebase_context: ToolDefinition = tool({
     diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
   },
   async execute(args, context) {
-    return (await executeCodebaseContext(context?.worktree, DEFAULT_HOST, args)).text;
+    const result = await executeCodebaseContext(context?.worktree, DEFAULT_HOST, args);
+    if (!args.diagnostic || !result.details?.diagnostic) {
+      return result.text;
+    }
+
+    return `${result.text}${formatCodebaseContextDiagnostic(result.details.diagnostic)}`;
   },
 });
 

--- a/src/adapters/opencode/tools.ts
+++ b/src/adapters/opencode/tools.ts
@@ -99,6 +99,7 @@ export const codebase_context: ToolDefinition = tool({
     tokenBudget: z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET)
       .nullable().optional().default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET)
       .describe(`Maximum response tokens (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
+    diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
   },
   async execute(args, context) {
     return (await executeCodebaseContext(context?.worktree, DEFAULT_HOST, args)).text;

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -94,6 +94,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
         Type.Integer({ minimum: MIN_CONTEXT_PATH_DEPTH, maximum: MAX_CONTEXT_PATH_DEPTH }),
         Type.Null(),
       ], { default: 10, description: `Maximum call-graph traversal depth (${MIN_CONTEXT_PATH_DEPTH}-${MAX_CONTEXT_PATH_DEPTH})` })),
+      diagnostic: Type.Optional(Type.Union([Type.Boolean(), Type.Null()], { description: "Collect diagnostic routing and search traces without changing normal output." })),
       fileType: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Filter by file extension, e.g., ts, py, rs" })),
       directory: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Filter by directory path" })),
       tokenBudget: Type.Optional(Type.Union([
@@ -105,7 +106,11 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await resolveCodebaseContext(projectRoot(ctx), HOST, params);
+      const normalizedParams = {
+        ...params,
+        diagnostic: params.diagnostic ?? undefined,
+      };
+      const result = await resolveCodebaseContext(projectRoot(ctx), HOST, normalizedParams);
       return text(result.text, result.details);
     },
   });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -369,6 +369,40 @@ export interface SearchResult {
   blame?: GitBlameMetadata;
 }
 
+interface CandidateSnapshot {
+  id: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  chunkType: string;
+  name?: string;
+}
+
+export interface SearchTrace {
+  semanticCandidates: CandidateSnapshot[];
+  keywordCandidates: CandidateSnapshot[];
+  hybridCandidates: CandidateSnapshot[];
+  postExternalRerankCandidates: CandidateSnapshot[];
+  tieredCandidates: CandidateSnapshot[];
+  finalCandidates: CandidateSnapshot[];
+}
+
+interface SearchOptions {
+  hybridWeight?: number;
+  fileType?: string;
+  directory?: string;
+  chunkType?: string;
+  contextLines?: number;
+  filterByBranch?: boolean;
+  metadataOnly?: boolean;
+  definitionIntent?: boolean;
+  blameAuthor?: string;
+  blameSha?: string;
+  blameSince?: string;
+  trace?: (trace: SearchTrace) => void;
+}
+
 export interface HealthCheckResult {
   removed: number;
   filePaths: string[];
@@ -4613,6 +4647,22 @@ export class Indexer {
     }
   }
 
+  private buildCandidateSnapshot(candidate: RankedCandidate): CandidateSnapshot {
+    return {
+      id: candidate.id,
+      filePath: candidate.metadata.filePath,
+      startLine: candidate.metadata.startLine,
+      endLine: candidate.metadata.endLine,
+      score: candidate.score,
+      chunkType: candidate.metadata.chunkType,
+      name: candidate.metadata.name,
+    };
+  }
+
+  private buildCandidateSnapshotList(candidates: RankedCandidate[]): CandidateSnapshot[] {
+    return candidates.map((candidate) => this.buildCandidateSnapshot(candidate));
+  }
+
   private searchSemanticCandidates(
     store: VectorStore,
     embedding: number[],
@@ -4633,19 +4683,7 @@ export class Indexer {
   async search(
     query: string,
     limit?: number,
-    options?: {
-      hybridWeight?: number;
-      fileType?: string;
-      directory?: string;
-      chunkType?: string;
-      contextLines?: number;
-      filterByBranch?: boolean;
-      metadataOnly?: boolean;
-      definitionIntent?: boolean;
-      blameAuthor?: string;
-      blameSha?: string;
-      blameSince?: string;
-    }
+    options?: SearchOptions
   ): Promise<SearchResult[]> {
     const { store, provider, invertedIndex, database, readIssues, compatibility } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "vectors", "database");
@@ -4869,6 +4907,17 @@ export class Indexer {
       prefilterMs: Math.round(prefilterMs * 100) / 100,
       fusionMs: Math.round(fusionMs * 100) / 100,
     });
+
+    if (options?.trace) {
+      options.trace({
+        semanticCandidates: this.buildCandidateSnapshotList(scopedSemanticCandidates),
+        keywordCandidates: this.buildCandidateSnapshotList(scopedKeywordCandidates),
+        hybridCandidates: this.buildCandidateSnapshotList(combined),
+        postExternalRerankCandidates: this.buildCandidateSnapshotList(rerankedCombined),
+        tieredCandidates: this.buildCandidateSnapshotList(tiered),
+        finalCandidates: this.buildCandidateSnapshotList(finalResults),
+      });
+    }
 
     const metadataOnly = options?.metadataOnly ?? false;
 

--- a/src/indexer/intent-aware-ranking.ts
+++ b/src/indexer/intent-aware-ranking.ts
@@ -217,6 +217,11 @@ export function isTestPath(filePath: string): boolean {
     /\.(?:test|spec)\.[^/]+$/u.test(normalized);
 }
 
+export function isBenchmarkPath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  return /(?:^|\/)(?:bench|benches)(?:\/|$)/u.test(normalized) || /\.bench\.[^/]+$/u.test(normalized);
+}
+
 export function isFixturePath(filePath: string): boolean {
   const normalized = normalizePath(filePath);
   return /(?:^|\/)(?:fixture|fixtures|testdata|snapshots?)(?:\/|$)/u.test(normalized) || normalized.endsWith(".snap");
@@ -344,6 +349,7 @@ function scoreCandidate(query: string, intent: QueryIntentProfile, candidate: Ra
 
   if (intent.primary === "conceptual") {
     boost += Math.min(0.14, overlap * 0.14);
+    if (isBenchmarkPath(metadata.filePath)) boost -= 0.12;
     if (generatedOrVendor) boost -= 0.18;
     if (importChunk || weakContainer) boost -= 0.04;
   } else if (intent.primary === "test") {

--- a/src/indexer/intent-aware-ranking.ts
+++ b/src/indexer/intent-aware-ranking.ts
@@ -264,7 +264,7 @@ function isWeakContainer(metadata: ChunkMetadata): boolean {
 }
 
 export function isLikelyImplementationPath(filePath: string): boolean {
-  if (isTestPath(filePath) || isFixturePath(filePath) || isDocumentationPath(filePath) || isGeneratedOrVendorPath(filePath)) {
+  if (isBenchmarkPath(filePath) || isTestPath(filePath) || isFixturePath(filePath) || isDocumentationPath(filePath) || isGeneratedOrVendorPath(filePath)) {
     return false;
   }
   if (!isConfigPath(filePath)) return true;

--- a/src/tools/context-pack.ts
+++ b/src/tools/context-pack.ts
@@ -21,6 +21,50 @@ export interface ContextPackOptions {
   includeExactSearchHandoff?: boolean;
   preferImplementationPaths?: boolean;
   preserveInputOrder?: boolean;
+  trace?: (trace: ContextPackTrace) => void;
+}
+
+export interface ContextPackTrace {
+  inputCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  rankedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  deduplicatedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  diversifiedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  selectedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
 }
 
 export interface ContextPackResult {
@@ -160,6 +204,17 @@ function compactEvidenceValue(value: string, maxChars: number): string {
 const MAX_EXACT_SEARCH_HANDOFF_NAMES = 3;
 const MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS = 64;
 
+function toContextPackTraceCandidate(result: SearchResult): ContextPackTrace["inputCandidates"][number] {
+  return {
+    filePath: result.filePath,
+    startLine: result.startLine,
+    endLine: result.endLine,
+    score: result.score,
+    chunkType: result.chunkType,
+    name: result.name,
+  };
+}
+
 export function formatExactSearchHandoff(results: SearchResult[]): string | null {
   const suggestedNames: string[] = [];
   const seen = new Set<string>();
@@ -232,8 +287,11 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const ranked = preserveInputOrder
     ? results.map((result, originalIndex) => ({ result, originalIndex }))
     : rankContextCandidates(results, options.preferImplementationPaths ?? false);
+  const rankedCandidates = ranked.map((entry) => toContextPackTraceCandidate(entry.result));
   const deduplicated = deduplicateContextCandidates(ranked);
+  const deduplicatedCandidates = deduplicated.map((result) => toContextPackTraceCandidate(result));
   const diversified = preserveInputOrder ? deduplicated : diversifyContextCandidates(deduplicated);
+  const diversifiedCandidates = diversified.map((result) => toContextPackTraceCandidate(result));
   const duplicateCount = candidateCount - deduplicated.length;
   const selectable = diversified.slice(0, maxResults);
   const limitOmittedCount = deduplicated.length - selectable.length;
@@ -268,6 +326,15 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const fitted = fitTextToContextBudget(text, tokenBudget);
   const budgetOmittedCount = selectable.length - selected.length;
   const omittedCount = candidateCount - selected.length;
+  if (options.trace) {
+    options.trace({
+      inputCandidates: results.map(toContextPackTraceCandidate),
+      rankedCandidates,
+      deduplicatedCandidates,
+      diversifiedCandidates,
+      selectedCandidates: selected.map(toContextPackTraceCandidate),
+    });
+  }
   return {
     requestedTokenBudget,
     tokenBudget,

--- a/src/tools/context-search.ts
+++ b/src/tools/context-search.ts
@@ -1,7 +1,9 @@
 import type { SearchResult } from "../indexer/index.js";
+import type { SearchTrace } from "../indexer/index.js";
 import { analyzeQueryIntent } from "../indexer/intent-aware-ranking.js";
 import { inferExactSymbolFromQuery } from "./symbol-inference.js";
 import { buildContextPack, fitTextToContextBudget } from "./utils.js";
+import type { ContextPackTrace } from "./context-pack.js";
 
 export interface CodebaseContextInput {
   query: string;
@@ -15,6 +17,7 @@ export interface CodebaseContextInput {
   fileType?: string | null;
   directory?: string | null;
   tokenBudget?: number | null;
+  diagnostic?: boolean;
 }
 
 export const MIN_CONTEXT_RESULT_LIMIT = 1;
@@ -56,6 +59,17 @@ export interface CodebaseContextResult {
       }>;
       successfulAttemptIndex?: number;
     };
+    diagnostic?: {
+      route: "definition" | "conceptual";
+      routedQuery: string;
+      searchQuery: string;
+      searchScope: {
+        fileType?: string;
+        directory?: string;
+      };
+      searchTrace?: SearchTrace;
+      contextPackTrace?: ContextPackTrace;
+    };
     results?: ContextLocation[];
   };
 }
@@ -96,8 +110,18 @@ function packedResult(
 }
 
 interface SearchContextOperations {
-  lookup(symbol: string, limit: number, scope: SearchScope): Promise<SearchResult[]>;
-  search(query: string, limit: number, scope: SearchScope): Promise<SearchResult[]>;
+  lookup(
+    symbol: string,
+    limit: number,
+    scope: SearchScope,
+    trace?: (trace: SearchTrace) => void,
+  ): Promise<SearchResult[]>;
+  search(
+    query: string,
+    limit: number,
+    scope: SearchScope,
+    trace?: (trace: SearchTrace) => void,
+  ): Promise<SearchResult[]>;
 }
 
 type RecoveryScope = "scoped" | "unscoped";
@@ -108,6 +132,15 @@ interface RecoveryAttempt {
   resultCount: number;
   relaxedFields: Array<"directory" | "fileType">;
 }
+
+interface SearchAttemptState extends RecoveryAttempt {
+  query: string;
+  scopeFilter: SearchScope;
+  searchTrace?: SearchTrace;
+  contextPackTrace?: ContextPackTrace;
+}
+
+type SearchDiagnostic = NonNullable<NonNullable<CodebaseContextResult["details"]>["diagnostic"]>;
 
 interface SearchScope {
   fileType?: string;
@@ -214,6 +247,30 @@ function buildRecoveryDetails(attempts: RecoveryAttempt[], successIndex: number 
     };
 }
 
+function serializeAttempts(attempts: SearchAttemptState[]): RecoveryAttempt[] {
+  return attempts.map((attempt) => ({
+    kind: attempt.kind,
+    scope: attempt.scope,
+    resultCount: attempt.resultCount,
+    relaxedFields: attempt.relaxedFields,
+  }));
+}
+
+function buildSearchDiagnostic(attempt: SearchAttemptState | undefined): SearchDiagnostic | undefined {
+  if (!attempt) {
+    return undefined;
+  }
+
+  return {
+    route: attempt.kind,
+    routedQuery: attempt.query,
+    searchQuery: attempt.query,
+    searchScope: attempt.scopeFilter,
+    searchTrace: attempt.searchTrace,
+    contextPackTrace: attempt.contextPackTrace,
+  };
+}
+
 export function trimOrUndefined(value: string | null | undefined): string | undefined {
   const normalized = value?.trim();
   if (!normalized) {
@@ -248,7 +305,7 @@ function relaxedHintFields(fileType?: string, directory?: string): Array<"direct
 }
 
 export async function resolveSearchContext(
-  input: Pick<CodebaseContextInput, "query" | "symbol" | "limit" | "tokenBudget" | "fileType" | "directory">,
+  input: Pick<CodebaseContextInput, "query" | "symbol" | "limit" | "tokenBudget" | "fileType" | "directory" | "diagnostic">,
   operations: SearchContextOperations,
 ): Promise<CodebaseContextResult> {
   const query = trimOrUndefined(input.query);
@@ -264,6 +321,7 @@ export async function resolveSearchContext(
   const hasFilters = Boolean(fileType || directory);
   const relaxedFields = relaxedHintFields(fileType, directory);
   const attempts: RecoveryAttempt[] = [];
+  const attemptStates: SearchAttemptState[] = [];
   const decisions: RecoveryDecisions = {
     inferredDefinitionMiss: false,
     fallbackFromOriginalConceptualToInferred: false,
@@ -294,15 +352,27 @@ export async function resolveSearchContext(
     attemptQuery: string,
     scope: SearchScope,
     relaxedFieldsForAttempt: Array<"directory" | "fileType">,
-    runAttempt: () => Promise<SearchResult[]>,
+    runAttempt: (trace?: (trace: SearchTrace) => void) => Promise<SearchResult[]>,
   ): Promise<SearchResult[]> => {
     const key = attemptKey(kind, attemptQuery, scope);
     if (seenAttempts.has(key)) {
       return [];
     }
 
-    const results = await runAttempt();
+    const attemptState: SearchAttemptState = {
+      kind,
+      scope: describeScope(scope.fileType, scope.directory),
+      resultCount: 0,
+      relaxedFields: [...relaxedFieldsForAttempt],
+      query: attemptQuery,
+      scopeFilter: scope,
+    };
+    const results = await runAttempt((trace) => {
+      attemptState.searchTrace = trace;
+    });
+    attemptState.resultCount = results.length;
     seenAttempts.add(key);
+    attemptStates.push(attemptState);
     attempts.push({
       kind,
       scope: describeScope(scope.fileType, scope.directory),
@@ -329,7 +399,7 @@ export async function resolveSearchContext(
       symbol,
       scope,
       relaxedFieldsForAttempt,
-      () => operations.lookup(symbol, MAX_CONTEXT_RESULT_LIMIT, scope),
+      (trace) => operations.lookup(symbol, MAX_CONTEXT_RESULT_LIMIT, scope, input.diagnostic ? trace : undefined),
     );
   };
 
@@ -343,18 +413,33 @@ export async function resolveSearchContext(
       searchQuery,
       scope,
       relaxedFieldsForAttempt,
-      () => operations.search(searchQuery, MAX_CONTEXT_RESULT_LIMIT, scope),
+      (trace) => operations.search(searchQuery, MAX_CONTEXT_RESULT_LIMIT, scope, input.diagnostic ? trace : undefined),
     );
+  };
+
+  const findSuccessfulAttemptState = (
+    route: "definition" | "conceptual",
+  ): SearchAttemptState | undefined => {
+    for (let index = attemptStates.length - 1; index >= 0; index -= 1) {
+      const attempt = attemptStates[index];
+      if (attempt.kind === route && attempt.resultCount > 0) {
+        return attempt;
+      }
+    }
+
+    return undefined;
   };
 
   const toResult = (
     route: "definition" | "conceptual",
     routedQuery: string,
     pack: ReturnType<typeof buildContextPack>,
+    successfulAttempt?: SearchAttemptState,
   ): CodebaseContextResult => {
     const base = packedResult(route, routedQuery, pack);
     const baseDetails = base.details as NonNullable<CodebaseContextResult["details"]>;
     const successIndex = findSuccessfulAttemptIndex(route, attempts);
+    const successState = successfulAttempt ?? findSuccessfulAttemptState(route);
     return {
       text: base.text,
       details: {
@@ -362,7 +447,10 @@ export async function resolveSearchContext(
         tokenBudget: baseDetails.tokenBudget,
         tokenEstimate: baseDetails.tokenEstimate,
         truncated: false,
-        recovery: buildRecoveryDetails(attempts, successIndex),
+        recovery: buildRecoveryDetails(serializeAttempts(attemptStates), successIndex),
+        ...(input.diagnostic && {
+          diagnostic: buildSearchDiagnostic(successState),
+        }),
       },
     };
   };
@@ -379,7 +467,16 @@ export async function resolveSearchContext(
           maxResults: limit,
           heading,
           preserveInputOrder: true,
+          ...(input.diagnostic ? {
+            trace: (trace) => {
+              const attemptState = findSuccessfulAttemptState("definition");
+              if (attemptState) {
+                attemptState.contextPackTrace = trace;
+              }
+            },
+          } : undefined),
         }),
+        findSuccessfulAttemptState("definition"),
       );
     }
 
@@ -395,13 +492,22 @@ export async function resolveSearchContext(
           return toResult(
             "definition",
             definitionSymbol,
-          buildContextPack(unscopedDefinitionResults, {
-            tokenBudget,
-            maxResults: limit,
-            heading,
-            preserveInputOrder: true,
-          }),
-        );
+            buildContextPack(unscopedDefinitionResults, {
+              tokenBudget,
+              maxResults: limit,
+              heading,
+              preserveInputOrder: true,
+              ...(input.diagnostic ? {
+                trace: (trace) => {
+                  const attemptState = findSuccessfulAttemptState("definition");
+                  if (attemptState) {
+                    attemptState.contextPackTrace = trace;
+                  }
+                },
+              } : undefined),
+            }),
+            findSuccessfulAttemptState("definition"),
+          );
         }
       }
 
@@ -419,7 +525,10 @@ export async function resolveSearchContext(
           tokenBudget: heading.tokenBudget,
           tokenEstimate: heading.tokenEstimate,
           truncated: heading.truncated,
-          recovery: buildRecoveryDetails(attempts, null),
+          recovery: buildRecoveryDetails(serializeAttempts(attemptStates), null),
+          ...(input.diagnostic && {
+            diagnostic: buildSearchDiagnostic(attemptStates[attemptStates.length - 1]),
+          }),
         },
       };
     }
@@ -465,7 +574,16 @@ export async function resolveSearchContext(
           includeExactSearchHandoff: true,
           preferImplementationPaths:
             intent.preferSourcePaths || (intent.primary !== "docs" && intent.primary !== "test"),
+          ...(input.diagnostic ? {
+            trace: (trace) => {
+              const attemptState = findSuccessfulAttemptState("conceptual");
+              if (attemptState) {
+                attemptState.contextPackTrace = trace;
+              }
+            },
+          } : undefined),
         }),
+        findSuccessfulAttemptState("conceptual"),
       );
     }
   }
@@ -482,7 +600,10 @@ export async function resolveSearchContext(
       tokenBudget: fallbackText.tokenBudget,
       tokenEstimate: fallbackText.tokenEstimate,
       truncated: fallbackText.truncated,
-      recovery: buildRecoveryDetails(attempts, null),
+      recovery: buildRecoveryDetails(serializeAttempts(attemptStates), null),
+      ...(input.diagnostic && {
+        diagnostic: buildSearchDiagnostic(attemptStates[attemptStates.length - 1]),
+      }),
     },
   };
 }

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -118,17 +118,27 @@ async function resolveCodebaseContextUnmeasured(
     };
   }
 
-  return resolveSearchContext({ query: input.query, symbol, limit, tokenBudget, fileType, directory }, {
-    lookup: (lookupSymbol, retrievalLimit, scope) => implementationLookup(projectRoot, host, lookupSymbol, {
+  return resolveSearchContext({
+    query: input.query,
+    symbol,
+    limit,
+    tokenBudget,
+    fileType,
+    directory,
+    diagnostic: input.diagnostic,
+  }, {
+    lookup: (lookupSymbol, retrievalLimit, scope, trace) => implementationLookup(projectRoot, host, lookupSymbol, {
       limit: retrievalLimit,
       fileType: scope.fileType,
       directory: scope.directory,
+      trace,
     }),
-    search: (queryText, retrievalLimit, scope) => searchCodebase(projectRoot, host, queryText, {
+    search: (queryText, retrievalLimit, scope, trace) => searchCodebase(projectRoot, host, queryText, {
       limit: retrievalLimit,
       fileType: scope.fileType,
       directory: scope.directory,
       metadataOnly: true,
+      trace,
     }),
   });
 }

--- a/src/tools/contracts.ts
+++ b/src/tools/contracts.ts
@@ -44,6 +44,7 @@ export interface SharedCodebaseContextArgs {
   fileType?: string | null;
   directory?: string | null;
   tokenBudget?: number | null;
+  diagnostic?: boolean;
 }
 
 export interface SharedCodebaseEditContextArgs {

--- a/src/tools/execute-common.ts
+++ b/src/tools/execute-common.ts
@@ -36,6 +36,7 @@ import { formatCodeCommunities } from "./format-communities.js";
 
 export interface ExecutionResult {
   text: string;
+  details?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -46,7 +47,8 @@ export async function executeCodebaseContext(
   host: HostMode,
   args: SharedCodebaseContextArgs,
 ): Promise<ExecutionResult> {
-  return { text: (await resolveCodebaseContext(projectRoot, host, args)).text };
+  const result = await resolveCodebaseContext(projectRoot, host, args);
+  return { text: result.text, details: result.details };
 }
 
 export async function executeCodebaseEditContext(

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -22,6 +22,7 @@ import type { LogLevel } from "../config/schema.js";
 import type { LogEntry } from "../utils/logger.js";
 import type { CostEstimate } from "../utils/cost.js";
 import type { AutoIndexStatusSnapshot } from "../utils/auto-index.js";
+import type { SearchTrace } from "../indexer/index.js";
 import {
   formatEffectivenessMetrics,
   getProcessEffectivenessMetrics,
@@ -231,6 +232,7 @@ export async function searchCodebase(
     blameAuthor?: string;
     blameSha?: string;
     blameSince?: string;
+    trace?: (trace: SearchTrace) => void;
   } = {},
 ): Promise<SearchResult[]> {
   await ensureAutoIndexReadyForRetrieval(projectRoot, host);
@@ -245,6 +247,7 @@ export async function searchCodebase(
     blameAuthor: options.blameAuthor,
     blameSha: options.blameSha,
     blameSince: options.blameSince,
+    trace: options.trace,
   });
 }
 
@@ -321,6 +324,7 @@ export async function implementationLookup(
     limit?: number;
     fileType?: string;
     directory?: string;
+    trace?: (trace: SearchTrace) => void;
   } = {},
 ): Promise<SearchResult[]> {
   await ensureAutoIndexReadyForRetrieval(projectRoot, host);
@@ -329,6 +333,7 @@ export async function implementationLookup(
     fileType: options.fileType,
     directory: options.directory,
     definitionIntent: true,
+    trace: options.trace,
   });
 }
 

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -241,7 +241,49 @@ describe("cross-repo CodeGraph comparator", () => {
     expect(definitionQueries.every((query) => !query.expected.filePath.startsWith(".github/workflows/"))).toBe(true);
     expect(definitionQueries.every((query) => !query.expected.filePath.includes("/__tests__/"))).toBe(true);
     expect(definitionQueries.every((query) => !query.expected.filePath.includes("/fixtures/"))).toBe(true);
-    });
+  });
+
+  it("excludes benchmark paths and files from definition candidates", () => {
+    const repoPath = "/repo";
+    const sourceFile = (name: string): ParsedFile => {
+      const symbol = path.basename(name).replace(/\.[^.]+$/, "").replace(/[^a-z]/gi, "");
+      return {
+        path: path.join(repoPath, name),
+        hash: name,
+        symbols: [],
+        chunks: [{
+          content: `export function ${symbol}() { return 1; }`,
+          startLine: 1,
+          endLine: 1,
+          chunkType: "function",
+          name: symbol,
+          language: "typescript",
+        }],
+      };
+    };
+
+    const parsedFiles = [
+      sourceFile("src/alpha.ts"),
+      sourceFile("src/beta.ts"),
+      sourceFile("src/gamma.ts"),
+      sourceFile("src/benches/bench-helper.ts"),
+      sourceFile("benches/benchmark.ts"),
+      sourceFile("src/feature.bench.ts"),
+    ];
+
+    const dataset = buildGoldenDataset("fixture", repoPath, parsedFiles);
+    const definitionQueries = dataset.queries.filter((query) => query.queryType === "definition");
+
+    expect(definitionQueries).toHaveLength(3);
+    expect(
+      definitionQueries.some((query) =>
+        query.expected.filePath.includes("/benches/") ||
+        query.expected.filePath.includes("/bench/") ||
+        query.expected.filePath.endsWith(".bench.ts") ||
+        query.expected.filePath.endsWith(".bench.js")
+      )
+    ).toBe(false);
+  });
 
   it("excludes documentation candidates from source definition set and keeps source candidates", () => {
     const repoPath = "/repo";

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { execSync } from "node:child_process";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -16,6 +17,8 @@ import {
   MAX_FILE_SIZE_BYTES,
   parseCliArgs,
   runCodeGraphRepeat,
+  parseManifest,
+  type RepoDescriptor,
   type CliOptions,
   type RepoBenchmarkResult,
 } from "../scripts/cross-repo-benchmark.js";
@@ -65,8 +68,9 @@ function fixture(): { dataset: GoldenDataset; pluginPerQuery: PerQueryEvalResult
 }
 
 function cliOptions(repoPath: string): CliOptions {
+  const repoName = path.basename(repoPath);
   return {
-    repos: [repoPath],
+    repos: [{ name: repoName, path: repoPath }],
     outputRoot: repoPath,
     reindex: false,
     repeats: 2,
@@ -76,6 +80,17 @@ function cliOptions(repoPath: string): CliOptions {
     skipSg: true,
     codegraph: true,
   };
+}
+
+function createTempGitRepo(repoRoot: string): string {
+  fs.mkdirSync(repoRoot, { recursive: true });
+  execSync(`git -C ${JSON.stringify(repoRoot)} init -q`);
+  fs.writeFileSync(path.join(repoRoot, "README.md"), "temporary repo\n", "utf-8");
+  execSync(`git -C ${JSON.stringify(repoRoot)} add README.md`);
+  execSync(
+    `git -C ${JSON.stringify(repoRoot)} commit -q --author="Test <test@example.com>" --date=now -m "initial commit" --allow-empty`
+  );
+  return execSync(`git -C ${JSON.stringify(repoRoot)} rev-parse HEAD`, { encoding: "utf-8" }).trim();
 }
 
 describe("cross-repo CodeGraph comparator", () => {
@@ -91,6 +106,56 @@ describe("cross-repo CodeGraph comparator", () => {
     const repoPath = tempDir("cross-repo-cg-cli-");
     expect(parseCliArgs(["--repos", repoPath]).codegraph).toBe(false);
     expect(parseCliArgs(["--repos", repoPath, "--codegraph"]).codegraph).toBe(true);
+  });
+
+  it("loads manifest entries and resolves relative repo paths", () => {
+    const root = tempDir("cross-repo-manifest-");
+    const repoDir = path.join(root, "repos", "axios");
+    const manifestPath = path.join(root, "manifest.json");
+    const commitSha = createTempGitRepo(repoDir);
+
+    const manifest = [
+      {
+        name: "axios",
+        repositoryUrl: "https://github.com/axios/axios",
+        commitSha,
+        path: "repos/axios",
+      },
+    ];
+
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest), "utf-8");
+
+    const repos = parseManifest(manifestPath);
+
+    expect(repos).toEqual<RepoDescriptor[]>([
+      {
+        name: "axios",
+        path: repoDir,
+        repositoryUrl: "https://github.com/axios/axios",
+        commitSha,
+      },
+    ]);
+  });
+
+  it("throws when manifest commit SHA does not match repo HEAD", () => {
+    const root = tempDir("cross-repo-manifest-mismatch-");
+    const repoDir = path.join(root, "repos", "express");
+    const manifestPath = path.join(root, "manifest.json");
+    const commitSha = createTempGitRepo(repoDir);
+
+    const manifest = [
+      {
+        name: "express",
+        repositoryUrl: "https://github.com/expressjs/express",
+        commitSha: commitSha === "0000000000000000000000000000000000000000" ?
+          "1111111111111111111111111111111111111111" : "0000000000000000000000000000000000000000",
+        path: "repos/express",
+      },
+    ];
+
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest), "utf-8");
+
+    expect(() => parseManifest(manifestPath)).toThrow("commit mismatch");
   });
 
   it("routes generated definition queries through context definition lookup", () => {

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -269,6 +269,41 @@ describe("cross-repo CodeGraph comparator", () => {
     ).toBe(true);
   });
 
+  it("excludes duplicate symbols from definition candidates across source files", () => {
+    const repoPath = "/repo";
+    const sourceFile = (name: string, symbol: string): ParsedFile => ({
+      path: path.join(repoPath, name),
+      hash: name,
+      symbols: [],
+      chunks: [{
+        content: `export function ${symbol}() { return 1; }`,
+        startLine: 1,
+        endLine: 1,
+        chunkType: "function",
+        name: symbol,
+        language: "typescript",
+      }],
+    });
+
+    const parsedFiles: ParsedFile[] = [
+      sourceFile("src/duplicate.ts", "shared"),
+      sourceFile("src/unique-one.ts", "uniqueOne"),
+      sourceFile("src/duplicate-two.ts", "shared"),
+      sourceFile("src/unique-two.ts", "uniqueTwo"),
+      sourceFile("src/unique-three.ts", "uniqueThree"),
+    ];
+
+    const dataset = buildGoldenDataset("fixture", repoPath, parsedFiles);
+    const definitions = dataset.queries.filter((query) => query.queryType === "definition");
+    const definitionSymbols = definitions.map((query) => query.expected.symbol);
+
+    expect(definitions).toHaveLength(3);
+    expect(definitionSymbols).toContain("uniqueOne");
+    expect(definitionSymbols).toContain("uniqueTwo");
+    expect(definitionSymbols).toContain("uniqueThree");
+    expect(definitionSymbols).not.toContain("shared");
+  });
+
   it("fails when all definition candidates are in test or fixture paths", () => {
     const repoPath = "/repo";
     const parsedFiles = [

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -89,7 +89,7 @@ function createTempGitRepo(repoRoot: string): string {
   fs.writeFileSync(path.join(repoRoot, "README.md"), "temporary repo\n", "utf-8");
   execSync(`git -C ${JSON.stringify(repoRoot)} add README.md`);
   execSync(
-    `git -C ${JSON.stringify(repoRoot)} commit -q --author="Test <test@example.com>" --date=now -m "initial commit" --allow-empty`
+    `git -C ${JSON.stringify(repoRoot)} -c user.name=Test -c user.email=test@example.com commit -q --author="Test <test@example.com>" --date=now -m "initial commit" --allow-empty`,
   );
   return execSync(`git -C ${JSON.stringify(repoRoot)} rev-parse HEAD`, { encoding: "utf-8" }).trim();
 }

--- a/tests/cross-repo-codegraph.test.ts
+++ b/tests/cross-repo-codegraph.test.ts
@@ -13,6 +13,7 @@ import {
   buildReportMarkdown,
   buildPluginEvalRunOptions,
   controlledEvalConfigPath,
+  resolveBenchmarkDataset,
   writeControlledEvalConfig,
   MAX_FILE_SIZE_BYTES,
   parseCliArgs,
@@ -135,6 +136,18 @@ describe("cross-repo CodeGraph comparator", () => {
         commitSha,
       },
     ]);
+  });
+
+  it("parses --dataset-dir CLI flag", () => {
+    const repoPath = tempDir("cross-repo-dataset-dir-cli-");
+    const root = tempDir("cross-repo-dataset-dir-dir-");
+    const options = parseCliArgs([
+      "--repos",
+      repoPath,
+      "--dataset-dir",
+      path.join(root, "datasets"),
+    ]);
+    expect(options.datasetDir).toBe(path.join(root, "datasets"));
   });
 
   it("throws when manifest commit SHA does not match repo HEAD", () => {
@@ -374,6 +387,96 @@ describe("cross-repo CodeGraph comparator", () => {
     expect(() => buildGoldenDataset("fixture", repoPath, parsedFiles)).toThrow(
       "No definition candidates outside unsupported CodeGraph source paths in fixture"
     );
+  });
+
+  it("loads datasets from --dataset-dir and copies exact files into run and golden artifacts", () => {
+    const repoPath = tempDir("cross-repo-dataset-dir-repo-");
+    const datasetSourceDir = tempDir("cross-repo-dataset-dir-src-");
+    const datasetRoot = tempDir("cross-repo-dataset-dir-run-");
+    const goldenRoot = tempDir("cross-repo-dataset-dir-golden-");
+    const datasetPath = path.join(datasetSourceDir, `${path.basename(repoPath)}.json`);
+    const datasetPayload = {
+      version: "1.0.0",
+      name: "from-fixture",
+      queries: [
+        {
+          id: "alpha-definition-01",
+          query: "where is Alpha defined",
+          queryType: "definition",
+          expected: {
+            filePath: "src/a.ts",
+            symbol: "Alpha",
+            expectedRoute: "definition",
+          },
+        },
+      ],
+    };
+    fs.writeFileSync(datasetPath, JSON.stringify(datasetPayload, null, 2), "utf-8");
+
+    const resolved = resolveBenchmarkDataset(
+      { name: path.basename(repoPath), path: repoPath },
+      {
+        datasetDir: datasetSourceDir,
+        maxParseFiles: 10,
+        persistDatasets: true,
+      },
+      datasetRoot,
+      goldenRoot,
+    );
+
+    const runDatasetPath = path.join(datasetRoot, `${path.basename(repoPath)}.json`);
+    const goldenDatasetPath = path.join(goldenRoot, `${path.basename(repoPath)}.json`);
+
+    expect(resolved.datasetPath).toBe(runDatasetPath);
+    expect(resolved.collection.files).toEqual([]);
+    expect(resolved.collection.truncated).toBe(false);
+    expect(resolved.dataset).toMatchObject({ version: "1.0.0", name: "from-fixture" });
+    expect(fs.readFileSync(runDatasetPath, "utf-8")).toBe(fs.readFileSync(datasetPath, "utf-8"));
+    expect(fs.readFileSync(goldenDatasetPath, "utf-8")).toBe(fs.readFileSync(datasetPath, "utf-8"));
+  });
+
+  it("requires a matching dataset file for each repo when --dataset-dir is provided", () => {
+    const repoPath = tempDir("cross-repo-dataset-dir-missing-");
+    const datasetSourceDir = tempDir("cross-repo-dataset-dir-missing-src-");
+    const datasetRoot = tempDir("cross-repo-dataset-dir-missing-run-");
+    const goldenRoot = tempDir("cross-repo-dataset-dir-missing-golden-");
+
+    expect(() => resolveBenchmarkDataset(
+      { name: path.basename(repoPath), path: repoPath },
+      {
+        datasetDir: datasetSourceDir,
+        maxParseFiles: 10,
+        persistDatasets: false,
+      },
+      datasetRoot,
+      goldenRoot,
+    )).toThrow(`Missing dataset file for repository ${path.basename(repoPath)}`);
+  });
+
+  it("validates loaded dataset files with parseGoldenDataset", () => {
+    const repoPath = tempDir("cross-repo-dataset-dir-invalid-");
+    const datasetSourceDir = tempDir("cross-repo-dataset-dir-invalid-src-");
+    const datasetRoot = tempDir("cross-repo-dataset-dir-invalid-run-");
+    const goldenRoot = tempDir("cross-repo-dataset-dir-invalid-golden-");
+    const repoName = path.basename(repoPath);
+    const datasetPath = path.join(datasetSourceDir, `${repoName}.json`);
+
+    fs.writeFileSync(datasetPath, JSON.stringify({
+      version: "invalid",
+      name: "bad",
+      queries: [],
+    }), "utf-8");
+
+    expect(() => resolveBenchmarkDataset(
+      { name: repoName, path: repoPath },
+      {
+        datasetDir: datasetSourceDir,
+        maxParseFiles: 10,
+        persistDatasets: false,
+      },
+      datasetRoot,
+      goldenRoot,
+    )).toThrow(`${datasetPath}.version must be a valid semantic version (MAJOR.MINOR.PATCH)`);
   });
 
   it("uses a fresh isolated repo per repeat, exact pinned commands, strict scoped metrics, and raw artifacts", async () => {

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -51,12 +51,12 @@ function readText(filePath: string): string {
   return readFileSync(filePath, "utf-8");
 }
 
-function prepareMetadata(packageName: string, outputDir: string, repositoryUrl?: string): void {
+function prepareMetadata(packageName: string, outputDir: string, repositoryUrl?: string, projectRoot = process.cwd()): void {
   const args = [
     "--package-name",
     packageName,
     "--project-root",
-    process.cwd(),
+    projectRoot,
     "--output-dir",
     outputDir,
   ];
@@ -65,6 +65,48 @@ function prepareMetadata(packageName: string, outputDir: string, repositoryUrl?:
   }
 
   execFileSync(process.execPath, [path.join(process.cwd(), "scripts", "prepare-package-metadata.mjs"), ...args]);
+}
+
+function writeFixtureProjectManifestFiles(projectRoot: string): void {
+  const current = IDENTITY_CATALOG.product.current;
+  writeFileSync(
+    path.join(projectRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: current.packageName,
+        bin: {
+          [current.mcpBinary]: "dist/cli.js",
+        },
+        repository: {
+          url: current.repository,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+  writeFileSync(
+    path.join(projectRoot, "package-lock.json"),
+    `${JSON.stringify(
+      {
+        name: current.packageName,
+        lockfileVersion: 3,
+        packages: {
+          "": {
+            name: current.packageName,
+            version: "0.0.0",
+            bin: {
+              [current.mcpBinary]: "dist/cli.js",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
 }
 
 describe("Phase 1 product identity compatibility", () => {
@@ -201,6 +243,53 @@ describe("Phase 1 product identity compatibility", () => {
       expect(packageJson).toEqual(checkedInPackageJson);
       expect(packageLock).toEqual(checkedInPackageLock);
     } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes persisted host index artifacts from copied project metadata", () => {
+    const projectRoot = mkdtempSync(path.join(os.tmpdir(), "codebase-index-staging-input-"));
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-staging-output-"));
+    try {
+      writeFixtureProjectManifestFiles(projectRoot);
+      writeFileSync(path.join(projectRoot, "README.md"), "Staging input fixture\n", "utf-8");
+
+      const hostIndexPaths = [
+        [".opencode", "index"],
+        [".claude", "index"],
+        [".codebase-index", "index"],
+      ] as const;
+      for (const [hostDir, indexDir] of hostIndexPaths) {
+        const hostIndexRoot = path.join(projectRoot, hostDir, indexDir);
+        const retainedFile = path.join(hostIndexRoot, "should-not-copy.txt");
+        mkdirSync(hostIndexRoot, { recursive: true });
+        writeFileSync(retainedFile, `${hostDir}/${indexDir}\n`, "utf-8");
+      }
+
+      const nestedNodeModulesPath = path.join(projectRoot, ".opencode", "runtime", "node_modules", "foo", "index.js");
+      mkdirSync(path.dirname(nestedNodeModulesPath), { recursive: true });
+      writeFileSync(nestedNodeModulesPath, "module fixture\n", "utf-8");
+
+      const demoRepositoryPath = path.join(projectRoot, "demo-repos", "fixture", "index.ts");
+      mkdirSync(path.dirname(demoRepositoryPath), { recursive: true });
+      writeFileSync(demoRepositoryPath, "export {};\n", "utf-8");
+
+      const opencodeKeepPath = path.join(projectRoot, ".opencode", "keep-me.txt");
+      mkdirSync(path.dirname(opencodeKeepPath), { recursive: true });
+      writeFileSync(opencodeKeepPath, "keep me\n", "utf-8");
+
+      prepareMetadata(IDENTITY_CATALOG.product.current.packageName, tempDir, undefined, projectRoot);
+
+      for (const [hostDir, indexDir] of hostIndexPaths) {
+        const stagedHostIndex = path.join(tempDir, hostDir, indexDir);
+        expect(existsSync(stagedHostIndex)).toBe(false);
+      }
+      expect(existsSync(path.join(tempDir, ".opencode", "runtime", "node_modules", "foo"))).toBe(false);
+      expect(existsSync(path.join(tempDir, "demo-repos"))).toBe(false);
+      expect(readText(path.join(tempDir, ".opencode", "keep-me.txt"))).toBe("keep me\n");
+      expect(readText(path.join(tempDir, "README.md"))).toBe("Staging input fixture\n");
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
       rmSync(tempDir, { recursive: true, force: true });
     }
   });

--- a/tests/intent-aware-ranking-eval.test.ts
+++ b/tests/intent-aware-ranking-eval.test.ts
@@ -73,6 +73,16 @@ function toCandidate(candidate: FixtureCandidate): RankedCandidate {
   };
 }
 
+function fixtureCandidate(
+  id: string,
+  filePath: string,
+  score: number,
+  name: string,
+  chunkType = "function_item",
+): RankedCandidate {
+  return toCandidate({ id, filePath, score, name, chunkType, startLine: 1, endLine: 4 });
+}
+
 function evidenceRecallAtK(ids: string[], relevantIds: string[], k: number): number {
   const relevant = new Set(relevantIds);
   const found = new Set(ids.slice(0, k).filter((id) => relevant.has(id)));
@@ -141,5 +151,28 @@ describe("intent-aware local ranking evaluation", () => {
     expect(actual).toEqual(golden);
     expect(actual.intentAware.evidenceRecallAt3).toBeGreaterThan(actual.baseline.evidenceRecallAt3);
     expect(actual.intentAware.mrr).toBeGreaterThan(actual.baseline.mrr);
+  });
+
+  it("keeps source-oriented conceptual queries ahead of benchmark artifacts", () => {
+    const rankedConceptual = rankIntentAwareCandidates(
+      "std io buffer",
+      [
+        fixtureCandidate("bench", "crates/abc/benches/buf.rs", 0.95, "bench_artifact", "function_item"),
+        fixtureCandidate("source", "src/buf/reader.rs", 0.9, "source_artifact", "function_item"),
+      ],
+      2,
+    ).map((candidate) => candidate.id);
+
+    const rankedBenchmark = rankIntentAwareCandidates(
+      "std io benchmark",
+      [
+        fixtureCandidate("source", "src/buf/reader.rs", 0.9, "source_artifact", "function_item"),
+        fixtureCandidate("bench", "crates/abc/benches/buf.rs", 0.95, "bench_artifact", "function_item"),
+      ],
+      2,
+    ).map((candidate) => candidate.id);
+
+    expect(rankedConceptual).toEqual(["source", "bench"]);
+    expect(rankedBenchmark).toEqual(["bench", "source"]);
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -512,6 +512,15 @@ describe("MCP server tools and prompts", () => {
     expect(descriptions.get("pr_impact")).toContain("FIRST TOOL");
   });
 
+  it("should expose a diagnostic option on codebase_context schema", async () => {
+    const tools = await client.listTools();
+    const codebaseContext = tools.tools.find((tool) => tool.name === "codebase_context");
+
+    const properties = codebaseContext?.inputSchema?.properties;
+    expect(properties).toBeDefined();
+    expect(properties).toHaveProperty("diagnostic");
+  });
+
   it("should register all 5 prompts", async () => {
     const prompts = await client.listPrompts();
 
@@ -802,6 +811,19 @@ describe("MCP server tools and prompts", () => {
       100,
       expect.objectContaining({ definitionIntent: true }),
     );
+  });
+
+  it("should return codebase_context diagnostics as MCP structured content on request", async () => {
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "where is validateToken defined", symbol: "validateToken", diagnostic: true },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain('function "validateToken"');
+    expect(result.structuredContent).toMatchObject({
+      diagnostic: expect.objectContaining({ route: "definition" }),
+    });
   });
 
   it("should infer an exact symbol and route through implementation lookup", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -185,6 +185,44 @@ describe("Pi adapter conformance", () => {
       default: 10,
       anyOf: expect.arrayContaining([expect.objectContaining({ minimum: 1, maximum: 100 })]),
     }));
+    expect(tools.get("codebase_context")?.parameters?.properties?.diagnostic).toEqual(
+      expect.objectContaining({
+        anyOf: expect.arrayContaining([expect.objectContaining({ type: "boolean" })]),
+      }),
+    );
+  });
+
+  it("keeps Pi normal output unchanged when diagnostic is false", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      chunkType: "function",
+      name: "validateToken",
+      filePath: "src/auth.ts",
+      startLine: 12,
+      endLine: 30,
+      score: 0.95,
+      content: "function validateToken() {}",
+    }]);
+
+    const { tools } = await registerPiTools();
+
+    const withoutDiagnostic = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128 },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+    const withDiagnosticFalse = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128, diagnostic: false },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(withDiagnosticFalse?.content[0]?.text).toEqual(withoutDiagnostic?.content[0]?.text);
+    expect(withDiagnosticFalse?.details).toBeDefined();
+    expect(withDiagnosticFalse?.details).not.toHaveProperty("diagnostic");
   });
 
   it("formats metadata-only peek results with the shared exact-search handoff", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -219,10 +219,21 @@ describe("Pi adapter conformance", () => {
       () => {},
       { cwd: "/repo" },
     );
+    const withDiagnostic = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128, diagnostic: true },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
 
     expect(withDiagnosticFalse?.content[0]?.text).toEqual(withoutDiagnostic?.content[0]?.text);
     expect(withDiagnosticFalse?.details).toBeDefined();
     expect(withDiagnosticFalse?.details).not.toHaveProperty("diagnostic");
+    expect(withDiagnostic?.content[0]?.text).toEqual(withoutDiagnostic?.content[0]?.text);
+    expect(withDiagnostic?.details).toMatchObject({
+      diagnostic: expect.objectContaining({ route: "definition", routedQuery: "validateToken" }),
+    });
   });
 
   it("formats metadata-only peek results with the shared exact-search handoff", async () => {

--- a/tests/run-codegraph-official-agent-benchmark.test.ts
+++ b/tests/run-codegraph-official-agent-benchmark.test.ts
@@ -18,14 +18,19 @@ import {
 interface MockCall {
   command: string;
   args: string[];
+  cwd?: string;
 }
 
 function makeCommandRunner(
   callMap: MockCall[],
   options: { gitHeadByPath?: Record<string, string>; defaultGitHead?: string },
 ): (command: string, args: string[], runnerOptions?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }> {
-  return async (command: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
-    callMap.push({ command, args: [...args] });
+  return async (
+    command: string,
+    args: string[],
+    runnerOptions?: { cwd?: string },
+  ): Promise<{ stdout: string; stderr: string }> => {
+    callMap.push({ command, args: [...args], cwd: runnerOptions?.cwd });
 
     if (
       command === "git" &&
@@ -258,7 +263,14 @@ describe("run-codegraph-official-agent benchmark execution plumbing", () => {
         expect(text).toContain("--model sonnet");
         expect(text).toContain("--effort high");
         expect(text).toContain("--output-format stream-json");
+        expect(text).toContain("--strict-mcp-config");
+        expect(text).toContain("--permission-mode bypassPermissions");
+        expect(text).toContain("--max-budget-usd 4");
+        expect(call.cwd).toContain(path.join("run-1", "workspace"));
       }
+
+      expect(commands.some((entry) => entry.command === "npx" && entry.args.includes("init"))).toBe(true);
+      expect(commands.some((entry) => entry.command === "node" && entry.args.includes("index"))).toBe(true);
     } finally {
       rmSync(outputDir, { recursive: true, force: true });
     }

--- a/tests/run-codegraph-official-agent-benchmark.test.ts
+++ b/tests/run-codegraph-official-agent-benchmark.test.ts
@@ -286,6 +286,39 @@ describe("run-codegraph-official-agent benchmark execution plumbing", () => {
     }
   });
 
+  it("resumes an incomplete selected session from its existing workspace without re-indexing", async () => {
+    const manifest = miniManifest();
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-selected-resume-"));
+    const commands: MockCall[] = [];
+    const runner = makeCommandRunner(commands, { defaultGitHead: manifest.repositories[0].commit });
+
+    try {
+      const repoPath = path.join(outputDir, "prepared", "mini");
+      fs.mkdirSync(repoPath, { recursive: true });
+      fs.writeFileSync(path.join(repoPath, "file.txt"), "ready", "utf-8");
+      await prepareRepositories(manifest, outputDir, undefined, runner);
+
+      const runRoot = path.join(outputDir, "runs", "manual-root");
+      const workspaceRoot = path.join(runRoot, "mini", "open-codebase-index", "run-1", "workspace");
+      fs.mkdirSync(workspaceRoot, { recursive: true });
+      fs.writeFileSync(path.join(workspaceRoot, "partial-index-marker"), "keep", "utf-8");
+
+      await executeBenchmark(manifest, outputDir, 1, 1, 4, runner, {
+        runRoot,
+        repositoryId: "mini",
+        run: 1,
+        arm: "open-codebase-index",
+      });
+
+      expect(fs.readFileSync(path.join(workspaceRoot, "partial-index-marker"), "utf-8")).toBe("keep");
+      expect(fs.existsSync(path.join(path.dirname(workspaceRoot), "turn-1.jsonl"))).toBe(true);
+      expect(commands.some((entry) => entry.command === "node" && entry.args.includes("index"))).toBe(false);
+      expect(commands.filter((entry) => entry.command === "claude")).toHaveLength(1);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects selected sessions with missing run root", async () => {
     const manifest = miniManifest();
     const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-selected-missing-run-root-"));

--- a/tests/run-codegraph-official-agent-benchmark.test.ts
+++ b/tests/run-codegraph-official-agent-benchmark.test.ts
@@ -188,8 +188,9 @@ describe("run-codegraph-official-agent benchmark planning", () => {
     expect(summary).toContain("Repos: 7");
     expect(summary).toContain("Runs per repo: 4");
     expect(summary).toContain("Turns per run: 3");
-    expect(summary).toContain("Total planned agent sessions: 84");
-    expect(summary).toContain("Max budget ceiling: $4.00 per session");
+    expect(summary).toContain("Total arm sessions: 84");
+    expect(summary).toContain("Total Claude invocations: 252");
+    expect(summary).toContain("Max budget ceiling: $4.00 per invocation, $1008.00 total");
   });
 });
 

--- a/tests/run-codegraph-official-agent-benchmark.test.ts
+++ b/tests/run-codegraph-official-agent-benchmark.test.ts
@@ -177,6 +177,41 @@ describe("run-codegraph-official-agent benchmark CLI args", () => {
     expect(args.turns).toBe(1);
     expect(args.maxBudgetUsd).toBe(7.5);
   });
+
+  it("parses single-session execution selectors", () => {
+    const args = parseCliArgs([
+      "--execute",
+      "--run-root",
+      "/tmp/session-root",
+      "--repo",
+      "vscode",
+      "--run",
+      "1",
+      "--arm",
+      "codegraph",
+    ]);
+
+    expect(args.mode).toBe("execute");
+    expect(args.selectedRunRoot).toBe("/tmp/session-root");
+    expect(args.selectedRepo).toBe("vscode");
+    expect(args.selectedRun).toBe(1);
+    expect(args.selectedArm).toBe("codegraph");
+  });
+
+  it("rejects partial single-session selectors", () => {
+    expect(() => parseCliArgs(["--execute", "--run-root", "/tmp/session-root", "--repo", "vscode", "--arm", "codegraph"])).toThrow(
+      /Selection requires/,
+    );
+    expect(() => parseCliArgs(["--repo", "vscode", "--run", "1", "--arm", "codegraph", "--run-root", "/tmp/session-root"])).toThrow(
+      /Single-session selection requires --execute/,
+    );
+  });
+
+  it("rejects invalid arm in selection mode", () => {
+    expect(() =>
+      parseCliArgs(["--execute", "--run-root", "/tmp/session-root", "--repo", "vscode", "--run", "1", "--arm", "bad"]),
+    ).toThrow(/--arm must/);
+  });
 });
 
 describe("run-codegraph-official-agent benchmark planning", () => {
@@ -206,6 +241,105 @@ describe("run-codegraph-official-agent benchmark execution plumbing", () => {
     });
 
     rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("executes selected session in existing run root and skips completed session artifacts", async () => {
+    const manifest = miniManifest();
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-selected-run-"));
+    const commands: MockCall[] = [];
+    const runner = makeCommandRunner(commands, { defaultGitHead: manifest.repositories[0].commit });
+
+    try {
+      const repoPath = path.join(outputDir, "prepared", "mini");
+      fs.mkdirSync(repoPath, { recursive: true });
+      fs.writeFileSync(path.join(repoPath, "file.txt"), "ready", "utf-8");
+      await prepareRepositories(manifest, outputDir, undefined, runner);
+
+      const runRoot = path.join(outputDir, "runs", "manual-root");
+      const sessionRoot = path.join(runRoot, "mini", "codegraph", "run-1");
+      const completedArtifact = path.join(sessionRoot, "turn-1.jsonl");
+      fs.mkdirSync(sessionRoot, { recursive: true });
+      fs.writeFileSync(completedArtifact, "{\"session_id\":\"existing\",\"type\":\"final\"}\n", "utf-8");
+
+      await executeBenchmark(
+        manifest,
+        outputDir,
+        1,
+        1,
+        4,
+        runner,
+        {
+          runRoot,
+          repositoryId: "mini",
+          run: 1,
+          arm: "codegraph",
+        },
+      );
+
+      const after = fs.readFileSync(completedArtifact, "utf-8");
+      expect(after).toBe("{\"session_id\":\"existing\",\"type\":\"final\"}\n");
+
+      const claudeCalls = commands.filter((entry) => entry.command === "claude");
+      expect(claudeCalls).toHaveLength(0);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects selected sessions with missing run root", async () => {
+    const manifest = miniManifest();
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-selected-missing-run-root-"));
+    const commands: MockCall[] = [];
+
+    try {
+      const repoPath = path.join(outputDir, "prepared", "mini");
+      fs.mkdirSync(repoPath, { recursive: true });
+      fs.writeFileSync(path.join(repoPath, "file.txt"), "ready", "utf-8");
+      await prepareRepositories(manifest, outputDir, undefined, makeCommandRunner(commands, { defaultGitHead: manifest.repositories[0].commit }));
+
+      await expect(
+        executeBenchmark(manifest, outputDir, 1, 1, 4, async () => ({ stdout: "", stderr: "" }), {
+          runRoot: path.join(outputDir, "does-not-exist"),
+          repositoryId: "mini",
+          run: 1,
+          arm: "codegraph",
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("Selected run root does not exist"),
+      });
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects selected sessions with repository not in manifest", async () => {
+    const manifest = miniManifest();
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-selected-repo-mismatch-"));
+    const commands: MockCall[] = [];
+
+    try {
+      const repoPath = path.join(outputDir, "prepared", "mini");
+      fs.mkdirSync(repoPath, { recursive: true });
+      fs.writeFileSync(path.join(repoPath, "file.txt"), "ready", "utf-8");
+      const runner = makeCommandRunner(commands, { defaultGitHead: manifest.repositories[0].commit });
+      await prepareRepositories(manifest, outputDir, undefined, runner);
+
+      const runRoot = path.join(outputDir, "runs", "manual-root");
+      fs.mkdirSync(runRoot, { recursive: true });
+
+      await expect(
+        executeBenchmark(manifest, outputDir, 1, 1, 4, runner, {
+          runRoot,
+          repositoryId: "not-present",
+          run: 1,
+          arm: "codegraph",
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("not in the manifest"),
+      });
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
   });
 
   it("prepares repositories and executes with strict MCP configs and jsonl outputs", async () => {

--- a/tests/run-codegraph-official-agent-benchmark.test.ts
+++ b/tests/run-codegraph-official-agent-benchmark.test.ts
@@ -1,0 +1,299 @@
+import * as fs from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BenchmarkManifest,
+  ensurePreparedWorkspace,
+  executeBenchmark,
+  parseCliArgs,
+  parseManifest,
+  planSummary,
+  prepareRepositories,
+} from "../scripts/run-codegraph-official-agent-benchmark.js";
+
+interface MockCall {
+  command: string;
+  args: string[];
+}
+
+function makeCommandRunner(
+  callMap: MockCall[],
+  options: { gitHeadByPath?: Record<string, string>; defaultGitHead?: string },
+): (command: string, args: string[], runnerOptions?: { cwd?: string }) => Promise<{ stdout: string; stderr: string }> {
+  return async (command: string, args: string[]): Promise<{ stdout: string; stderr: string }> => {
+    callMap.push({ command, args: [...args] });
+
+    if (
+      command === "git" &&
+      args.includes("rev-parse") &&
+      args.includes("HEAD") &&
+      args.includes("-C")
+    ) {
+      const repoIndex = args.indexOf("-C");
+      const repoPath = repoIndex >= 0 ? args[repoIndex + 1] : "";
+      const head = options.gitHeadByPath?.[repoPath] ?? options.defaultGitHead;
+      return { stdout: `${head ?? ""}\n`, stderr: "" };
+    }
+
+    if (command === "claude") {
+      return { stdout: "{\"type\":\"final\"}\n", stderr: "" };
+    }
+
+    return { stdout: "", stderr: "" };
+  };
+}
+
+function miniManifest(): BenchmarkManifest {
+  return {
+    version: 1,
+    source: {
+      name: "Mini benchmark",
+      methodologyRepository: "https://github.com/colbymchenry/codegraph.git",
+      methodologyCommit: "a".repeat(40),
+      codegraphPackage: "@colbymchenry/codegraph@1.5.0",
+      defaultRuns: 2,
+      defaultTurns: 1,
+      model: "sonnet",
+      effort: "high",
+    },
+    repositories: [
+      {
+        id: "mini",
+        url: "https://github.com/example/example.git",
+        commit: "b".repeat(40),
+        questions: ["What happens next?"],
+      },
+    ],
+  };
+}
+
+function buildSevenRepoManifest(): BenchmarkManifest {
+  return {
+    version: 1,
+    source: {
+      name: "CodeGraph README agent benchmark",
+      methodologyRepository: "https://github.com/colbymchenry/codegraph",
+      methodologyCommit: "a".repeat(40),
+      codegraphPackage: "@colbymchenry/codegraph@1.5.0",
+      defaultRuns: 4,
+      defaultTurns: 3,
+      model: "sonnet",
+      effort: "high",
+    },
+    repositories: [
+      { id: "vscode", url: "https://github.com/microsoft/vscode.git", commit: "b".repeat(40), questions: ["How?", "Why?", "What?"] },
+      { id: "excalidraw", url: "https://github.com/excalidraw/excalidraw.git", commit: "c".repeat(40), questions: ["How?", "Why?", "What?"] },
+      { id: "django", url: "https://github.com/django/django.git", commit: "d".repeat(40), questions: ["How?", "Why?", "What?"] },
+      { id: "tokio", url: "https://github.com/tokio-rs/tokio.git", commit: "e".repeat(40), questions: ["How?", "Why?", "What?"] },
+      { id: "okhttp", url: "https://github.com/square/okhttp.git", commit: "f".repeat(40), questions: ["How?", "Why?", "What?"] },
+      { id: "gin", url: "https://github.com/gin-gonic/gin.git", commit: "1".repeat(40), questions: ["How?", "Why?", "What?"] },
+      { id: "alamofire", url: "https://github.com/Alamofire/Alamofire.git", commit: "2".repeat(40), questions: ["How?", "Why?", "What?"] },
+    ],
+  };
+}
+
+function withManifestFile(manifest: BenchmarkManifest, apply?: (obj: BenchmarkManifest) => BenchmarkManifest): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-manifest-"));
+  const file = path.join(root, "manifest.json");
+
+  const data = apply ? apply({ ...manifest }) : manifest;
+  fs.writeFileSync(file, JSON.stringify(data), "utf-8");
+  return file;
+}
+
+describe("run-codegraph-official-agent benchmark manifest parser", () => {
+  it("parses and validates the committed JSON manifest", () => {
+    const manifest = buildSevenRepoManifest();
+    const manifestPath = withManifestFile(manifest);
+
+    try {
+      const parsed = parseManifest(manifestPath);
+      expect(parsed.version).toBe(1);
+      expect(parsed.source.codegraphPackage).toBe("@colbymchenry/codegraph@1.5.0");
+      expect(parsed.repositories).toHaveLength(7);
+    } finally {
+      rmSync(path.dirname(manifestPath), { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unknown top-level and repository fields", () => {
+    const fixturePath = withManifestFile(buildSevenRepoManifest());
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-top-"));
+    const topPath = path.join(tempDir, "top.json");
+
+    const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf-8")) as {
+      repositories: Array<Record<string, unknown>>;
+      [key: string]: unknown;
+    };
+
+    const mutatedTop = { ...fixture, unexpected: true };
+    const mutatedRepo = {
+      ...fixture.repositories[0],
+      unexpectedRepoField: 5,
+    };
+    const mutatedSource = {
+      ...fixture,
+      repositories: [mutatedRepo],
+    };
+    const repoPath = path.join(tempDir, "repo.json");
+
+    try {
+      fs.writeFileSync(topPath, JSON.stringify(mutatedTop), "utf-8");
+      expect(() => parseManifest(topPath)).toThrow(/unexpected top-level field/i);
+
+      fs.writeFileSync(repoPath, JSON.stringify(mutatedSource), "utf-8");
+      expect(() => parseManifest(repoPath)).toThrow(/unexpected field/i);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(path.dirname(fixturePath), { recursive: true, force: true });
+    }
+  });
+});
+
+describe("run-codegraph-official-agent benchmark CLI args", () => {
+  it("accepts explicit mode flags and keeps defaults", () => {
+    const args = parseCliArgs(["--dry-run"]);
+    expect(args.mode).toBe("dry-run");
+    expect(args.runs).toBe(0);
+    expect(args.turns).toBe(0);
+  });
+
+  it("enforces mutually exclusive --prepare and --execute", () => {
+    expect(() => parseCliArgs(["--prepare", "--execute"])).toThrow(/Cannot combine/);
+  });
+
+  it("parses run and turn overrides", () => {
+    const args = parseCliArgs(["--runs", "2", "--turns", "1", "--max-budget", "7.5"]);
+    expect(args.runs).toBe(2);
+    expect(args.turns).toBe(1);
+    expect(args.maxBudgetUsd).toBe(7.5);
+  });
+});
+
+describe("run-codegraph-official-agent benchmark planning", () => {
+  const manifest = buildSevenRepoManifest();
+
+  it("prints total sessions for three-arm plan", () => {
+    const summary = planSummary(manifest, 4, 3, 4);
+    expect(summary).toContain("Three-arm plan");
+    expect(summary).toContain("Repos: 7");
+    expect(summary).toContain("Runs per repo: 4");
+    expect(summary).toContain("Turns per run: 3");
+    expect(summary).toContain("Total planned agent sessions: 84");
+    expect(summary).toContain("Max budget ceiling: $4.00 per session");
+  });
+});
+
+describe("run-codegraph-official-agent benchmark execution plumbing", () => {
+  it("enforces prepared-workspace precondition for execute", async () => {
+    const manifest = miniManifest();
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-no-prepare-"));
+
+    await expect(
+      executeBenchmark(manifest, outputDir, 1, 1, 4, async () => ({ stdout: "", stderr: "" })),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("No prepared repos found"),
+    });
+
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("prepares repositories and executes with strict MCP configs and jsonl outputs", async () => {
+    const manifest = miniManifest();
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-prepare-run-"));
+    const commands: MockCall[] = [];
+    const runner = makeCommandRunner(commands, { defaultGitHead: manifest.repositories[0].commit });
+
+    try {
+      const repoPath = path.join(outputDir, "prepared", "mini");
+      fs.mkdirSync(repoPath, { recursive: true });
+      fs.writeFileSync(path.join(repoPath, "file.txt"), "ready", "utf-8");
+
+      await prepareRepositories(manifest, outputDir, undefined, runner);
+
+      const preparedStatePath = path.join(outputDir, "prepared.json");
+      expect(fs.existsSync(preparedStatePath)).toBe(true);
+
+      await executeBenchmark(manifest, outputDir, 1, 1, 4, runner);
+
+      const runsRoot = path.join(outputDir, "runs");
+      const runDirs = fs.readdirSync(runsRoot);
+      expect(runDirs).toHaveLength(1);
+
+      const runRoot = path.join(runsRoot, runDirs[0]);
+      const armRoots = ["baseline", "codegraph", "open-codebase-index"];
+      for (const arm of armRoots) {
+        const armConfig = path.join(runRoot, "mini", arm, "run-1", `mcp-config-${arm}.json`);
+        expect(fs.existsSync(armConfig)).toBe(true);
+
+        const armArtifact = path.join(runRoot, "mini", arm, "run-1", "turn-1.jsonl");
+        expect(fs.existsSync(armArtifact)).toBe(true);
+
+        const text = fs.readFileSync(armArtifact, "utf-8");
+        expect(text).toContain("\"type\":\"final\"");
+      }
+
+      const openCodebaseConfig = JSON.parse(
+        fs.readFileSync(
+          path.join(runRoot, "mini", "open-codebase-index", "run-1", "mcp-config-open-codebase-index.json"),
+          "utf-8",
+        ),
+      ) as {
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      };
+      expect(openCodebaseConfig.mcpServers["open-codebase-index"]).toEqual(
+        expect.objectContaining({
+          command: "node",
+        }),
+      );
+
+      const claudeCalls = commands.filter((entry) => entry.command === "claude");
+      expect(claudeCalls).toHaveLength(3);
+      for (const call of claudeCalls) {
+        const text = call.args.join(" ");
+        expect(text).toContain("--model sonnet");
+        expect(text).toContain("--effort high");
+        expect(text).toContain("--output-format stream-json");
+      }
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects prepared state whose commit no longer matches current manifest", async () => {
+    const manifest = miniManifest();
+    const mismatchCommit = "c".repeat(40);
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-bench-mismatch-"));
+    const marker = {
+      manifestPath: path.join(tempDir, "manifest.json"),
+      source: manifest.source,
+      repositories: [
+        {
+          id: manifest.repositories[0].id,
+          path: path.join(tempDir, "repo"),
+          commit: mismatchCommit,
+        },
+      ],
+      preparedAt: new Date().toISOString(),
+    };
+
+    fs.mkdirSync(marker.repositories[0].path, { recursive: true });
+    fs.writeFileSync(path.join(tempDir, "prepared.json"), JSON.stringify(marker), "utf-8");
+    await expect(
+      ensurePreparedWorkspace(
+        manifest,
+        tempDir,
+        async () => ({
+          stdout: `${manifest.repositories[0].commit}\n`,
+          stderr: "",
+        }),
+      ),
+    ).rejects.toThrowError(/commit mismatch/i);
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+});

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -948,6 +948,63 @@ describe("native OpenCode codebase_context", () => {
     });
   });
 
+  it("preserves OpenCode text output when diagnostic is disabled", async () => {
+    const baseline = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: false,
+    });
+
+    const noDiagnostic = await opencodeCodebaseContext.execute({
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: false,
+    }, context);
+
+    const omittedDiagnostic = await opencodeCodebaseContext.execute({
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+    }, context);
+
+    expect(noDiagnostic).toBe(baseline.text);
+    expect(omittedDiagnostic).toBe(baseline.text);
+  });
+
+  it("appends diagnostics text in OpenCode output when diagnostic is true", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      filePath: "src/resolve.ts",
+      startLine: 10,
+      endLine: 20,
+      name: "resolveContext",
+      chunkType: "function",
+      content: "function resolveContext() {}",
+      score: 0.99,
+    }]);
+
+    const withDiagnostic = await opencodeCodebaseContext.execute({
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: true,
+    }, context);
+
+    const baseline = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: true,
+    });
+
+    expect(withDiagnostic.startsWith(baseline.text)).toBe(true);
+    expect(withDiagnostic).toContain("\nDiagnostics:\n");
+    expect(withDiagnostic).toContain('"route"');
+    expect(withDiagnostic).toContain("\"route\": \"definition\"");
+    expect(withDiagnostic).not.toContain('"selectedCount"');
+  });
+
   it("omits diagnostic details when diagnostic flag is false", async () => {
     operationMocks.implementationLookup.mockResolvedValue([{
       filePath: "src/resolve.ts",

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SearchTrace } from "../src/indexer/index.js";
+
 import { countContextTokens } from "../src/tools/utils.js";
 import { resolveSearchContext } from "../src/tools/context.js";
 
@@ -563,8 +565,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "find request helpers", 100, { fileType: "ts", directory: "src" });
-    expect(search).toHaveBeenNthCalledWith(2, "find request helpers", 100, { fileType: undefined, directory: undefined });
+    expect(search).toHaveBeenNthCalledWith(1, "find request helpers", 100, { fileType: "ts", directory: "src" }, undefined);
+    expect(search).toHaveBeenNthCalledWith(2, "find request helpers", 100, { fileType: undefined, directory: undefined }, undefined);
     expect(result.details?.recovery?.attempts).toEqual([
       {
         kind: "conceptual",
@@ -616,8 +618,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "where is `getStatus` defined", 100, { fileType: undefined, directory: undefined });
-    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined });
+    expect(search).toHaveBeenNthCalledWith(1, "where is `getStatus` defined", 100, { fileType: undefined, directory: undefined }, undefined);
+    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined);
     expect(result.text).toContain("src/auth.ts:1-8");
     expect(result.text).toContain("Recovery: inferred definition missed; inferred-symbol query tried.");
     expect(result.text.indexOf("Recovery:")).toBeLessThan(result.text.indexOf("[1]"));
@@ -680,8 +682,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "getStatus", 100, { fileType: "ts", directory: "src" });
-    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined });
+    expect(search).toHaveBeenNthCalledWith(1, "getStatus", 100, { fileType: "ts", directory: "src" }, undefined);
+    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined);
     expect(result.details?.recovery?.attempts).toHaveLength(3);
     expect(new Set(result.details?.recovery?.attempts.map((attempt) => JSON.stringify(attempt))).size)
       .toBe(3);
@@ -737,8 +739,8 @@ describe("native OpenCode codebase_context", () => {
     expect(lookup).toHaveBeenNthCalledWith(1, "resolveSearchContext", 100, {
       fileType: "ts",
       directory: "src/tools",
-    });
-    expect(lookup).toHaveBeenNthCalledWith(2, "resolveSearchContext", 100, {});
+    }, undefined);
+    expect(lookup).toHaveBeenNthCalledWith(2, "resolveSearchContext", 100, {}, undefined);
     expect(search).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({
       route: "definition",
@@ -779,10 +781,10 @@ describe("native OpenCode codebase_context", () => {
     });
 
     expect(search.mock.calls).toEqual([
-      ["where is `getStatus` defined", 100, { fileType: "ts", directory: "private/scope" }],
-      ["getStatus", 100, { fileType: "ts", directory: "private/scope" }],
-      ["where is `getStatus` defined", 100, {}],
-      ["getStatus", 100, {}],
+      ["where is `getStatus` defined", 100, { fileType: "ts", directory: "private/scope" }, undefined],
+      ["getStatus", 100, { fileType: "ts", directory: "private/scope" }, undefined],
+      ["where is `getStatus` defined", 100, {}, undefined],
+      ["getStatus", 100, {}, undefined],
     ]);
     const recoveryLine = result.text.split("\n").find((line) => line.startsWith("Recovery:"));
     expect(recoveryLine).toBe("Recovery: inferred definition missed; inferred-symbol query tried; directory filter removed; file-type filter removed.");
@@ -822,5 +824,65 @@ describe("native OpenCode codebase_context", () => {
     expect(result.details?.truncated).toBe(false);
     expect(result.details?.tokenEstimate).toBe(countContextTokens(result.text));
     expect(countContextTokens(result.text)).toBeLessThanOrEqual(128);
+  });
+
+  it("captures search and context-pack traces when diagnostic flag is set", async () => {
+    const search = vi.fn().mockImplementation(async (_query: string, _limit: number, _scope: unknown, trace?: (trace: SearchTrace) => void) => {
+      trace?.({
+        semanticCandidates: [],
+        keywordCandidates: [],
+        hybridCandidates: [],
+        postExternalRerankCandidates: [],
+        tieredCandidates: [],
+        finalCandidates: [],
+      });
+      return [
+        {
+          filePath: "src/trace.ts",
+          startLine: 4,
+          endLine: 12,
+          name: "traceTarget",
+          chunkType: "function",
+          content: "function traceTarget() {}",
+          score: 0.9,
+        },
+      ];
+    });
+
+    const result = await resolveSearchContext({
+      query: "where is traceTarget defined",
+      symbol: undefined,
+      limit: 10,
+      tokenBudget: 128,
+      fileType: undefined,
+      directory: undefined,
+      diagnostic: true,
+    }, {
+      lookup: vi.fn().mockResolvedValue([]),
+      search,
+    });
+
+    expect(search).toHaveBeenCalledWith("where is traceTarget defined", 100, {}, expect.any(Function));
+    expect(result.details?.diagnostic).toMatchObject({
+      route: "conceptual",
+      searchQuery: expect.any(String),
+      searchScope: {},
+      searchTrace: {
+        semanticCandidates: [],
+        keywordCandidates: [],
+      },
+      contextPackTrace: {
+        inputCandidates: [
+          {
+            filePath: "src/trace.ts",
+            startLine: 4,
+            endLine: 12,
+            score: 0.9,
+            chunkType: "function",
+            name: "traceTarget",
+          },
+        ],
+      },
+    });
   });
 });

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SearchTrace } from "../src/indexer/index.js";
 
+import { codebase_context as opencodeCodebaseContext } from "../src/adapters/opencode/tools.js";
 import { countContextTokens } from "../src/tools/utils.js";
 import { resolveCodebaseContext, resolveSearchContext } from "../src/tools/context.js";
 
@@ -981,5 +982,10 @@ describe("native OpenCode codebase_context", () => {
     };
     expect(lookupOptions.trace).toBeUndefined();
     expect(result.text).toContain("src/resolve.ts");
+  });
+
+  it("exposes the diagnostic flag in OpenCode schema", () => {
+    const args = (opencodeCodebaseContext as { args: Record<string, unknown> }).args;
+    expect(args).toHaveProperty("diagnostic");
   });
 });

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SearchTrace } from "../src/indexer/index.js";
 
 import { countContextTokens } from "../src/tools/utils.js";
-import { resolveSearchContext } from "../src/tools/context.js";
+import { resolveCodebaseContext, resolveSearchContext } from "../src/tools/context.js";
 
 const operationMocks = vi.hoisted(() => ({
   searchCodebase: vi.fn(),
@@ -884,5 +884,102 @@ describe("native OpenCode codebase_context", () => {
         ],
       },
     });
+  });
+
+  it("forwards the diagnostic flag from codebase context into search traces", async () => {
+    operationMocks.implementationLookup.mockImplementation(async (_projectRoot, _host, _query, options) => {
+      options.trace?.({
+        semanticCandidates: [],
+        keywordCandidates: [],
+        hybridCandidates: [],
+        postExternalRerankCandidates: [],
+        tieredCandidates: [],
+        finalCandidates: [],
+      });
+
+      return [{
+        filePath: "src/resolve.ts",
+        startLine: 10,
+        endLine: 20,
+        name: "resolveContext",
+        chunkType: "function",
+        content: "function resolveContext() {}",
+        score: 0.99,
+      }];
+    });
+
+    const result = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: true,
+    });
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith(
+      "/repo",
+      "opencode",
+      "resolveContext",
+      expect.objectContaining({
+        limit: 100,
+        fileType: undefined,
+        directory: undefined,
+        trace: expect.any(Function),
+      }),
+    );
+    expect(operationMocks.searchCodebase).not.toHaveBeenCalled();
+    expect(result.details?.diagnostic).toMatchObject({
+      route: "definition",
+      searchTrace: {
+        semanticCandidates: [],
+      },
+      contextPackTrace: {
+        selectedCandidates: [
+          {
+            filePath: "src/resolve.ts",
+            startLine: 10,
+            endLine: 20,
+            score: 0.99,
+            chunkType: "function",
+            name: "resolveContext",
+          },
+        ],
+      },
+    });
+  });
+
+  it("omits diagnostic details when diagnostic flag is false", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      filePath: "src/resolve.ts",
+      startLine: 1,
+      endLine: 2,
+      name: "resolveContext",
+      chunkType: "function",
+      content: "function resolveContext() {}",
+      score: 0.9,
+    }]);
+
+    const result = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: false,
+    });
+
+    expect(result.details?.diagnostic).toBeUndefined();
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith(
+      "/repo",
+      "opencode",
+      "resolveContext",
+      expect.objectContaining({
+        limit: 100,
+        fileType: undefined,
+        directory: undefined,
+      }),
+    );
+    const lookupOptions = operationMocks.implementationLookup.mock.calls[0][3] as {
+      trace?: ((trace: SearchTrace) => void) | undefined;
+    };
+    expect(lookupOptions.trace).toBeUndefined();
+    expect(result.text).toContain("src/resolve.ts");
   });
 });

--- a/tests/tools-utils.test.ts
+++ b/tests/tools-utils.test.ts
@@ -817,6 +817,39 @@ describe("tools utils", () => {
       ]);
     });
 
+    it("puts source files ahead of benchmark artifacts when source evidence is requested", () => {
+      const results: SearchResult[] = [
+        {
+          filePath: "crates/abc/benches/feature.rs",
+          startLine: 1,
+          endLine: 20,
+          content: "benchmark",
+          score: 0.99,
+          chunkType: "function",
+          name: "bench_impl",
+        },
+        {
+          filePath: "src/feature.ts",
+          startLine: 1,
+          endLine: 30,
+          content: "implementation",
+          score: 0.60,
+          chunkType: "function",
+          name: "feature",
+        },
+      ];
+
+      const packed = buildContextPack(results, {
+        tokenBudget: 2048,
+        preferImplementationPaths: true,
+      });
+
+      expect(packed.results.map((result) => result.filePath)).toEqual([
+        "src/feature.ts",
+        "crates/abc/benches/feature.rs",
+      ]);
+    });
+
     it("preserves score ordering when implementation preference is disabled", () => {
       const results: SearchResult[] = [
         {

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -18,6 +18,7 @@ vi.mock("../src/git/index.js", async (importOriginal) => ({
 }));
 
 import { parseConfig } from "../src/config/schema.js";
+import { resetAutoIndexCoordinatorsForTests } from "../src/utils/auto-index.js";
 import { createWatcherWithIndexer } from "../src/watcher/index.js";
 
 const WATCH_EVENT_TIMEOUT_MS = 10000;
@@ -86,7 +87,8 @@ describe("watcher config refresh", () => {
     operationMocks.refreshIndexerForDirectory.mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await resetAutoIndexCoordinatorsForTests();
     rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -5,6 +5,10 @@ import * as os from "os";
 import { FileWatcher, GitHeadWatcher, FileChange, createWatcherWithIndexer } from "../src/watcher/index.js";
 import { ParsedCodebaseIndexConfig } from "../src/config/schema.js";
 import { IndexLockContentionError } from "../src/indexer/index-lock.js";
+import {
+  requestBackgroundIndex,
+  resetAutoIndexCoordinatorsForTests,
+} from "../src/utils/auto-index.js";
 
 const createTestConfig = (overrides: Partial<ParsedCodebaseIndexConfig> = {}): ParsedCodebaseIndexConfig => ({
   embeddingProvider: "auto",
@@ -55,16 +59,6 @@ const createTestConfig = (overrides: Partial<ParsedCodebaseIndexConfig> = {}): P
   ...overrides,
 });
 
-const waitForIndexerCalls = async (
-  indexer: { index: ReturnType<typeof vi.fn> },
-  expectedCalls: number,
-  timeoutMs = 3000,
-): Promise<void> => {
-  await vi.waitFor(() => {
-    expect(indexer.index).toHaveBeenCalledTimes(expectedCalls);
-  }, { timeout: timeoutMs });
-};
-
 const writeUntilObserved = async (
   write: (attempt: number) => void,
   assertion: () => void,
@@ -99,6 +93,7 @@ describe("FileWatcher", () => {
 
   afterEach(async () => {
     await watcher?.stop();
+    await resetAutoIndexCoordinatorsForTests();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -310,13 +305,15 @@ describe("FileWatcher", () => {
       resolveIndex?.();
     });
 
-    it("coalesces file-triggered reindex requests while one is running", async () => {
-      vi.setConfig({ testTimeout: 6000 });
+    it("coalesces pending watcher requests while a file-triggered reindex is running", async () => {
+      let blockIndex = true;
       const pendingResolves: Array<() => void> = [];
       const indexer = {
-        index: vi.fn(() => new Promise<void>((resolve) => {
-          pendingResolves.push(resolve);
-        })),
+        index: vi.fn(() => blockIndex
+          ? new Promise<void>((resolve) => {
+              pendingResolves.push(resolve);
+            })
+          : Promise.resolve()),
       };
       const combinedWatcher = createWatcherWithIndexer(
         () => indexer,
@@ -325,18 +322,27 @@ describe("FileWatcher", () => {
         "opencode",
       );
 
-      await combinedWatcher.whenReady();
-      fs.writeFileSync(path.join(tempDir, "src", "first.ts"), "export const first = 1;");
-      await waitForIndexerCalls(indexer, 1);
-      fs.writeFileSync(path.join(tempDir, "src", "second.ts"), "export const second = 2;");
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      try {
+        await combinedWatcher.whenReady();
+        await writeUntilObserved(
+          (attempt) => fs.writeFileSync(
+            path.join(tempDir, "src", "first.ts"),
+            `export const first = ${attempt};`,
+          ),
+          () => expect(indexer.index).toHaveBeenCalledTimes(1),
+        );
 
-      expect(indexer.index).toHaveBeenCalledTimes(1);
-      pendingResolves[0]?.();
-      await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2));
+        requestBackgroundIndex(tempDir, "opencode");
+        requestBackgroundIndex(tempDir, "opencode");
+        expect(indexer.index).toHaveBeenCalledTimes(1);
 
-      await combinedWatcher.stop();
-      pendingResolves[1]?.();
+        pendingResolves[0]?.();
+        await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2));
+      } finally {
+        blockIndex = false;
+        pendingResolves.forEach((resolve) => resolve());
+        await combinedWatcher.stop();
+      }
     });
 
     it("keeps one pending request and retries after INDEX_BUSY", async () => {


### PR DESCRIPTION
## Summary
- add diagnostic routing and search traces to `codebase_context` across MCP, OpenCode, and Pi
- render requested diagnostics in OpenCode while preserving normal output
- stabilize metadata staging and watcher validation coverage

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (81 files, 1,375 tests passed)