### PR TITLE
chore(release): prepare v0.22.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.22.4"
+      "version": "0.22.5"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.5] - 2026-08-09
+
 ### Added
 
+- **codebase-memory-mcp comparator**: Added an opt-in, fixed-version fair comparator to the cross-repository benchmark runner. It uses repeat-local source copies and cache state, retains raw artifacts, and disqualifies malformed or unsafe results rather than scoring them as misses.
 - **Expanded cross-repo benchmark pilot**: Added a frozen 25-query definition cohort across JavaScript, Python, Go, and Rust, plus reproducible three-way results for the plugin, CodeGraph, and codebase-memory-mcp.
 
 ### Fixed
 
 - **Frozen benchmark inputs**: `cross-repo-benchmark --dataset-dir` now requires a validated dataset for every requested repository instead of silently mixing reviewed inputs with generated candidates.
+- **Exact definition ranking**: Prefer same-module results for duplicate exact definition names while preserving explicit file hints and exact-match safety.
+- **Cross-repository comparator isolation**: Exclude existing `.opencode` data from comparator source copies and tolerate codebase-memory-mcp file-level results that omit source lines without accepting unusable paths.
 
 ## [0.22.4] - 2026-08-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.22.4",
+      "version": "0.22.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release 0.22.5

### Added
- Opt-in fixed-version codebase-memory-mcp comparator for cross-repository benchmarks.
- Frozen 25-query, five-repository definition benchmark cohort and documented three-way pilot.

### Fixed
- Deterministic same-module preference for duplicate exact definition names.
- `--dataset-dir` requires a validated fixed dataset for every repository.
- Comparator source-copy isolation and safe file-level codebase-memory-mcp result handling.
- Host plugin manifests synchronized to package version 0.22.5.

### Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (1,393 passed)
- `npm pack --dry-run --json` (0.22.5 package verified)