### PR TITLE
feat: expose codebase context diagnostics

### DIFF
--- a/src/adapters/mcp/register-tools.ts
+++ b/src/adapters/mcp/register-tools.ts
@@ -80,10 +80,14 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET).optional()
           .default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET),
       ).describe(`Maximum response tokens for this context pack (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
+      diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
     },
     async (args) => {
       const result = await executeCodebaseContext(runtime.projectRoot, runtime.host, args);
-      return { content: [{ type: "text", text: result.text }] };
+      return {
+        content: [{ type: "text", text: result.text }],
+        ...(args.diagnostic ? { structuredContent: result.details } : {}),
+      };
     },
   );
 

--- a/src/adapters/opencode/tools.ts
+++ b/src/adapters/opencode/tools.ts
@@ -68,6 +68,31 @@ const DEFAULT_HOST: HostMode = "opencode";
 const CHUNK_TYPE_VALUES = CHUNK_TYPES;
 const RELATIONSHIP_TYPE_VALUES = RELATIONSHIP_TYPES;
 
+function stableSortedDiagnosticValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => stableSortedDiagnosticValue(item));
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const entries = Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const sorted: Record<string, unknown> = {};
+
+  for (const [key, item] of entries) {
+    sorted[key] = stableSortedDiagnosticValue(item);
+  }
+
+  return sorted;
+}
+
+function formatCodebaseContextDiagnostic(details: unknown): string {
+  const sorted = stableSortedDiagnosticValue(details);
+  return `\nDiagnostics:\n${JSON.stringify(sorted, null, 2)}`;
+}
+
 export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig): void {
   initializeToolOperations(projectRoot, config, DEFAULT_HOST);
 }
@@ -102,7 +127,12 @@ export const codebase_context: ToolDefinition = tool({
     diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
   },
   async execute(args, context) {
-    return (await executeCodebaseContext(context?.worktree, DEFAULT_HOST, args)).text;
+    const result = await executeCodebaseContext(context?.worktree, DEFAULT_HOST, args);
+    if (!args.diagnostic || !result.details?.diagnostic) {
+      return result.text;
+    }
+
+    return `${result.text}${formatCodebaseContextDiagnostic(result.details.diagnostic)}`;
   },
 });
 

--- a/src/adapters/opencode/tools.ts
+++ b/src/adapters/opencode/tools.ts
@@ -99,6 +99,7 @@ export const codebase_context: ToolDefinition = tool({
     tokenBudget: z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET)
       .nullable().optional().default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET)
       .describe(`Maximum response tokens (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
+    diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
   },
   async execute(args, context) {
     return (await executeCodebaseContext(context?.worktree, DEFAULT_HOST, args)).text;

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -94,6 +94,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
         Type.Integer({ minimum: MIN_CONTEXT_PATH_DEPTH, maximum: MAX_CONTEXT_PATH_DEPTH }),
         Type.Null(),
       ], { default: 10, description: `Maximum call-graph traversal depth (${MIN_CONTEXT_PATH_DEPTH}-${MAX_CONTEXT_PATH_DEPTH})` })),
+      diagnostic: Type.Optional(Type.Union([Type.Boolean(), Type.Null()], { description: "Collect diagnostic routing and search traces without changing normal output." })),
       fileType: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Filter by file extension, e.g., ts, py, rs" })),
       directory: Type.Optional(Type.Union([Type.String(), Type.Null()], { description: "Filter by directory path" })),
       tokenBudget: Type.Optional(Type.Union([
@@ -105,7 +106,11 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await resolveCodebaseContext(projectRoot(ctx), HOST, params);
+      const normalizedParams = {
+        ...params,
+        diagnostic: params.diagnostic ?? undefined,
+      };
+      const result = await resolveCodebaseContext(projectRoot(ctx), HOST, normalizedParams);
       return text(result.text, result.details);
     },
   });

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -369,6 +369,40 @@ export interface SearchResult {
   blame?: GitBlameMetadata;
 }
 
+interface CandidateSnapshot {
+  id: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  score: number;
+  chunkType: string;
+  name?: string;
+}
+
+export interface SearchTrace {
+  semanticCandidates: CandidateSnapshot[];
+  keywordCandidates: CandidateSnapshot[];
+  hybridCandidates: CandidateSnapshot[];
+  postExternalRerankCandidates: CandidateSnapshot[];
+  tieredCandidates: CandidateSnapshot[];
+  finalCandidates: CandidateSnapshot[];
+}
+
+interface SearchOptions {
+  hybridWeight?: number;
+  fileType?: string;
+  directory?: string;
+  chunkType?: string;
+  contextLines?: number;
+  filterByBranch?: boolean;
+  metadataOnly?: boolean;
+  definitionIntent?: boolean;
+  blameAuthor?: string;
+  blameSha?: string;
+  blameSince?: string;
+  trace?: (trace: SearchTrace) => void;
+}
+
 export interface HealthCheckResult {
   removed: number;
   filePaths: string[];
@@ -4613,6 +4647,22 @@ export class Indexer {
     }
   }
 
+  private buildCandidateSnapshot(candidate: RankedCandidate): CandidateSnapshot {
+    return {
+      id: candidate.id,
+      filePath: candidate.metadata.filePath,
+      startLine: candidate.metadata.startLine,
+      endLine: candidate.metadata.endLine,
+      score: candidate.score,
+      chunkType: candidate.metadata.chunkType,
+      name: candidate.metadata.name,
+    };
+  }
+
+  private buildCandidateSnapshotList(candidates: RankedCandidate[]): CandidateSnapshot[] {
+    return candidates.map((candidate) => this.buildCandidateSnapshot(candidate));
+  }
+
   private searchSemanticCandidates(
     store: VectorStore,
     embedding: number[],
@@ -4633,19 +4683,7 @@ export class Indexer {
   async search(
     query: string,
     limit?: number,
-    options?: {
-      hybridWeight?: number;
-      fileType?: string;
-      directory?: string;
-      chunkType?: string;
-      contextLines?: number;
-      filterByBranch?: boolean;
-      metadataOnly?: boolean;
-      definitionIntent?: boolean;
-      blameAuthor?: string;
-      blameSha?: string;
-      blameSince?: string;
-    }
+    options?: SearchOptions
   ): Promise<SearchResult[]> {
     const { store, provider, invertedIndex, database, readIssues, compatibility } = await this.ensureInitialized();
     this.requireReadableComponents(readIssues, "vectors", "database");
@@ -4869,6 +4907,17 @@ export class Indexer {
       prefilterMs: Math.round(prefilterMs * 100) / 100,
       fusionMs: Math.round(fusionMs * 100) / 100,
     });
+
+    if (options?.trace) {
+      options.trace({
+        semanticCandidates: this.buildCandidateSnapshotList(scopedSemanticCandidates),
+        keywordCandidates: this.buildCandidateSnapshotList(scopedKeywordCandidates),
+        hybridCandidates: this.buildCandidateSnapshotList(combined),
+        postExternalRerankCandidates: this.buildCandidateSnapshotList(rerankedCombined),
+        tieredCandidates: this.buildCandidateSnapshotList(tiered),
+        finalCandidates: this.buildCandidateSnapshotList(finalResults),
+      });
+    }
 
     const metadataOnly = options?.metadataOnly ?? false;
 

--- a/src/tools/context-pack.ts
+++ b/src/tools/context-pack.ts
@@ -21,6 +21,50 @@ export interface ContextPackOptions {
   includeExactSearchHandoff?: boolean;
   preferImplementationPaths?: boolean;
   preserveInputOrder?: boolean;
+  trace?: (trace: ContextPackTrace) => void;
+}
+
+export interface ContextPackTrace {
+  inputCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  rankedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  deduplicatedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  diversifiedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
+  selectedCandidates: Array<{
+    filePath: string;
+    startLine: number;
+    endLine: number;
+    score: number;
+    chunkType: string;
+    name?: string;
+  }>;
 }
 
 export interface ContextPackResult {
@@ -160,6 +204,17 @@ function compactEvidenceValue(value: string, maxChars: number): string {
 const MAX_EXACT_SEARCH_HANDOFF_NAMES = 3;
 const MAX_EXACT_SEARCH_HANDOFF_NAME_CHARS = 64;
 
+function toContextPackTraceCandidate(result: SearchResult): ContextPackTrace["inputCandidates"][number] {
+  return {
+    filePath: result.filePath,
+    startLine: result.startLine,
+    endLine: result.endLine,
+    score: result.score,
+    chunkType: result.chunkType,
+    name: result.name,
+  };
+}
+
 export function formatExactSearchHandoff(results: SearchResult[]): string | null {
   const suggestedNames: string[] = [];
   const seen = new Set<string>();
@@ -232,8 +287,11 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const ranked = preserveInputOrder
     ? results.map((result, originalIndex) => ({ result, originalIndex }))
     : rankContextCandidates(results, options.preferImplementationPaths ?? false);
+  const rankedCandidates = ranked.map((entry) => toContextPackTraceCandidate(entry.result));
   const deduplicated = deduplicateContextCandidates(ranked);
+  const deduplicatedCandidates = deduplicated.map((result) => toContextPackTraceCandidate(result));
   const diversified = preserveInputOrder ? deduplicated : diversifyContextCandidates(deduplicated);
+  const diversifiedCandidates = diversified.map((result) => toContextPackTraceCandidate(result));
   const duplicateCount = candidateCount - deduplicated.length;
   const selectable = diversified.slice(0, maxResults);
   const limitOmittedCount = deduplicated.length - selectable.length;
@@ -268,6 +326,15 @@ export function buildContextPack(results: SearchResult[], options: ContextPackOp
   const fitted = fitTextToContextBudget(text, tokenBudget);
   const budgetOmittedCount = selectable.length - selected.length;
   const omittedCount = candidateCount - selected.length;
+  if (options.trace) {
+    options.trace({
+      inputCandidates: results.map(toContextPackTraceCandidate),
+      rankedCandidates,
+      deduplicatedCandidates,
+      diversifiedCandidates,
+      selectedCandidates: selected.map(toContextPackTraceCandidate),
+    });
+  }
   return {
     requestedTokenBudget,
     tokenBudget,

--- a/src/tools/context-search.ts
+++ b/src/tools/context-search.ts
@@ -1,7 +1,9 @@
 import type { SearchResult } from "../indexer/index.js";
+import type { SearchTrace } from "../indexer/index.js";
 import { analyzeQueryIntent } from "../indexer/intent-aware-ranking.js";
 import { inferExactSymbolFromQuery } from "./symbol-inference.js";
 import { buildContextPack, fitTextToContextBudget } from "./utils.js";
+import type { ContextPackTrace } from "./context-pack.js";
 
 export interface CodebaseContextInput {
   query: string;
@@ -15,6 +17,7 @@ export interface CodebaseContextInput {
   fileType?: string | null;
   directory?: string | null;
   tokenBudget?: number | null;
+  diagnostic?: boolean;
 }
 
 export const MIN_CONTEXT_RESULT_LIMIT = 1;
@@ -56,6 +59,17 @@ export interface CodebaseContextResult {
       }>;
       successfulAttemptIndex?: number;
     };
+    diagnostic?: {
+      route: "definition" | "conceptual";
+      routedQuery: string;
+      searchQuery: string;
+      searchScope: {
+        fileType?: string;
+        directory?: string;
+      };
+      searchTrace?: SearchTrace;
+      contextPackTrace?: ContextPackTrace;
+    };
     results?: ContextLocation[];
   };
 }
@@ -96,8 +110,18 @@ function packedResult(
 }
 
 interface SearchContextOperations {
-  lookup(symbol: string, limit: number, scope: SearchScope): Promise<SearchResult[]>;
-  search(query: string, limit: number, scope: SearchScope): Promise<SearchResult[]>;
+  lookup(
+    symbol: string,
+    limit: number,
+    scope: SearchScope,
+    trace?: (trace: SearchTrace) => void,
+  ): Promise<SearchResult[]>;
+  search(
+    query: string,
+    limit: number,
+    scope: SearchScope,
+    trace?: (trace: SearchTrace) => void,
+  ): Promise<SearchResult[]>;
 }
 
 type RecoveryScope = "scoped" | "unscoped";
@@ -108,6 +132,15 @@ interface RecoveryAttempt {
   resultCount: number;
   relaxedFields: Array<"directory" | "fileType">;
 }
+
+interface SearchAttemptState extends RecoveryAttempt {
+  query: string;
+  scopeFilter: SearchScope;
+  searchTrace?: SearchTrace;
+  contextPackTrace?: ContextPackTrace;
+}
+
+type SearchDiagnostic = NonNullable<NonNullable<CodebaseContextResult["details"]>["diagnostic"]>;
 
 interface SearchScope {
   fileType?: string;
@@ -214,6 +247,30 @@ function buildRecoveryDetails(attempts: RecoveryAttempt[], successIndex: number 
     };
 }
 
+function serializeAttempts(attempts: SearchAttemptState[]): RecoveryAttempt[] {
+  return attempts.map((attempt) => ({
+    kind: attempt.kind,
+    scope: attempt.scope,
+    resultCount: attempt.resultCount,
+    relaxedFields: attempt.relaxedFields,
+  }));
+}
+
+function buildSearchDiagnostic(attempt: SearchAttemptState | undefined): SearchDiagnostic | undefined {
+  if (!attempt) {
+    return undefined;
+  }
+
+  return {
+    route: attempt.kind,
+    routedQuery: attempt.query,
+    searchQuery: attempt.query,
+    searchScope: attempt.scopeFilter,
+    searchTrace: attempt.searchTrace,
+    contextPackTrace: attempt.contextPackTrace,
+  };
+}
+
 export function trimOrUndefined(value: string | null | undefined): string | undefined {
   const normalized = value?.trim();
   if (!normalized) {
@@ -248,7 +305,7 @@ function relaxedHintFields(fileType?: string, directory?: string): Array<"direct
 }
 
 export async function resolveSearchContext(
-  input: Pick<CodebaseContextInput, "query" | "symbol" | "limit" | "tokenBudget" | "fileType" | "directory">,
+  input: Pick<CodebaseContextInput, "query" | "symbol" | "limit" | "tokenBudget" | "fileType" | "directory" | "diagnostic">,
   operations: SearchContextOperations,
 ): Promise<CodebaseContextResult> {
   const query = trimOrUndefined(input.query);
@@ -264,6 +321,7 @@ export async function resolveSearchContext(
   const hasFilters = Boolean(fileType || directory);
   const relaxedFields = relaxedHintFields(fileType, directory);
   const attempts: RecoveryAttempt[] = [];
+  const attemptStates: SearchAttemptState[] = [];
   const decisions: RecoveryDecisions = {
     inferredDefinitionMiss: false,
     fallbackFromOriginalConceptualToInferred: false,
@@ -294,15 +352,27 @@ export async function resolveSearchContext(
     attemptQuery: string,
     scope: SearchScope,
     relaxedFieldsForAttempt: Array<"directory" | "fileType">,
-    runAttempt: () => Promise<SearchResult[]>,
+    runAttempt: (trace?: (trace: SearchTrace) => void) => Promise<SearchResult[]>,
   ): Promise<SearchResult[]> => {
     const key = attemptKey(kind, attemptQuery, scope);
     if (seenAttempts.has(key)) {
       return [];
     }
 
-    const results = await runAttempt();
+    const attemptState: SearchAttemptState = {
+      kind,
+      scope: describeScope(scope.fileType, scope.directory),
+      resultCount: 0,
+      relaxedFields: [...relaxedFieldsForAttempt],
+      query: attemptQuery,
+      scopeFilter: scope,
+    };
+    const results = await runAttempt((trace) => {
+      attemptState.searchTrace = trace;
+    });
+    attemptState.resultCount = results.length;
     seenAttempts.add(key);
+    attemptStates.push(attemptState);
     attempts.push({
       kind,
       scope: describeScope(scope.fileType, scope.directory),
@@ -329,7 +399,7 @@ export async function resolveSearchContext(
       symbol,
       scope,
       relaxedFieldsForAttempt,
-      () => operations.lookup(symbol, MAX_CONTEXT_RESULT_LIMIT, scope),
+      (trace) => operations.lookup(symbol, MAX_CONTEXT_RESULT_LIMIT, scope, input.diagnostic ? trace : undefined),
     );
   };
 
@@ -343,18 +413,33 @@ export async function resolveSearchContext(
       searchQuery,
       scope,
       relaxedFieldsForAttempt,
-      () => operations.search(searchQuery, MAX_CONTEXT_RESULT_LIMIT, scope),
+      (trace) => operations.search(searchQuery, MAX_CONTEXT_RESULT_LIMIT, scope, input.diagnostic ? trace : undefined),
     );
+  };
+
+  const findSuccessfulAttemptState = (
+    route: "definition" | "conceptual",
+  ): SearchAttemptState | undefined => {
+    for (let index = attemptStates.length - 1; index >= 0; index -= 1) {
+      const attempt = attemptStates[index];
+      if (attempt.kind === route && attempt.resultCount > 0) {
+        return attempt;
+      }
+    }
+
+    return undefined;
   };
 
   const toResult = (
     route: "definition" | "conceptual",
     routedQuery: string,
     pack: ReturnType<typeof buildContextPack>,
+    successfulAttempt?: SearchAttemptState,
   ): CodebaseContextResult => {
     const base = packedResult(route, routedQuery, pack);
     const baseDetails = base.details as NonNullable<CodebaseContextResult["details"]>;
     const successIndex = findSuccessfulAttemptIndex(route, attempts);
+    const successState = successfulAttempt ?? findSuccessfulAttemptState(route);
     return {
       text: base.text,
       details: {
@@ -362,7 +447,10 @@ export async function resolveSearchContext(
         tokenBudget: baseDetails.tokenBudget,
         tokenEstimate: baseDetails.tokenEstimate,
         truncated: false,
-        recovery: buildRecoveryDetails(attempts, successIndex),
+        recovery: buildRecoveryDetails(serializeAttempts(attemptStates), successIndex),
+        ...(input.diagnostic && {
+          diagnostic: buildSearchDiagnostic(successState),
+        }),
       },
     };
   };
@@ -379,7 +467,16 @@ export async function resolveSearchContext(
           maxResults: limit,
           heading,
           preserveInputOrder: true,
+          ...(input.diagnostic ? {
+            trace: (trace) => {
+              const attemptState = findSuccessfulAttemptState("definition");
+              if (attemptState) {
+                attemptState.contextPackTrace = trace;
+              }
+            },
+          } : undefined),
         }),
+        findSuccessfulAttemptState("definition"),
       );
     }
 
@@ -395,13 +492,22 @@ export async function resolveSearchContext(
           return toResult(
             "definition",
             definitionSymbol,
-          buildContextPack(unscopedDefinitionResults, {
-            tokenBudget,
-            maxResults: limit,
-            heading,
-            preserveInputOrder: true,
-          }),
-        );
+            buildContextPack(unscopedDefinitionResults, {
+              tokenBudget,
+              maxResults: limit,
+              heading,
+              preserveInputOrder: true,
+              ...(input.diagnostic ? {
+                trace: (trace) => {
+                  const attemptState = findSuccessfulAttemptState("definition");
+                  if (attemptState) {
+                    attemptState.contextPackTrace = trace;
+                  }
+                },
+              } : undefined),
+            }),
+            findSuccessfulAttemptState("definition"),
+          );
         }
       }
 
@@ -419,7 +525,10 @@ export async function resolveSearchContext(
           tokenBudget: heading.tokenBudget,
           tokenEstimate: heading.tokenEstimate,
           truncated: heading.truncated,
-          recovery: buildRecoveryDetails(attempts, null),
+          recovery: buildRecoveryDetails(serializeAttempts(attemptStates), null),
+          ...(input.diagnostic && {
+            diagnostic: buildSearchDiagnostic(attemptStates[attemptStates.length - 1]),
+          }),
         },
       };
     }
@@ -465,7 +574,16 @@ export async function resolveSearchContext(
           includeExactSearchHandoff: true,
           preferImplementationPaths:
             intent.preferSourcePaths || (intent.primary !== "docs" && intent.primary !== "test"),
+          ...(input.diagnostic ? {
+            trace: (trace) => {
+              const attemptState = findSuccessfulAttemptState("conceptual");
+              if (attemptState) {
+                attemptState.contextPackTrace = trace;
+              }
+            },
+          } : undefined),
         }),
+        findSuccessfulAttemptState("conceptual"),
       );
     }
   }
@@ -482,7 +600,10 @@ export async function resolveSearchContext(
       tokenBudget: fallbackText.tokenBudget,
       tokenEstimate: fallbackText.tokenEstimate,
       truncated: fallbackText.truncated,
-      recovery: buildRecoveryDetails(attempts, null),
+      recovery: buildRecoveryDetails(serializeAttempts(attemptStates), null),
+      ...(input.diagnostic && {
+        diagnostic: buildSearchDiagnostic(attemptStates[attemptStates.length - 1]),
+      }),
     },
   };
 }

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -118,17 +118,27 @@ async function resolveCodebaseContextUnmeasured(
     };
   }
 
-  return resolveSearchContext({ query: input.query, symbol, limit, tokenBudget, fileType, directory }, {
-    lookup: (lookupSymbol, retrievalLimit, scope) => implementationLookup(projectRoot, host, lookupSymbol, {
+  return resolveSearchContext({
+    query: input.query,
+    symbol,
+    limit,
+    tokenBudget,
+    fileType,
+    directory,
+    diagnostic: input.diagnostic,
+  }, {
+    lookup: (lookupSymbol, retrievalLimit, scope, trace) => implementationLookup(projectRoot, host, lookupSymbol, {
       limit: retrievalLimit,
       fileType: scope.fileType,
       directory: scope.directory,
+      trace,
     }),
-    search: (queryText, retrievalLimit, scope) => searchCodebase(projectRoot, host, queryText, {
+    search: (queryText, retrievalLimit, scope, trace) => searchCodebase(projectRoot, host, queryText, {
       limit: retrievalLimit,
       fileType: scope.fileType,
       directory: scope.directory,
       metadataOnly: true,
+      trace,
     }),
   });
 }

--- a/src/tools/contracts.ts
+++ b/src/tools/contracts.ts
@@ -44,6 +44,7 @@ export interface SharedCodebaseContextArgs {
   fileType?: string | null;
   directory?: string | null;
   tokenBudget?: number | null;
+  diagnostic?: boolean;
 }
 
 export interface SharedCodebaseEditContextArgs {

--- a/src/tools/execute-common.ts
+++ b/src/tools/execute-common.ts
@@ -36,6 +36,7 @@ import { formatCodeCommunities } from "./format-communities.js";
 
 export interface ExecutionResult {
   text: string;
+  details?: Record<string, unknown>;
   isError?: boolean;
 }
 
@@ -46,7 +47,8 @@ export async function executeCodebaseContext(
   host: HostMode,
   args: SharedCodebaseContextArgs,
 ): Promise<ExecutionResult> {
-  return { text: (await resolveCodebaseContext(projectRoot, host, args)).text };
+  const result = await resolveCodebaseContext(projectRoot, host, args);
+  return { text: result.text, details: result.details };
 }
 
 export async function executeCodebaseEditContext(

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -22,6 +22,7 @@ import type { LogLevel } from "../config/schema.js";
 import type { LogEntry } from "../utils/logger.js";
 import type { CostEstimate } from "../utils/cost.js";
 import type { AutoIndexStatusSnapshot } from "../utils/auto-index.js";
+import type { SearchTrace } from "../indexer/index.js";
 import {
   formatEffectivenessMetrics,
   getProcessEffectivenessMetrics,
@@ -231,6 +232,7 @@ export async function searchCodebase(
     blameAuthor?: string;
     blameSha?: string;
     blameSince?: string;
+    trace?: (trace: SearchTrace) => void;
   } = {},
 ): Promise<SearchResult[]> {
   await ensureAutoIndexReadyForRetrieval(projectRoot, host);
@@ -245,6 +247,7 @@ export async function searchCodebase(
     blameAuthor: options.blameAuthor,
     blameSha: options.blameSha,
     blameSince: options.blameSince,
+    trace: options.trace,
   });
 }
 
@@ -321,6 +324,7 @@ export async function implementationLookup(
     limit?: number;
     fileType?: string;
     directory?: string;
+    trace?: (trace: SearchTrace) => void;
   } = {},
 ): Promise<SearchResult[]> {
   await ensureAutoIndexReadyForRetrieval(projectRoot, host);
@@ -329,6 +333,7 @@ export async function implementationLookup(
     fileType: options.fileType,
     directory: options.directory,
     definitionIntent: true,
+    trace: options.trace,
   });
 }
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -512,6 +512,15 @@ describe("MCP server tools and prompts", () => {
     expect(descriptions.get("pr_impact")).toContain("FIRST TOOL");
   });
 
+  it("should expose a diagnostic option on codebase_context schema", async () => {
+    const tools = await client.listTools();
+    const codebaseContext = tools.tools.find((tool) => tool.name === "codebase_context");
+
+    const properties = codebaseContext?.inputSchema?.properties;
+    expect(properties).toBeDefined();
+    expect(properties).toHaveProperty("diagnostic");
+  });
+
   it("should register all 5 prompts", async () => {
     const prompts = await client.listPrompts();
 
@@ -802,6 +811,19 @@ describe("MCP server tools and prompts", () => {
       100,
       expect.objectContaining({ definitionIntent: true }),
     );
+  });
+
+  it("should return codebase_context diagnostics as MCP structured content on request", async () => {
+    const result = await client.callTool({
+      name: "codebase_context",
+      arguments: { query: "where is validateToken defined", symbol: "validateToken", diagnostic: true },
+    });
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    expect(content[0].text).toContain('function "validateToken"');
+    expect(result.structuredContent).toMatchObject({
+      diagnostic: expect.objectContaining({ route: "definition" }),
+    });
   });
 
   it("should infer an exact symbol and route through implementation lookup", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -185,6 +185,44 @@ describe("Pi adapter conformance", () => {
       default: 10,
       anyOf: expect.arrayContaining([expect.objectContaining({ minimum: 1, maximum: 100 })]),
     }));
+    expect(tools.get("codebase_context")?.parameters?.properties?.diagnostic).toEqual(
+      expect.objectContaining({
+        anyOf: expect.arrayContaining([expect.objectContaining({ type: "boolean" })]),
+      }),
+    );
+  });
+
+  it("keeps Pi normal output unchanged when diagnostic is false", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      chunkType: "function",
+      name: "validateToken",
+      filePath: "src/auth.ts",
+      startLine: 12,
+      endLine: 30,
+      score: 0.95,
+      content: "function validateToken() {}",
+    }]);
+
+    const { tools } = await registerPiTools();
+
+    const withoutDiagnostic = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128 },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+    const withDiagnosticFalse = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128, diagnostic: false },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(withDiagnosticFalse?.content[0]?.text).toEqual(withoutDiagnostic?.content[0]?.text);
+    expect(withDiagnosticFalse?.details).toBeDefined();
+    expect(withDiagnosticFalse?.details).not.toHaveProperty("diagnostic");
   });
 
   it("formats metadata-only peek results with the shared exact-search handoff", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -219,10 +219,21 @@ describe("Pi adapter conformance", () => {
       () => {},
       { cwd: "/repo" },
     );
+    const withDiagnostic = await tools.get("codebase_context")?.execute(
+      "tool-call",
+      { query: "unused", symbol: "validateToken", limit: 8, tokenBudget: 128, diagnostic: true },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
 
     expect(withDiagnosticFalse?.content[0]?.text).toEqual(withoutDiagnostic?.content[0]?.text);
     expect(withDiagnosticFalse?.details).toBeDefined();
     expect(withDiagnosticFalse?.details).not.toHaveProperty("diagnostic");
+    expect(withDiagnostic?.content[0]?.text).toEqual(withoutDiagnostic?.content[0]?.text);
+    expect(withDiagnostic?.details).toMatchObject({
+      diagnostic: expect.objectContaining({ route: "definition", routedQuery: "validateToken" }),
+    });
   });
 
   it("formats metadata-only peek results with the shared exact-search handoff", async () => {

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -948,6 +948,63 @@ describe("native OpenCode codebase_context", () => {
     });
   });
 
+  it("preserves OpenCode text output when diagnostic is disabled", async () => {
+    const baseline = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: false,
+    });
+
+    const noDiagnostic = await opencodeCodebaseContext.execute({
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: false,
+    }, context);
+
+    const omittedDiagnostic = await opencodeCodebaseContext.execute({
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+    }, context);
+
+    expect(noDiagnostic).toBe(baseline.text);
+    expect(omittedDiagnostic).toBe(baseline.text);
+  });
+
+  it("appends diagnostics text in OpenCode output when diagnostic is true", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      filePath: "src/resolve.ts",
+      startLine: 10,
+      endLine: 20,
+      name: "resolveContext",
+      chunkType: "function",
+      content: "function resolveContext() {}",
+      score: 0.99,
+    }]);
+
+    const withDiagnostic = await opencodeCodebaseContext.execute({
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: true,
+    }, context);
+
+    const baseline = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: true,
+    });
+
+    expect(withDiagnostic.startsWith(baseline.text)).toBe(true);
+    expect(withDiagnostic).toContain("\nDiagnostics:\n");
+    expect(withDiagnostic).toContain('"route"');
+    expect(withDiagnostic).toContain("\"route\": \"definition\"");
+    expect(withDiagnostic).not.toContain('"selectedCount"');
+  });
+
   it("omits diagnostic details when diagnostic flag is false", async () => {
     operationMocks.implementationLookup.mockResolvedValue([{
       filePath: "src/resolve.ts",

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SearchTrace } from "../src/indexer/index.js";
+
 import { countContextTokens } from "../src/tools/utils.js";
 import { resolveSearchContext } from "../src/tools/context.js";
 
@@ -563,8 +565,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "find request helpers", 100, { fileType: "ts", directory: "src" });
-    expect(search).toHaveBeenNthCalledWith(2, "find request helpers", 100, { fileType: undefined, directory: undefined });
+    expect(search).toHaveBeenNthCalledWith(1, "find request helpers", 100, { fileType: "ts", directory: "src" }, undefined);
+    expect(search).toHaveBeenNthCalledWith(2, "find request helpers", 100, { fileType: undefined, directory: undefined }, undefined);
     expect(result.details?.recovery?.attempts).toEqual([
       {
         kind: "conceptual",
@@ -616,8 +618,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "where is `getStatus` defined", 100, { fileType: undefined, directory: undefined });
-    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined });
+    expect(search).toHaveBeenNthCalledWith(1, "where is `getStatus` defined", 100, { fileType: undefined, directory: undefined }, undefined);
+    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined);
     expect(result.text).toContain("src/auth.ts:1-8");
     expect(result.text).toContain("Recovery: inferred definition missed; inferred-symbol query tried.");
     expect(result.text.indexOf("Recovery:")).toBeLessThan(result.text.indexOf("[1]"));
@@ -680,8 +682,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "getStatus", 100, { fileType: "ts", directory: "src" });
-    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined });
+    expect(search).toHaveBeenNthCalledWith(1, "getStatus", 100, { fileType: "ts", directory: "src" }, undefined);
+    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined);
     expect(result.details?.recovery?.attempts).toHaveLength(3);
     expect(new Set(result.details?.recovery?.attempts.map((attempt) => JSON.stringify(attempt))).size)
       .toBe(3);
@@ -737,8 +739,8 @@ describe("native OpenCode codebase_context", () => {
     expect(lookup).toHaveBeenNthCalledWith(1, "resolveSearchContext", 100, {
       fileType: "ts",
       directory: "src/tools",
-    });
-    expect(lookup).toHaveBeenNthCalledWith(2, "resolveSearchContext", 100, {});
+    }, undefined);
+    expect(lookup).toHaveBeenNthCalledWith(2, "resolveSearchContext", 100, {}, undefined);
     expect(search).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({
       route: "definition",
@@ -779,10 +781,10 @@ describe("native OpenCode codebase_context", () => {
     });
 
     expect(search.mock.calls).toEqual([
-      ["where is `getStatus` defined", 100, { fileType: "ts", directory: "private/scope" }],
-      ["getStatus", 100, { fileType: "ts", directory: "private/scope" }],
-      ["where is `getStatus` defined", 100, {}],
-      ["getStatus", 100, {}],
+      ["where is `getStatus` defined", 100, { fileType: "ts", directory: "private/scope" }, undefined],
+      ["getStatus", 100, { fileType: "ts", directory: "private/scope" }, undefined],
+      ["where is `getStatus` defined", 100, {}, undefined],
+      ["getStatus", 100, {}, undefined],
     ]);
     const recoveryLine = result.text.split("\n").find((line) => line.startsWith("Recovery:"));
     expect(recoveryLine).toBe("Recovery: inferred definition missed; inferred-symbol query tried; directory filter removed; file-type filter removed.");
@@ -822,5 +824,65 @@ describe("native OpenCode codebase_context", () => {
     expect(result.details?.truncated).toBe(false);
     expect(result.details?.tokenEstimate).toBe(countContextTokens(result.text));
     expect(countContextTokens(result.text)).toBeLessThanOrEqual(128);
+  });
+
+  it("captures search and context-pack traces when diagnostic flag is set", async () => {
+    const search = vi.fn().mockImplementation(async (_query: string, _limit: number, _scope: unknown, trace?: (trace: SearchTrace) => void) => {
+      trace?.({
+        semanticCandidates: [],
+        keywordCandidates: [],
+        hybridCandidates: [],
+        postExternalRerankCandidates: [],
+        tieredCandidates: [],
+        finalCandidates: [],
+      });
+      return [
+        {
+          filePath: "src/trace.ts",
+          startLine: 4,
+          endLine: 12,
+          name: "traceTarget",
+          chunkType: "function",
+          content: "function traceTarget() {}",
+          score: 0.9,
+        },
+      ];
+    });
+
+    const result = await resolveSearchContext({
+      query: "where is traceTarget defined",
+      symbol: undefined,
+      limit: 10,
+      tokenBudget: 128,
+      fileType: undefined,
+      directory: undefined,
+      diagnostic: true,
+    }, {
+      lookup: vi.fn().mockResolvedValue([]),
+      search,
+    });
+
+    expect(search).toHaveBeenCalledWith("where is traceTarget defined", 100, {}, expect.any(Function));
+    expect(result.details?.diagnostic).toMatchObject({
+      route: "conceptual",
+      searchQuery: expect.any(String),
+      searchScope: {},
+      searchTrace: {
+        semanticCandidates: [],
+        keywordCandidates: [],
+      },
+      contextPackTrace: {
+        inputCandidates: [
+          {
+            filePath: "src/trace.ts",
+            startLine: 4,
+            endLine: 12,
+            score: 0.9,
+            chunkType: "function",
+            name: "traceTarget",
+          },
+        ],
+      },
+    });
   });
 });

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SearchTrace } from "../src/indexer/index.js";
 
+import { codebase_context as opencodeCodebaseContext } from "../src/adapters/opencode/tools.js";
 import { countContextTokens } from "../src/tools/utils.js";
 import { resolveCodebaseContext, resolveSearchContext } from "../src/tools/context.js";
 
@@ -981,5 +982,10 @@ describe("native OpenCode codebase_context", () => {
     };
     expect(lookupOptions.trace).toBeUndefined();
     expect(result.text).toContain("src/resolve.ts");
+  });
+
+  it("exposes the diagnostic flag in OpenCode schema", () => {
+    const args = (opencodeCodebaseContext as { args: Record<string, unknown> }).args;
+    expect(args).toHaveProperty("diagnostic");
   });
 });

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SearchTrace } from "../src/indexer/index.js";
 
 import { countContextTokens } from "../src/tools/utils.js";
-import { resolveSearchContext } from "../src/tools/context.js";
+import { resolveCodebaseContext, resolveSearchContext } from "../src/tools/context.js";
 
 const operationMocks = vi.hoisted(() => ({
   searchCodebase: vi.fn(),
@@ -884,5 +884,102 @@ describe("native OpenCode codebase_context", () => {
         ],
       },
     });
+  });
+
+  it("forwards the diagnostic flag from codebase context into search traces", async () => {
+    operationMocks.implementationLookup.mockImplementation(async (_projectRoot, _host, _query, options) => {
+      options.trace?.({
+        semanticCandidates: [],
+        keywordCandidates: [],
+        hybridCandidates: [],
+        postExternalRerankCandidates: [],
+        tieredCandidates: [],
+        finalCandidates: [],
+      });
+
+      return [{
+        filePath: "src/resolve.ts",
+        startLine: 10,
+        endLine: 20,
+        name: "resolveContext",
+        chunkType: "function",
+        content: "function resolveContext() {}",
+        score: 0.99,
+      }];
+    });
+
+    const result = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: true,
+    });
+
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith(
+      "/repo",
+      "opencode",
+      "resolveContext",
+      expect.objectContaining({
+        limit: 100,
+        fileType: undefined,
+        directory: undefined,
+        trace: expect.any(Function),
+      }),
+    );
+    expect(operationMocks.searchCodebase).not.toHaveBeenCalled();
+    expect(result.details?.diagnostic).toMatchObject({
+      route: "definition",
+      searchTrace: {
+        semanticCandidates: [],
+      },
+      contextPackTrace: {
+        selectedCandidates: [
+          {
+            filePath: "src/resolve.ts",
+            startLine: 10,
+            endLine: 20,
+            score: 0.99,
+            chunkType: "function",
+            name: "resolveContext",
+          },
+        ],
+      },
+    });
+  });
+
+  it("omits diagnostic details when diagnostic flag is false", async () => {
+    operationMocks.implementationLookup.mockResolvedValue([{
+      filePath: "src/resolve.ts",
+      startLine: 1,
+      endLine: 2,
+      name: "resolveContext",
+      chunkType: "function",
+      content: "function resolveContext() {}",
+      score: 0.9,
+    }]);
+
+    const result = await resolveCodebaseContext("/repo", "opencode", {
+      ...commonArgs,
+      query: "resolve context",
+      symbol: "resolveContext",
+      diagnostic: false,
+    });
+
+    expect(result.details?.diagnostic).toBeUndefined();
+    expect(operationMocks.implementationLookup).toHaveBeenCalledWith(
+      "/repo",
+      "opencode",
+      "resolveContext",
+      expect.objectContaining({
+        limit: 100,
+        fileType: undefined,
+        directory: undefined,
+      }),
+    );
+    const lookupOptions = operationMocks.implementationLookup.mock.calls[0][3] as {
+      trace?: ((trace: SearchTrace) => void) | undefined;
+    };
+    expect(lookupOptions.trace).toBeUndefined();
+    expect(result.text).toContain("src/resolve.ts");
   });
 });


### PR DESCRIPTION
## Summary\n- expose bounded retrieval diagnostics through shared context operations and OpenCode, MCP, and Pi adapters\n- preserve normal output when diagnostics are disabled\n- normalize diagnostic result typing across hosts\n\n## Validation\n- npx vitest run tests/tools-context.test.ts tests/mcp-server.test.ts tests/pi-conformance.test.ts\n- npm run typecheck\n- npm run lint\n\nThis replaces closed PR #252 with its user-facing diagnostics scope only. Benchmark infrastructure is intentionally excluded.