### PR TITLE
fix: preserve native watcher content rewrites

### DIFF
--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -8,7 +8,7 @@ import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 import { NativeRecursiveWatcher } from "./native-recursive-watcher.js";
-import { FileSnapshotReconciler } from "./snapshot-reconciler.js";
+import { FileSnapshotReconciler, type SnapshotInvalidation } from "./snapshot-reconciler.js";
 
 export type FileChangeType = "add" | "change" | "unlink";
 
@@ -45,7 +45,7 @@ export class FileWatcher {
   private nativeSetupGeneration = 0;
   private nativeStarting = false;
   private nativeReconcileTimer: NodeJS.Timeout | null = null;
-  private nativeInvalidatedPaths: Set<string | null> = new Set();
+  private nativeInvalidatedPaths: Map<string | null, boolean> = new Map();
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -255,20 +255,24 @@ export class FileWatcher {
   private scheduleNativeReconciliation(generation: number, filePath: string | null): void {
     if (!this.isCurrentNativeSetup(generation)) return;
 
-    this.nativeInvalidatedPaths.add(filePath);
+    const requiresFullReconciliation = filePath === path.join(this.projectRoot, ".gitignore");
+    const invalidatedPath = requiresFullReconciliation ? null : filePath;
+    this.nativeInvalidatedPaths.set(invalidatedPath, invalidatedPath !== null);
 
     if (this.nativeReconcileTimer) {
       clearTimeout(this.nativeReconcileTimer);
     }
     this.nativeReconcileTimer = setTimeout(() => {
       this.nativeReconcileTimer = null;
-      const invalidatedPaths = [...this.nativeInvalidatedPaths];
+      const invalidatedPaths: SnapshotInvalidation[] = [...this.nativeInvalidatedPaths].map(
+        ([invalidatedPath, forceChange]) => ({ path: invalidatedPath, forceChange }),
+      );
       this.nativeInvalidatedPaths.clear();
       void this.reconcileNativeWatcher(generation, invalidatedPaths);
     }, 100);
   }
 
-  private async reconcileNativeWatcher(generation: number, invalidatedPaths: readonly (string | null)[]): Promise<void> {
+  private async reconcileNativeWatcher(generation: number, invalidatedPaths: readonly SnapshotInvalidation[]): Promise<void> {
     if (!this.isCurrentNativeSetup(generation) || !this.nativeReconciler) return;
 
     try {

--- a/src/watcher/snapshot-reconciler.ts
+++ b/src/watcher/snapshot-reconciler.ts
@@ -13,6 +13,11 @@ import {
 
 export type { SnapshotFilterConfig } from "./snapshot.js";
 
+export type SnapshotInvalidation = string | null | {
+  path: string | null;
+  forceChange?: boolean;
+};
+
 export class FileSnapshotReconciler {
   private snapshot: FileSnapshotMap | null = null;
   private reconciliationTail: Promise<void> = Promise.resolve();
@@ -27,7 +32,7 @@ export class FileSnapshotReconciler {
     this.snapshot = (await buildFileSnapshotScan(this.projectRoot, this.config, this.configPaths)).entries;
   }
 
-  async reconcile(invalidatedPaths: readonly (string | null)[] = []): Promise<FileChange[]> {
+  async reconcile(invalidations: readonly SnapshotInvalidation[] = []): Promise<FileChange[]> {
     if (this.snapshot === null) {
       throw new Error("FileSnapshotReconciler is not initialized. Call initialize() before reconcile().");
     }
@@ -38,12 +43,22 @@ export class FileSnapshotReconciler {
         throw new Error("FileSnapshotReconciler is not initialized. Call initialize() before reconcile().");
       }
 
-      const scopedPaths = invalidatedPaths.filter((filePath): filePath is string => filePath !== null);
-      const scan = scopedPaths.length === 0 || scopedPaths.length !== invalidatedPaths.length
+      const normalizedInvalidations = invalidations.map((invalidation) => typeof invalidation === "string" || invalidation === null
+        ? { path: invalidation, forceChange: false }
+        : { path: invalidation.path, forceChange: invalidation.forceChange === true });
+      const scopedPaths = normalizedInvalidations
+        .map((invalidation) => invalidation.path)
+        .filter((filePath): filePath is string => filePath !== null);
+      const scan = scopedPaths.length === 0 || scopedPaths.length !== normalizedInvalidations.length
         ? await buildFileSnapshotScan(this.projectRoot, this.config, this.configPaths)
         : await this.reconcilePaths(previousSnapshot, scopedPaths);
       const nextSnapshot = completeFileSnapshot(previousSnapshot, scan);
-      const changes = diffFileSnapshots(previousSnapshot, nextSnapshot);
+      const forcedChanges = new Set(normalizedInvalidations
+        .filter((invalidation): invalidation is { path: string; forceChange: true } => (
+          invalidation.path !== null && invalidation.forceChange
+        ))
+        .map((invalidation) => invalidation.path));
+      const changes = diffFileSnapshots(previousSnapshot, nextSnapshot, forcedChanges);
       this.snapshot = nextSnapshot;
       return changes;
     });

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -215,12 +215,20 @@ function isPermissionFsError(error: unknown): error is NodeJS.ErrnoException {
 
 const diffTypeOrder: Record<FileChangeType, number> = { add: 0, change: 1, unlink: 2 };
 
-export function diffFileSnapshots(previous: FileSnapshotMap, current: FileSnapshotMap): FileChange[] {
+export function diffFileSnapshots(
+  previous: FileSnapshotMap,
+  current: FileSnapshotMap,
+  forcedChanges: ReadonlySet<string> = new Set(),
+): FileChange[] {
   const changes: FileChange[] = [];
   for (const [filePath, previousEntry] of previous) {
     const currentEntry = current.get(filePath);
     if (!currentEntry) changes.push({ type: "unlink", path: filePath });
-    else if (currentEntry.size !== previousEntry.size || currentEntry.mtimeMs !== previousEntry.mtimeMs) {
+    else if (
+      forcedChanges.has(filePath)
+      || currentEntry.size !== previousEntry.size
+      || currentEntry.mtimeMs !== previousEntry.mtimeMs
+    ) {
       changes.push({ type: "change", path: filePath });
     }
   }

--- a/tests/watcher-snapshot-reconciler.test.ts
+++ b/tests/watcher-snapshot-reconciler.test.ts
@@ -136,6 +136,23 @@ describe("watcher snapshot reconciler", () => {
     ]);
   });
 
+  it("reports a forced invalidation when content is rewritten with identical metadata", async () => {
+    const trackedFile = path.join(projectRoot, "tracked.ts");
+    fs.writeFileSync(trackedFile, "export const value = 1;");
+    const initialStat = fs.statSync(trackedFile);
+
+    const reconciler = new FileSnapshotReconciler(projectRoot, reconcileConfig, []);
+    await reconciler.initialize();
+
+    fs.writeFileSync(trackedFile, "export const value = 2;");
+    fs.utimesSync(trackedFile, initialStat.atimeMs / 1_000, initialStat.mtimeMs / 1_000);
+    expect(fs.statSync(trackedFile).mtimeMs).toBeCloseTo(initialStat.mtimeMs, 2);
+
+    expect(await reconciler.reconcile([{ path: trackedFile, forceChange: true }])).toEqual([
+      { path: trackedFile, type: "change" },
+    ]);
+  });
+
   it("removes every tracked descendant when an invalidated directory was deleted", async () => {
     const removedDirectory = path.join(projectRoot, "removed");
     const firstFile = path.join(removedDirectory, "first.ts");


### PR DESCRIPTION
## Summary
- force a `change` from native file-event invalidations when a file survives a same-size, same-mtime rewrite
- keep normal snapshot metadata diffs and scoped reconciliation unchanged
- use a full reconciliation when the native event is for root `.gitignore`

## Evidence
A regression test rewrites a tracked file with the same byte length and restores the exact prior `mtimeMs`. Before this change reconciliation emitted no event.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/watcher-snapshot-reconciler.test.ts tests/watcher.test.ts`