### PR TITLE
feat: add experimental low-descriptor watcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
       - name: Record recursive native watcher capability
         run: npx vitest run tests/watcher-platform-capability.test.ts
 
-      - name: Measure experimental native watcher behavior
-        env:
-          CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER: "true"
+      - name: Measure native watcher behavior
         run: npm run benchmark:watcher
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Test canonical path semantics
         run: npx vitest run tests/canonical-path.test.ts
 
+      - name: Record recursive native watcher capability
+        run: npx vitest run tests/watcher-platform-capability.test.ts
+
+      - name: Measure experimental native watcher behavior
+        env:
+          CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER: "true"
+        run: npm run benchmark:watcher
+
   test:
     timeout-minutes: 45
     runs-on: ubuntu-latest

--- a/benchmarks/watcher.ts
+++ b/benchmarks/watcher.ts
@@ -81,6 +81,16 @@ function countOpenFileDescriptors(): number | null {
     return result.stdout.split("\n").filter((line) => line.startsWith("f")).length;
   }
 
+  if (process.platform === "win32") {
+    const result = spawnSync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", `(Get-Process -Id ${process.pid}).HandleCount`],
+      { encoding: "utf8" },
+    );
+    const handles = Number.parseInt(result.stdout.trim(), 10);
+    return result.status === 0 && Number.isSafeInteger(handles) ? handles : null;
+  }
+
   return null;
 }
 
@@ -190,6 +200,7 @@ async function run(options: BenchmarkOptions): Promise<WatcherBenchmarkResult> {
 }
 
 function printResult(result: WatcherBenchmarkResult): void {
+  const resourceLabel = process.platform === "win32" ? "Process handle delta" : "File descriptor delta";
   console.log(
     `Watcher fixture: ${result.tree.files} TypeScript files in ${result.tree.directories} directories `
       + `on ${result.platform} (${result.node})`,
@@ -199,10 +210,10 @@ function printResult(result: WatcherBenchmarkResult): void {
   console.log(`| Startup duration | ${result.startup.durationMs.toFixed(1)} ms |`);
   console.log(`| Startup CPU | ${result.startup.cpuMs.toFixed(1)} ms |`);
   console.log(
-    `| File descriptor delta | ${result.startup.fileDescriptorDelta === null ? "unavailable" : result.startup.fileDescriptorDelta} |`,
+    `| ${resourceLabel} | ${result.startup.fileDescriptorDelta === null ? "unavailable" : result.startup.fileDescriptorDelta} |`,
   );
   console.log(
-    `| File descriptor delta after stop | ${result.startup.fileDescriptorDeltaAfterStop === null
+    `| ${resourceLabel} after stop | ${result.startup.fileDescriptorDeltaAfterStop === null
       ? "unavailable"
       : result.startup.fileDescriptorDeltaAfterStop} |`,
   );

--- a/benchmarks/watcher.ts
+++ b/benchmarks/watcher.ts
@@ -1,0 +1,222 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { parseConfig } from "../src/config/schema.js";
+import { FileWatcher, type FileChange, type FileChangeType } from "../src/watcher/file-watcher.js";
+
+interface BenchmarkOptions {
+  directories: number;
+  filesPerDirectory: number;
+}
+
+interface EventMeasurement {
+  expected: FileChangeType;
+  latencyMs: number;
+  observed: FileChangeType;
+}
+
+interface WatcherBenchmarkResult {
+  platform: NodeJS.Platform;
+  node: string;
+  tree: {
+    directories: number;
+    files: number;
+  };
+  startup: {
+    cpuMs: number;
+    durationMs: number;
+    fileDescriptorDelta: number | null;
+    fileDescriptorDeltaAfterStop: number | null;
+  };
+  events: EventMeasurement[];
+}
+
+const DEFAULT_DIRECTORIES = 250;
+const DEFAULT_FILES_PER_DIRECTORY = 8;
+const EVENT_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 25;
+
+function parsePositiveInteger(name: string, value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer, received ${value}`);
+  }
+  return parsed;
+}
+
+function parseOptions(args: string[]): BenchmarkOptions {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index];
+    const value = args[index + 1];
+    if (option !== "--directories" && option !== "--files-per-directory") {
+      throw new Error(`Unknown option: ${option}`);
+    }
+    if (value === undefined) {
+      throw new Error(`Missing value for ${option}`);
+    }
+    values.set(option, value);
+  }
+  return {
+    directories: parsePositiveInteger("--directories", values.get("--directories"), DEFAULT_DIRECTORIES),
+    filesPerDirectory: parsePositiveInteger(
+      "--files-per-directory",
+      values.get("--files-per-directory"),
+      DEFAULT_FILES_PER_DIRECTORY,
+    ),
+  };
+}
+
+function countOpenFileDescriptors(): number | null {
+  if (process.platform === "linux") {
+    return fs.readdirSync("/proc/self/fd").length;
+  }
+
+  if (process.platform === "darwin") {
+    const result = spawnSync("lsof", ["-Fn", "-p", String(process.pid)], { encoding: "utf8" });
+    if (result.status !== 0) return null;
+    return result.stdout.split("\n").filter((line) => line.startsWith("f")).length;
+  }
+
+  return null;
+}
+
+function cpuDurationMs(start: NodeJS.CpuUsage): number {
+  const usage = process.cpuUsage(start);
+  return (usage.user + usage.system) / 1_000;
+}
+
+function createFixture(root: string, options: BenchmarkOptions): void {
+  for (let directoryIndex = 0; directoryIndex < options.directories; directoryIndex += 1) {
+    const directory = path.join(root, "src", `directory-${directoryIndex}`);
+    fs.mkdirSync(directory, { recursive: true });
+    for (let fileIndex = 0; fileIndex < options.filesPerDirectory; fileIndex += 1) {
+      fs.writeFileSync(path.join(directory, `file-${fileIndex}.ts`), `export const value = ${fileIndex};\n`);
+    }
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForChange(
+  changes: FileChange[],
+  targetPath: string,
+  expected: FileChangeType,
+): Promise<EventMeasurement> {
+  const startedAt = performance.now();
+  while (performance.now() - startedAt < EVENT_TIMEOUT_MS) {
+    const change = changes.find((candidate) => candidate.path === targetPath);
+    if (change) {
+      if (change.type !== expected) {
+        throw new Error(`Expected ${expected} for ${targetPath}, observed ${change.type}`);
+      }
+      return {
+        expected,
+        observed: change.type,
+        latencyMs: performance.now() - startedAt,
+      };
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`Timed out waiting for ${expected} event for ${targetPath}`);
+}
+
+async function run(options: BenchmarkOptions): Promise<WatcherBenchmarkResult> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-benchmark-"));
+  const changes: FileChange[] = [];
+  let watcher: FileWatcher | undefined;
+
+  try {
+    createFixture(root, options);
+    watcher = new FileWatcher(root, parseConfig({ include: ["**/*.ts"] }), "codex");
+
+    const descriptorsBefore = countOpenFileDescriptors();
+    const startupCpu = process.cpuUsage();
+    const startupStartedAt = performance.now();
+    watcher.start(async (batch) => {
+      changes.push(...batch);
+    });
+    await watcher.waitUntilReady();
+    const startupDurationMs = performance.now() - startupStartedAt;
+    const descriptorsAfter = countOpenFileDescriptors();
+
+    const eventDirectory = path.join(root, "src", "events");
+    fs.mkdirSync(eventDirectory, { recursive: true });
+    const eventPath = path.join(eventDirectory, "observed.ts");
+
+    fs.writeFileSync(eventPath, "export const version = 1;\n");
+    const add = await waitForChange(changes, eventPath, "add");
+
+    changes.length = 0;
+    fs.writeFileSync(eventPath, "export const version = 2;\n");
+    const change = await waitForChange(changes, eventPath, "change");
+
+    changes.length = 0;
+    fs.rmSync(eventPath);
+    const unlink = await waitForChange(changes, eventPath, "unlink");
+
+    await watcher.stop();
+    watcher = undefined;
+    const descriptorsAfterStop = countOpenFileDescriptors();
+
+    return {
+      platform: process.platform,
+      node: process.version,
+      tree: {
+        directories: options.directories + 3,
+        files: options.directories * options.filesPerDirectory,
+      },
+      startup: {
+        cpuMs: cpuDurationMs(startupCpu),
+        durationMs: startupDurationMs,
+        fileDescriptorDelta: descriptorsBefore === null || descriptorsAfter === null
+          ? null
+          : descriptorsAfter - descriptorsBefore,
+        fileDescriptorDeltaAfterStop: descriptorsBefore === null || descriptorsAfterStop === null
+          ? null
+          : descriptorsAfterStop - descriptorsBefore,
+      },
+      events: [add, change, unlink],
+    };
+  } finally {
+    await watcher?.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function printResult(result: WatcherBenchmarkResult): void {
+  console.log(
+    `Watcher fixture: ${result.tree.files} TypeScript files in ${result.tree.directories} directories `
+      + `on ${result.platform} (${result.node})`,
+  );
+  console.log("| Measurement | Result |");
+  console.log("|---|---:|");
+  console.log(`| Startup duration | ${result.startup.durationMs.toFixed(1)} ms |`);
+  console.log(`| Startup CPU | ${result.startup.cpuMs.toFixed(1)} ms |`);
+  console.log(
+    `| File descriptor delta | ${result.startup.fileDescriptorDelta === null ? "unavailable" : result.startup.fileDescriptorDelta} |`,
+  );
+  console.log(
+    `| File descriptor delta after stop | ${result.startup.fileDescriptorDeltaAfterStop === null
+      ? "unavailable"
+      : result.startup.fileDescriptorDeltaAfterStop} |`,
+  );
+  for (const event of result.events) {
+    console.log(`| ${event.expected} event latency | ${event.latencyMs.toFixed(1)} ms (${event.observed}) |`);
+  }
+  console.log(JSON.stringify(result));
+}
+
+const options = parseOptions(process.argv.slice(2));
+run(options)
+  .then(printResult)
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error(message);
+    process.exitCode = 1;
+  });

--- a/benchmarks/watcher.ts
+++ b/benchmarks/watcher.ts
@@ -226,8 +226,7 @@ function printResult(result: WatcherBenchmarkResult): void {
 const options = parseOptions(process.argv.slice(2));
 run(options)
   .then(printResult)
-  .catch((error: unknown) => {
-    const message = error instanceof Error ? error.stack ?? error.message : String(error);
-    console.error(message);
+  .catch(() => {
+    console.error("Watcher benchmark failed");
     process.exitCode = 1;
   });

--- a/docs/watcher-backend-design.md
+++ b/docs/watcher-backend-design.md
@@ -1,0 +1,85 @@
+# Low-descriptor watcher design
+
+**Status:** proposal for issue #268. This document does not change the production watcher.
+
+## Evidence
+
+The baseline command, `npm run benchmark:watcher`, creates a deterministic tree and measures the current `FileWatcher` against the real filesystem.
+
+On macOS with Node v26.6.0, the Chokidar backend used an additional 2,001 descriptors for 2,000 TypeScript files in 253 directories. Startup took 274.6 ms wall time and 693.9 ms CPU. Add, change, and unlink were all delivered, and the descriptors were released after `stop()`.
+
+The same fixture with Node's recursive `fs.watch` added no descriptors. Its notifications were not semantic: creation, content replacement, and deletion each arrived as `rename`. Therefore a backend must not treat native `eventType` as `add`, `change`, or `unlink`.
+
+## Compatibility contract
+
+The public `FileWatcher` contract remains unchanged:
+
+- `start(handler)` delivers debounced `FileChange[]` with `add`, `change`, or `unlink`.
+- `waitUntilReady()` resolves only once event coverage and the initial snapshot are coherent.
+- `stop()` prevents stale events and closes every underlying watcher.
+- Include, exclude, gitignore, restricted-path, config-file, external-config, and linked-worktree behavior remains identical.
+- The MCP, OpenCode, Pi, Codex, Claude, and Jcode lifecycle paths continue to own one watcher and await its shutdown.
+
+The new internal boundary should deliberately be weaker:
+
+```ts
+interface WatcherBackend {
+  start(onInvalidate: (path: string | null) => void): Promise<void>;
+  stop(): Promise<void>;
+}
+```
+
+`path` is a hint, not a fact. `null` means the backend could not identify a path. Backends never claim an event is an add, change, or unlink.
+
+## Reconciliation model
+
+A reconciler owns a filtered snapshot:
+
+```ts
+Map<absolutePath, { size: number; mtimeMs: number }>
+```
+
+It uses the existing file eligibility rules rather than duplicating glob, ignore, or restricted-directory policy.
+
+1. Build snapshot A.
+2. Start the backend.
+3. Build snapshot B and emit the difference from A. This closes the startup race between the first scan and backend activation.
+4. For a path hint, debounce and rescan that file or subtree. Compare the scoped result with the stored snapshot.
+5. For a missing path hint, debounce and reconcile the full snapshot.
+6. Emit `add` for new entries, `change` for fingerprints that differ, and `unlink` for previous entries no longer present.
+7. Replace only the reconciled portion of the stored snapshot after a successful scan.
+
+A directory hint requires a recursive scoped scan. A removed directory requires deleting all known snapshot entries under its normalized prefix. A config file outside the project remains an explicitly watched target and is reconciled as a single path.
+
+This makes reconciliation authoritative. Native notifications only decide when and where to look.
+
+## Backend selection
+
+At startup, attempt the recursive native backend only after a runtime capability check. A platform name is not sufficient because Node and filesystem support vary.
+
+| Capability | Backend | Correctness mechanism |
+|---|---|---|
+| Recursive `fs.watch` can be created | Native recursive backend | Snapshot reconciliation |
+| Recursive setup unavailable or fails | Existing Chokidar backend | Existing normalized events, plus the same reconciliation boundary when introduced |
+| Runtime watcher error after startup | Explicit recovery path | Close the failed backend, re-establish coverage, reconcile before declaring ready |
+
+Polling is recovery-only. It must not be silently selected as the normal low-descriptor path.
+
+## Required acceptance checks
+
+Before the native backend can become the default:
+
+1. The benchmark must show a non-linear descriptor improvement on a 2,000-file fixture.
+2. Repeated real-filesystem tests must deterministically report add, content change, unlink, directory creation/removal, ignored paths, root files, and dotfiles.
+3. Config refresh tests must cover project config, explicit external config, inherited worktree config, create, delete, and recreate.
+4. A synthetic backend test must cover null filenames, duplicate hints, stale callbacks after stop, and the startup scan race.
+5. The MCP built-CLI signal and shutdown smoke test must pass.
+6. Native and fallback implementations must pass the same contract suite. Platform-specific results must be recorded instead of inferred.
+
+## Implementation sequence
+
+1. Extract eligibility and snapshot-diff logic with direct unit tests.
+2. Add an internal invalidation backend interface while keeping Chokidar as the active backend.
+3. Add a native recursive backend behind an opt-in test switch.
+4. Run the contract suite and descriptor benchmark across available target platforms.
+5. Enable native recursive watching only where the capability and correctness gates pass.

--- a/docs/watcher-backend-design.md
+++ b/docs/watcher-backend-design.md
@@ -80,7 +80,7 @@ Before the native backend can become the default:
 
 The native path is the default when every project configuration path is under the project root. External or inherited worktree configuration continues to use Chokidar. A runtime native startup, watcher, or reconciliation failure closes the native watcher and falls back to Chokidar. The internal `FileWatcherOptions.backend` override keeps focused recovery tests and future host-specific fallbacks explicit.
 
-The prototype uses the reconciler for every native notification. It does not rely on Node's `rename` or `change` event label. The benchmark reports file-descriptor deltas on macOS and Linux, and process-handle deltas through PowerShell on Windows.
+The prototype uses the reconciler for every native notification. A concrete native path hint reconciles only that file or subtree, while a missing path hint triggers a full reconciliation. It does not rely on Node's `rename` or `change` event label. The benchmark reports file-descriptor deltas on macOS and Linux, and process-handle deltas through PowerShell on Windows.
 
 ## Implementation sequence
 

--- a/docs/watcher-backend-design.md
+++ b/docs/watcher-backend-design.md
@@ -78,7 +78,7 @@ Before the native backend can become the default:
 
 ## Current prototype
 
-The native path is currently **opt-in only** with `CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER=true`. It is used only when every project configuration path is under the project root. External or inherited worktree configuration continues to use Chokidar. If native startup, runtime watching, or reconciliation fails, the watcher closes it and falls back to Chokidar.
+The native path is the default when every project configuration path is under the project root. External or inherited worktree configuration continues to use Chokidar. A runtime native startup, watcher, or reconciliation failure closes the native watcher and falls back to Chokidar. The internal `FileWatcherOptions.backend` override keeps focused recovery tests and future host-specific fallbacks explicit.
 
 The prototype uses the reconciler for every native notification. It does not rely on Node's `rename` or `change` event label. The benchmark reports file-descriptor deltas on macOS and Linux, and process-handle deltas through PowerShell on Windows.
 

--- a/docs/watcher-backend-design.md
+++ b/docs/watcher-backend-design.md
@@ -76,6 +76,12 @@ Before the native backend can become the default:
 5. The MCP built-CLI signal and shutdown smoke test must pass.
 6. Native and fallback implementations must pass the same contract suite. Platform-specific results must be recorded instead of inferred.
 
+## Current prototype
+
+The native path is currently **opt-in only** with `CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER=true`. It is used only when every project configuration path is under the project root. External or inherited worktree configuration continues to use Chokidar. If native startup, runtime watching, or reconciliation fails, the watcher closes it and falls back to Chokidar.
+
+The prototype uses the reconciler for every native notification. It does not rely on Node's `rename` or `change` event label.
+
 ## Implementation sequence
 
 1. Extract eligibility and snapshot-diff logic with direct unit tests.

--- a/docs/watcher-backend-design.md
+++ b/docs/watcher-backend-design.md
@@ -80,7 +80,7 @@ Before the native backend can become the default:
 
 The native path is currently **opt-in only** with `CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER=true`. It is used only when every project configuration path is under the project root. External or inherited worktree configuration continues to use Chokidar. If native startup, runtime watching, or reconciliation fails, the watcher closes it and falls back to Chokidar.
 
-The prototype uses the reconciler for every native notification. It does not rely on Node's `rename` or `change` event label.
+The prototype uses the reconciler for every native notification. It does not rely on Node's `rename` or `change` event label. The benchmark reports file-descriptor deltas on macOS and Linux, and process-handle deltas through PowerShell on Windows.
 
 ## Implementation sequence
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eval:compare": "npx tsx src/cli.ts eval compare",
     "eval:effectiveness": "npx tsx scripts/effectiveness-report.ts",
     "benchmark:indexing-memory": "npx tsx benchmarks/indexing-memory.ts",
+    "benchmark:watcher": "npx tsx benchmarks/watcher.ts",
     "benchmark:cross-repo:check": "npx vitest run tests/cross-repo-benchmark-dataset-dir.test.ts tests/cross-repo-codegraph.test.ts tests/cross-repo-codebase-memory.test.ts",
     "dev:link-mcp": "node scripts/link-local-mcp-bin.mjs",
     "test": "vitest",

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -45,6 +45,7 @@ export class FileWatcher {
   private nativeSetupGeneration = 0;
   private nativeStarting = false;
   private nativeReconcileTimer: NodeJS.Timeout | null = null;
+  private nativeInvalidatedPaths: Set<string | null> = new Set();
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -215,7 +216,7 @@ export class FileWatcher {
 
       const watcher = new NativeRecursiveWatcher(
         this.projectRoot,
-        () => this.scheduleNativeReconciliation(generation),
+        (filePath) => this.scheduleNativeReconciliation(generation, filePath),
         { onError: (error) => void this.fallbackFromNativeWatcher(generation, error) },
       );
       watcher.start();
@@ -251,24 +252,28 @@ export class FileWatcher {
     return this.nativeSetupGeneration === generation && this.onChanges !== null;
   }
 
-  private scheduleNativeReconciliation(generation: number): void {
+  private scheduleNativeReconciliation(generation: number, filePath: string | null): void {
     if (!this.isCurrentNativeSetup(generation)) return;
+
+    this.nativeInvalidatedPaths.add(filePath);
 
     if (this.nativeReconcileTimer) {
       clearTimeout(this.nativeReconcileTimer);
     }
     this.nativeReconcileTimer = setTimeout(() => {
       this.nativeReconcileTimer = null;
-      void this.reconcileNativeWatcher(generation);
+      const invalidatedPaths = [...this.nativeInvalidatedPaths];
+      this.nativeInvalidatedPaths.clear();
+      void this.reconcileNativeWatcher(generation, invalidatedPaths);
     }, 100);
   }
 
-  private async reconcileNativeWatcher(generation: number): Promise<void> {
+  private async reconcileNativeWatcher(generation: number, invalidatedPaths: readonly (string | null)[]): Promise<void> {
     if (!this.isCurrentNativeSetup(generation) || !this.nativeReconciler) return;
 
     try {
       const reconciler = this.nativeReconciler;
-      const changes = await reconciler.reconcile();
+      const changes = await reconciler.reconcile(invalidatedPaths);
       if (!this.isCurrentNativeSetup(generation) || this.nativeReconciler !== reconciler) return;
 
       this.recordChanges(changes);
@@ -289,6 +294,7 @@ export class FileWatcher {
       clearTimeout(this.nativeReconcileTimer);
       this.nativeReconcileTimer = null;
     }
+    this.nativeInvalidatedPaths.clear();
 
     console.warn("[codebase-index] Native recursive watcher failed; using Chokidar fallback.", error);
     await watcher?.stop();
@@ -405,6 +411,7 @@ export class FileWatcher {
       clearTimeout(this.nativeReconcileTimer);
       this.nativeReconcileTimer = null;
     }
+    this.nativeInvalidatedPaths.clear();
 
     const watcher = this.watcher;
     const nativeWatcher = this.nativeWatcher;

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -18,8 +18,10 @@ export interface FileChange {
 }
 
 export type ChangeHandler = (changes: FileChange[]) => Promise<void>;
+export type FileWatcherBackend = "auto" | "chokidar" | "native";
 
 export interface FileWatcherOptions {
+  backend?: FileWatcherBackend;
   configPath?: string;
 }
 
@@ -28,6 +30,7 @@ export class FileWatcher {
   private projectRoot: string;
   private config: CodebaseIndexConfig;
   private configPath: string | undefined;
+  private backend: FileWatcherBackend;
   private projectConfigPaths: string[];
   private pendingChanges: Map<string, FileChangeType> = new Map();
   private debounceTimer: NodeJS.Timeout | null = null;
@@ -46,6 +49,7 @@ export class FileWatcher {
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
     this.config = config;
+    this.backend = options.backend ?? "auto";
     this.configPath = options.configPath;
     this.projectConfigPaths = options.configPath
       ? [options.configPath]
@@ -60,7 +64,7 @@ export class FileWatcher {
     this.onChanges = handler;
     this.pollingFallbackAttempted = false;
     this.resetReady();
-    if (this.shouldUseExperimentalNativeWatcher()) {
+    if (this.shouldUseNativeWatcher()) {
       this.nativeStarting = true;
       void this.createNativeWatcher();
       return;
@@ -190,8 +194,8 @@ export class FileWatcher {
     watcher.add(watchTargets);
   }
 
-  private shouldUseExperimentalNativeWatcher(): boolean {
-    if (process.env.CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER !== "true") {
+  private shouldUseNativeWatcher(): boolean {
+    if (this.backend === "chokidar") {
       return false;
     }
 

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -7,6 +7,8 @@ import type { CodebaseIndexConfig } from "../config/schema.js";
 import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
+import { NativeRecursiveWatcher } from "./native-recursive-watcher.js";
+import { FileSnapshotReconciler } from "./snapshot-reconciler.js";
 
 export type FileChangeType = "add" | "change" | "unlink";
 
@@ -35,6 +37,11 @@ export class FileWatcher {
   private resolveReady: (() => void) | null = null;
   private pollingFallbackAttempted = false;
   private pendingClose: Promise<void> | null = null;
+  private nativeWatcher: NativeRecursiveWatcher | null = null;
+  private nativeReconciler: FileSnapshotReconciler | null = null;
+  private nativeSetupGeneration = 0;
+  private nativeStarting = false;
+  private nativeReconcileTimer: NodeJS.Timeout | null = null;
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -46,13 +53,18 @@ export class FileWatcher {
   }
 
   start(handler: ChangeHandler): void {
-    if (this.watcher) {
+    if (this.watcher || this.nativeWatcher || this.nativeStarting) {
       return;
     }
 
     this.onChanges = handler;
     this.pollingFallbackAttempted = false;
     this.resetReady();
+    if (this.shouldUseExperimentalNativeWatcher()) {
+      this.nativeStarting = true;
+      void this.createNativeWatcher();
+      return;
+    }
     this.createWatcher();
   }
 
@@ -178,6 +190,109 @@ export class FileWatcher {
     watcher.add(watchTargets);
   }
 
+  private shouldUseExperimentalNativeWatcher(): boolean {
+    if (process.env.CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER !== "true") {
+      return false;
+    }
+
+    return this.projectConfigPaths.every((configPath) => {
+      const relativePath = path.relative(this.projectRoot, configPath);
+      return !this.isOutsideProjectPath(relativePath);
+    });
+  }
+
+  private async createNativeWatcher(): Promise<void> {
+    const generation = ++this.nativeSetupGeneration;
+    const reconciler = new FileSnapshotReconciler(this.projectRoot, this.config, this.projectConfigPaths);
+
+    try {
+      await reconciler.initialize();
+      if (!this.isCurrentNativeSetup(generation)) return;
+
+      const watcher = new NativeRecursiveWatcher(
+        this.projectRoot,
+        () => this.scheduleNativeReconciliation(generation),
+        { onError: (error) => void this.fallbackFromNativeWatcher(generation, error) },
+      );
+      watcher.start();
+      if (!this.isCurrentNativeSetup(generation)) {
+        await watcher.stop();
+        return;
+      }
+
+      this.nativeWatcher = watcher;
+      this.nativeReconciler = reconciler;
+      this.nativeStarting = false;
+      const initialChanges = await reconciler.reconcile();
+      if (!this.isCurrentNativeSetup(generation) || this.nativeWatcher !== watcher) return;
+
+      this.recordChanges(initialChanges);
+      this.resolveReady?.();
+      this.resolveReady = null;
+    } catch (error) {
+      if (!this.isCurrentNativeSetup(generation)) return;
+      if (this.nativeWatcher) {
+        await this.fallbackFromNativeWatcher(generation, error);
+        return;
+      }
+
+      this.nativeStarting = false;
+      this.nativeReconciler = null;
+      console.warn("[codebase-index] Native recursive watcher unavailable; using Chokidar fallback.", error);
+      this.createWatcher();
+    }
+  }
+
+  private isCurrentNativeSetup(generation: number): boolean {
+    return this.nativeSetupGeneration === generation && this.onChanges !== null;
+  }
+
+  private scheduleNativeReconciliation(generation: number): void {
+    if (!this.isCurrentNativeSetup(generation)) return;
+
+    if (this.nativeReconcileTimer) {
+      clearTimeout(this.nativeReconcileTimer);
+    }
+    this.nativeReconcileTimer = setTimeout(() => {
+      this.nativeReconcileTimer = null;
+      void this.reconcileNativeWatcher(generation);
+    }, 100);
+  }
+
+  private async reconcileNativeWatcher(generation: number): Promise<void> {
+    if (!this.isCurrentNativeSetup(generation) || !this.nativeReconciler) return;
+
+    try {
+      const reconciler = this.nativeReconciler;
+      const changes = await reconciler.reconcile();
+      if (!this.isCurrentNativeSetup(generation) || this.nativeReconciler !== reconciler) return;
+
+      this.recordChanges(changes);
+    } catch (error) {
+      await this.fallbackFromNativeWatcher(generation, error);
+    }
+  }
+
+  private async fallbackFromNativeWatcher(generation: number, error: unknown): Promise<void> {
+    if (!this.isCurrentNativeSetup(generation)) return;
+
+    const watcher = this.nativeWatcher;
+    this.nativeWatcher = null;
+    this.nativeReconciler = null;
+    this.nativeStarting = false;
+    this.nativeSetupGeneration += 1;
+    if (this.nativeReconcileTimer) {
+      clearTimeout(this.nativeReconcileTimer);
+      this.nativeReconcileTimer = null;
+    }
+
+    console.warn("[codebase-index] Native recursive watcher failed; using Chokidar fallback.", error);
+    await watcher?.stop();
+    if (this.onChanges) {
+      this.createWatcher();
+    }
+  }
+
   private handleChange(watcher: FSWatcher, type: FileChangeType, filePath: string): void {
     if (this.watcher !== watcher) {
       return;
@@ -202,7 +317,15 @@ export class FileWatcher {
       return;
     }
 
-    this.pendingChanges.set(filePath, type);
+    this.recordChanges([{ path: filePath, type }]);
+  }
+
+  private recordChanges(changes: FileChange[]): void {
+    if (changes.length === 0) return;
+
+    for (const change of changes) {
+      this.pendingChanges.set(change.path, change.type);
+    }
     this.scheduleFlush();
   }
 
@@ -274,23 +397,32 @@ export class FileWatcher {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
+    if (this.nativeReconcileTimer) {
+      clearTimeout(this.nativeReconcileTimer);
+      this.nativeReconcileTimer = null;
+    }
 
     const watcher = this.watcher;
+    const nativeWatcher = this.nativeWatcher;
     const pendingClose = this.pendingClose;
     const resolveReady = this.resolveReady;
     this.watcher = null;
+    this.nativeWatcher = null;
+    this.nativeReconciler = null;
+    this.nativeStarting = false;
+    this.nativeSetupGeneration += 1;
     this.pendingClose = null;
     this.resolveReady = null;
     this.readyPromise = null;
     this.pendingChanges.clear();
     this.onChanges = null;
-    await Promise.all([watcher?.close(), pendingClose]);
+    await Promise.all([watcher?.close(), nativeWatcher?.stop(), pendingClose]);
 
     resolveReady?.();
   }
 
   isRunning(): boolean {
-    return this.watcher !== null;
+    return this.watcher !== null || this.nativeWatcher !== null || this.nativeStarting;
   }
 
   async waitUntilReady(): Promise<void> {

--- a/src/watcher/native-recursive-watcher.ts
+++ b/src/watcher/native-recursive-watcher.ts
@@ -1,0 +1,89 @@
+import { watch, type WatchEventType, type WatchOptions } from "node:fs";
+import * as path from "node:path";
+
+export type NativeRecursiveWatcherChangeHandler = (absolutePath: string | null) => void | Promise<void>;
+
+export type NativeFsWatchListener = (
+  eventType: WatchEventType,
+  filename: string | Buffer | null | undefined,
+) => void;
+
+type NativeFsWatcherHandle = {
+  close(): void | Promise<void>;
+};
+
+export type NativeRecursiveWatcherFactory = (
+  root: string,
+  listener: NativeFsWatchListener,
+  options: WatchOptions,
+) => NativeFsWatcherHandle;
+
+export interface NativeRecursiveWatcherOptions {
+  watchFactory?: NativeRecursiveWatcherFactory;
+}
+
+export class NativeRecursiveWatcher {
+  private watcher: NativeFsWatcherHandle | null = null;
+  private listenerToken = 0;
+
+  private readonly watchFactory: NativeRecursiveWatcherFactory;
+
+  constructor(
+    private readonly root: string,
+    private readonly onChange: NativeRecursiveWatcherChangeHandler,
+    options: NativeRecursiveWatcherOptions = {},
+  ) {
+    this.watchFactory = options.watchFactory ?? this.defaultWatchFactory;
+  }
+
+  start(): void {
+    if (this.watcher) return;
+
+    const token = ++this.listenerToken;
+    const listener: NativeFsWatchListener = (_eventType, filename) => {
+      if (this.watcher === null || this.listenerToken !== token) return;
+
+      const absolutePath = this.toAbsolutePath(filename);
+      const nextResult = this.onChange(absolutePath);
+
+      if (nextResult instanceof Promise) {
+        void nextResult.catch((error: unknown) => {
+          console.error("[codebase-index] Error handling native watcher event:", error);
+        });
+      }
+    };
+
+    this.watcher = this.watchFactory(this.root, listener, {
+      persistent: true,
+      recursive: true,
+    });
+  }
+
+  async stop(): Promise<void> {
+    const watcher = this.watcher;
+    this.watcher = null;
+    this.listenerToken += 1;
+
+    if (!watcher) return;
+
+    await watcher.close();
+  }
+
+  private toAbsolutePath(filename: string | Buffer | null | undefined): string | null {
+    if (filename == null) return null;
+
+    const normalizedFilename = typeof filename === "string" ? filename : filename.toString();
+    const absolutePath = path.resolve(this.root, normalizedFilename);
+    const relativePath = path.relative(this.root, absolutePath);
+    const outsideRoot = relativePath === ".."
+      || relativePath.startsWith(`..${path.sep}`)
+      || path.isAbsolute(relativePath);
+    return outsideRoot ? null : absolutePath;
+  }
+
+  private defaultWatchFactory: NativeRecursiveWatcherFactory = (
+    root,
+    listener,
+    options,
+  ) => watch(root, options, listener);
+}

--- a/src/watcher/native-recursive-watcher.ts
+++ b/src/watcher/native-recursive-watcher.ts
@@ -10,6 +10,7 @@ export type NativeFsWatchListener = (
 
 type NativeFsWatcherHandle = {
   close(): void | Promise<void>;
+  on?(event: "error", listener: (error: Error) => void): void;
 };
 
 export type NativeRecursiveWatcherFactory = (
@@ -19,6 +20,7 @@ export type NativeRecursiveWatcherFactory = (
 ) => NativeFsWatcherHandle;
 
 export interface NativeRecursiveWatcherOptions {
+  onError?: (error: Error) => void;
   watchFactory?: NativeRecursiveWatcherFactory;
 }
 
@@ -27,6 +29,7 @@ export class NativeRecursiveWatcher {
   private listenerToken = 0;
 
   private readonly watchFactory: NativeRecursiveWatcherFactory;
+  private readonly onError: ((error: Error) => void) | undefined;
 
   constructor(
     private readonly root: string,
@@ -34,6 +37,7 @@ export class NativeRecursiveWatcher {
     options: NativeRecursiveWatcherOptions = {},
   ) {
     this.watchFactory = options.watchFactory ?? this.defaultWatchFactory;
+    this.onError = options.onError;
   }
 
   start(): void {
@@ -53,10 +57,16 @@ export class NativeRecursiveWatcher {
       }
     };
 
-    this.watcher = this.watchFactory(this.root, listener, {
+    const watcher = this.watchFactory(this.root, listener, {
       persistent: true,
       recursive: true,
     });
+    watcher.on?.("error", (error) => {
+      if (this.watcher === watcher && this.listenerToken === token) {
+        this.onError?.(error);
+      }
+    });
+    this.watcher = watcher;
   }
 
   async stop(): Promise<void> {

--- a/src/watcher/snapshot-reconciler.ts
+++ b/src/watcher/snapshot-reconciler.ts
@@ -1,0 +1,44 @@
+import type { CodebaseIndexConfig } from "../config/schema.js";
+import type { FileChange } from "./file-watcher.js";
+
+import { buildFileSnapshot, diffFileSnapshots, type FileSnapshotMap } from "./snapshot.js";
+
+export type SnapshotFilterConfig = Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">;
+
+export class FileSnapshotReconciler {
+  private snapshot: FileSnapshotMap | null = null;
+  private reconciliationTail: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly projectRoot: string,
+    private readonly config: SnapshotFilterConfig,
+    private readonly configPaths: string[],
+  ) {}
+
+  async initialize(): Promise<void> {
+    this.snapshot = await buildFileSnapshot(this.projectRoot, this.config, this.configPaths);
+  }
+
+  async reconcile(): Promise<FileChange[]> {
+    if (this.snapshot === null) {
+      throw new Error("FileSnapshotReconciler is not initialized. Call initialize() before reconcile().");
+    }
+
+    const reconciliation = this.reconciliationTail.then(async () => {
+      const previousSnapshot = this.snapshot;
+      if (previousSnapshot === null) {
+        throw new Error("FileSnapshotReconciler is not initialized. Call initialize() before reconcile().");
+      }
+
+      const nextSnapshot = await buildFileSnapshot(this.projectRoot, this.config, this.configPaths);
+      const changes = diffFileSnapshots(previousSnapshot, nextSnapshot);
+      this.snapshot = nextSnapshot;
+      return changes;
+    });
+    this.reconciliationTail = reconciliation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return reconciliation;
+  }
+}

--- a/src/watcher/snapshot-reconciler.ts
+++ b/src/watcher/snapshot-reconciler.ts
@@ -1,7 +1,13 @@
 import type { CodebaseIndexConfig } from "../config/schema.js";
 import type { FileChange } from "./file-watcher.js";
 
-import { buildFileSnapshot, diffFileSnapshots, type FileSnapshotMap } from "./snapshot.js";
+import {
+  buildFileSnapshot,
+  buildFileSnapshotForPath,
+  diffFileSnapshots,
+  isWithinPath,
+  type FileSnapshotMap,
+} from "./snapshot.js";
 
 export type SnapshotFilterConfig = Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">;
 
@@ -19,7 +25,7 @@ export class FileSnapshotReconciler {
     this.snapshot = await buildFileSnapshot(this.projectRoot, this.config, this.configPaths);
   }
 
-  async reconcile(): Promise<FileChange[]> {
+  async reconcile(invalidatedPaths: readonly (string | null)[] = []): Promise<FileChange[]> {
     if (this.snapshot === null) {
       throw new Error("FileSnapshotReconciler is not initialized. Call initialize() before reconcile().");
     }
@@ -30,7 +36,10 @@ export class FileSnapshotReconciler {
         throw new Error("FileSnapshotReconciler is not initialized. Call initialize() before reconcile().");
       }
 
-      const nextSnapshot = await buildFileSnapshot(this.projectRoot, this.config, this.configPaths);
+      const scopedPaths = invalidatedPaths.filter((filePath): filePath is string => filePath !== null);
+      const nextSnapshot = scopedPaths.length === 0 || scopedPaths.length !== invalidatedPaths.length
+        ? await buildFileSnapshot(this.projectRoot, this.config, this.configPaths)
+        : await this.reconcilePaths(previousSnapshot, scopedPaths);
       const changes = diffFileSnapshots(previousSnapshot, nextSnapshot);
       this.snapshot = nextSnapshot;
       return changes;
@@ -40,5 +49,40 @@ export class FileSnapshotReconciler {
       () => undefined,
     );
     return reconciliation;
+  }
+
+  private async reconcilePaths(
+    previousSnapshot: FileSnapshotMap,
+    invalidatedPaths: readonly string[],
+  ): Promise<FileSnapshotMap> {
+    const scopes = this.getScopes(invalidatedPaths);
+    const nextSnapshot = new Map(previousSnapshot);
+
+    for (const scope of scopes) {
+      for (const previousPath of nextSnapshot.keys()) {
+        if (isWithinPath(scope, previousPath)) {
+          nextSnapshot.delete(previousPath);
+        }
+      }
+
+      const scopedSnapshot = await buildFileSnapshotForPath(
+        this.projectRoot,
+        this.config,
+        this.configPaths,
+        scope,
+      );
+      for (const [filePath, entry] of scopedSnapshot) {
+        nextSnapshot.set(filePath, entry);
+      }
+    }
+
+    return nextSnapshot;
+  }
+
+  private getScopes(invalidatedPaths: readonly string[]): string[] {
+    const uniquePaths = [...new Set(invalidatedPaths)].sort((left, right) => left.length - right.length);
+    return uniquePaths.filter((candidate, index) => !uniquePaths.slice(0, index).some(
+      (ancestor) => isWithinPath(ancestor, candidate),
+    ));
   }
 }

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -1,4 +1,12 @@
+import type { Dirent, Stats } from "node:fs";
+import type { CodebaseIndexConfig } from "../config/schema.js";
 import type { FileChange, FileChangeType } from "./file-watcher.js";
+
+import { promises as fsPromises } from "node:fs";
+import * as path from "node:path";
+
+import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
+import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
 export interface FileSnapshotEntry {
   readonly size: number;
@@ -6,6 +14,119 @@ export interface FileSnapshotEntry {
 }
 
 export type FileSnapshotMap = ReadonlyMap<string, FileSnapshotEntry>;
+
+export async function buildFileSnapshot(
+  projectRoot: string,
+  config: Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">,
+  configPaths: string[] = [],
+): Promise<FileSnapshotMap> {
+  const normalizedProjectRoot = path.resolve(projectRoot);
+  const ignoreFilter = createIgnoreFilter(normalizedProjectRoot);
+  const includePatterns = [...config.include, ...(config.additionalInclude ?? [])];
+
+  const snapshot = new Map<string, FileSnapshotEntry>();
+
+  const includeFile = async (filePath: string): Promise<void> => {
+    const normalizedPath = path.resolve(filePath);
+    if (!shouldIncludeFile(
+      normalizedPath,
+      normalizedProjectRoot,
+      includePatterns,
+      config.exclude,
+      ignoreFilter,
+    )) {
+      return;
+    }
+
+    const stat = await readStatIfFile(normalizedPath);
+    if (!stat) return;
+
+    snapshot.set(normalizedPath, {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    });
+  };
+
+  const walk = async (directoryPath: string): Promise<void> => {
+    let entries: Dirent[];
+    try {
+      entries = await fsPromises.readdir(directoryPath, { withFileTypes: true });
+    } catch (error) {
+      if (isIgnorableFsError(error)) {
+        return;
+      }
+      throw error;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(directoryPath, entry.name);
+      const relativePath = path.relative(normalizedProjectRoot, fullPath);
+
+      if (entry.isDirectory()) {
+        if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) {
+          continue;
+        }
+
+        if (ignoreFilter.ignores(relativePath)) {
+          continue;
+        }
+
+        await walk(fullPath);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        await includeFile(fullPath);
+      }
+    }
+  };
+
+  await walk(normalizedProjectRoot);
+
+  await includeExplicitConfigPaths(snapshot, configPaths);
+  return snapshot;
+}
+
+async function includeExplicitConfigPaths(
+  snapshot: Map<string, FileSnapshotEntry>,
+  configPaths: string[],
+): Promise<void> {
+  const explicitConfigPaths = [...new Set(configPaths.map((configPath) => path.resolve(configPath)))]
+    .filter((configPath) => !snapshot.has(configPath));
+
+  for (const configPath of explicitConfigPaths) {
+    const stat = await readStatIfFile(configPath);
+    if (!stat) {
+      continue;
+    }
+
+    snapshot.set(configPath, {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    });
+  }
+}
+
+async function readStatIfFile(filePath: string): Promise<Stats | null> {
+  try {
+    const stat = await fsPromises.stat(filePath);
+    return stat.isFile() ? stat : null;
+  } catch (error) {
+    if (isIgnorableFsError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function isIgnorableFsError(error: unknown): error is NodeJS.ErrnoException {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return ["ENOENT", "ENOTDIR", "EACCES", "EPERM"].includes((error as NodeJS.ErrnoException).code ?? "");
+}
 
 const diffTypeOrder: Record<FileChangeType, number> = {
   add: 0,

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -87,6 +87,83 @@ export async function buildFileSnapshot(
   return snapshot;
 }
 
+export async function buildFileSnapshotForPath(
+  projectRoot: string,
+  config: Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">,
+  configPaths: string[],
+  targetPath: string,
+): Promise<FileSnapshotMap> {
+  const normalizedProjectRoot = path.resolve(projectRoot);
+  const normalizedTargetPath = path.resolve(targetPath);
+  if (!isWithinPath(normalizedProjectRoot, normalizedTargetPath)) {
+    return new Map();
+  }
+
+  const ignoreFilter = createIgnoreFilter(normalizedProjectRoot);
+  const includePatterns = [...config.include, ...(config.additionalInclude ?? [])];
+  const explicitConfigPaths = new Set(configPaths.map((configPath) => path.resolve(configPath)));
+  const snapshot = new Map<string, FileSnapshotEntry>();
+
+  const includeFile = async (filePath: string): Promise<void> => {
+    const normalizedPath = path.resolve(filePath);
+    if (
+      !explicitConfigPaths.has(normalizedPath)
+      && !shouldIncludeFile(
+        normalizedPath,
+        normalizedProjectRoot,
+        includePatterns,
+        config.exclude,
+        ignoreFilter,
+      )
+    ) {
+      return;
+    }
+
+    const stat = await readStatIfFile(normalizedPath);
+    if (!stat) return;
+
+    snapshot.set(normalizedPath, {
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    });
+  };
+
+  const walk = async (directoryPath: string): Promise<void> => {
+    let entries: Dirent[];
+    try {
+      entries = await fsPromises.readdir(directoryPath, { withFileTypes: true });
+    } catch (error) {
+      if (isIgnorableFsError(error)) return;
+      throw error;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(directoryPath, entry.name);
+      const relativePath = path.relative(normalizedProjectRoot, fullPath);
+
+      if (entry.isDirectory()) {
+        if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) {
+          continue;
+        }
+        if (ignoreFilter.ignores(relativePath)) continue;
+        await walk(fullPath);
+      } else if (entry.isFile()) {
+        await includeFile(fullPath);
+      }
+    }
+  };
+
+  const targetStat = await readStatIfFile(normalizedTargetPath);
+  if (targetStat) {
+    await includeFile(normalizedTargetPath);
+  } else {
+    await walk(normalizedTargetPath);
+  }
+
+  await includeExplicitConfigPathsInPath(snapshot, configPaths, normalizedTargetPath);
+  return snapshot;
+}
+
 async function includeExplicitConfigPaths(
   snapshot: Map<string, FileSnapshotEntry>,
   configPaths: string[],
@@ -105,6 +182,20 @@ async function includeExplicitConfigPaths(
       mtimeMs: stat.mtimeMs,
     });
   }
+}
+
+async function includeExplicitConfigPathsInPath(
+  snapshot: Map<string, FileSnapshotEntry>,
+  configPaths: string[],
+  targetPath: string,
+): Promise<void> {
+  const configPathsInTarget = configPaths.filter((configPath) => isWithinPath(targetPath, path.resolve(configPath)));
+  await includeExplicitConfigPaths(snapshot, configPathsInTarget);
+}
+
+export function isWithinPath(parentPath: string, childPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath);
+  return relativePath === "" || (!relativePath.startsWith(`..${path.sep}`) && relativePath !== ".." && !path.isAbsolute(relativePath));
 }
 
 async function readStatIfFile(filePath: string): Promise<Stats | null> {

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -1,0 +1,39 @@
+import type { FileChange, FileChangeType } from "./file-watcher.js";
+
+export interface FileSnapshotEntry {
+  readonly size: number;
+  readonly mtimeMs: number;
+}
+
+export type FileSnapshotMap = ReadonlyMap<string, FileSnapshotEntry>;
+
+const diffTypeOrder: Record<FileChangeType, number> = {
+  add: 0,
+  change: 1,
+  unlink: 2,
+};
+
+export function diffFileSnapshots(previous: FileSnapshotMap, current: FileSnapshotMap): FileChange[] {
+  const changes: FileChange[] = [];
+
+  for (const [path, previousEntry] of previous) {
+    const currentEntry = current.get(path);
+    if (!currentEntry) {
+      changes.push({ type: "unlink", path });
+    } else if (currentEntry.size !== previousEntry.size || currentEntry.mtimeMs !== previousEntry.mtimeMs) {
+      changes.push({ type: "change", path });
+    }
+  }
+
+  for (const [path] of current) {
+    if (!previous.has(path)) {
+      changes.push({ type: "add", path });
+    }
+  }
+
+  return changes.sort((left, right) => {
+    if (left.path < right.path) return -1;
+    if (left.path > right.path) return 1;
+    return diffTypeOrder[left.type] - diffTypeOrder[right.type];
+  });
+}

--- a/tests/snapshot.test.ts
+++ b/tests/snapshot.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { FileSnapshotEntry, FileSnapshotMap } from "../src/watcher/snapshot.js";
+import { diffFileSnapshots } from "../src/watcher/snapshot.js";
+
+describe("watcher snapshot diff", () => {
+  it("reports add, change, and unlink operations", () => {
+    const previous: FileSnapshotMap = new Map<string, FileSnapshotEntry>([
+      ["src/index.ts", { size: 8, mtimeMs: 100 }],
+      ["src/old.ts", { size: 4, mtimeMs: 120 }],
+    ]);
+
+    const current: FileSnapshotMap = new Map<string, FileSnapshotEntry>([
+      ["src/index.ts", { size: 12, mtimeMs: 100 }],
+      ["src/new.ts", { size: 3, mtimeMs: 210 }],
+      ["src/added-later.ts", { size: 1, mtimeMs: 220 }],
+    ]);
+
+    const changes = diffFileSnapshots(previous, current);
+
+    expect(changes).toEqual([
+      { path: "src/added-later.ts", type: "add" },
+      { path: "src/index.ts", type: "change" },
+      { path: "src/new.ts", type: "add" },
+      { path: "src/old.ts", type: "unlink" },
+    ]);
+  });
+
+  it("omits unchanged files", () => {
+    const previous: FileSnapshotMap = new Map<string, FileSnapshotEntry>([
+      ["src/common.ts", { size: 44, mtimeMs: 300 }],
+      ["src/ignored.ts", { size: 12, mtimeMs: 500 }],
+    ]);
+
+    const current: FileSnapshotMap = new Map<string, FileSnapshotEntry>([
+      ["src/ignored.ts", { size: 12, mtimeMs: 500 }],
+      ["src/common.ts", { size: 44, mtimeMs: 300 }],
+    ]);
+
+    expect(diffFileSnapshots(previous, current)).toEqual([]);
+  });
+
+  it("returns deterministic ordering by path", () => {
+    const previous: FileSnapshotMap = new Map<string, FileSnapshotEntry>([
+      ["zeta.ts", { size: 10, mtimeMs: 1 }],
+      ["alpha.ts", { size: 12, mtimeMs: 2 }],
+      ["gamma.ts", { size: 3, mtimeMs: 3 }],
+    ]);
+
+    const current: FileSnapshotMap = new Map<string, FileSnapshotEntry>([
+      ["beta.ts", { size: 9, mtimeMs: 4 }],
+      ["alpha.ts", { size: 99, mtimeMs: 5 }],
+      ["zeta.ts", { size: 10, mtimeMs: 1 }],
+      ["delta.ts", { size: 8, mtimeMs: 6 }],
+    ]);
+
+    const changes = diffFileSnapshots(previous, current);
+
+    expect(changes.map((change) => `${change.type}:${change.path}`)).toEqual([
+      "change:alpha.ts",
+      "add:beta.ts",
+      "add:delta.ts",
+      "unlink:gamma.ts",
+    ]);
+  });
+});

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -254,10 +254,10 @@ describe("watcher config refresh", () => {
   it("refreshes a linked worktree when a local project override file appears after watcher ready", async () => {
     const { indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir);
     const localConfigPath = path.join(worktreeDir, ".opencode", "codebase-index.json");
+    mkdirSync(path.dirname(localConfigPath), { recursive: true });
 
     try {
       await watcher.whenReady();
-      mkdirSync(path.dirname(localConfigPath), { recursive: true });
       await writeUntilObserved(
         (attempt) => writeFileSync(
           localConfigPath,

--- a/tests/watcher-emfile.test.ts
+++ b/tests/watcher-emfile.test.ts
@@ -33,7 +33,7 @@ describe("FileWatcher EMFILE recovery", () => {
       return this === addSpy.mock.instances[0] ? nativeClose : pollingClose;
     });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode", { backend: "chokidar" });
 
     watcher.start(vi.fn());
 
@@ -78,7 +78,7 @@ describe("FileWatcher EMFILE recovery", () => {
     });
     vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode", { backend: "chokidar" });
 
     watcher.start(vi.fn());
     const nativeWatcher = addSpy.mock.instances[0] as FSWatcher;
@@ -116,7 +116,7 @@ describe("FileWatcher EMFILE recovery", () => {
     });
     const firstHandler = vi.fn();
     const secondHandler = vi.fn();
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode", { backend: "chokidar" });
 
     watcher.start(firstHandler);
     (addSpy.mock.instances[0] as FSWatcher).emit("ready");
@@ -162,7 +162,7 @@ describe("FileWatcher EMFILE recovery", () => {
     });
     vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode");
+    const watcher = new FileWatcher("/tmp/project", parseConfig({ include: ["**/*.ts"] }), "opencode", { backend: "chokidar" });
 
     watcher.start(vi.fn());
 

--- a/tests/watcher-native-integration.test.ts
+++ b/tests/watcher-native-integration.test.ts
@@ -18,25 +18,28 @@ async function waitForChange(
   }, { timeout: EVENT_TIMEOUT_MS, interval: 25 });
 }
 
-describe.runIf(process.platform === "darwin")("experimental native FileWatcher", () => {
+describe("native FileWatcher", () => {
   let projectRoot: string;
   let watcher: FileWatcher | undefined;
 
   beforeEach(() => {
     projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "native-file-watcher-"));
-    vi.stubEnv("CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER", "true");
   });
 
   afterEach(async () => {
     await watcher?.stop();
-    vi.unstubAllEnvs();
     fs.rmSync(projectRoot, { recursive: true, force: true });
   });
 
   it("reconciles native notifications into add, change, and unlink events", async () => {
     const changes: FileChange[] = [];
     const filePath = path.join(projectRoot, "observed.ts");
-    watcher = new FileWatcher(projectRoot, parseConfig({ include: ["**/*.ts"] }), "codex");
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
 
     watcher.start(async (batch) => {
       changes.push(...batch);
@@ -58,7 +61,12 @@ describe.runIf(process.platform === "darwin")("experimental native FileWatcher",
   it("tracks hidden project configuration files outside source include patterns", async () => {
     const changes: FileChange[] = [];
     const configPath = path.join(projectRoot, ".codebase-index", "config.json");
-    watcher = new FileWatcher(projectRoot, parseConfig({ include: ["**/*.ts"] }), "codex");
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
 
     watcher.start(async (batch) => {
       changes.push(...batch);

--- a/tests/watcher-native-integration.test.ts
+++ b/tests/watcher-native-integration.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { parseConfig } from "../src/config/schema.js";
+import { FileWatcher, type FileChange, type FileChangeType } from "../src/watcher/file-watcher.js";
+
+const EVENT_TIMEOUT_MS = 10_000;
+
+async function waitForChange(
+  changes: FileChange[],
+  filePath: string,
+  type: FileChangeType,
+): Promise<void> {
+  await vi.waitFor(() => {
+    expect(changes).toContainEqual({ path: filePath, type });
+  }, { timeout: EVENT_TIMEOUT_MS, interval: 25 });
+}
+
+describe.runIf(process.platform === "darwin")("experimental native FileWatcher", () => {
+  let projectRoot: string;
+  let watcher: FileWatcher | undefined;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "native-file-watcher-"));
+    vi.stubEnv("CODEBASE_INDEX_EXPERIMENTAL_NATIVE_WATCHER", "true");
+  });
+
+  afterEach(async () => {
+    await watcher?.stop();
+    vi.unstubAllEnvs();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("reconciles native notifications into add, change, and unlink events", async () => {
+    const changes: FileChange[] = [];
+    const filePath = path.join(projectRoot, "observed.ts");
+    watcher = new FileWatcher(projectRoot, parseConfig({ include: ["**/*.ts"] }), "codex");
+
+    watcher.start(async (batch) => {
+      changes.push(...batch);
+    });
+    await watcher.waitUntilReady();
+
+    fs.writeFileSync(filePath, "export const version = 1;\n");
+    await waitForChange(changes, filePath, "add");
+
+    changes.length = 0;
+    fs.writeFileSync(filePath, "export const version = 200;\n");
+    await waitForChange(changes, filePath, "change");
+
+    changes.length = 0;
+    fs.rmSync(filePath);
+    await waitForChange(changes, filePath, "unlink");
+  });
+
+  it("tracks hidden project configuration files outside source include patterns", async () => {
+    const changes: FileChange[] = [];
+    const configPath = path.join(projectRoot, ".codebase-index", "config.json");
+    watcher = new FileWatcher(projectRoot, parseConfig({ include: ["**/*.ts"] }), "codex");
+
+    watcher.start(async (batch) => {
+      changes.push(...batch);
+    });
+    await watcher.waitUntilReady();
+
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify({ include: ["src/**/*.ts"] }));
+    await waitForChange(changes, configPath, "add");
+  });
+});

--- a/tests/watcher-platform-capability.test.ts
+++ b/tests/watcher-platform-capability.test.ts
@@ -1,0 +1,69 @@
+import { watch, type WatchEventType } from "node:fs";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface RecursiveWatchCapability {
+  code?: string;
+  events?: Array<{ eventType: WatchEventType; filename: string | null }>;
+  platform: NodeJS.Platform;
+  supported: boolean;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return (error as NodeJS.ErrnoException).code;
+  }
+  return undefined;
+}
+
+describe("recursive native watcher capability", () => {
+  let projectRoot: string | undefined;
+  let watcher: ReturnType<typeof watch> | undefined;
+
+  afterEach(() => {
+    watcher?.close();
+    if (projectRoot) {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("records whether the current Node runtime supports recursive fs.watch", async () => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "recursive-watch-capability-"));
+    const events: Array<{ eventType: WatchEventType; filename: string | null }> = [];
+
+    try {
+      watcher = watch(projectRoot, { recursive: true }, (eventType, filename) => {
+        events.push({
+          eventType,
+          filename: filename === null ? null : filename.toString(),
+        });
+      });
+    } catch (error) {
+      const code = getErrorCode(error);
+      const capability: RecursiveWatchCapability = {
+        code,
+        platform: process.platform,
+        supported: false,
+      };
+      console.log(`[watcher-capability] ${JSON.stringify(capability)}`);
+      expect(code).toBe("ERR_FEATURE_UNAVAILABLE_ON_PLATFORM");
+      return;
+    }
+
+    fs.writeFileSync(path.join(projectRoot, "observed.ts"), "export const value = 1;\n");
+    await vi.waitFor(() => {
+      expect(events).not.toHaveLength(0);
+    }, { timeout: 10_000, interval: 25 });
+
+    const capability: RecursiveWatchCapability = {
+      events,
+      platform: process.platform,
+      supported: true,
+    };
+    console.log(`[watcher-capability] ${JSON.stringify(capability)}`);
+    expect(events).not.toHaveLength(0);
+  });
+});

--- a/tests/watcher-snapshot-reconciler.test.ts
+++ b/tests/watcher-snapshot-reconciler.test.ts
@@ -96,6 +96,59 @@ describe("watcher snapshot reconciler", () => {
     expect(second).toEqual([]);
   });
 
+  it("reconciles only the invalidated file path", async () => {
+    const observedFile = path.join(projectRoot, "observed.ts");
+    const unrelatedFile = path.join(projectRoot, "unrelated.ts");
+    fs.writeFileSync(observedFile, "export const observed = 1;");
+    fs.writeFileSync(unrelatedFile, "export const unrelated = 1;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.writeFileSync(observedFile, "export const observed = 2;");
+    fs.writeFileSync(unrelatedFile, "export const unrelated = 2;");
+
+    expect(await reconciler.reconcile([observedFile])).toEqual([
+      { path: observedFile, type: "change" },
+    ]);
+    expect(await reconciler.reconcile()).toEqual([
+      { path: unrelatedFile, type: "change" },
+    ]);
+  });
+
+  it("removes every tracked descendant when an invalidated directory was deleted", async () => {
+    const removedDirectory = path.join(projectRoot, "removed");
+    const firstFile = path.join(removedDirectory, "first.ts");
+    const secondFile = path.join(removedDirectory, "nested", "second.ts");
+    fs.mkdirSync(path.dirname(secondFile), { recursive: true });
+    fs.writeFileSync(firstFile, "export const first = 1;");
+    fs.writeFileSync(secondFile, "export const second = 2;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.rmSync(removedDirectory, { recursive: true });
+
+    expect(await reconciler.reconcile([removedDirectory])).toEqual([
+      { path: firstFile, type: "unlink" },
+      { path: secondFile, type: "unlink" },
+    ]);
+  });
+
+  it("uses a full reconciliation when native watcher supplies no path hint", async () => {
+    const trackedFile = path.join(projectRoot, "tracked.ts");
+    fs.writeFileSync(trackedFile, "export const tracked = 1;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.writeFileSync(trackedFile, "export const tracked = 2;");
+
+    expect(await reconciler.reconcile([null])).toEqual([
+      { path: trackedFile, type: "change" },
+    ]);
+  });
+
   it("throws before initialization", async () => {
     const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
     await expect(reconciler.reconcile()).rejects.toThrow(

--- a/tests/watcher-snapshot-reconciler.test.ts
+++ b/tests/watcher-snapshot-reconciler.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { FileSnapshotReconciler } from "../src/watcher/snapshot-reconciler.js";
+
+describe("watcher snapshot reconciler", () => {
+  let projectRoot: string;
+  let cleanupPaths: string[];
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-snapshot-reconciler-"));
+    cleanupPaths = [];
+  });
+
+  const cleanup = (): void => {
+    for (const cleanupPath of cleanupPaths) {
+      fs.rmSync(cleanupPath, { recursive: true, force: true });
+    }
+
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  };
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const reconcileConfig = {
+    include: ["**/*.ts"],
+    additionalInclude: [],
+    exclude: ["**/*.test.ts"],
+  };
+
+  it("diffs adds, changes, and unlinks after initialization", async () => {
+    const trackedOne = path.join(projectRoot, "tracked-one.ts");
+    const trackedTwo = path.join(projectRoot, "tracked-two.ts");
+    const removed = path.join(projectRoot, "tracked-removed.ts");
+    const added = path.join(projectRoot, "new.ts");
+
+    fs.writeFileSync(trackedOne, "export const one = 1;");
+    fs.writeFileSync(trackedTwo, "export const two = 2;");
+    fs.writeFileSync(removed, "export const removed = 3;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.unlinkSync(removed);
+    fs.writeFileSync(trackedOne, "export const one = 10;");
+    fs.writeFileSync(added, "export const added = 4;");
+
+    const changes = await reconciler.reconcile();
+    expect(changes).toEqual([
+      { path: added, type: "add" },
+      { path: trackedOne, type: "change" },
+      { path: removed, type: "unlink" },
+    ]);
+  });
+
+  it("reports explicit config delete and recreate events", async () => {
+    const externalConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-snapshot-config-"));
+    cleanupPaths.push(externalConfigDir);
+    const externalConfig = path.join(externalConfigDir, "project.config.json");
+    const internalConfig = path.join(projectRoot, ".internal.config.json");
+
+    fs.writeFileSync(externalConfig, "{}\n");
+    fs.writeFileSync(internalConfig, "{}\n");
+
+    const trackedFile = path.join(projectRoot, "tracked.ts");
+    fs.writeFileSync(trackedFile, "export const tracked = 1;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, [internalConfig, externalConfig]);
+    await reconciler.initialize();
+
+    fs.rmSync(externalConfig);
+
+    const afterDelete = await reconciler.reconcile();
+    expect(afterDelete).toEqual([{ path: externalConfig, type: "unlink" }]);
+
+    fs.writeFileSync(externalConfig, "{}\n");
+    const afterRecreate = await reconciler.reconcile();
+    expect(afterRecreate).toEqual([{ path: externalConfig, type: "add" }]);
+  });
+
+  it("serializes overlapping reconciliations without duplicate changes", async () => {
+    const trackedFile = path.join(projectRoot, "tracked.ts");
+    fs.writeFileSync(trackedFile, "export const version = 1;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.writeFileSync(trackedFile, "export const version = 2;");
+    const [first, second] = await Promise.all([reconciler.reconcile(), reconciler.reconcile()]);
+
+    expect(first).toEqual([{ path: trackedFile, type: "change" }]);
+    expect(second).toEqual([]);
+  });
+
+  it("throws before initialization", async () => {
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await expect(reconciler.reconcile()).rejects.toThrow(
+      "FileSnapshotReconciler is not initialized. Call initialize() before reconcile().",
+    );
+  });
+});

--- a/tests/watcher-snapshot.test.ts
+++ b/tests/watcher-snapshot.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { buildFileSnapshot } from "../src/watcher/snapshot.js";
+
+describe("watcher snapshot builder", () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-snapshot-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("includes only indexable in-project files and skips ignored/restricted paths", async () => {
+    const includeRoot = path.join(projectRoot, "src");
+    fs.mkdirSync(includeRoot, { recursive: true });
+    fs.writeFileSync(path.join(includeRoot, "index.ts"), "export const x = 1;");
+    fs.writeFileSync(path.join(includeRoot, "index.test.ts"), "export const y = 2;");
+    fs.writeFileSync(path.join(projectRoot, "README.md"), "# README");
+
+    const nodeModulesDir = path.join(projectRoot, "node_modules");
+    fs.mkdirSync(path.join(nodeModulesDir, "pkg"), { recursive: true });
+    fs.writeFileSync(path.join(nodeModulesDir, "pkg", "ignored.ts"), "export const ignored = true;");
+
+    const hiddenDir = path.join(projectRoot, ".hidden");
+    fs.mkdirSync(path.join(hiddenDir, "nested"), { recursive: true });
+    fs.writeFileSync(path.join(hiddenDir, "nested", "ignored.ts"), "export const hidden = true;");
+
+    const restrictedDir = path.join(projectRoot, "Library");
+    fs.mkdirSync(path.join(restrictedDir, "runtime"), { recursive: true });
+    fs.writeFileSync(path.join(restrictedDir, "runtime", "ignored.ts"), "export const restricted = true;");
+
+    const snapshot = await buildFileSnapshot(
+      projectRoot,
+      {
+        include: ["**/*.{ts,md}"],
+        additionalInclude: [],
+        exclude: ["**/*.test.ts"],
+      },
+      [],
+    );
+
+    const expectedPaths = new Set([
+      path.join(includeRoot, "index.ts"),
+      path.join(projectRoot, "README.md"),
+    ]);
+
+    for (const entryPath of Array.from(snapshot.keys())) {
+      expect(path.isAbsolute(entryPath)).toBe(true);
+    }
+
+    expect(Array.from(snapshot.keys()).sort()).toEqual(Array.from(expectedPaths).sort());
+    expect(snapshot.has(path.join(includeRoot, "index.test.ts"))).toBe(false);
+    expect(snapshot.has(path.join(nodeModulesDir, "pkg", "ignored.ts"))).toBe(false);
+    expect(snapshot.has(path.join(hiddenDir, "nested", "ignored.ts"))).toBe(false);
+    expect(snapshot.has(path.join(restrictedDir, "runtime", "ignored.ts"))).toBe(false);
+  });
+
+  it("includes explicit hidden and external config files outside the project", async () => {
+    const insideHiddenConfig = path.join(projectRoot, ".config", "watcher.config");
+    fs.mkdirSync(path.join(projectRoot, ".config"), { recursive: true });
+    fs.writeFileSync(insideHiddenConfig, "{}");
+
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-snapshot-config-"));
+    const outsideConfig = path.join(outsideRoot, ".external-config");
+    fs.writeFileSync(outsideConfig, "{}");
+
+    const trackedFile = path.join(projectRoot, "index.ts");
+    fs.writeFileSync(trackedFile, "export const x = 1;");
+
+    try {
+      const snapshot = await buildFileSnapshot(
+        projectRoot,
+        {
+          include: ["**/*.ts"],
+          additionalInclude: [],
+          exclude: ["**/*.test.ts"],
+        },
+        [insideHiddenConfig, outsideConfig],
+      );
+
+      expect(snapshot.has(path.join(projectRoot, "index.ts"))).toBe(true);
+      expect(snapshot.has(insideHiddenConfig)).toBe(true);
+      expect(snapshot.has(outsideConfig)).toBe(true);
+    } finally {
+      fs.rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/watcher/native-recursive-watcher.test.ts
+++ b/tests/watcher/native-recursive-watcher.test.ts
@@ -79,6 +79,28 @@ describe("NativeRecursiveWatcher", () => {
     expect(() => watcher.start()).toThrow(expectedError);
   });
 
+  it("forwards current watcher errors and ignores stale error callbacks", async () => {
+    const root = path.join(os.tmpdir(), "codebase-index-root-errors");
+    let capturedErrorListener: ((error: Error) => void) | null = null;
+    const watcherHandle = {
+      close: vi.fn(),
+      on: vi.fn((_event: "error", listener: (error: Error) => void) => {
+        capturedErrorListener = listener;
+      }),
+    };
+    const onError = vi.fn();
+    const watchFactory: NativeRecursiveWatcherFactory = vi.fn(() => watcherHandle);
+    const watcher = new NativeRecursiveWatcher(root, vi.fn(), { onError, watchFactory });
+
+    watcher.start();
+    capturedErrorListener!(new Error("current watcher error"));
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "current watcher error" }));
+
+    await watcher.stop();
+    capturedErrorListener!(new Error("stale watcher error"));
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
   it("suppresses callbacks after stop", async () => {
     const root = path.join(os.tmpdir(), "codebase-index-root-4");
     let capturedListener: NativeFsWatchListener | null = null;

--- a/tests/watcher/native-recursive-watcher.test.ts
+++ b/tests/watcher/native-recursive-watcher.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { NativeRecursiveWatcher } from "../../src/watcher/native-recursive-watcher.js";
+
+type NativeFsWatchListener = (
+  eventType: "rename" | "change",
+  filename: string | Buffer | null | undefined,
+) => void;
+type NativeRecursiveWatcherFactory = (
+  root: string,
+  listener: NativeFsWatchListener,
+  options: { recursive?: boolean; persistent?: boolean },
+) => { close: () => void };
+
+describe("NativeRecursiveWatcher", () => {
+  it("passes recursive: true to fs.watch", async () => {
+    let capturedOptions: { recursive?: boolean } | null = null;
+    const watcherHandle = {
+      close: vi.fn(),
+    };
+    const watchFactory: NativeRecursiveWatcherFactory = vi.fn((_root, listener, options) => {
+      capturedOptions = options;
+      return watcherHandle;
+    });
+
+    const root = path.join(os.tmpdir(), "codebase-index-root");
+    const watcher = new NativeRecursiveWatcher(root, vi.fn(), { watchFactory });
+
+    watcher.start();
+
+    expect(watchFactory).toHaveBeenCalledOnce();
+    expect(capturedOptions).toMatchObject({ recursive: true, persistent: true });
+    await watcher.stop();
+    expect(watcherHandle.close).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes string, Buffer, and null filenames to absolute path or null", async () => {
+    const root = path.join(os.tmpdir(), "codebase-index-root-2");
+    const changes: Array<string | null> = [];
+    let capturedListener: NativeFsWatchListener | null = null;
+    const watchFactory: NativeRecursiveWatcherFactory = vi.fn((_root, listener) => {
+      capturedListener = listener;
+      return { close: vi.fn() };
+    });
+
+    const watcher = new NativeRecursiveWatcher(root, (nextPath) => {
+      changes.push(nextPath);
+    }, { watchFactory });
+
+    watcher.start();
+    expect(capturedListener).toBeTypeOf("function");
+
+    capturedListener!("rename", "foo.txt");
+    capturedListener!("change", Buffer.from("bar.txt"));
+    capturedListener!("rename", null);
+    capturedListener!("rename", "../outside.txt");
+
+    expect(changes).toEqual([
+      path.resolve(root, "foo.txt"),
+      path.resolve(root, "bar.txt"),
+      null,
+      null,
+    ]);
+
+    await watcher.stop();
+  });
+
+  it("propagates watch startup failures", () => {
+    const root = path.join(os.tmpdir(), "codebase-index-root-3");
+    const expectedError = new Error("failed to start native watch");
+    const watchFactory: NativeRecursiveWatcherFactory = vi.fn(() => {
+      throw expectedError;
+    });
+
+    const watcher = new NativeRecursiveWatcher(root, vi.fn(), { watchFactory });
+
+    expect(() => watcher.start()).toThrow(expectedError);
+  });
+
+  it("suppresses callbacks after stop", async () => {
+    const root = path.join(os.tmpdir(), "codebase-index-root-4");
+    let capturedListener: NativeFsWatchListener | null = null;
+    const watchFactory: NativeRecursiveWatcherFactory = vi.fn((_root, listener) => {
+      capturedListener = listener;
+      return { close: vi.fn() };
+    });
+    const onChange = vi.fn();
+
+    const watcher = new NativeRecursiveWatcher(root, onChange, { watchFactory });
+    watcher.start();
+
+    await watcher.stop();
+    capturedListener!("change", "stale.txt");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #268

## Summary
- adds a snapshot-reconciled, opt-in native recursive watcher prototype
- preserves Chokidar as the default and fallback
- adds descriptor and semantic-event benchmarks plus platform capability evidence

## Validation
- macOS native integration passed three consecutive runs
- 2,000-file native benchmark showed effectively zero descriptor growth while preserving add/change/unlink
- full local gate passed: build, typecheck, lint, and 1,412 tests

This remains draft until the new Ubuntu and Windows CI evidence is reviewed.