### PR TITLE
fix: reconcile external config changes after watcher ready

### DIFF
--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { FSWatcher } from "chokidar";
 import * as path from "path";
 
@@ -25,6 +25,11 @@ export interface FileWatcherOptions {
   configPath?: string;
 }
 
+interface ConfigPathState {
+  mtimeMs: number;
+  size: number;
+}
+
 export class FileWatcher {
   private watcher: FSWatcher | null = null;
   private projectRoot: string;
@@ -46,6 +51,7 @@ export class FileWatcher {
   private nativeStarting = false;
   private nativeReconcileTimer: NodeJS.Timeout | null = null;
   private nativeInvalidatedPaths: Map<string | null, boolean> = new Map();
+  private configPathStates: Map<string, ConfigPathState> = new Map();
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -80,6 +86,7 @@ export class FileWatcher {
   }
 
   private createWatcher(usePolling = false): void {
+    this.configPathStates = this.getConfigPathStates();
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
     let watchTargets: string | string[] = this.projectRoot;
     if (this.configPath) {
@@ -151,8 +158,9 @@ export class FileWatcher {
       watcher = new FSWatcher(watcherOptions);
     }
     this.watcher = watcher;
-    watcher.once("ready", () => {
+    watcher.on("ready", () => {
       if (this.watcher !== watcher) return;
+      this.reconcileConfigPathStates();
       this.resolveReady?.();
       this.resolveReady = null;
     });
@@ -313,6 +321,7 @@ export class FileWatcher {
     }
 
     if (this.isProjectConfigPath(filePath)) {
+      this.updateConfigPathState(filePath);
       this.pendingChanges.set(filePath, type);
       this.scheduleFlush();
       return;
@@ -376,6 +385,53 @@ export class FileWatcher {
     return this.projectConfigPaths.map(
       (configPath) => path.normalize(path.relative(this.projectRoot, configPath)),
     );
+  }
+
+  private getConfigPathStates(): Map<string, ConfigPathState> {
+    const states = new Map<string, ConfigPathState>();
+    for (const configPath of this.projectConfigPaths) {
+      const state = this.getConfigPathState(configPath);
+      if (state) states.set(configPath, state);
+    }
+    return states;
+  }
+
+  private getConfigPathState(configPath: string): ConfigPathState | undefined {
+    try {
+      const stats = statSync(configPath);
+      return stats.isFile() ? { mtimeMs: stats.mtimeMs, size: stats.size } : undefined;
+    } catch (error: unknown) {
+      // A config file may disappear between the watch event and this stat.
+      void error;
+      return undefined;
+    }
+  }
+
+  private updateConfigPathState(configPath: string): void {
+    const state = this.getConfigPathState(configPath);
+    if (state) {
+      this.configPathStates.set(configPath, state);
+    } else {
+      this.configPathStates.delete(configPath);
+    }
+  }
+
+  private reconcileConfigPathStates(): void {
+    const nextStates = this.getConfigPathStates();
+    const changes: FileChange[] = [];
+    for (const configPath of this.projectConfigPaths) {
+      const previous = this.configPathStates.get(configPath);
+      const next = nextStates.get(configPath);
+      if (!previous && next) {
+        changes.push({ path: configPath, type: "add" });
+      } else if (previous && !next) {
+        changes.push({ path: configPath, type: "unlink" });
+      } else if (previous && next && (previous.size !== next.size || previous.mtimeMs !== next.mtimeMs)) {
+        changes.push({ path: configPath, type: "change" });
+      }
+    }
+    this.configPathStates = nextStates;
+    this.recordChanges(changes);
   }
 
   private scheduleFlush(): void {

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -319,6 +319,31 @@ describe("watcher config refresh", () => {
     }
   });
 
+  it("reconciles an inherited config created between Chokidar ready events", async () => {
+    const { configPath, indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir, false);
+    const chokidarWatcher = watcher.fileWatcher as unknown as {
+      watcher: { emit(event: string): boolean; removeAllListeners(event?: string): unknown } | null;
+    };
+
+    try {
+      await watcher.whenReady();
+      chokidarWatcher.watcher?.removeAllListeners("add");
+      writeFileSync(configPath, JSON.stringify({ include: ["created-during-ready/**/*.ts"] }));
+      chokidarWatcher.watcher?.emit("ready");
+
+      await vi.waitFor(() => {
+        expect(operationMocks.refreshIndexerForDirectory).toHaveBeenCalledWith(
+          worktreeDir,
+          "opencode",
+          undefined,
+        );
+        expect(indexer.index).toHaveBeenCalledTimes(1);
+      }, { timeout: WATCH_EVENT_TIMEOUT_MS });
+    } finally {
+      await watcher.stop();
+    }
+  });
+
   it("refreshes from explicit config path when configured", async () => {
     const projectRoot = path.join(tempDir, "project");
     mkdirSync(projectRoot, { recursive: true });


### PR DESCRIPTION
## Summary
- reconcile only tracked configuration files on every Chokidar `ready` event
- cover the external-worktree config creation gap between ready events
- preserve direct configuration events and avoid whole-project rescans

## Validation
- `npx vitest run tests/watcher-config-refresh.test.ts`
- `npm run build:native && npm run build && npm run typecheck && npm run lint && npm run test:run`