### PR TITLE
chore(release): prepare v0.22.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.22.3"
+      "version": "0.22.4"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dependency vulnerabilities**: Bumped transitive dependency pins to patched releases so `npm audit` reports 0 vulnerabilities: `hono` 4.12.34 (CORS ReDoS), `ip-address` 10.4.0 (SSRF and trust-boundary bypasses), `fast-uri` 3.1.5 (host confusion), `postcss` 8.5.26 (source-map disclosure), `undici` 8.9.0 via `@earendil-works/pi-coding-agent` 0.84.0 (CRLF injection, cache parsing, cookie and retry issues), `brace-expansion` 5.0.9 (DoS), and `@eslint/config-array` 0.23.5 (minimatch-based DoS path).
 
+- **JS-YAML vulnerability**: Pinned transitive `js-yaml` to 4.3.1 to remediate CVE-2026-59870 quadratic CPU consumption in `!!omap` resolution.
+
 - **Pre-edit fallback quality gates**: Added optional `minRouteAccuracy` and `minOutcomeAccuracy` evaluation budget thresholds and applied them in `benchmarks/budgets/pre-edit.json` so unresolved `expectedRoute`/`expectedOutcome` assertions now gate CI.
 
 - **Cross-repo comparison latency**: Omit non-comparable CodeGraph CLI startup time from fair quality tables while retaining raw timing artifacts for diagnostics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4] - 2026-08-07
+
 ### Added
 
 - **Context diagnostics**: `codebase_context` now supports an optional `diagnostic` flag across MCP, OpenCode, and Pi. It exposes bounded routing, retrieval, and evidence-pack traces for troubleshooting without changing normal text output.
+- **Pre-edit context**: Added the portable `codebase_edit_context` tool for gathering bounded, edit-oriented repository evidence across MCP, OpenCode, and Pi.
 - **Pre-edit evaluation gate**: `codebase_edit_context` now has a documented CI evaluation gate. The budget gate supports a `minGraphNeighborRecall` threshold, and `npm run eval:pre-edit:ci` runs the deterministic mock-embedding baseline (Hit@5 1.0, MRR@10 1.0, graph-neighbor recall 1.0) with thresholds in `benchmarks/budgets/pre-edit.json`. The golden dataset covers a resolvable caller lookup, a target-only lookup, and an unresolved-symbol fallback that must route to the conceptual search pack.
+- **Fair CodeGraph comparator**: Added a documented cross-repository benchmark harness and public comparison matrix for normalized CodeGraph retrieval measurements.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@opencode-ai/plugin": "~1.3.13",
+        "@opencode-ai/plugin": "^1.0.0",
         "chokidar": "^5.0.0",
         "ignore": "^7.0.5",
         "p-queue": "^9.1.1",
@@ -7055,9 +7055,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.22.3",
+      "version": "0.22.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@opencode-ai/plugin": "~1.3.13",
+    "@opencode-ai/plugin": "^1.0.0",
     "chokidar": "^5.0.0",
     "ignore": "^7.0.5",
     "p-queue": "^9.1.1",
@@ -126,7 +126,7 @@
     "vite": "8.0.16",
     "esbuild": "0.28.1",
     "body-parser": "2.3.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "undici": "8.10.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Release contents
- Context diagnostics and portable pre-edit context with deterministic quality gates
- Fair CodeGraph comparator and public benchmark matrix
- Dependency vulnerability remediation
- Community-performance, package-staging, and Node 24 CI stability fixes

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (81 files, 1371 tests)
- `npm run smoke:package`

Prepared for merge only. No tag or npm publication is included.