### PR TITLE
fix: handle MCP shutdown signals during startup

### DIFF
--- a/scripts/smoke-test-built-cli.mjs
+++ b/scripts/smoke-test-built-cli.mjs
@@ -6,7 +6,7 @@ import * as path from "node:path";
 
 const require = createRequire(import.meta.url);
 
-function runCliCommand(args, { killAfterMs = null, action = null } = {}) {
+function runCliCommand(args, { killAfterMs = null, action = null, actionDelayMs = 1_000 } = {}) {
   return new Promise((resolve, reject) => {
     const command = [cliPath, ...args];
     const child = spawn(process.execPath, command, {
@@ -36,7 +36,7 @@ function runCliCommand(args, { killAfterMs = null, action = null } = {}) {
     const actionTimer = action
       ? setTimeout(() => {
         action(child);
-      }, 250)
+      }, actionDelayMs)
       : null;
 
     child.once("exit", (code, signal) => {

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -249,23 +249,7 @@ export async function runMcpCli(argv: string[]): Promise<void> {
 
   const server = createMcpServer(args.project, config, args.host);
   const transport = new StdioServerTransport();
-
-  await server.connect(transport);
-
   let watcher: CombinedWatcher | null = null;
-  const isHomeDir = isHomeDirectory(args.project);
-  const isValidProject = !isHomeDir && (!config.indexing.requireProjectMarker || hasProjectMarker(args.project));
-
-  if (config.indexing.watchFiles && isValidProject) {
-    watcher = createWatcherWithIndexer(
-      () => getIndexerForProject(args.project, args.host),
-      args.project,
-      config,
-      args.host,
-      args.config ? { configPath: args.config } : {},
-    );
-  }
-
   let shutdownPromise: Promise<void> | undefined;
   const onServerClose = server.server.onclose;
 
@@ -320,6 +304,22 @@ export async function runMcpCli(argv: string[]): Promise<void> {
   if (process.platform !== "win32") {
     process.once("SIGHUP", requestShutdown);
     process.once("SIGTERM", requestShutdown);
+  }
+
+  await server.connect(transport);
+  if (shutdownPromise) return;
+
+  const isHomeDir = isHomeDirectory(args.project);
+  const isValidProject = !isHomeDir && (!config.indexing.requireProjectMarker || hasProjectMarker(args.project));
+
+  if (config.indexing.watchFiles && isValidProject) {
+    watcher = createWatcherWithIndexer(
+      () => getIndexerForProject(args.project, args.host),
+      args.project,
+      config,
+      args.host,
+      args.config ? { configPath: args.config } : {},
+    );
   }
 }
 

--- a/tests/mcp-cli-lifecycle.test.ts
+++ b/tests/mcp-cli-lifecycle.test.ts
@@ -199,6 +199,35 @@ describe("MCP CLI shutdown lifecycle", () => {
     expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:1"]);
   });
 
+  it("handles SIGINT while MCP transport startup is still pending", async () => {
+    const connectGate = createDeferred<void>();
+    server.connect = vi.fn(() => connectGate.promise);
+    lifecycleMocks.createMcpServer.mockReturnValue(server);
+
+    const cliPromise = runMcpCli([
+      "node",
+      "dist/cli.js",
+      "--host",
+      "jcode",
+      "--project",
+      tempDir,
+      "--config",
+      path.join(tempDir, "config.json"),
+    ]);
+    await Promise.resolve();
+
+    process.emit("SIGINT");
+    connectGate.resolve();
+    await cliPromise;
+
+    await vi.waitFor(() => {
+      expect(lifecycleMocks.exit).toHaveBeenCalledWith(0);
+    });
+    expect(watcher.stop).not.toHaveBeenCalled();
+    expect(lifecycleMocks.stopAutoIndex).toHaveBeenCalledOnce();
+    expect(server.close).toHaveBeenCalledOnce();
+  });
+
   it("runs teardown when the MCP server closes", async () => {
     await startCli();
 


### PR DESCRIPTION
Fixes the main CI regression introduced by #267: signal handlers are installed before awaiting MCP transport connection, so SIGINT/SIGTERM/SIGHUP cannot terminate the process with their default signal behavior during startup. Adds a regression test for SIGINT while transport startup is pending.\n\nValidation: 
> opencode-codebase-index@0.22.5 typecheck
> tsc --noEmit, 
[1m[46m RUN [49m[22m [36mv4.1.2 [39m[90m/Users/kenneth/.jcode/scratch/mcp-signal-hotfix-1227[39m

 [32m✓[39m tests/mcp-cli-lifecycle.test.ts [2m([22m[2m10 tests[22m[2m)[22m[33m 530[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m10 passed[39m[22m[90m (10)[39m
[2m   Start at [22m 14:28:14
[2m   Duration [22m 1.30s[2m (transform 462ms, setup 0ms, import 653ms, tests 530ms, environment 0ms)[22m, and 
> opencode-codebase-index@0.22.5 build:ts
> tsup && node scripts/smoke-test-built-cli.mjs

CLI Building entry: src/cli.ts, src/index.ts, src/pi-extension.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/kenneth/.jcode/scratch/mcp-signal-hotfix-1227/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
ESM dist/cli.js              830.40 KB
ESM dist/pi-extension.js     618.74 KB
ESM dist/index.js            751.86 KB
ESM dist/index.js.map        1.39 MB
ESM dist/pi-extension.js.map 1.17 MB
ESM dist/cli.js.map          1.54 MB
ESM ⚡️ Build success in 176ms
CJS dist/pi-extension.cjs     624.45 KB
CJS dist/cli.cjs              834.46 KB
CJS dist/index.cjs            754.84 KB
CJS dist/pi-extension.cjs.map 1.17 MB
CJS dist/index.cjs.map        1.39 MB
CJS dist/cli.cjs.map          1.54 MB
CJS ⚡️ Build success in 177ms.