### PR TITLE
fix: shut down project watchers with host lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Mixed-intent cross-repo benchmark pilot**: Expanded the frozen five-repository cohort from 25 exact-definition queries to 35 reviewed queries by adding keyword-heavy production retrieval coverage across JavaScript, Python, Go, and Rust. The report keeps CodeGraph and codebase-memory-mcp comparison scoped to their shared 25-query exact-definition interface.
 - **Mixed-intent benchmark coverage and CI gate**: Expanded the frozen cohort to 45 queries with implementation-intent and conceptual coverage, and added a no-model cross-repo benchmark contract check to pull-request CI.
 
+### Changed
+
+- **Serialized watcher replacement**: On OpenCode plugin reloads, the next project watcher is only created after the previous one has fully stopped, so concurrent reloads cannot leak or double-start watchers.
+
 ### Fixed
 
 - **Frozen cross-repo definition benchmark**: Reject contradictory exact-symbol targets in reviewed fixed datasets, and replace the ambiguous duplicate Express `error` query with an unambiguous `GithubView` lookup.
 - **Source-intent keyword retrieval**: Recognize Go, Rust, and Python test filenames and retain a wider candidate pool for identifier-rich source queries, so related test assertions do not displace production evidence before reranking.
+- **MCP server clean shutdown**: `opencode-codebase-index-mcp` now terminates its file watcher, auto-index coordination, and stdio transport on stdin EOF, protocol close, or `SIGHUP`/`SIGINT`/`SIGTERM`, exiting 0 instead of leaving persistent watcher processes and file descriptors behind after the host disappears.
 
 ## [0.22.5] - 2026-08-09
 

--- a/scripts/smoke-test-built-cli.mjs
+++ b/scripts/smoke-test-built-cli.mjs
@@ -1,9 +1,12 @@
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 const require = createRequire(import.meta.url);
 
-function runCliCommand(args, { killAfterMs = null } = {}) {
+function runCliCommand(args, { killAfterMs = null, action = null } = {}) {
   return new Promise((resolve, reject) => {
     const command = [cliPath, ...args];
     const child = spawn(process.execPath, command, {
@@ -26,32 +29,71 @@ function runCliCommand(args, { killAfterMs = null } = {}) {
 
     const cleanupTimer = killAfterMs
       ? setTimeout(() => {
-        child.kill("SIGTERM");
+        child.kill("SIGKILL");
       }, killAfterMs)
+      : null;
+
+    const actionTimer = action
+      ? setTimeout(() => {
+        action(child);
+      }, 250)
       : null;
 
     child.once("exit", (code, signal) => {
       if (cleanupTimer !== null) {
         clearTimeout(cleanupTimer);
       }
-      resolve({ code, signal, stdout, stderr, survived: signal === "SIGTERM" });
+      if (actionTimer !== null) {
+        clearTimeout(actionTimer);
+      }
+      resolve({ code, signal, stdout, stderr });
     });
   });
 }
 
 const cliPath = process.argv[2] ?? "dist/cli.js";
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-smoke-"));
+try {
+  const configPath = path.join(tempDir, "config.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify({ indexing: { autoIndex: false, watchFiles: true, requireProjectMarker: false } }),
+  );
+  const projectArgs = ["--host", "jcode", "--project", tempDir, "--config", configPath];
 
-const mcpStartup = await runCliCommand(["--host", "jcode"], { killAfterMs: 2_000 });
-if (!mcpStartup.survived && mcpStartup.code !== 0) {
-  throw new Error(`Built ESM CLI failed in MCP startup mode with exit code ${mcpStartup.code}:\n${mcpStartup.stderr}`);
-}
+  const mcpStartup = await runCliCommand(projectArgs, { killAfterMs: 2_000 });
+  if (mcpStartup.signal === null && mcpStartup.code !== 0) {
+    throw new Error(`Built ESM CLI failed in MCP startup mode with exit code ${mcpStartup.code}:\n${mcpStartup.stderr}`);
+  }
 
-const indexHelp = await runCliCommand(["index", "--help"]);
-if (indexHelp.code !== 0 || !indexHelp.stderr.includes("Usage:")) {
-  throw new Error(`Built ESM CLI failed in index mode:\n${indexHelp.stderr}`);
-}
+  const indexHelp = await runCliCommand(["index", "--help"]);
+  if (indexHelp.code !== 0 || !indexHelp.stderr.includes("Usage:")) {
+    throw new Error(`Built ESM CLI failed in index mode:\n${indexHelp.stderr}`);
+  }
 
-const cjsModule = require("../dist/index.cjs");
-if (typeof cjsModule.default !== "function") {
-  throw new Error("Built CommonJS entry point is missing its default plugin export");
+  const cjsModule = require("../dist/index.cjs");
+  if (typeof cjsModule.default !== "function") {
+    throw new Error("Built CommonJS entry point is missing its default plugin export");
+  }
+
+  const shutdownScenarios = [
+    { name: "stdin EOF", action: (child) => { child.stdin.end(); } },
+  ];
+  if (process.platform !== "win32") {
+    shutdownScenarios.push(
+      { name: "SIGINT", action: (child) => { child.kill("SIGINT"); } },
+      { name: "SIGTERM", action: (child) => { child.kill("SIGTERM"); } },
+      { name: "SIGHUP", action: (child) => { child.kill("SIGHUP"); } },
+    );
+  }
+  for (const scenario of shutdownScenarios) {
+    const result = await runCliCommand(projectArgs, { killAfterMs: 5_000, action: scenario.action });
+    if (result.code !== 0 || result.signal !== null) {
+      throw new Error(
+        `Built ESM CLI did not shut down cleanly on ${scenario.name} (code=${result.code}, signal=${result.signal}):\n${result.stderr}`,
+      );
+    }
+  }
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
 }

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -16,7 +16,7 @@ import { getIndexerForProject } from "../../tools/operations.js";
 import { initializeTools } from "../../tools/operation-runtime.js";
 import { executeIndexCodebase } from "../../tools/execute-common.js";
 import { hasProjectMarker } from "../../utils/files.js";
-import { isHomeDirectory } from "../../utils/auto-index.js";
+import { isHomeDirectory, stopAutoIndex } from "../../utils/auto-index.js";
 import { createWatcherWithIndexer, type CombinedWatcher } from "../../watcher/index.js";
 import { attachRecentActivity } from "../../tools/visualize/activity.js";
 import { generateVisualizationHtml, transformForVisualization } from "../../tools/visualize/index.js";
@@ -284,6 +284,12 @@ export async function runMcpCli(argv: string[]): Promise<void> {
       } catch (error) {
         exitCode = 1;
         console.error("Failed to stop MCP file watcher cleanly:", error);
+      }
+      try {
+        await stopAutoIndex(args.project, args.host);
+      } catch (error) {
+        exitCode = 1;
+        console.error("Failed to stop automatic indexing cleanly:", error);
       }
       try {
         await server.close();

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -16,7 +16,7 @@ import { getIndexerForProject } from "../../tools/operations.js";
 import { initializeTools } from "../../tools/operation-runtime.js";
 import { executeIndexCodebase } from "../../tools/execute-common.js";
 import { hasProjectMarker } from "../../utils/files.js";
-import { isHomeDirectory, stopAutoIndex } from "../../utils/auto-index.js";
+import { isHomeDirectory } from "../../utils/auto-index.js";
 import { createWatcherWithIndexer, type CombinedWatcher } from "../../watcher/index.js";
 import { attachRecentActivity } from "../../tools/visualize/activity.js";
 import { generateVisualizationHtml, transformForVisualization } from "../../tools/visualize/index.js";
@@ -266,23 +266,55 @@ export async function runMcpCli(argv: string[]): Promise<void> {
     );
   }
 
-  let shuttingDown = false;
-  const shutdown = async (): Promise<void> => {
-    if (shuttingDown) return;
-    shuttingDown = true;
+  let shutdownPromise: Promise<void> | undefined;
+  const onServerClose = server.server.onclose;
+
+  const shutdown = (): Promise<void> => {
+    if (shutdownPromise) return shutdownPromise;
+    process.stdin.removeListener("end", requestShutdown);
+    process.stdin.removeListener("close", requestShutdown);
+    process.removeListener("SIGHUP", requestShutdown);
+    process.removeListener("SIGINT", requestShutdown);
+    process.removeListener("SIGTERM", requestShutdown);
+    server.server.onclose = onServerClose;
+    shutdownPromise = (async (): Promise<void> => {
+      let exitCode = 0;
+      try {
+        await watcher?.stop();
+      } catch (error) {
+        exitCode = 1;
+        console.error("Failed to stop MCP file watcher cleanly:", error);
+      }
+      try {
+        await server.close();
+      } catch (error) {
+        exitCode = 1;
+        console.error("Failed to close MCP server cleanly:", error);
+      }
+      process.exit(exitCode);
+    })();
+    return shutdownPromise;
+  };
+
+  const requestShutdown = (): void => {
+    void shutdown();
+  };
+
+  server.server.onclose = () => {
     try {
-      await watcher?.stop();
-      await stopAutoIndex(args.project, args.host);
-      await server.close();
-      process.exit(0);
-    } catch (error) {
-      console.error("Failed to stop MCP server cleanly:", error);
-      process.exit(1);
+      onServerClose?.();
+    } finally {
+      requestShutdown();
     }
   };
 
-  process.on("SIGINT", () => { void shutdown(); });
-  process.on("SIGTERM", () => { void shutdown(); });
+  process.stdin.once("end", requestShutdown);
+  process.stdin.once("close", requestShutdown);
+  process.once("SIGINT", requestShutdown);
+  if (process.platform !== "win32") {
+    process.once("SIGHUP", requestShutdown);
+    process.once("SIGTERM", requestShutdown);
+  }
 }
 
 interface CliIndexCommandDeps {

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -37,15 +37,38 @@ import { isGitRepo } from "../git/index.js";
 import type { CombinedWatcher } from "../watcher/index.js";
 
 const activeWatchers = new Map<string, CombinedWatcher>();
+const watcherReplacementChains = new Map<string, Promise<void>>();
 
-function replaceActiveWatcher(projectRoot: string, nextWatcher: CombinedWatcher | null): void {
-  const existing = activeWatchers.get(projectRoot);
-  if (existing) {
-    existing.stop();
-    activeWatchers.delete(projectRoot);
-  }
-  if (nextWatcher) {
-    activeWatchers.set(projectRoot, nextWatcher);
+async function replaceActiveWatcher(
+  projectRoot: string,
+  createNextWatcher: (() => CombinedWatcher) | null,
+): Promise<void> {
+  const chain = (watcherReplacementChains.get(projectRoot) ?? Promise.resolve())
+    .catch(() => undefined)
+    .then(async () => {
+      const existing = activeWatchers.get(projectRoot);
+      if (existing) {
+        try {
+          await existing.stop();
+        } catch (error) {
+          console.error("[codebase-index] Failed to stop replaced watcher:", error);
+          throw error;
+        }
+        if (activeWatchers.get(projectRoot) === existing) {
+          activeWatchers.delete(projectRoot);
+        }
+      }
+      if (createNextWatcher) {
+        activeWatchers.set(projectRoot, createNextWatcher());
+      }
+    });
+  watcherReplacementChains.set(projectRoot, chain);
+  try {
+    await chain;
+  } finally {
+    if (watcherReplacementChains.get(projectRoot) === chain) {
+      watcherReplacementChains.delete(projectRoot);
+    }
   }
 }
 
@@ -130,9 +153,12 @@ const plugin: Plugin = async ({ directory, worktree }) => {
     }
 
     if (config.indexing.watchFiles && isValidProject) {
-      replaceActiveWatcher(projectRoot, createWatcherWithIndexer(getProjectIndexer, projectRoot, config, "opencode"));
+      await replaceActiveWatcher(
+        projectRoot,
+        () => createWatcherWithIndexer(getProjectIndexer, projectRoot, config, "opencode"),
+      );
     } else {
-      replaceActiveWatcher(projectRoot, null);
+      await replaceActiveWatcher(projectRoot, null);
     }
 
     return {

--- a/tests/mcp-cli-lifecycle.test.ts
+++ b/tests/mcp-cli-lifecycle.test.ts
@@ -7,11 +7,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const lifecycleMocks = vi.hoisted(() => ({
   createMcpServer: vi.fn(),
   createWatcherWithIndexer: vi.fn(),
+  isHomeDirectory: vi.fn(() => false),
+  stopAutoIndex: vi.fn(),
   exit: vi.fn(),
 }));
 
 vi.mock("../src/mcp-server.js", () => ({
   createMcpServer: lifecycleMocks.createMcpServer,
+}));
+
+vi.mock("../src/utils/auto-index.js", () => ({
+  isHomeDirectory: lifecycleMocks.isHomeDirectory,
+  stopAutoIndex: lifecycleMocks.stopAutoIndex,
 }));
 
 vi.mock("../src/watcher/index.js", () => ({
@@ -62,6 +69,7 @@ describe("MCP CLI shutdown lifecycle", () => {
 
     lifecycleMocks.createMcpServer.mockReset();
     lifecycleMocks.createWatcherWithIndexer.mockReset();
+    lifecycleMocks.stopAutoIndex.mockReset();
     lifecycleMocks.exit.mockReset();
     vi.spyOn(process, "exit").mockImplementation(((code?: number | string) => {
       events.push(`exit:${String(code)}`);
@@ -73,6 +81,9 @@ describe("MCP CLI shutdown lifecycle", () => {
         events.push("watcher.stop");
       }),
     };
+    lifecycleMocks.stopAutoIndex.mockImplementation(async () => {
+      events.push("autoIndex.stop");
+    });
     server = {
       close: vi.fn(async () => {
         events.push("server.close");
@@ -114,6 +125,7 @@ describe("MCP CLI shutdown lifecycle", () => {
       expect(lifecycleMocks.exit).toHaveBeenCalledWith(0);
     });
     expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.stopAutoIndex).toHaveBeenCalledOnce();
     expect(server.close).toHaveBeenCalledOnce();
   }
 
@@ -135,7 +147,7 @@ describe("MCP CLI shutdown lifecycle", () => {
 
     stopGate.resolve();
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["watcher.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
   });
 
   it("runs teardown when stdin closes without an end event", async () => {
@@ -144,7 +156,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     process.stdin.emit("close");
 
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["watcher.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
   });
 
   it("still closes the server when watcher teardown fails", async () => {
@@ -164,7 +176,27 @@ describe("MCP CLI shutdown lifecycle", () => {
     });
     expect(server.close).toHaveBeenCalledOnce();
     expect(error).toHaveBeenCalledWith("Failed to stop MCP file watcher cleanly:", stopError);
-    expect(events).toEqual(["watcher.stop", "server.close", "exit:1"]);
+    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:1"]);
+  });
+
+  it("still closes the server when auto-index shutdown fails", async () => {
+    const stopError = new Error("auto-index stop failed");
+    lifecycleMocks.stopAutoIndex.mockImplementation(async () => {
+      events.push("autoIndex.stop");
+      throw stopError;
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await startCli();
+
+    process.stdin.emit("close");
+
+    await vi.waitFor(() => {
+      expect(lifecycleMocks.exit).toHaveBeenCalledWith(1);
+    });
+    expect(lifecycleMocks.stopAutoIndex).toHaveBeenCalledOnce();
+    expect(server.close).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("Failed to stop automatic indexing cleanly:", stopError);
+    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:1"]);
   });
 
   it("runs teardown when the MCP server closes", async () => {
@@ -173,7 +205,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     server.server.onclose?.();
 
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["server.onclose", "watcher.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["server.onclose", "watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
   });
 
   if (process.platform !== "win32") {
@@ -183,7 +215,7 @@ describe("MCP CLI shutdown lifecycle", () => {
       process.emit(signal);
 
       await expectSuccessfulShutdown();
-      expect(events).toEqual(["watcher.stop", "server.close", "exit:0"]);
+      expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
     });
   }
 

--- a/tests/mcp-cli-lifecycle.test.ts
+++ b/tests/mcp-cli-lifecycle.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const lifecycleMocks = vi.hoisted(() => ({
+  createMcpServer: vi.fn(),
+  createWatcherWithIndexer: vi.fn(),
+  exit: vi.fn(),
+}));
+
+vi.mock("../src/mcp-server.js", () => ({
+  createMcpServer: lifecycleMocks.createMcpServer,
+}));
+
+vi.mock("../src/watcher/index.js", () => ({
+  createWatcherWithIndexer: lifecycleMocks.createWatcherWithIndexer,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: class {},
+}));
+
+import { runMcpCli } from "../src/adapters/mcp/cli.js";
+
+interface FakeMcpServer {
+  close: () => Promise<void>;
+  connect: (transport: unknown) => Promise<void>;
+  server: {
+    onclose?: () => void;
+  };
+}
+
+interface FakeWatcher {
+  stop: () => Promise<void>;
+}
+
+const processPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("MCP CLI shutdown lifecycle", () => {
+  let events: string[];
+  let server: FakeMcpServer;
+  let tempDir: string;
+  let watcher: FakeWatcher;
+
+  beforeEach(() => {
+    events = [];
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "mcp-cli-lifecycle-"));
+    writeFileSync(
+      path.join(tempDir, "config.json"),
+      JSON.stringify({ indexing: { autoIndex: false, watchFiles: true, requireProjectMarker: false } }),
+    );
+
+    lifecycleMocks.createMcpServer.mockReset();
+    lifecycleMocks.createWatcherWithIndexer.mockReset();
+    lifecycleMocks.exit.mockReset();
+    vi.spyOn(process, "exit").mockImplementation(((code?: number | string) => {
+      events.push(`exit:${String(code)}`);
+      lifecycleMocks.exit(code);
+    }) as never);
+
+    watcher = {
+      stop: vi.fn(async () => {
+        events.push("watcher.stop");
+      }),
+    };
+    server = {
+      close: vi.fn(async () => {
+        events.push("server.close");
+      }),
+      connect: vi.fn(async () => {}),
+      server: {
+        onclose: () => {
+          events.push("server.onclose");
+        },
+      },
+    };
+    lifecycleMocks.createMcpServer.mockReturnValue(server);
+    lifecycleMocks.createWatcherWithIndexer.mockReturnValue(watcher);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (processPlatformDescriptor) {
+      Object.defineProperty(process, "platform", processPlatformDescriptor);
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function startCli(): Promise<void> {
+    await runMcpCli([
+      "node",
+      "dist/cli.js",
+      "--host",
+      "jcode",
+      "--project",
+      tempDir,
+      "--config",
+      path.join(tempDir, "config.json"),
+    ]);
+  }
+
+  async function expectSuccessfulShutdown(): Promise<void> {
+    await vi.waitFor(() => {
+      expect(lifecycleMocks.exit).toHaveBeenCalledWith(0);
+    });
+    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(server.close).toHaveBeenCalledOnce();
+  }
+
+  it("runs teardown once when stdin emits end and close", async () => {
+    const stopGate = createDeferred<void>();
+    watcher.stop = vi.fn(() => {
+      events.push("watcher.stop");
+      return stopGate.promise;
+    });
+    lifecycleMocks.createWatcherWithIndexer.mockReturnValue(watcher);
+    await startCli();
+
+    process.stdin.emit("end");
+    process.stdin.emit("close");
+    await Promise.resolve();
+
+    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(server.close).not.toHaveBeenCalled();
+
+    stopGate.resolve();
+    await expectSuccessfulShutdown();
+    expect(events).toEqual(["watcher.stop", "server.close", "exit:0"]);
+  });
+
+  it("runs teardown when stdin closes without an end event", async () => {
+    await startCli();
+
+    process.stdin.emit("close");
+
+    await expectSuccessfulShutdown();
+    expect(events).toEqual(["watcher.stop", "server.close", "exit:0"]);
+  });
+
+  it("still closes the server when watcher teardown fails", async () => {
+    const stopError = new Error("watcher stop failed");
+    watcher.stop = vi.fn(async () => {
+      events.push("watcher.stop");
+      throw stopError;
+    });
+    lifecycleMocks.createWatcherWithIndexer.mockReturnValue(watcher);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await startCli();
+
+    process.stdin.emit("close");
+
+    await vi.waitFor(() => {
+      expect(lifecycleMocks.exit).toHaveBeenCalledWith(1);
+    });
+    expect(server.close).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("Failed to stop MCP file watcher cleanly:", stopError);
+    expect(events).toEqual(["watcher.stop", "server.close", "exit:1"]);
+  });
+
+  it("runs teardown when the MCP server closes", async () => {
+    await startCli();
+
+    server.server.onclose?.();
+
+    await expectSuccessfulShutdown();
+    expect(events).toEqual(["server.onclose", "watcher.stop", "server.close", "exit:0"]);
+  });
+
+  if (process.platform !== "win32") {
+    it.each(["SIGINT", "SIGTERM", "SIGHUP"] as const)("runs teardown for %s", async (signal) => {
+      await startCli();
+
+      process.emit(signal);
+
+      await expectSuccessfulShutdown();
+      expect(events).toEqual(["watcher.stop", "server.close", "exit:0"]);
+    });
+  }
+
+  it("uses SIGINT but not POSIX-only shutdown signals on Windows", async () => {
+    if (!processPlatformDescriptor) {
+      throw new Error("Unable to override process.platform for this lifecycle test.");
+    }
+    Object.defineProperty(process, "platform", { ...processPlatformDescriptor, value: "win32" });
+    await startCli();
+
+    process.emit("SIGTERM");
+    process.emit("SIGHUP");
+    await Promise.resolve();
+
+    expect(watcher.stop).not.toHaveBeenCalled();
+    expect(server.close).not.toHaveBeenCalled();
+
+    process.emit("SIGINT");
+    await expectSuccessfulShutdown();
+  });
+});

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -109,6 +109,14 @@ import { configureAutoIndex, resetAutoIndexCoordinatorsForTests } from "../src/u
 import type { ParsedCodebaseIndexConfig } from "../src/config/schema.js";
 import { OPENCODE_TOOL_NAMES } from "../src/tools/tool-names.js";
 
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("plugin routing hint hook selection", () => {
   beforeEach(() => {
     mockState.config = {
@@ -209,15 +217,14 @@ describe("plugin routing hint hook selection", () => {
     expect(new Set(Object.keys(runtime.tool ?? {})).size).toBe(OPENCODE_TOOL_NAMES.length);
   });
 
-  it("reloads without waiting for a stuck watcher or starting a redundant index", async () => {
+  it("waits for the previous watcher to stop before creating the next one", async () => {
     mockState.config.indexing.autoIndex = true;
     mockState.config.indexing.watchFiles = true;
-    let resolveIndex: (() => void) | undefined;
-    mockState.indexer.index.mockImplementationOnce(() => new Promise((resolve) => {
-      resolveIndex = () => resolve({});
-    }));
+    const indexGate = createDeferred<{}>();
+    mockState.indexer.index.mockImplementationOnce(() => indexGate.promise);
+    const stopGate = createDeferred<void>();
     const firstWatcher = {
-      stop: vi.fn(() => new Promise<void>(() => {})),
+      stop: vi.fn(() => stopGate.promise),
     };
     const secondWatcher = { stop: vi.fn().mockResolvedValue(undefined) };
     mockState.createWatcherWithIndexer
@@ -227,12 +234,86 @@ describe("plugin routing hint hook selection", () => {
     await plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0]);
     await vi.waitFor(() => expect(mockState.indexer.index).toHaveBeenCalledOnce());
 
-    await expect(plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0])).resolves.toBeDefined();
+    const secondReload = plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0]);
+    await vi.waitFor(() => expect(firstWatcher.stop).toHaveBeenCalledOnce());
+    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledOnce();
 
-    expect(firstWatcher.stop).toHaveBeenCalledOnce();
+    stopGate.resolve();
+    await secondReload;
+
+    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledTimes(2);
     expect(mockState.indexer.index).toHaveBeenCalledOnce();
-    resolveIndex?.();
+    indexGate.resolve({});
     await vi.waitFor(() => expect(mockState.indexer.getStatus).toHaveBeenCalled());
+  });
+
+  it("does not create a second watcher when stopping the previous one fails", async () => {
+    mockState.config.indexing.watchFiles = true;
+    const stopError = new Error("stop failed");
+    const firstWatcher = {
+      stop: vi.fn()
+        .mockRejectedValueOnce(stopError)
+        .mockResolvedValue(undefined),
+    };
+    mockState.createWatcherWithIndexer.mockReturnValue(firstWatcher);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const projectRoot = "/tmp/stop-failure-project";
+
+    try {
+      await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
+      const failedReload = await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
+
+      expect(failedReload.tool).toBeUndefined();
+      expect(firstWatcher.stop).toHaveBeenCalledOnce();
+      expect(error).toHaveBeenCalledWith("[codebase-index] Failed to stop replaced watcher:", stopError);
+      expect(mockState.createWatcherWithIndexer).toHaveBeenCalledOnce();
+    } finally {
+      mockState.config.indexing.watchFiles = false;
+      await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
+      error.mockRestore();
+    }
+  });
+
+  it("serializes concurrent reloads while replaced watcher shutdowns are pending", async () => {
+    mockState.config.indexing.watchFiles = true;
+    const firstStopGate = createDeferred<void>();
+    const secondStopGate = createDeferred<void>();
+    const firstWatcher = { stop: vi.fn(() => firstStopGate.promise) };
+    const secondWatcher = { stop: vi.fn(() => secondStopGate.promise) };
+    const finalWatcher = { stop: vi.fn().mockResolvedValue(undefined) };
+    mockState.createWatcherWithIndexer
+      .mockReturnValueOnce(firstWatcher)
+      .mockReturnValueOnce(secondWatcher)
+      .mockReturnValueOnce(finalWatcher);
+
+    const projectRoot = "/tmp/concurrent-reload-project";
+    const reloads = [
+      plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]),
+      plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]),
+      plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]),
+    ];
+
+    await vi.waitFor(() => expect(firstWatcher.stop).toHaveBeenCalledOnce());
+    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledOnce();
+    expect(secondWatcher.stop).not.toHaveBeenCalled();
+
+    firstStopGate.resolve();
+    await vi.waitFor(() => expect(secondWatcher.stop).toHaveBeenCalledOnce());
+    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledTimes(2);
+    expect(finalWatcher.stop).not.toHaveBeenCalled();
+
+    secondStopGate.resolve();
+    await Promise.all(reloads);
+
+    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledTimes(3);
+    expect(firstWatcher.stop).toHaveBeenCalledOnce();
+    expect(secondWatcher.stop).toHaveBeenCalledOnce();
+    expect(finalWatcher.stop).not.toHaveBeenCalled();
+
+    mockState.config.indexing.watchFiles = false;
+    await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
+
+    expect(finalWatcher.stop).toHaveBeenCalledOnce();
   });
 
   it("injects hints through system transform when role is system", async () => {


### PR DESCRIPTION
## Behavior

- **MCP watcher shutdown**: `opencode-codebase-index-mcp` now shuts down its file watcher and stdio transport idempotently on stdin EOF, protocol close, or `SIGHUP`/`SIGINT`/`SIGTERM`, exiting 0 instead of leaving watcher processes behind when the host disappears.
- **Serialized OpenCode watcher replacement**: On plugin reloads, the next project watcher is only created after the previous one has fully stopped, so concurrent reloads cannot leak or double-start watchers.

## Verification

```bash
npx vitest run tests/mcp-cli-lifecycle.test.ts tests/plugin-hooks.test.ts
npm run build:ts
```

`npm run build:ts` builds the CLI and runs the built-binary smoke covering stdin EOF and, outside Windows, SIGINT/SIGTERM/SIGHUP with exit code 0 and no `SIGKILL` fallback.
