### PR TITLE
fix: harden watcher snapshot reconciliation

### DIFF
--- a/src/watcher/snapshot-reconciler.ts
+++ b/src/watcher/snapshot-reconciler.ts
@@ -1,15 +1,17 @@
-import type { CodebaseIndexConfig } from "../config/schema.js";
 import type { FileChange } from "./file-watcher.js";
 
 import {
-  buildFileSnapshot,
-  buildFileSnapshotForPath,
+  buildFileSnapshotScan,
+  buildFileSnapshotForPathScan,
+  completeFileSnapshot,
   diffFileSnapshots,
   isWithinPath,
   type FileSnapshotMap,
+  type FileSnapshotScan,
+  type SnapshotFilterConfig,
 } from "./snapshot.js";
 
-export type SnapshotFilterConfig = Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">;
+export type { SnapshotFilterConfig } from "./snapshot.js";
 
 export class FileSnapshotReconciler {
   private snapshot: FileSnapshotMap | null = null;
@@ -22,7 +24,7 @@ export class FileSnapshotReconciler {
   ) {}
 
   async initialize(): Promise<void> {
-    this.snapshot = await buildFileSnapshot(this.projectRoot, this.config, this.configPaths);
+    this.snapshot = (await buildFileSnapshotScan(this.projectRoot, this.config, this.configPaths)).entries;
   }
 
   async reconcile(invalidatedPaths: readonly (string | null)[] = []): Promise<FileChange[]> {
@@ -37,46 +39,37 @@ export class FileSnapshotReconciler {
       }
 
       const scopedPaths = invalidatedPaths.filter((filePath): filePath is string => filePath !== null);
-      const nextSnapshot = scopedPaths.length === 0 || scopedPaths.length !== invalidatedPaths.length
-        ? await buildFileSnapshot(this.projectRoot, this.config, this.configPaths)
+      const scan = scopedPaths.length === 0 || scopedPaths.length !== invalidatedPaths.length
+        ? await buildFileSnapshotScan(this.projectRoot, this.config, this.configPaths)
         : await this.reconcilePaths(previousSnapshot, scopedPaths);
+      const nextSnapshot = completeFileSnapshot(previousSnapshot, scan);
       const changes = diffFileSnapshots(previousSnapshot, nextSnapshot);
       this.snapshot = nextSnapshot;
       return changes;
     });
-    this.reconciliationTail = reconciliation.then(
-      () => undefined,
-      () => undefined,
-    );
+    this.reconciliationTail = reconciliation.then(() => undefined, () => undefined);
     return reconciliation;
   }
 
   private async reconcilePaths(
     previousSnapshot: FileSnapshotMap,
     invalidatedPaths: readonly string[],
-  ): Promise<FileSnapshotMap> {
+  ): Promise<FileSnapshotScan> {
     const scopes = this.getScopes(invalidatedPaths);
-    const nextSnapshot = new Map(previousSnapshot);
+    const entries = new Map(previousSnapshot);
+    const unreadablePrefixes = new Set<string>();
 
     for (const scope of scopes) {
-      for (const previousPath of nextSnapshot.keys()) {
-        if (isWithinPath(scope, previousPath)) {
-          nextSnapshot.delete(previousPath);
-        }
+      for (const previousPath of entries.keys()) {
+        if (isWithinPath(scope, previousPath)) entries.delete(previousPath);
       }
 
-      const scopedSnapshot = await buildFileSnapshotForPath(
-        this.projectRoot,
-        this.config,
-        this.configPaths,
-        scope,
-      );
-      for (const [filePath, entry] of scopedSnapshot) {
-        nextSnapshot.set(filePath, entry);
-      }
+      const scopedScan = await buildFileSnapshotForPathScan(this.projectRoot, this.config, this.configPaths, scope);
+      for (const [filePath, entry] of scopedScan.entries) entries.set(filePath, entry);
+      for (const unreadablePrefix of scopedScan.unreadablePrefixes) unreadablePrefixes.add(unreadablePrefix);
     }
 
-    return nextSnapshot;
+    return { entries, unreadablePrefixes };
   }
 
   private getScopes(invalidatedPaths: readonly string[]): string[] {

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -2,7 +2,7 @@ import type { Dirent, Stats } from "node:fs";
 import type { CodebaseIndexConfig } from "../config/schema.js";
 import type { FileChange, FileChangeType } from "./file-watcher.js";
 
-import { promises as fsPromises } from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
@@ -14,45 +14,51 @@ export interface FileSnapshotEntry {
 }
 
 export type FileSnapshotMap = ReadonlyMap<string, FileSnapshotEntry>;
+export type SnapshotFilterConfig = Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude"> & {
+  indexing?: { maxDepth?: number };
+};
+
+export interface FileSnapshotScan {
+  readonly entries: FileSnapshotMap;
+  readonly unreadablePrefixes: ReadonlySet<string>;
+}
 
 export async function buildFileSnapshot(
   projectRoot: string,
-  config: Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">,
+  config: SnapshotFilterConfig,
   configPaths: string[] = [],
 ): Promise<FileSnapshotMap> {
+  return (await buildFileSnapshotScan(projectRoot, config, configPaths)).entries;
+}
+
+export async function buildFileSnapshotScan(
+  projectRoot: string,
+  config: SnapshotFilterConfig,
+  configPaths: string[] = [],
+): Promise<FileSnapshotScan> {
   const normalizedProjectRoot = path.resolve(projectRoot);
   const ignoreFilter = createIgnoreFilter(normalizedProjectRoot);
   const includePatterns = [...config.include, ...(config.additionalInclude ?? [])];
-
+  const maxDepth = config.indexing?.maxDepth ?? -1;
   const snapshot = new Map<string, FileSnapshotEntry>();
+  const unreadablePrefixes = new Set<string>();
 
   const includeFile = async (filePath: string): Promise<void> => {
     const normalizedPath = path.resolve(filePath);
-    if (!shouldIncludeFile(
-      normalizedPath,
-      normalizedProjectRoot,
-      includePatterns,
-      config.exclude,
-      ignoreFilter,
-    )) {
-      return;
-    }
+    if (!shouldIncludeFile(normalizedPath, normalizedProjectRoot, includePatterns, config.exclude, ignoreFilter)) return;
 
-    const stat = await readStatIfFile(normalizedPath);
-    if (!stat) return;
-
-    snapshot.set(normalizedPath, {
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-    });
+    const stat = await readStatIfFile(normalizedPath, unreadablePrefixes);
+    if (stat) snapshot.set(normalizedPath, { size: stat.size, mtimeMs: stat.mtimeMs });
   };
 
-  const walk = async (directoryPath: string): Promise<void> => {
+  const walk = async (directoryPath: string, depth: number): Promise<void> => {
     let entries: Dirent[];
     try {
       entries = await fsPromises.readdir(directoryPath, { withFileTypes: true });
     } catch (error) {
-      if (isIgnorableFsError(error)) {
+      if (isMissingFsError(error)) return;
+      if (isPermissionFsError(error)) {
+        unreadablePrefixes.add(path.resolve(directoryPath));
         return;
       }
       throw error;
@@ -61,136 +67,123 @@ export async function buildFileSnapshot(
     for (const entry of entries) {
       const fullPath = path.join(directoryPath, entry.name);
       const relativePath = path.relative(normalizedProjectRoot, fullPath);
-
       if (entry.isDirectory()) {
-        if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) {
-          continue;
-        }
-
-        if (ignoreFilter.ignores(relativePath)) {
-          continue;
-        }
-
-        await walk(fullPath);
-        continue;
-      }
-
-      if (entry.isFile()) {
-        await includeFile(fullPath);
-      }
-    }
-  };
-
-  await walk(normalizedProjectRoot);
-
-  await includeExplicitConfigPaths(snapshot, configPaths);
-  return snapshot;
-}
-
-export async function buildFileSnapshotForPath(
-  projectRoot: string,
-  config: Pick<CodebaseIndexConfig, "include" | "additionalInclude" | "exclude">,
-  configPaths: string[],
-  targetPath: string,
-): Promise<FileSnapshotMap> {
-  const normalizedProjectRoot = path.resolve(projectRoot);
-  const normalizedTargetPath = path.resolve(targetPath);
-  if (!isWithinPath(normalizedProjectRoot, normalizedTargetPath)) {
-    return new Map();
-  }
-
-  const ignoreFilter = createIgnoreFilter(normalizedProjectRoot);
-  const includePatterns = [...config.include, ...(config.additionalInclude ?? [])];
-  const explicitConfigPaths = new Set(configPaths.map((configPath) => path.resolve(configPath)));
-  const snapshot = new Map<string, FileSnapshotEntry>();
-
-  const includeFile = async (filePath: string): Promise<void> => {
-    const normalizedPath = path.resolve(filePath);
-    if (
-      !explicitConfigPaths.has(normalizedPath)
-      && !shouldIncludeFile(
-        normalizedPath,
-        normalizedProjectRoot,
-        includePatterns,
-        config.exclude,
-        ignoreFilter,
-      )
-    ) {
-      return;
-    }
-
-    const stat = await readStatIfFile(normalizedPath);
-    if (!stat) return;
-
-    snapshot.set(normalizedPath, {
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-    });
-  };
-
-  const walk = async (directoryPath: string): Promise<void> => {
-    let entries: Dirent[];
-    try {
-      entries = await fsPromises.readdir(directoryPath, { withFileTypes: true });
-    } catch (error) {
-      if (isIgnorableFsError(error)) return;
-      throw error;
-    }
-
-    for (const entry of entries) {
-      const fullPath = path.join(directoryPath, entry.name);
-      const relativePath = path.relative(normalizedProjectRoot, fullPath);
-
-      if (entry.isDirectory()) {
-        if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) {
-          continue;
-        }
+        if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) continue;
         if (ignoreFilter.ignores(relativePath)) continue;
-        await walk(fullPath);
+        if (maxDepth === -1 || depth < maxDepth) await walk(fullPath, depth + 1);
       } else if (entry.isFile()) {
         await includeFile(fullPath);
       }
     }
   };
 
-  const targetStat = await readStatIfFile(normalizedTargetPath);
-  if (targetStat) {
-    await includeFile(normalizedTargetPath);
-  } else {
-    await walk(normalizedTargetPath);
+  await walk(normalizedProjectRoot, 0);
+  await includeExplicitConfigPaths(snapshot, unreadablePrefixes, configPaths);
+  return { entries: snapshot, unreadablePrefixes };
+}
+
+export async function buildFileSnapshotForPath(
+  projectRoot: string,
+  config: SnapshotFilterConfig,
+  configPaths: string[],
+  targetPath: string,
+): Promise<FileSnapshotMap> {
+  return (await buildFileSnapshotForPathScan(projectRoot, config, configPaths, targetPath)).entries;
+}
+
+export async function buildFileSnapshotForPathScan(
+  projectRoot: string,
+  config: SnapshotFilterConfig,
+  configPaths: string[],
+  targetPath: string,
+): Promise<FileSnapshotScan> {
+  const normalizedProjectRoot = path.resolve(projectRoot);
+  const normalizedTargetPath = path.resolve(targetPath);
+  if (!isWithinPath(normalizedProjectRoot, normalizedTargetPath)) {
+    return { entries: new Map(), unreadablePrefixes: new Set() };
   }
 
-  await includeExplicitConfigPathsInPath(snapshot, configPaths, normalizedTargetPath);
-  return snapshot;
+  const ignoreFilter = createIgnoreFilter(normalizedProjectRoot);
+  const includePatterns = [...config.include, ...(config.additionalInclude ?? [])];
+  const maxDepth = config.indexing?.maxDepth ?? -1;
+  const explicitConfigPaths = new Set(configPaths.map((configPath) => path.resolve(configPath)));
+  const snapshot = new Map<string, FileSnapshotEntry>();
+  const unreadablePrefixes = new Set<string>();
+
+  const includeFile = async (filePath: string): Promise<void> => {
+    const normalizedPath = path.resolve(filePath);
+    if (!explicitConfigPaths.has(normalizedPath) && !shouldIncludeFile(
+      normalizedPath, normalizedProjectRoot, includePatterns, config.exclude, ignoreFilter,
+    )) return;
+    const stat = await readStatIfFile(normalizedPath, unreadablePrefixes);
+    if (stat) snapshot.set(normalizedPath, { size: stat.size, mtimeMs: stat.mtimeMs });
+  };
+
+  const walk = async (directoryPath: string, depth: number): Promise<void> => {
+    let entries: Dirent[];
+    try {
+      entries = await fsPromises.readdir(directoryPath, { withFileTypes: true });
+    } catch (error) {
+      if (isMissingFsError(error)) return;
+      if (isPermissionFsError(error)) {
+        unreadablePrefixes.add(path.resolve(directoryPath));
+        return;
+      }
+      throw error;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(directoryPath, entry.name);
+      const relativePath = path.relative(normalizedProjectRoot, fullPath);
+      if (entry.isDirectory()) {
+        if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) continue;
+        if (ignoreFilter.ignores(relativePath)) continue;
+        if (maxDepth === -1 || depth < maxDepth) await walk(fullPath, depth + 1);
+      } else if (entry.isFile()) {
+        await includeFile(fullPath);
+      }
+    }
+  };
+
+  const targetStat = await readStatIfFile(normalizedTargetPath, unreadablePrefixes);
+  if (targetStat) await includeFile(normalizedTargetPath);
+  else await walk(normalizedTargetPath, 0);
+  await includeExplicitConfigPathsInPath(snapshot, unreadablePrefixes, configPaths, normalizedTargetPath);
+  return { entries: snapshot, unreadablePrefixes };
+}
+
+export function completeFileSnapshot(previous: FileSnapshotMap, scan: FileSnapshotScan): FileSnapshotMap {
+  const completed = new Map(scan.entries);
+  for (const unreadablePrefix of scan.unreadablePrefixes) {
+    for (const [entryPath, entry] of previous) {
+      if (isWithinPath(unreadablePrefix, entryPath) && !completed.has(entryPath)) completed.set(entryPath, entry);
+    }
+  }
+  return completed;
 }
 
 async function includeExplicitConfigPaths(
   snapshot: Map<string, FileSnapshotEntry>,
+  unreadablePrefixes: Set<string>,
   configPaths: string[],
 ): Promise<void> {
-  const explicitConfigPaths = [...new Set(configPaths.map((configPath) => path.resolve(configPath)))]
-    .filter((configPath) => !snapshot.has(configPath));
-
-  for (const configPath of explicitConfigPaths) {
-    const stat = await readStatIfFile(configPath);
-    if (!stat) {
-      continue;
-    }
-
-    snapshot.set(configPath, {
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-    });
+  for (const configPath of [...new Set(configPaths.map((value) => path.resolve(value)))]) {
+    if (snapshot.has(configPath)) continue;
+    const stat = await readStatIfFile(configPath, unreadablePrefixes);
+    if (stat) snapshot.set(configPath, { size: stat.size, mtimeMs: stat.mtimeMs });
   }
 }
 
 async function includeExplicitConfigPathsInPath(
   snapshot: Map<string, FileSnapshotEntry>,
+  unreadablePrefixes: Set<string>,
   configPaths: string[],
   targetPath: string,
 ): Promise<void> {
-  const configPathsInTarget = configPaths.filter((configPath) => isWithinPath(targetPath, path.resolve(configPath)));
-  await includeExplicitConfigPaths(snapshot, configPathsInTarget);
+  await includeExplicitConfigPaths(
+    snapshot,
+    unreadablePrefixes,
+    configPaths.filter((configPath) => isWithinPath(targetPath, path.resolve(configPath))),
+  );
 }
 
 export function isWithinPath(parentPath: string, childPath: string): boolean {
@@ -198,54 +191,41 @@ export function isWithinPath(parentPath: string, childPath: string): boolean {
   return relativePath === "" || (!relativePath.startsWith(`..${path.sep}`) && relativePath !== ".." && !path.isAbsolute(relativePath));
 }
 
-async function readStatIfFile(filePath: string): Promise<Stats | null> {
+async function readStatIfFile(filePath: string, unreadablePrefixes: Set<string>): Promise<Stats | null> {
   try {
     const stat = await fsPromises.stat(filePath);
     return stat.isFile() ? stat : null;
   } catch (error) {
-    if (isIgnorableFsError(error)) {
+    if (isMissingFsError(error)) return null;
+    if (isPermissionFsError(error)) {
+      unreadablePrefixes.add(path.resolve(filePath));
       return null;
     }
-
     throw error;
   }
 }
 
-function isIgnorableFsError(error: unknown): error is NodeJS.ErrnoException {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return ["ENOENT", "ENOTDIR", "EACCES", "EPERM"].includes((error as NodeJS.ErrnoException).code ?? "");
+function isMissingFsError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && ["ENOENT", "ENOTDIR"].includes((error as NodeJS.ErrnoException).code ?? "");
 }
 
-const diffTypeOrder: Record<FileChangeType, number> = {
-  add: 0,
-  change: 1,
-  unlink: 2,
-};
+function isPermissionFsError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && ["EACCES", "EPERM"].includes((error as NodeJS.ErrnoException).code ?? "");
+}
+
+const diffTypeOrder: Record<FileChangeType, number> = { add: 0, change: 1, unlink: 2 };
 
 export function diffFileSnapshots(previous: FileSnapshotMap, current: FileSnapshotMap): FileChange[] {
   const changes: FileChange[] = [];
-
-  for (const [path, previousEntry] of previous) {
-    const currentEntry = current.get(path);
-    if (!currentEntry) {
-      changes.push({ type: "unlink", path });
-    } else if (currentEntry.size !== previousEntry.size || currentEntry.mtimeMs !== previousEntry.mtimeMs) {
-      changes.push({ type: "change", path });
+  for (const [filePath, previousEntry] of previous) {
+    const currentEntry = current.get(filePath);
+    if (!currentEntry) changes.push({ type: "unlink", path: filePath });
+    else if (currentEntry.size !== previousEntry.size || currentEntry.mtimeMs !== previousEntry.mtimeMs) {
+      changes.push({ type: "change", path: filePath });
     }
   }
-
-  for (const [path] of current) {
-    if (!previous.has(path)) {
-      changes.push({ type: "add", path });
-    }
+  for (const [filePath] of current) {
+    if (!previous.has(filePath)) changes.push({ type: "add", path: filePath });
   }
-
-  return changes.sort((left, right) => {
-    if (left.path < right.path) return -1;
-    if (left.path > right.path) return 1;
-    return diffTypeOrder[left.type] - diffTypeOrder[right.type];
-  });
+  return changes.sort((left, right) => left.path.localeCompare(right.path) || diffTypeOrder[left.type] - diffTypeOrder[right.type]);
 }

--- a/tests/watcher-snapshot-reconciler.test.ts
+++ b/tests/watcher-snapshot-reconciler.test.ts
@@ -1,9 +1,29 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-
 import { FileSnapshotReconciler } from "../src/watcher/snapshot-reconciler.js";
+
+const readdirPermissionOverrides = new Map<string, string>();
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+
+  return {
+    ...actual,
+    readdir: async (directoryPath: string | URL, options: any) => {
+      const resolvedPath = path.resolve(String(directoryPath));
+      const permissionCode = readdirPermissionOverrides.get(resolvedPath);
+      if (permissionCode) {
+        const permissionError = new Error("Permission denied") as NodeJS.ErrnoException;
+        permissionError.code = permissionCode;
+        throw permissionError;
+      }
+
+      return actual.readdir(directoryPath, options);
+    },
+  };
+});
 
 describe("watcher snapshot reconciler", () => {
   let projectRoot: string;
@@ -154,5 +174,50 @@ describe("watcher snapshot reconciler", () => {
     await expect(reconciler.reconcile()).rejects.toThrow(
       "FileSnapshotReconciler is not initialized. Call initialize() before reconcile().",
     );
+  });
+
+  it("preserves tracked files under unreadable directories during full reconciliation", async () => {
+    const visibleFile = path.join(projectRoot, "visible.ts");
+    const unreadableDirectory = path.join(projectRoot, "private");
+    const unreadableFile = path.join(unreadableDirectory, "secret.ts");
+
+    fs.writeFileSync(visibleFile, "export const visible = 1;");
+    fs.mkdirSync(unreadableDirectory, { recursive: true });
+    fs.writeFileSync(unreadableFile, "export const secret = 1;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.unlinkSync(visibleFile);
+
+    readdirPermissionOverrides.set(unreadableDirectory, "EACCES");
+    try {
+      const changes = await reconciler.reconcile();
+      expect(changes).toEqual([{ path: visibleFile, type: "unlink" }]);
+    } finally {
+      readdirPermissionOverrides.delete(unreadableDirectory);
+    }
+  });
+
+  it("keeps scope-limited reconciliations scoped and preserves unreadable scope roots", async () => {
+    const scopeDirectory = path.join(projectRoot, "private");
+    const visibleFile = path.join(projectRoot, "visible.ts");
+    const unreadableFile = path.join(scopeDirectory, "secret.ts");
+
+    fs.mkdirSync(scopeDirectory, { recursive: true });
+    fs.writeFileSync(visibleFile, "export const visible = 1;");
+    fs.writeFileSync(unreadableFile, "export const secret = 1;");
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    readdirPermissionOverrides.set(scopeDirectory, "EPERM");
+    fs.writeFileSync(visibleFile, "export const visible = 2;");
+    try {
+      const scopedChanges = await reconciler.reconcile([scopeDirectory]);
+      expect(scopedChanges).toEqual([]);
+    } finally {
+      readdirPermissionOverrides.delete(scopeDirectory);
+    }
   });
 });

--- a/tests/watcher-snapshot.test.ts
+++ b/tests/watcher-snapshot.test.ts
@@ -91,4 +91,55 @@ describe("watcher snapshot builder", () => {
       fs.rmSync(outsideRoot, { recursive: true, force: true });
     }
   });
+
+  it("limits traversal depth using config.indexing.maxDepth", async () => {
+    const rootFile = path.join(projectRoot, "root.ts");
+    const nestedLevelOne = path.join(projectRoot, "level-one", "nested.ts");
+    const nestedLevelTwo = path.join(projectRoot, "level-one", "level-two", "deeper.ts");
+
+    fs.mkdirSync(path.dirname(nestedLevelOne), { recursive: true });
+    fs.mkdirSync(path.dirname(nestedLevelTwo), { recursive: true });
+    fs.writeFileSync(rootFile, "export const root = 1;");
+    fs.writeFileSync(nestedLevelOne, "export const one = 1;");
+    fs.writeFileSync(nestedLevelTwo, "export const two = 1;");
+
+    const limitedDepth = await buildFileSnapshot(
+      projectRoot,
+      {
+        include: ["**/*.ts"],
+        additionalInclude: [],
+        exclude: [],
+        indexing: {
+          maxDepth: 1,
+        },
+      },
+      [],
+    );
+
+    expect(Array.from(limitedDepth.keys()).sort()).toEqual([rootFile, nestedLevelOne].sort());
+  });
+
+  it("preserves unlimited traversal when indexing.maxDepth is absent", async () => {
+    const rootFile = path.join(projectRoot, "root.ts");
+    const nestedLevelOne = path.join(projectRoot, "level-one", "nested.ts");
+    const nestedLevelTwo = path.join(projectRoot, "level-one", "level-two", "deeper.ts");
+
+    fs.mkdirSync(path.dirname(nestedLevelOne), { recursive: true });
+    fs.mkdirSync(path.dirname(nestedLevelTwo), { recursive: true });
+    fs.writeFileSync(rootFile, "export const root = 1;");
+    fs.writeFileSync(nestedLevelOne, "export const one = 1;");
+    fs.writeFileSync(nestedLevelTwo, "export const two = 1;");
+
+    const unlimitedDepth = await buildFileSnapshot(
+      projectRoot,
+      {
+        include: ["**/*.ts"],
+        additionalInclude: [],
+        exclude: [],
+      },
+      [],
+    );
+
+    expect(Array.from(unlimitedDepth.keys()).sort()).toEqual([rootFile, nestedLevelOne, nestedLevelTwo].sort());
+  });
 });


### PR DESCRIPTION
## Summary
- respect `indexing.maxDepth` while building watcher snapshots
- preserve prior entries under unreadable paths instead of emitting false unlinks
- retain scoped reconciliation from #269 and cover full and scoped permission regressions

## Validation
- `npm run typecheck`
- `npx vitest run tests/watcher-snapshot.test.ts tests/watcher-snapshot-reconciler.test.ts`
- `npx vitest run tests/watcher.test.ts tests/watcher/native-recursive-watcher.test.ts`

Supersedes the relevant hardening portions of #270 without its whole-project scan per event regression.