### PR TITLE
fix(ci): update actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GitHub Actions runtime**: Updated the CI path-semantics job to Node 24-compatible `actions/checkout` and `actions/setup-node` releases, removing the deprecated Node 20 action-runtime warning.
+
 - **Community detection performance**: Avoid cloning adjacency sets on every label-propagation pass, keeping the 10k-node community and coupling workload within its CI performance budget.
 
 - **Package metadata staging**: Exclude local indexes, benchmark results, and other generated workspace artifacts from staged package copies, preventing release-validation timeouts and accidental inclusion of local data.


### PR DESCRIPTION
## Summary
- update the path-semantics job to SHA-pinned `actions/checkout` v7.0.1 and `actions/setup-node` v7.0.0
- remove GitHub Actions Node 20 runtime deprecation warnings

## Validation
- YAML parse of `.github/workflows/ci.yml`
- `npx vitest run tests/canonical-path.test.ts`
- `git diff --check`

The updated action hashes are already used by the main CI test job and other repository workflows.