### PR TITLE
fix: stabilize community performance CI and metadata staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Community detection performance**: Avoid cloning adjacency sets on every label-propagation pass, keeping the 10k-node community and coupling workload within its CI performance budget.
 
+- **Package metadata staging**: Exclude local indexes, benchmark results, and other generated workspace artifacts from staged package copies, preventing release-validation timeouts and accidental inclusion of local data.
+
 - **Dependency vulnerabilities**: Bumped transitive dependency pins to patched releases so `npm audit` reports 0 vulnerabilities: `hono` 4.12.34 (CORS ReDoS), `ip-address` 10.4.0 (SSRF and trust-boundary bypasses), `fast-uri` 3.1.5 (host confusion), `postcss` 8.5.26 (source-map disclosure), `undici` 8.9.0 via `@earendil-works/pi-coding-agent` 0.84.0 (CRLF injection, cache parsing, cookie and retry issues), `brace-expansion` 5.0.9 (DoS), and `@eslint/config-array` 0.23.5 (minimatch-based DoS path).
 
 - **Pre-edit fallback quality gates**: Added optional `minRouteAccuracy` and `minOutcomeAccuracy` evaluation budget thresholds and applied them in `benchmarks/budgets/pre-edit.json` so unresolved `expectedRoute`/`expectedOutcome` assertions now gate CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Community detection performance**: Avoid cloning adjacency sets on every label-propagation pass, keeping the 10k-node community and coupling workload within its CI performance budget.
+
 - **Dependency vulnerabilities**: Bumped transitive dependency pins to patched releases so `npm audit` reports 0 vulnerabilities: `hono` 4.12.34 (CORS ReDoS), `ip-address` 10.4.0 (SSRF and trust-boundary bypasses), `fast-uri` 3.1.5 (host confusion), `postcss` 8.5.26 (source-map disclosure), `undici` 8.9.0 via `@earendil-works/pi-coding-agent` 0.84.0 (CRLF injection, cache parsing, cookie and retry issues), `brace-expansion` 5.0.9 (DoS), and `@eslint/config-array` 0.23.5 (minimatch-based DoS path).
 
 - **Pre-edit fallback quality gates**: Added optional `minRouteAccuracy` and `minOutcomeAccuracy` evaluation budget thresholds and applied them in `benchmarks/budgets/pre-edit.json` so unresolved `expectedRoute`/`expectedOutcome` assertions now gate CI.

--- a/native/src/community.rs
+++ b/native/src/community.rs
@@ -403,19 +403,24 @@ pub fn detect_communities(
     for _ in 0..50 {
         let mut changed = false;
         for id in &order {
-            let neighbors = adjacency.get(id).cloned().unwrap_or_default();
-            let active_neighbors: Vec<&String> = neighbors
-                .iter()
-                .filter(|n| active_ids.contains(*n))
-                .collect();
-            if active_neighbors.is_empty() {
+            let Some(neighbors) = adjacency.get(id) else {
                 continue;
-            }
+            };
 
             let mut label_counts: HashMap<String, usize> = HashMap::new();
-            for n in &active_neighbors {
-                let lbl = labels.get(*n).cloned().unwrap_or_else(|| (*n).clone());
+            for neighbor in neighbors
+                .iter()
+                .filter(|neighbor| active_ids.contains(*neighbor))
+            {
+                let lbl = labels
+                    .get(neighbor)
+                    .cloned()
+                    .unwrap_or_else(|| neighbor.clone());
                 *label_counts.entry(lbl).or_insert(0) += 1;
+            }
+
+            if label_counts.is_empty() {
+                continue;
             }
 
             let mut best_label: Option<String> = None;

--- a/scripts/prepare-package-metadata.mjs
+++ b/scripts/prepare-package-metadata.mjs
@@ -112,7 +112,18 @@ function copyProject() {
       if (relative === "") return true;
       const segments = relative.split(path.sep);
       const firstSegment = segments[0];
-      if (firstSegment === ".git" || firstSegment === "node_modules") return false;
+      if (
+        firstSegment === ".git"
+        || firstSegment === "node_modules"
+        || firstSegment === ".opencode"
+        || firstSegment === ".claude"
+        || firstSegment === ".codebase-index"
+        || firstSegment === ".codegraph"
+        || firstSegment === ".sisyphus"
+        || firstSegment === ".omo"
+        || firstSegment === "opencode-codebase-index"
+        || (firstSegment === "benchmarks" && segments[1] === "results")
+      ) return false;
       return !(firstSegment === "native" && segments[1] === "target");
     },
   });

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -260,6 +260,10 @@ describe("Phase 1 product identity compatibility", () => {
       expect(stagedCodexManifest.author?.url).toBe(IDENTITY_CATALOG.product.current.repository);
       expect(stagedCodexManifest.interface.websiteURL).toBe(IDENTITY_CATALOG.product.current.repository);
       expect(stagedClaudeMarketplace.owner.url).toBe(IDENTITY_CATALOG.product.current.repository);
+      expect(existsSync(path.join(tempDir, ".opencode"))).toBe(false);
+      expect(existsSync(path.join(tempDir, ".claude"))).toBe(false);
+      expect(existsSync(path.join(tempDir, ".codebase-index"))).toBe(false);
+      expect(existsSync(path.join(tempDir, "benchmarks", "results"))).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- avoid cloning adjacency sets on every label-propagation pass
- exclude local indexes, benchmark outputs, and generated workspace artifacts from staged package metadata copies
- cover staging exclusions in identity compatibility tests

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `cargo fmt --check && cargo test community::tests --release`
- `npx vitest run tests/identity-phase0.test.ts`
- `npx vitest run tests/watcher-config-refresh.test.ts`

`npm run test:run` reached 80/81 files and 1370/1371 tests before one known watcher timing flake. The affected watcher file passes in isolation unchanged. The previous identity staging timeouts are resolved: staging fell from 1m53s to 0.71s locally.