### PR TITLE
docs: document watcher hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Low-descriptor native file watching**: On platforms that support it, file watching now uses one native recursive watcher and deterministic snapshot reconciliation for `add`, `change`, and `unlink` events, with automatic Chokidar fallback when native watching is unavailable.
 - **Mixed-intent cross-repo benchmark pilot**: Expanded the frozen five-repository cohort from 25 exact-definition queries to 35 reviewed queries by adding keyword-heavy production retrieval coverage across JavaScript, Python, Go, and Rust. The report keeps CodeGraph and codebase-memory-mcp comparison scoped to their shared 25-query exact-definition interface.
 - **Mixed-intent benchmark coverage and CI gate**: Expanded the frozen cohort to 45 queries with implementation-intent and conceptual coverage, and added a no-model cross-repo benchmark contract check to pull-request CI.
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Watcher reconciliation correctness**: Reconcile native watcher path hints selectively, respect `indexing.maxDepth`, and retain prior entries below temporarily unreadable paths rather than emitting false `unlink` events.
 - **Frozen cross-repo definition benchmark**: Reject contradictory exact-symbol targets in reviewed fixed datasets, and replace the ambiguous duplicate Express `error` query with an unambiguous `GithubView` lookup.
 - **Source-intent keyword retrieval**: Recognize Go, Rust, and Python test filenames and retain a wider candidate pool for identifier-rich source queries, so related test assertions do not displace production evidence before reranking.
 - **MCP server clean shutdown**: `opencode-codebase-index-mcp` now terminates its file watcher, auto-index coordination, and stdio transport on stdin EOF, protocol close, or `SIGHUP`/`SIGINT`/`SIGTERM`, exiting 0 instead of leaving persistent watcher processes and file descriptors behind after the host disappears.


### PR DESCRIPTION
## Summary
- document low-descriptor native watcher reconciliation in `Unreleased`
- document scoped, depth-aware, permission-safe reconciliation correctness fixes

## Validation
- `git diff --check`
- verified against merged PRs #269, #272, and #273