### PR TITLE
test: harden mixed-intent retrieval benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Validate frozen cross-repo benchmark inputs and comparator contracts
+        run: npm run benchmark:cross-repo:check
+
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Mixed-intent cross-repo benchmark pilot**: Expanded the frozen five-repository cohort from 25 exact-definition queries to 35 reviewed queries by adding keyword-heavy production retrieval coverage across JavaScript, Python, Go, and Rust. The report keeps CodeGraph and codebase-memory-mcp comparison scoped to their shared 25-query exact-definition interface.
+- **Mixed-intent benchmark coverage and CI gate**: Expanded the frozen cohort to 45 queries with implementation-intent and conceptual coverage, and added a no-model cross-repo benchmark contract check to pull-request CI.
 
 ### Fixed
 
 - **Frozen cross-repo definition benchmark**: Reject contradictory exact-symbol targets in reviewed fixed datasets, and replace the ambiguous duplicate Express `error` query with an unambiguous `GithubView` lookup.
+- **Source-intent keyword retrieval**: Recognize Go, Rust, and Python test filenames and retain a wider candidate pool for identifier-rich source queries, so related test assertions do not displace production evidence before reranking.
 
 ## [0.22.5] - 2026-08-09
 

--- a/benchmarks/golden/expanded-cross-repo/axios.json
+++ b/benchmarks/golden/expanded-cross-repo/axios.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1.0",
-  "name": "expanded-axios-definitions",
-  "description": "Hand-curated definition and keyword-heavy queries for pinned axios revision d8233d9e8e9a64bfba9bbe01d475ba417510b82b.",
+  "version": "1.2.0",
+  "name": "expanded-axios-mixed-intent",
+  "description": "Hand-curated definition, keyword-heavy, implementation-intent, and conceptual queries for pinned axios revision d8233d9e8e9a64bfba9bbe01d475ba417510b82b.",
   "queries": [
     {
       "id": "axios-build-url",
@@ -120,6 +120,60 @@
           },
           {
             "path": "lib/core/mergeConfig.js",
+            "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "axios-request-dispatch-implementation",
+      "query": "implementation that prepares request data applies transforms flattens headers and invokes the configured adapter",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": [
+        "implementation",
+        "request-lifecycle",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/core/dispatchRequest.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/core/transformData.js",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "axios-config-merge-concept",
+      "query": "combine default request configuration with request-specific values and select property merge strategies",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": [
+        "conceptual",
+        "configuration",
+        "merge-strategy"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/core/mergeConfig.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/axios.js",
             "relevance": 1
           }
         ]

--- a/benchmarks/golden/expanded-cross-repo/click.json
+++ b/benchmarks/golden/expanded-cross-repo/click.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1.0",
-  "name": "expanded-click-definitions",
-  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
+  "version": "1.2.0",
+  "name": "expanded-click-mixed-intent",
+  "description": "Hand-curated definition, keyword-heavy, implementation-intent, and conceptual queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "click-echo",
@@ -131,6 +131,60 @@
           },
           {
             "path": "src/click/types.py",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "click-command-invocation-implementation",
+      "query": "implementation that parses command line arguments invokes command callbacks and formats command errors",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "python",
+      "difficulty": "medium",
+      "tags": [
+        "implementation",
+        "command-lifecycle",
+        "errors"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "src/click/core.py",
+            "relevance": 3
+          },
+          {
+            "path": "src/click/exceptions.py",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "click-shell-completion-concept",
+      "query": "resolve shell completion context and produce completion items for command line arguments",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "python",
+      "difficulty": "medium",
+      "tags": [
+        "conceptual",
+        "shell-completion",
+        "arguments"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "src/click/shell_completion.py",
+            "relevance": 3
+          },
+          {
+            "path": "src/click/core.py",
             "relevance": 2
           }
         ]

--- a/benchmarks/golden/expanded-cross-repo/cobra.json
+++ b/benchmarks/golden/expanded-cross-repo/cobra.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1.0",
-  "name": "expanded-cobra-definitions",
-  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
+  "version": "1.2.0",
+  "name": "expanded-cobra-mixed-intent",
+  "description": "Hand-curated definition, keyword-heavy, implementation-intent, and conceptual queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "cobra-no-args",
@@ -133,6 +133,60 @@
           },
           {
             "path": "completions.go",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "cobra-command-execution-implementation",
+      "query": "implementation that parses command flags validates command groups and invokes command run handlers",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "go",
+      "difficulty": "medium",
+      "tags": [
+        "implementation",
+        "command-lifecycle",
+        "flags"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "command.go",
+            "relevance": 3
+          },
+          {
+            "path": "flag_groups.go",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "cobra-shell-completion-concept",
+      "query": "generate shell completion candidates directives and active help messages for command arguments",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "go",
+      "difficulty": "medium",
+      "tags": [
+        "conceptual",
+        "shell-completion",
+        "active-help"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "completions.go",
+            "relevance": 3
+          },
+          {
+            "path": "active_help.go",
             "relevance": 2
           }
         ]

--- a/benchmarks/golden/expanded-cross-repo/cohort.json
+++ b/benchmarks/golden/expanded-cross-repo/cohort.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.1.0",
-  "name": "expanded-cross-repo-mixed-intent-pilot",
-  "description": "Reviewed definition and keyword-heavy queries for a frozen, local-only cross-repository comparison cohort.",
-  "queryCountPerRepository": 7,
+  "version": "1.2.0",
+  "name": "expanded-cross-repo-mixed-intent-pilot-v2",
+  "description": "Reviewed definition, keyword-heavy, implementation-intent, and conceptual queries for a frozen, local-only cross-repository comparison cohort.",
+  "queryCountPerRepository": 9,
   "repositories": [
     {
       "name": "axios",

--- a/benchmarks/golden/expanded-cross-repo/express.json
+++ b/benchmarks/golden/expanded-cross-repo/express.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1.0",
-  "name": "expanded-express-definitions",
-  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
+  "version": "1.2.0",
+  "name": "expanded-express-mixed-intent",
+  "description": "Hand-curated definition, keyword-heavy, implementation-intent, and conceptual queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "express-create-application",
@@ -117,6 +117,60 @@
         "response",
         "file-transfer",
         "streaming"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/response.js",
+            "relevance": 3
+          }
+        ]
+      }
+    },
+    {
+      "id": "express-view-rendering-implementation",
+      "query": "implementation that resolves a view renders a response and propagates rendering callback errors",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "medium",
+      "tags": [
+        "implementation",
+        "rendering",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/application.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/view.js",
+            "relevance": 3
+          },
+          {
+            "path": "lib/response.js",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "express-file-transfer-concept",
+      "query": "send response files safely with root containment range support headers and transfer callbacks",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "javascript",
+      "difficulty": "hard",
+      "tags": [
+        "conceptual",
+        "response",
+        "file-transfer"
       ],
       "expected": {
         "expectedRoute": "search",

--- a/benchmarks/golden/expanded-cross-repo/ripgrep.json
+++ b/benchmarks/golden/expanded-cross-repo/ripgrep.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.1.0",
-  "name": "expanded-ripgrep-definitions",
-  "description": "Hand-curated definition and keyword-heavy queries for the pinned expanded public benchmark cohort.",
+  "version": "1.2.0",
+  "name": "expanded-ripgrep-mixed-intent",
+  "description": "Hand-curated definition, keyword-heavy, implementation-intent, and conceptual queries for the pinned expanded public benchmark cohort.",
   "queries": [
     {
       "id": "ripgrep-glob-escape",
@@ -133,6 +133,56 @@
           {
             "path": "crates/printer/src/stats.rs",
             "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "ripgrep-search-worker-implementation",
+      "query": "implementation that configures search workers prints matches and handles search failures",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "medium",
+      "tags": [
+        "implementation",
+        "search",
+        "worker"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "crates/core/search.rs",
+            "relevance": 3
+          }
+        ]
+      }
+    },
+    {
+      "id": "ripgrep-ignore-filtering-concept",
+      "query": "parse ignore files apply overrides and decide whether a file path should be filtered",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "rust",
+      "difficulty": "hard",
+      "tags": [
+        "conceptual",
+        "ignore",
+        "path-filtering"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "crates/ignore/src/dir.rs",
+            "relevance": 3
+          },
+          {
+            "path": "crates/ignore/src/overrides.rs",
+            "relevance": 2
           }
         ]
       }

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -80,6 +80,16 @@ npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --
 
 - File parsing is capped (`--max-parse-files`, default `2500`). Reports include whether truncation occurred.
 
+## Lightweight CI integrity gate
+
+The main CI workflow runs the following no-model check on every pull request. It validates frozen dataset shape, input loading, and the CodeGraph and codebase-memory-mcp comparator contracts without cloning external repositories, invoking Ollama, or running an expensive comparison.
+
+```bash
+npm run benchmark:cross-repo:check
+```
+
+Run the full local benchmark manually or from a scheduled quality workflow when a retrieval change needs measured quality results.
+
 ## Optional baseline toggles
 
 ```bash

--- a/docs/benchmarks/2026-08-09-expanded-cross-repo-mixed-intent-pilot.md
+++ b/docs/benchmarks/2026-08-09-expanded-cross-repo-mixed-intent-pilot.md
@@ -1,11 +1,11 @@
 # Expanded cross-repo mixed-intent benchmark pilot
 
-This reproducible local benchmark expands the frozen five-repository definition pilot with keyword-heavy retrieval. It measures a wider range of search behavior without using a remote model or paid API.
+This reproducible local benchmark expands the frozen five-repository definition pilot with keyword-heavy, implementation-intent, and conceptual retrieval. It measures a wider range of search behavior without using a remote model or paid API.
 
 ## Cohort and protocol
 
-- **Inputs:** [`benchmarks/golden/expanded-cross-repo/`](../../benchmarks/golden/expanded-cross-repo/), seven reviewed queries per repository, 35 total.
-- **Intent mix:** 25 exact-definition queries and 10 keyword-heavy production-code queries across JavaScript, Python, Go, and Rust.
+- **Inputs:** [`benchmarks/golden/expanded-cross-repo/`](../../benchmarks/golden/expanded-cross-repo/), nine reviewed queries per repository, 45 total.
+- **Intent mix:** 25 exact-definition queries, 10 keyword-heavy production-code queries, five implementation-intent queries, and five conceptual queries across JavaScript, Python, Go, and Rust.
 - **Pinned revisions:** recorded in [`cohort.json`](../../benchmarks/golden/expanded-cross-repo/cohort.json).
 - **Repositories:** Axios, Express, Click, Cobra, and ripgrep.
 - **Plugin embeddings:** local Ollama with `nomic-embed-text`.
@@ -23,21 +23,21 @@ npx tsx scripts/cross-repo-benchmark.ts \
 
 ## Results
 
-Local artifact retained at `benchmarks/results/cross-repo/2026-08-09T14-57-06-897Z/report.md`.
+Local artifact retained at `benchmarks/results/cross-repo/2026-08-09T17-26-32-926Z/report.md`.
 
-### All 35 queries
+### All 45 queries
 
-The plugin, ripgrep, and ast-grep scored all seven queries for every repository. These are useful local baselines, not equivalent semantic-comparator claims.
+The plugin and ripgrep scored all nine queries for every repository. ast-grep scored the five definition and two keyword-heavy queries, 35 queries total. These are useful local baselines, not equivalent semantic-comparator claims.
 
 | Metric | Plugin | Ripgrep | ast-grep |
 |---|---:|---:|---:|
-| Hit@1 | **94.29%** | 5.71% | 0.00% |
-| Hit@3 | **97.14%** | 11.43% | 0.00% |
-| Hit@5 | **97.14%** | 20.00% | 0.00% |
-| MRR@10 | **0.9571** | 0.1010 | 0.0000 |
-| nDCG@10 | **0.9225** | 0.1163 | 0.0000 |
+| Hit@1 | **86.67%** | 6.67% | 0.00% |
+| Hit@3 | **100.00%** | 8.89% | 0.00% |
+| Hit@5 | **100.00%** | 20.00% | 0.00% |
+| MRR@10 | **0.9222** | 0.1139 | 0.0000 |
+| nDCG@10 | **0.9002** | 0.1277 | 0.0000 |
 
-The only top-five miss was Cobra's `cobra-flag-group-validation` keyword-heavy query. Its top result was the related `flag_groups_test.go`; none of its reviewed production evidence files appeared in the top ten. The frozen cohort records that failure rather than tuning the ranking to this one result.
+The plugin now has no top-five miss in the 45-query cohort. The earlier Cobra flag-group query exposed that Go `_test.go` files were not recognized as tests by source-intent ranking. Test-path detection now covers Go, Rust, and Python filename conventions, and source-intent searches retain a wider candidate pool before applying production-code prioritization. The correction was verified with the real Cobra run before the full rerun.
 
 ### Exact-definition comparator scope
 
@@ -46,11 +46,11 @@ CodeGraph and codebase-memory-mcp currently accept exact symbol queries only. Th
 | Metric | Plugin | CodeGraph | codebase-memory-mcp |
 |---|---:|---:|---:|
 | Hit@1 | **96.00%** | 92.00% | 72.00% |
-| Hit@3 | **100.00%** | **100.00%** | 96.00% |
+| Hit@3 | **100.00%** | **100.00%** | 92.00% |
 | Hit@5 | **100.00%** | **100.00%** | **100.00%** |
-| MRR@10 | **0.9800** | 0.9600 | 0.8413 |
-| nDCG@10 | **0.9852** | 0.9705 | 0.8817 |
+| MRR@10 | **0.9800** | 0.9600 | 0.8400 |
+| nDCG@10 | **0.9852** | 0.9705 | 0.8806 |
 
 ## Interpretation and limits
 
-The mixed cohort is a stronger regression signal than the earlier definition-only pilot, but it is still small and hand-reviewed. It supports two bounded conclusions: the plugin leads the tested definition scope at Hit@1, and it returns reviewed production evidence in the top five for 34 of 35 mixed queries. It does **not** establish general superiority, and it does not compare CodeGraph or codebase-memory-mcp on keyword-heavy retrieval because their public interfaces do not support that scope. A broader comparison should preregister more independently reviewed queries and use a common mixed-intent interface where available.
+The mixed cohort is a stronger regression signal than the earlier definition-only pilot, but it is still small and hand-reviewed. It supports two bounded conclusions: the plugin leads the tested definition scope at Hit@1, and it returns reviewed production evidence in the top five for all 45 mixed queries. It does **not** establish general superiority, and it does not compare CodeGraph or codebase-memory-mcp on keyword-heavy, implementation, or conceptual retrieval because their public interfaces do not support that scope. A broader comparison should preregister more independently reviewed queries and use a common mixed-intent interface where available.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eval:compare": "npx tsx src/cli.ts eval compare",
     "eval:effectiveness": "npx tsx scripts/effectiveness-report.ts",
     "benchmark:indexing-memory": "npx tsx benchmarks/indexing-memory.ts",
+    "benchmark:cross-repo:check": "npx vitest run tests/cross-repo-benchmark-dataset-dir.test.ts tests/cross-repo-codegraph.test.ts tests/cross-repo-codebase-memory.test.ts",
     "dev:link-mcp": "node scripts/link-local-mcp-bin.mjs",
     "test": "vitest",
     "pretest:run": "node scripts/run-build-native-with-rustflags.mjs && npm run build:ts",

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4701,6 +4701,7 @@ export class Indexer {
     const filterByBranch = options?.filterByBranch ?? true;
     const sourceIntent = options?.definitionIntent === true || classifyQueryIntentRaw(query) === "source";
     const identifierHints = extractIdentifierHints(query);
+    const candidateLimit = maxResults * (sourceIntent ? 12 : 4);
 
     this.logger.search("debug", "Starting search", {
       query,
@@ -4743,7 +4744,7 @@ export class Indexer {
       ? this.searchSemanticCandidates(
           store,
           embedding,
-          maxResults * 4,
+          candidateLimit,
           branchChunkIds,
           shouldPrefilterByBranch,
         )
@@ -4753,7 +4754,7 @@ export class Indexer {
     const keywordStartTime = performance.now();
     const keywordCandidates = await this.keywordSearch(
       query,
-      maxResults * 4,
+      candidateLimit,
       store,
       invertedIndex,
       branchChunkIds,

--- a/src/indexer/intent-aware-ranking.ts
+++ b/src/indexer/intent-aware-ranking.ts
@@ -214,7 +214,8 @@ export function analyzeQueryIntent(query: string): QueryIntentProfile {
 export function isTestPath(filePath: string): boolean {
   const normalized = normalizePath(filePath);
   return /(?:^|\/)(?:test|tests|__tests__|spec|specs)(?:\/|$)/u.test(normalized) ||
-    /\.(?:test|spec)\.[^/]+$/u.test(normalized);
+    /(?:\.(?:test|spec)|_(?:test|spec))\.[^/]+$/u.test(normalized) ||
+    /(?:^|\/)(?:test|spec)_[^/]+\.[^/]+$/u.test(normalized);
 }
 
 export function isFixturePath(filePath: string): boolean {

--- a/src/indexer/search-ranking.ts
+++ b/src/indexer/search-ranking.ts
@@ -260,7 +260,11 @@ export function rankHybridResults(
     }
   }
 
-  const overfetchLimit = Math.max(options.limit * 4, options.limit);
+  // Identifier-rich source queries often match many test assertions before their
+  // implementation declarations. Keep a wider fused pool so intent-aware
+  // reranking can prefer the production evidence rather than losing it early.
+  const overfetchFactor = prioritizeSourcePaths ? 12 : 4;
+  const overfetchLimit = Math.max(options.limit * overfetchFactor, options.limit);
   const fused = options.fusionStrategy === "rrf"
     ? fuseResultsRrf(semanticResults, keywordResults, options.rrfK, overfetchLimit)
     : fuseResultsWeighted(semanticResults, keywordResults, options.hybridWeight, overfetchLimit);

--- a/tests/cross-repo-benchmark-dataset-dir.test.ts
+++ b/tests/cross-repo-benchmark-dataset-dir.test.ts
@@ -128,9 +128,9 @@ describe("cross-repo benchmark dataset-dir flag", () => {
     };
 
     expect(cohort).toMatchObject({
-      version: "1.1.0",
-      name: "expanded-cross-repo-mixed-intent-pilot",
-      queryCountPerRepository: 7,
+      version: "1.2.0",
+      name: "expanded-cross-repo-mixed-intent-pilot-v2",
+      queryCountPerRepository: 9,
     });
     expect(cohort.repositories).toHaveLength(5);
 
@@ -146,13 +146,22 @@ describe("cross-repo benchmark dataset-dir flag", () => {
       };
       const definitions = dataset.queries.filter((query) => query.queryType === "definition");
       const keywordHeavy = dataset.queries.filter((query) => query.queryType === "keyword-heavy");
+      const implementation = dataset.queries.filter((query) => query.queryType === "implementation-intent");
+      const conceptual = dataset.queries.filter((query) => query.queryType === "conceptual");
 
-      expect(dataset.version).toBe("1.1.0");
-      expect(new Set(dataset.queries.map((query) => query.id)).size).toBe(7);
+      expect(dataset.version).toBe("1.2.0");
+      expect(new Set(dataset.queries.map((query) => query.id)).size).toBe(9);
       expect(definitions).toHaveLength(5);
       expect(keywordHeavy).toHaveLength(2);
+      expect(implementation).toHaveLength(1);
+      expect(conceptual).toHaveLength(1);
       for (const query of keywordHeavy) {
         expect(query.retrievalMode).toBe("search");
+        expect(query.expected.expectedRoute).toBe("search");
+        expect(query.expected.gradedEvidence?.length).toBeGreaterThan(0);
+      }
+      for (const query of [...implementation, ...conceptual]) {
+        expect(query.retrievalMode).toBe("context");
         expect(query.expected.expectedRoute).toBe("search");
         expect(query.expected.gradedEvidence?.length).toBeGreaterThan(0);
       }

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -231,6 +231,37 @@ describe("retrieval ranking", () => {
     expect(reranked[0]?.id).toBe("srcImpl");
   });
 
+  it("keeps production evidence in the fused pool for identifier-rich keyword searches", () => {
+    const testCandidates: Candidate[] = Array.from({ length: 60 }, (_value, index) => ({
+      id: `test-${index}`,
+      score: 1 - index / 1000,
+      metadata: meta({
+        filePath: `/repo/flag_groups_test_${index}.go`,
+        name: `TestValidateFlagGroups${index}`,
+        chunkType: "function_declaration",
+      }),
+    }));
+    const source: Candidate = {
+      id: "source",
+      score: 0.5,
+      metadata: meta({
+        filePath: "/repo/flag_groups.go",
+        name: "ValidateFlagGroups",
+        chunkType: "function_declaration",
+      }),
+    };
+    const candidates = [...testCandidates, source];
+
+    const ranked = rankHybridResults(
+      "MarkFlagsRequiredTogether MarkFlagsOneRequired ValidateFlagGroups",
+      candidates,
+      candidates,
+      { fusionStrategy: "rrf", rrfK: 60, rerankTopN: 100, limit: 10, hybridWeight: 0.5 },
+    );
+
+    expect(ranked[0]?.id).toBe("source");
+  });
+
   it("does not force src priority for doc/test-intent queries", () => {
     const candidates: Candidate[] = [
       { id: "srcImpl", score: 0.92, metadata: meta({ filePath: "/repo/stacks/indexer/index.ts", name: "rankHybridResults", chunkType: "function" }) },


### PR DESCRIPTION
## Summary
- fix source-intent ranking for Go, Rust, and Python test filenames and widen the candidate pool for identifier-rich source searches
- expand the frozen cross-repo cohort from 35 to 45 queries with implementation-intent and conceptual coverage
- add an explicit no-model benchmark contract command to pull-request CI

## Measured result
- real three-repeat local benchmark across Axios, Express, Click, Cobra, and ripgrep
- all 45 plugin queries reached reviewed evidence by Hit@5
- fair definition-only comparison remains 25 queries: plugin Hit@1 96%, CodeGraph 92%, codebase-memory-mcp 72%
- Cobra flag-group retrieval improved from a top-five miss to Hit@5 100%

## Validation
- real 45-query runner: `--reindex --repeats 3 --codegraph --codebase-memory-mcp`
- `npm run benchmark:cross-repo:check`
- `npm run build && npm run typecheck && npm run lint && npm run test:run` (83 files, 1,396 tests)