### PR TITLE
test: expand frozen cross-repo benchmark to mixed intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Frozen cross-repo definition benchmark**: Reject contradictory exact-symbol targets in reviewed fixed datasets, and replace the ambiguous duplicate Express `error` query with an unambiguous `GithubView` lookup.
+
 ## [0.22.5] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mixed-intent cross-repo benchmark pilot**: Expanded the frozen five-repository cohort from 25 exact-definition queries to 35 reviewed queries by adding keyword-heavy production retrieval coverage across JavaScript, Python, Go, and Rust. The report keeps CodeGraph and codebase-memory-mcp comparison scoped to their shared 25-query exact-definition interface.
+
 ### Fixed
 
 - **Frozen cross-repo definition benchmark**: Reject contradictory exact-symbol targets in reviewed fixed datasets, and replace the ambiguous duplicate Express `error` query with an unambiguous `GithubView` lookup.

--- a/benchmarks/golden/expanded-cross-repo/axios.json
+++ b/benchmarks/golden/expanded-cross-repo/axios.json
@@ -1,1 +1,129 @@
-{"version":"1.0.0","name":"expanded-axios-definitions","description":"Hand-curated exact definition queries for pinned axios revision d8233d9e8e9a64bfba9bbe01d475ba417510b82b.","queries":[{"id":"axios-build-url","query":"where is buildURL defined","queryType":"definition","retrievalMode":"context","args":{"symbol":"buildURL"},"expected":{"filePath":"lib/helpers/buildURL.js","symbol":"buildURL","expectedRoute":"definition"}},{"id":"axios-to-form-data","query":"where is toFormData defined","queryType":"definition","retrievalMode":"context","args":{"symbol":"toFormData"},"expected":{"filePath":"lib/helpers/toFormData.js","symbol":"toFormData","expectedRoute":"definition"}},{"id":"axios-throttle","query":"where is throttle defined","queryType":"definition","retrievalMode":"context","args":{"symbol":"throttle"},"expected":{"filePath":"lib/helpers/throttle.js","symbol":"throttle","expectedRoute":"definition"}},{"id":"axios-spread","query":"where is spread defined","queryType":"definition","retrievalMode":"context","args":{"symbol":"spread"},"expected":{"filePath":"lib/helpers/spread.js","symbol":"spread","expectedRoute":"definition"}},{"id":"axios-create-instance","query":"where is createInstance defined","queryType":"definition","retrievalMode":"context","args":{"symbol":"createInstance"},"expected":{"filePath":"lib/axios.js","symbol":"createInstance","expectedRoute":"definition"}}]}
+{
+  "version": "1.1.0",
+  "name": "expanded-axios-definitions",
+  "description": "Hand-curated definition and keyword-heavy queries for pinned axios revision d8233d9e8e9a64bfba9bbe01d475ba417510b82b.",
+  "queries": [
+    {
+      "id": "axios-build-url",
+      "query": "where is buildURL defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "buildURL"
+      },
+      "expected": {
+        "filePath": "lib/helpers/buildURL.js",
+        "symbol": "buildURL",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-to-form-data",
+      "query": "where is toFormData defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "toFormData"
+      },
+      "expected": {
+        "filePath": "lib/helpers/toFormData.js",
+        "symbol": "toFormData",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-throttle",
+      "query": "where is throttle defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "throttle"
+      },
+      "expected": {
+        "filePath": "lib/helpers/throttle.js",
+        "symbol": "throttle",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-spread",
+      "query": "where is spread defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "spread"
+      },
+      "expected": {
+        "filePath": "lib/helpers/spread.js",
+        "symbol": "spread",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-create-instance",
+      "query": "where is createInstance defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "createInstance"
+      },
+      "expected": {
+        "filePath": "lib/axios.js",
+        "symbol": "createInstance",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "axios-config-merge-strategies",
+      "query": "merge config url method data baseURL validateStatus caseless headers defaultToConfig2 mergeDirectKeys",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "javascript",
+      "difficulty": "easy",
+      "tags": [
+        "keyword",
+        "configuration",
+        "merge-strategy"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/core/mergeConfig.js",
+            "relevance": 3
+          }
+        ]
+      }
+    },
+    {
+      "id": "axios-node-http-transport-controls",
+      "query": "maxRedirects beforeRedirect setProxy socketPath maxBodyLength maxContentLength decompress createUnzip",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "node-http",
+        "redirects",
+        "limits",
+        "compression"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/adapters/http.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/core/mergeConfig.js",
+            "relevance": 1
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/benchmarks/golden/expanded-cross-repo/click.json
+++ b/benchmarks/golden/expanded-cross-repo/click.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "expanded-click-definitions",
-  "description": "Hand-curated exact definition queries for the pinned expanded public benchmark cohort.",
+  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "click-echo",
@@ -71,6 +71,69 @@
         "filePath": "src/click/decorators.py",
         "symbol": "option",
         "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "click-shell-completion",
+      "query": "shell_complete CompletionItem incomplete get_completions BashComplete ZshComplete",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "python",
+      "difficulty": "medium",
+      "tags": [
+        "keyword",
+        "shell-completion",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "src/click/shell_completion.py",
+            "relevance": 3
+          },
+          {
+            "path": "src/click/core.py",
+            "relevance": 2
+          },
+          {
+            "path": "src/click/types.py",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "click-atomic-lazy-file-io",
+      "query": "atomic _LazyFile open_stream stdin stdout temporary os.replace close_intelligently",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "python",
+      "difficulty": "medium",
+      "tags": [
+        "keyword",
+        "file-io",
+        "resource-lifecycle",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "src/click/_compat.py",
+            "relevance": 3
+          },
+          {
+            "path": "src/click/utils.py",
+            "relevance": 3
+          },
+          {
+            "path": "src/click/types.py",
+            "relevance": 2
+          }
+        ]
       }
     }
   ]

--- a/benchmarks/golden/expanded-cross-repo/cobra.json
+++ b/benchmarks/golden/expanded-cross-repo/cobra.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "expanded-cobra-definitions",
-  "description": "Hand-curated exact definition queries for the pinned expanded public benchmark cohort.",
+  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "cobra-no-args",
@@ -71,6 +71,71 @@
         "filePath": "cobra.go",
         "symbol": "OnInitialize",
         "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "cobra-dynamic-shell-completion",
+      "query": "ValidArgsFunction RegisterFlagCompletionFunc ShellCompDirective NoFileComp FilterFileExt ActiveHelp",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "go",
+      "difficulty": "medium",
+      "tags": [
+        "keyword",
+        "shell-completion",
+        "directives",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "completions.go",
+            "relevance": 3
+          },
+          {
+            "path": "command.go",
+            "relevance": 2
+          },
+          {
+            "path": "active_help.go",
+            "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "cobra-flag-group-validation",
+      "query": "MarkFlagsRequiredTogether MarkFlagsOneRequired MarkFlagsMutuallyExclusive annotations ValidateFlagGroups enforceFlagGroupsForCompletion",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "go",
+      "difficulty": "medium",
+      "tags": [
+        "keyword",
+        "flags",
+        "validation",
+        "shell-completion",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "flag_groups.go",
+            "relevance": 3
+          },
+          {
+            "path": "command.go",
+            "relevance": 2
+          },
+          {
+            "path": "completions.go",
+            "relevance": 2
+          }
+        ]
       }
     }
   ]

--- a/benchmarks/golden/expanded-cross-repo/cohort.json
+++ b/benchmarks/golden/expanded-cross-repo/cohort.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.0",
-  "name": "expanded-cross-repo-definition-pilot",
-  "description": "Reviewed exact-definition queries for a frozen, local-only cross-repository comparison cohort.",
-  "queryCountPerRepository": 5,
+  "version": "1.1.0",
+  "name": "expanded-cross-repo-mixed-intent-pilot",
+  "description": "Reviewed definition and keyword-heavy queries for a frozen, local-only cross-repository comparison cohort.",
+  "queryCountPerRepository": 7,
   "repositories": [
     {
       "name": "axios",

--- a/benchmarks/golden/expanded-cross-repo/express.json
+++ b/benchmarks/golden/expanded-cross-repo/express.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "expanded-express-definitions",
-  "description": "Hand-curated exact definition queries for the pinned expanded public benchmark cohort.",
+  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "express-create-application",
@@ -71,6 +71,62 @@
         "filePath": "examples/view-constructor/github-view.js",
         "symbol": "GithubView",
         "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "express-view-render-resolution",
+      "query": "res.render _locals app.render view cache defaultEngine engines lookup nextTick",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "rendering",
+        "view-resolution",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/application.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/view.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/response.js",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "express-response-file-transfer",
+      "query": "sendFile download attachment Content-Disposition root sendfile onaborted onfinish",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": [
+        "keyword",
+        "response",
+        "file-transfer",
+        "streaming"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/response.js",
+            "relevance": 3
+          }
+        ]
       }
     }
   ]

--- a/benchmarks/golden/expanded-cross-repo/express.json
+++ b/benchmarks/golden/expanded-cross-repo/express.json
@@ -60,16 +60,16 @@
       }
     },
     {
-      "id": "express-web-error",
-      "query": "where is error defined",
+      "id": "express-github-view",
+      "query": "where is GithubView defined",
       "queryType": "definition",
       "retrievalMode": "context",
       "args": {
-        "symbol": "error"
+        "symbol": "GithubView"
       },
       "expected": {
-        "filePath": "examples/web-service/index.js",
-        "symbol": "error",
+        "filePath": "examples/view-constructor/github-view.js",
+        "symbol": "GithubView",
         "expectedRoute": "definition"
       }
     }

--- a/benchmarks/golden/expanded-cross-repo/ripgrep.json
+++ b/benchmarks/golden/expanded-cross-repo/ripgrep.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "name": "expanded-ripgrep-definitions",
-  "description": "Hand-curated exact definition queries for the pinned expanded public benchmark cohort.",
+  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "ripgrep-glob-escape",
@@ -71,6 +71,70 @@
         "filePath": "crates/cli/src/human.rs",
         "symbol": "parse_human_readable_size",
         "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "ripgrep-preprocessor-decompression",
+      "query": "preprocessor_globs should_preprocess search_preprocessor search_zip DecompressionReaderBuilder passthru",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "rust",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "preprocessing",
+        "decompression",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "crates/core/search.rs",
+            "relevance": 3
+          },
+          {
+            "path": "crates/cli/src/decompress.rs",
+            "relevance": 2
+          },
+          {
+            "path": "crates/core/flags/hiargs.rs",
+            "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "ripgrep-json-printer-events",
+      "query": "JSONSink Begin Match Context End submatches binary_offset stats",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "rust",
+      "difficulty": "medium",
+      "tags": [
+        "keyword",
+        "json-lines",
+        "printer",
+        "serialization"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "crates/printer/src/json.rs",
+            "relevance": 3
+          },
+          {
+            "path": "crates/printer/src/jsont.rs",
+            "relevance": 2
+          },
+          {
+            "path": "crates/printer/src/stats.rs",
+            "relevance": 1
+          }
+        ]
       }
     }
   ]

--- a/docs/benchmarks/2026-08-09-expanded-cross-repo-definition-pilot.md
+++ b/docs/benchmarks/2026-08-09-expanded-cross-repo-definition-pilot.md
@@ -4,7 +4,7 @@ This is a reproducible comparison of exact-definition retrieval across five publ
 
 ## Cohort and protocol
 
-- **Inputs:** [`benchmarks/golden/expanded-cross-repo/`](../../benchmarks/golden/expanded-cross-repo/), five reviewed definition queries per repository, 25 queries total.
+- **Inputs:** [`benchmarks/golden/expanded-cross-repo/`](../../benchmarks/golden/expanded-cross-repo/), five reviewed definition queries per repository, 25 queries total. Fixed definition datasets reject conflicting targets for the same exact symbol.
 - **Pinned revisions:** recorded in [`cohort.json`](../../benchmarks/golden/expanded-cross-repo/cohort.json).
 - **Repositories:** Axios, Express, Click, Cobra, and ripgrep.
 - **Plugin embeddings:** local Ollama with `nomic-embed-text`.
@@ -25,19 +25,21 @@ npx tsx scripts/cross-repo-benchmark.ts \
 
 ## Result
 
-Local artifact retained at `benchmarks/results/cross-repo/2026-08-09T08-05-15-123Z/report.md`.
+Local artifact retained at `benchmarks/results/cross-repo/2026-08-09T14-39-08-723Z/report.md`.
 
 Every comparator repeat was valid: **3/3 for every repository**. External CLI startup makes latency incomparable, so the comparator tables intentionally omit it.
 
 | Metric | Plugin | CodeGraph | codebase-memory-mcp |
 |---|---:|---:|---:|
-| Hit@1 | **92.00%** | 88.00% | 72.00% |
+| Hit@1 | **96.00%** | 92.00% | 72.00% |
 | Hit@3 | **100.00%** | **100.00%** | 96.00% |
 | Hit@5 | **100.00%** | **100.00%** | **100.00%** |
-| MRR@10 | **0.9600** | 0.9400 | 0.8347 |
-| nDCG@10 | **0.9705** | 0.9557 | 0.8764 |
+| MRR@10 | **0.9800** | 0.9600 | 0.8413 |
+| nDCG@10 | **0.9852** | 0.9705 | 0.8817 |
 
 The plugin ties CodeGraph at Hit@5, leads it by one query at Hit@1, and leads codebase-memory-mcp at Hit@1 and Hit@3. By repository, the plugin leads CodeGraph only on ripgrep at Hit@1 (80% versus 60%), ties it on the other four repositories, and leads or ties codebase-memory-mcp on every repository.
+
+The original pilot had two indistinguishable `error` lookups in Express with conflicting expected files. The fixed-dataset validator now rejects that invalid comparison shape, and the rerun replaces one of them with the unambiguous `GithubView` definition. The corrected metrics above must be compared only with the corrected frozen inputs.
 
 ## Interpretation and limits
 

--- a/docs/benchmarks/2026-08-09-expanded-cross-repo-mixed-intent-pilot.md
+++ b/docs/benchmarks/2026-08-09-expanded-cross-repo-mixed-intent-pilot.md
@@ -1,0 +1,56 @@
+# Expanded cross-repo mixed-intent benchmark pilot
+
+This reproducible local benchmark expands the frozen five-repository definition pilot with keyword-heavy retrieval. It measures a wider range of search behavior without using a remote model or paid API.
+
+## Cohort and protocol
+
+- **Inputs:** [`benchmarks/golden/expanded-cross-repo/`](../../benchmarks/golden/expanded-cross-repo/), seven reviewed queries per repository, 35 total.
+- **Intent mix:** 25 exact-definition queries and 10 keyword-heavy production-code queries across JavaScript, Python, Go, and Rust.
+- **Pinned revisions:** recorded in [`cohort.json`](../../benchmarks/golden/expanded-cross-repo/cohort.json).
+- **Repositories:** Axios, Express, Click, Cobra, and ripgrep.
+- **Plugin embeddings:** local Ollama with `nomic-embed-text`.
+- **Execution:** three repeats per repository, median per repository, then average across repositories. Reindexing was applied only to the first repeat.
+- **Isolation:** CodeGraph and codebase-memory-mcp each use a fresh source copy and exclude generated index directories, including `.opencode`.
+
+The completed run used:
+
+```bash
+npx tsx scripts/cross-repo-benchmark.ts \
+  --repos <axios>,<express>,<click>,<cobra>,<ripgrep> \
+  --dataset-dir benchmarks/golden/expanded-cross-repo \
+  --reindex --repeats 3 --codegraph --codebase-memory-mcp
+```
+
+## Results
+
+Local artifact retained at `benchmarks/results/cross-repo/2026-08-09T14-57-06-897Z/report.md`.
+
+### All 35 queries
+
+The plugin, ripgrep, and ast-grep scored all seven queries for every repository. These are useful local baselines, not equivalent semantic-comparator claims.
+
+| Metric | Plugin | Ripgrep | ast-grep |
+|---|---:|---:|---:|
+| Hit@1 | **94.29%** | 5.71% | 0.00% |
+| Hit@3 | **97.14%** | 11.43% | 0.00% |
+| Hit@5 | **97.14%** | 20.00% | 0.00% |
+| MRR@10 | **0.9571** | 0.1010 | 0.0000 |
+| nDCG@10 | **0.9225** | 0.1163 | 0.0000 |
+
+The only top-five miss was Cobra's `cobra-flag-group-validation` keyword-heavy query. Its top result was the related `flag_groups_test.go`; none of its reviewed production evidence files appeared in the top ten. The frozen cohort records that failure rather than tuning the ranking to this one result.
+
+### Exact-definition comparator scope
+
+CodeGraph and codebase-memory-mcp currently accept exact symbol queries only. They therefore each received the same five definition queries per repository, 25 queries total. Plugin metrics below are recomputed over exactly those query IDs. Every external repeat was valid, 3/3 for every repository. Latency is excluded because one-shot external CLI startup is not comparable with in-process plugin search.
+
+| Metric | Plugin | CodeGraph | codebase-memory-mcp |
+|---|---:|---:|---:|
+| Hit@1 | **96.00%** | 92.00% | 72.00% |
+| Hit@3 | **100.00%** | **100.00%** | 96.00% |
+| Hit@5 | **100.00%** | **100.00%** | **100.00%** |
+| MRR@10 | **0.9800** | 0.9600 | 0.8413 |
+| nDCG@10 | **0.9852** | 0.9705 | 0.8817 |
+
+## Interpretation and limits
+
+The mixed cohort is a stronger regression signal than the earlier definition-only pilot, but it is still small and hand-reviewed. It supports two bounded conclusions: the plugin leads the tested definition scope at Hit@1, and it returns reviewed production evidence in the top five for 34 of 35 mixed queries. It does **not** establish general superiority, and it does not compare CodeGraph or codebase-memory-mcp on keyword-heavy retrieval because their public interfaces do not support that scope. A broader comparison should preregister more independently reviewed queries and use a common mixed-intent interface where available.

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -445,6 +445,44 @@ export function validateDefinitionComparatorQueries(dataset: GoldenDataset): voi
   }
 }
 
+function validateFixedDefinitionComparatorQueries(dataset: GoldenDataset): void {
+  const expectedPathsBySymbol = new Map<string, { queryId: string; filePath: string }>();
+
+  for (const query of dataset.queries) {
+    if (query.queryType !== "definition") {
+      continue;
+    }
+
+    if (!query.args?.symbol) {
+      throw new Error(`Definition dataset query ${query.id} missing args.symbol`);
+    }
+
+    const normalizedSymbol = normalizeDefinitionSymbol(query.args.symbol);
+    const expectedFilePath = query.expected.filePath;
+    if (!expectedFilePath) {
+      continue;
+    }
+
+    const normalizedFilePath = normalizePathForMatch(expectedFilePath);
+    const prior = expectedPathsBySymbol.get(normalizedSymbol);
+    if (prior === undefined) {
+      expectedPathsBySymbol.set(normalizedSymbol, { queryId: query.id, filePath: normalizedFilePath });
+      continue;
+    }
+
+    if (prior.filePath !== normalizedFilePath) {
+      throw new Error(
+        `Conflicting fixed-definition dataset target for args.symbol '${query.args.symbol}'. ` +
+          `Query ${prior.queryId} points to '${prior.filePath}' and query ${query.id} points to '${normalizedFilePath}'.`,
+      );
+    }
+  }
+}
+
+function normalizeDefinitionSymbol(value: string): string {
+  return value.trim();
+}
+
 export function loadFixedDataset(datasetPath: string, repoPath: string): GoldenDataset {
   const rawText = readFileSync(datasetPath, "utf-8");
 
@@ -459,6 +497,7 @@ export function loadFixedDataset(datasetPath: string, repoPath: string): GoldenD
   const dataset = parseGoldenDataset(raw, datasetPath);
   validateDatasetEvidencePaths(dataset, repoPath);
   validateDefinitionComparatorQueries(dataset);
+  validateFixedDefinitionComparatorQueries(dataset);
   return dataset;
 }
 

--- a/tests/cross-repo-benchmark-dataset-dir.test.ts
+++ b/tests/cross-repo-benchmark-dataset-dir.test.ts
@@ -219,6 +219,90 @@ describe("cross-repo benchmark dataset-dir flag", () => {
     expect(() => loadFixedDataset(fixedPath, repoPath)).toThrow(/outside repository/);
   });
 
+  it("validates fixed definition comparator queries for consistent symbol file targets", () => {
+    const repoPath = tempDir("cross-repo-benchmark-fixed-symbol-validator-repo-");
+    const fixedDir = tempDir("cross-repo-benchmark-fixed-symbol-validator-");
+    const repoName = path.basename(repoPath);
+    fs.mkdirSync(path.join(repoPath, "lib"), { recursive: true });
+    fs.writeFileSync(path.join(repoPath, "lib", "a.ts"), "export function token() {}", "utf-8");
+    fs.writeFileSync(path.join(repoPath, "lib", "b.ts"), "export function token() {}", "utf-8");
+
+    const datasetPath = datasetPathForRepo(fixedDir, repoName);
+    writeJson(datasetPath, {
+      version: "1.0.0",
+      name: "symbol-target-validation",
+      queries: [
+        {
+          id: "good-1",
+          query: "where is token defined",
+          queryType: "definition",
+          retrievalMode: "context",
+          args: {
+            symbol: "token",
+          },
+          expected: {
+            filePath: "lib/a.ts",
+            symbol: "token",
+            expectedRoute: "definition",
+          },
+        },
+        {
+          id: "good-2",
+          query: "where is token defined",
+          queryType: "definition",
+          retrievalMode: "context",
+          args: {
+            symbol: "token",
+          },
+          expected: {
+            filePath: "lib/a.ts",
+            symbol: "token",
+            expectedRoute: "definition",
+          },
+        },
+      ],
+    });
+
+    writeJson(datasetPath, {
+      version: "1.0.0",
+      name: "symbol-target-validation-conflict",
+      queries: [
+        {
+          id: "conflict-1",
+          query: "where is token defined",
+          queryType: "definition",
+          retrievalMode: "context",
+          args: {
+            symbol: "token",
+          },
+          expected: {
+            filePath: "lib/a.ts",
+            symbol: "token",
+            expectedRoute: "definition",
+          },
+        },
+        {
+          id: "conflict-2",
+          query: "where is token defined",
+          queryType: "definition",
+          retrievalMode: "context",
+          args: {
+            symbol: "token",
+          },
+          expected: {
+            filePath: "lib/b.ts",
+            symbol: "token",
+            expectedRoute: "definition",
+          },
+        },
+      ],
+    });
+
+    expect(() => loadFixedDataset(datasetPath, repoPath)).toThrow(
+      /Conflicting fixed-definition dataset target/
+    );
+  });
+
   it("uses fixed dataset file when present and copies it to run artifacts", async () => {
     const repoPath = tempDir("cross-repo-benchmark-run-fixed-repo-");
     const fixedDir = tempDir("cross-repo-benchmark-run-fixed-");

--- a/tests/cross-repo-benchmark-dataset-dir.test.ts
+++ b/tests/cross-repo-benchmark-dataset-dir.test.ts
@@ -118,6 +118,47 @@ function withRunEvaluationMock(result: Awaited<ReturnType<typeof runner.runEvalu
 }
 
 describe("cross-repo benchmark dataset-dir flag", () => {
+  it("keeps the expanded frozen cohort balanced between definition and keyword-heavy retrieval", () => {
+    const cohortDir = path.join(process.cwd(), "benchmarks", "golden", "expanded-cross-repo");
+    const cohort = JSON.parse(fs.readFileSync(path.join(cohortDir, "cohort.json"), "utf-8")) as {
+      version: string;
+      name: string;
+      queryCountPerRepository: number;
+      repositories: Array<{ dataset: string }>;
+    };
+
+    expect(cohort).toMatchObject({
+      version: "1.1.0",
+      name: "expanded-cross-repo-mixed-intent-pilot",
+      queryCountPerRepository: 7,
+    });
+    expect(cohort.repositories).toHaveLength(5);
+
+    for (const repository of cohort.repositories) {
+      const dataset = JSON.parse(fs.readFileSync(path.join(cohortDir, repository.dataset), "utf-8")) as {
+        version: string;
+        queries: Array<{
+          id: string;
+          queryType: string;
+          retrievalMode?: string;
+          expected: { expectedRoute?: string; gradedEvidence?: unknown[] };
+        }>;
+      };
+      const definitions = dataset.queries.filter((query) => query.queryType === "definition");
+      const keywordHeavy = dataset.queries.filter((query) => query.queryType === "keyword-heavy");
+
+      expect(dataset.version).toBe("1.1.0");
+      expect(new Set(dataset.queries.map((query) => query.id)).size).toBe(7);
+      expect(definitions).toHaveLength(5);
+      expect(keywordHeavy).toHaveLength(2);
+      for (const query of keywordHeavy) {
+        expect(query.retrievalMode).toBe("search");
+        expect(query.expected.expectedRoute).toBe("search");
+        expect(query.expected.gradedEvidence?.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
   it("parses --dataset-dir in CLI args", () => {
     const repoPath = tempDir("cross-repo-benchmark-cli-repo-");
     const datasetDir = tempDir("cross-repo-benchmark-cli-fixed-");


### PR DESCRIPTION
## Summary
- expand the frozen five-repository cohort from 25 exact-definition queries to 35 reviewed definition and keyword-heavy queries
- preserve fair CodeGraph and codebase-memory-mcp comparison by explicitly scoping both to the shared 25 exact-symbol queries
- document the three-repeat local Ollama run and add a regression test that protects the cohort shape

## Measured result
- all 35 queries: plugin Hit@5 97.14% (34/35)
- exact-definition scope: plugin Hit@1 96%, CodeGraph 92%, codebase-memory-mcp 72%, with all three at Hit@5 100%
- the Cobra keyword-heavy miss is retained and documented, rather than tuned away

## Validation
- `npx tsx scripts/cross-repo-benchmark.ts --repos <five pinned repositories> --dataset-dir benchmarks/golden/expanded-cross-repo --reindex --repeats 3 --codegraph --codebase-memory-mcp`
- `npx vitest run tests/cross-repo-benchmark-dataset-dir.test.ts tests/cross-repo-codegraph.test.ts tests/cross-repo-codebase-memory.test.ts`
- `npm run build && npm run typecheck && npm run lint && npm run test:run`