### PR TITLE
fix: avoid slow watcher startup on large worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Large-project watcher startup**: Avoid a redundant native snapshot at startup and retain low-descriptor native project watching when a worktree configuration is inherited from outside the project, using Chokidar only for the external configuration target.
 - **Watcher reconciliation correctness**: Reconcile native watcher path hints selectively, respect `indexing.maxDepth`, and retain prior entries below temporarily unreadable paths rather than emitting false `unlink` events.
 - **Frozen cross-repo definition benchmark**: Reject contradictory exact-symbol targets in reviewed fixed datasets, and replace the ambiguous duplicate Express `error` query with an unambiguous `GithubView` lookup.
 - **Source-intent keyword retrieval**: Recognize Go, Rust, and Python test filenames and retain a wider candidate pool for identifier-rich source queries, so related test assertions do not displace production evidence before reranking.

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -118,7 +118,12 @@ export class FileWatcher {
     this.resolveReady = null;
   }
 
-  private createWatcher(watchTargets?: string | string[], usePolling = false): void {
+  private createWatcher(
+    watchTargets?: string | string[],
+    usePolling = false,
+    reportsStartupReady = true,
+  ): void {
+    let reportedStartupReady = false;
     this.configPathStates = this.getConfigPathStates();
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
     const resolvedWatchTargets = watchTargets ?? this.getFullChokidarWatchTargets();
@@ -178,7 +183,10 @@ export class FileWatcher {
     watcher.on("ready", () => {
       if (this.watcher !== watcher) return;
       this.reconcileConfigPathStates();
-      this.reportStartupReadySignal();
+      if (reportsStartupReady) {
+        this.reportStartupReadySignal();
+        reportedStartupReady = true;
+      }
     });
 
     watcher.on("error", (error: unknown) => {
@@ -200,10 +208,13 @@ export class FileWatcher {
           console.error("[codebase-index] Failed to close exhausted file watcher:", closeError);
         });
         if (this.onChanges) {
+          const replacementReportsStartupReady = reportsStartupReady || reportedStartupReady;
           if (!this.resolveReady) {
             this.resetReady();
+          } else if (reportedStartupReady) {
+            this.startupReadySignals += 1;
           }
-          this.createWatcher(resolvedWatchTargets, true);
+          this.createWatcher(resolvedWatchTargets, true, replacementReportsStartupReady);
         } else {
           this.watcher = null;
         }

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -49,6 +49,7 @@ export class FileWatcher {
   private nativeReconciler: FileSnapshotReconciler | null = null;
   private nativeSetupGeneration = 0;
   private nativeStarting = false;
+  private nativeInitializing = false;
   private nativeReconcileTimer: NodeJS.Timeout | null = null;
   private nativeInvalidatedPaths: Map<string | null, boolean> = new Map();
   private configPathStates: Map<string, ConfigPathState> = new Map();
@@ -217,33 +218,37 @@ export class FileWatcher {
   private async createNativeWatcher(): Promise<void> {
     const generation = ++this.nativeSetupGeneration;
     const reconciler = new FileSnapshotReconciler(this.projectRoot, this.config, this.projectConfigPaths);
+    const watcher = new NativeRecursiveWatcher(
+      this.projectRoot,
+      (filePath) => this.scheduleNativeReconciliation(generation, filePath),
+      { onError: (error) => void this.fallbackFromNativeWatcher(generation, error) },
+    );
+
+    this.nativeReconciler = reconciler;
+    this.nativeWatcher = watcher;
+    this.nativeInitializing = true;
 
     try {
-      await reconciler.initialize();
-      if (!this.isCurrentNativeSetup(generation)) return;
-
-      const watcher = new NativeRecursiveWatcher(
-        this.projectRoot,
-        (filePath) => this.scheduleNativeReconciliation(generation, filePath),
-        { onError: (error) => void this.fallbackFromNativeWatcher(generation, error) },
-      );
       watcher.start();
       if (!this.isCurrentNativeSetup(generation)) {
         await watcher.stop();
         return;
       }
 
-      this.nativeWatcher = watcher;
-      this.nativeReconciler = reconciler;
-      this.nativeStarting = false;
-      const initialChanges = await reconciler.reconcile();
-      if (!this.isCurrentNativeSetup(generation) || this.nativeWatcher !== watcher) return;
+      await reconciler.initialize();
+      if (!this.isCurrentNativeSetup(generation) || this.nativeWatcher !== watcher) {
+        await watcher.stop();
+        return;
+      }
 
-      this.recordChanges(initialChanges);
+      this.nativeStarting = false;
+      this.nativeInitializing = false;
+      await this.reconcileNativeWatcherWithPendingInvalidations(generation);
       this.resolveReady?.();
       this.resolveReady = null;
     } catch (error) {
       if (!this.isCurrentNativeSetup(generation)) return;
+      this.nativeInitializing = false;
       if (this.nativeWatcher) {
         await this.fallbackFromNativeWatcher(generation, error);
         return;
@@ -272,12 +277,17 @@ export class FileWatcher {
     }
     this.nativeReconcileTimer = setTimeout(() => {
       this.nativeReconcileTimer = null;
-      const invalidatedPaths: SnapshotInvalidation[] = [...this.nativeInvalidatedPaths].map(
-        ([invalidatedPath, forceChange]) => ({ path: invalidatedPath, forceChange }),
-      );
-      this.nativeInvalidatedPaths.clear();
-      void this.reconcileNativeWatcher(generation, invalidatedPaths);
+      void this.reconcileNativeWatcherFromQueue(generation);
     }, 100);
+  }
+
+  private reconcileNativeWatcherFromQueue(generation: number): void {
+    if (!this.isCurrentNativeSetup(generation) || this.nativeInitializing) return;
+
+    const invalidatedPaths = this.popNativeInvalidations();
+    if (invalidatedPaths.length === 0) return;
+
+    void this.reconcileNativeWatcher(generation, invalidatedPaths);
   }
 
   private async reconcileNativeWatcher(generation: number, invalidatedPaths: readonly SnapshotInvalidation[]): Promise<void> {
@@ -294,6 +304,24 @@ export class FileWatcher {
     }
   }
 
+  private async reconcileNativeWatcherWithPendingInvalidations(generation: number): Promise<void> {
+    const invalidatedPaths = this.popNativeInvalidations();
+    if (invalidatedPaths.length === 0) return;
+
+    await this.reconcileNativeWatcher(generation, invalidatedPaths);
+  }
+
+  private popNativeInvalidations(): SnapshotInvalidation[] {
+    if (this.nativeInvalidatedPaths.size === 0) return [];
+
+    const invalidations = [...this.nativeInvalidatedPaths].map(([invalidatedPath, forceChange]) => ({
+      path: invalidatedPath,
+      forceChange,
+    }));
+    this.nativeInvalidatedPaths.clear();
+    return invalidations;
+  }
+
   private async fallbackFromNativeWatcher(generation: number, error: unknown): Promise<void> {
     if (!this.isCurrentNativeSetup(generation)) return;
 
@@ -301,6 +329,7 @@ export class FileWatcher {
     this.nativeWatcher = null;
     this.nativeReconciler = null;
     this.nativeStarting = false;
+    this.nativeInitializing = false;
     this.nativeSetupGeneration += 1;
     if (this.nativeReconcileTimer) {
       clearTimeout(this.nativeReconcileTimer);
@@ -481,6 +510,7 @@ export class FileWatcher {
     this.nativeWatcher = null;
     this.nativeReconciler = null;
     this.nativeStarting = false;
+    this.nativeInitializing = false;
     this.nativeSetupGeneration += 1;
     this.pendingClose = null;
     this.resolveReady = null;

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -45,6 +45,7 @@ export class FileWatcher {
   private resolveReady: (() => void) | null = null;
   private pollingFallbackAttempted = false;
   private pendingClose: Promise<void> | null = null;
+  private startupReadySignals = 1;
   private nativeWatcher: NativeRecursiveWatcher | null = null;
   private nativeReconciler: FileSnapshotReconciler | null = null;
   private nativeSetupGeneration = 0;
@@ -73,6 +74,10 @@ export class FileWatcher {
     this.pollingFallbackAttempted = false;
     this.resetReady();
     if (this.shouldUseNativeWatcher()) {
+      if (this.hasExternalConfigWatchTarget()) {
+        this.setStartupReadySignals(2);
+        this.startExternalConfigWatcher();
+      }
       this.nativeStarting = true;
       void this.createNativeWatcher();
       return;
@@ -84,28 +89,39 @@ export class FileWatcher {
     this.readyPromise = new Promise<void>((resolve) => {
       this.resolveReady = resolve;
     });
+    this.startupReadySignals = 1;
   }
 
-  private createWatcher(usePolling = false): void {
+  private setStartupReadySignals(expectedSignals: number): void {
+    if (!this.readyPromise) {
+      return;
+    }
+
+    this.startupReadySignals = Math.max(0, expectedSignals);
+  }
+
+  private reportStartupReadySignal(): void {
+    if (!this.readyPromise || !this.resolveReady) {
+      return;
+    }
+
+    if (this.startupReadySignals <= 0) {
+      return;
+    }
+
+    this.startupReadySignals -= 1;
+    if (this.startupReadySignals !== 0) {
+      return;
+    }
+
+    this.resolveReady();
+    this.resolveReady = null;
+  }
+
+  private createWatcher(watchTargets?: string | string[], usePolling = false): void {
     this.configPathStates = this.getConfigPathStates();
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
-    let watchTargets: string | string[] = this.projectRoot;
-    if (this.configPath) {
-      watchTargets = [this.projectRoot, this.configPath];
-    } else {
-      const externalConfigTargets = this.projectConfigPaths
-        .filter((projectConfigPath) => {
-          const relativeConfigPath = path.relative(this.projectRoot, projectConfigPath);
-          return this.isOutsideProjectPath(relativeConfigPath);
-        })
-        .map((projectConfigPath) => existsSync(projectConfigPath)
-          ? projectConfigPath
-          : this.getNearestExistingDirectory(path.dirname(projectConfigPath)));
-      const uniqueExternalConfigTargets = [...new Set(externalConfigTargets)];
-      if (uniqueExternalConfigTargets.length > 0) {
-        watchTargets = [this.projectRoot, ...uniqueExternalConfigTargets];
-      }
-    }
+    const resolvedWatchTargets = watchTargets ?? this.getFullChokidarWatchTargets();
 
     const watcherOptions = {
       ignored: (filePath: string) => {
@@ -162,8 +178,7 @@ export class FileWatcher {
     watcher.on("ready", () => {
       if (this.watcher !== watcher) return;
       this.reconcileConfigPathStates();
-      this.resolveReady?.();
-      this.resolveReady = null;
+      this.reportStartupReadySignal();
     });
 
     watcher.on("error", (error: unknown) => {
@@ -188,7 +203,7 @@ export class FileWatcher {
           if (!this.resolveReady) {
             this.resetReady();
           }
-          this.createWatcher(true);
+          this.createWatcher(resolvedWatchTargets, true);
         } else {
           this.watcher = null;
         }
@@ -201,7 +216,7 @@ export class FileWatcher {
     watcher.on("add", (filePath) => this.handleChange(watcher, "add", filePath));
     watcher.on("change", (filePath) => this.handleChange(watcher, "change", filePath));
     watcher.on("unlink", (filePath) => this.handleChange(watcher, "unlink", filePath));
-    watcher.add(watchTargets);
+    watcher.add(resolvedWatchTargets);
   }
 
   private shouldUseNativeWatcher(): boolean {
@@ -209,10 +224,49 @@ export class FileWatcher {
       return false;
     }
 
-    return this.projectConfigPaths.every((configPath) => {
-      const relativePath = path.relative(this.projectRoot, configPath);
-      return !this.isOutsideProjectPath(relativePath);
-    });
+    return true;
+  }
+
+  private getFullChokidarWatchTargets(): string | string[] {
+    if (this.configPath) {
+      return [this.projectRoot, this.configPath];
+    }
+
+    const externalConfigTargets = this.getExternalConfigWatchTargets();
+    if (externalConfigTargets.length === 0) {
+      return this.projectRoot;
+    }
+
+    return [this.projectRoot, ...externalConfigTargets];
+  }
+
+  private getExternalConfigWatchTargets(): string[] {
+    return [...new Set(this.projectConfigPaths
+      .filter((projectConfigPath) => {
+        const relativeConfigPath = path.relative(this.projectRoot, projectConfigPath);
+        return this.isOutsideProjectPath(relativeConfigPath);
+      })
+      .map((projectConfigPath) => {
+        if (existsSync(projectConfigPath)) {
+          return projectConfigPath;
+        }
+
+        return this.getNearestExistingDirectory(path.dirname(projectConfigPath));
+      }),
+    )];
+  }
+
+  private hasExternalConfigWatchTarget(): boolean {
+    return this.getExternalConfigWatchTargets().length > 0;
+  }
+
+  private startExternalConfigWatcher(usePolling = false): void {
+    const externalTargets = this.getExternalConfigWatchTargets();
+    if (externalTargets.length === 0) {
+      return;
+    }
+
+    this.createWatcher(externalTargets, usePolling);
   }
 
   private async createNativeWatcher(): Promise<void> {
@@ -244,8 +298,7 @@ export class FileWatcher {
       this.nativeStarting = false;
       this.nativeInitializing = false;
       await this.reconcileNativeWatcherWithPendingInvalidations(generation);
-      this.resolveReady?.();
-      this.resolveReady = null;
+      this.reportStartupReadySignal();
     } catch (error) {
       if (!this.isCurrentNativeSetup(generation)) return;
       this.nativeInitializing = false;
@@ -255,8 +308,12 @@ export class FileWatcher {
       }
 
       this.nativeStarting = false;
+      const externalWatcher = this.watcher;
+      this.watcher = null;
       this.nativeReconciler = null;
+      await externalWatcher?.close();
       console.warn("[codebase-index] Native recursive watcher unavailable; using Chokidar fallback.", error);
+      this.setStartupReadySignals(1);
       this.createWatcher();
     }
   }
@@ -326,7 +383,9 @@ export class FileWatcher {
     if (!this.isCurrentNativeSetup(generation)) return;
 
     const watcher = this.nativeWatcher;
+    const externalWatcher = this.watcher;
     this.nativeWatcher = null;
+    this.watcher = null;
     this.nativeReconciler = null;
     this.nativeStarting = false;
     this.nativeInitializing = false;
@@ -336,9 +395,11 @@ export class FileWatcher {
       this.nativeReconcileTimer = null;
     }
     this.nativeInvalidatedPaths.clear();
+    this.setStartupReadySignals(1);
 
     console.warn("[codebase-index] Native recursive watcher failed; using Chokidar fallback.", error);
     await watcher?.stop();
+    await externalWatcher?.close();
     if (this.onChanges) {
       this.createWatcher();
     }

--- a/tests/watcher-config-refresh.test.ts
+++ b/tests/watcher-config-refresh.test.ts
@@ -210,6 +210,23 @@ describe("watcher config refresh", () => {
     await watcher.stop();
   });
 
+  it("uses native project watching alongside a lightweight external config watcher for linked worktrees", async () => {
+    const { watcher } = createLinkedWorktreeWatcher(tempDir);
+    const internals = watcher.fileWatcher as unknown as {
+      nativeWatcher: unknown;
+      watcher: unknown;
+    };
+
+    try {
+      await watcher.whenReady();
+
+      expect(internals.nativeWatcher).not.toBeNull();
+      expect(internals.watcher).not.toBeNull();
+    } finally {
+      await watcher.stop();
+    }
+  });
+
   it("refreshes a linked worktree when its inherited project config changes", async () => {
     const { configPath, indexer, watcher, worktreeDir } = createLinkedWorktreeWatcher(tempDir);
 

--- a/tests/watcher-native-startup-race.test.ts
+++ b/tests/watcher-native-startup-race.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { parseConfig } from "../src/config/schema.js";
+import { FileSnapshotReconciler, type SnapshotInvalidation } from "../src/watcher/snapshot-reconciler.js";
+import { FileWatcher } from "../src/watcher/file-watcher.js";
+
+interface FakeNativeWatcherState {
+  onChange: (filePath: string | null) => void;
+  onError?: (error: Error) => void;
+  stop: () => Promise<void>;
+}
+
+const nativeWatcherStates: FakeNativeWatcherState[] = [];
+
+vi.mock("../src/watcher/native-recursive-watcher.js", () => {
+  return {
+    NativeRecursiveWatcher: class {
+      public onChange: (filePath: string | null) => void;
+      public onError: ((error: Error) => void) | undefined;
+
+      constructor(_projectRoot: string, onChange: (filePath: string | null) => void, options: { onError?: (error: Error) => void } = {}) {
+        this.onChange = onChange;
+        this.onError = options.onError;
+        nativeWatcherStates.push(this);
+      }
+
+      start(): void {
+        return;
+      }
+
+      async stop(): Promise<void> {
+        return;
+      }
+    },
+  };
+});
+
+describe("native FileWatcher startup buffering", () => {
+  let projectRoot: string;
+  let watcher: FileWatcher | undefined;
+  let resolveInitialize: (() => void) | null = null;
+  const reconciliationCalls: SnapshotInvalidation[][] = [];
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "native-startup-race-"));
+    reconciliationCalls.length = 0;
+    resolveInitialize = null;
+    nativeWatcherStates.length = 0;
+
+    vi.spyOn(FileSnapshotReconciler.prototype, "initialize").mockImplementation(function () {
+      return new Promise<void>((resolve) => {
+        resolveInitialize = resolve;
+      });
+    });
+
+    vi.spyOn(FileSnapshotReconciler.prototype, "reconcile").mockImplementation(async (invalidations: readonly SnapshotInvalidation[]) => {
+      reconciliationCalls.push([...invalidations]);
+      return [];
+    });
+  });
+
+  afterEach(async () => {
+    await watcher?.stop();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    nativeWatcherStates.length = 0;
+  });
+
+  it("buffers invalidations raised during snapshot initialization and reconciles only those entries", async () => {
+    const observedFile = path.join(projectRoot, "observed.ts");
+
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
+    watcher.start(vi.fn());
+
+    const nativeWatcher = nativeWatcherStates.at(-1);
+    expect(nativeWatcher).toBeDefined();
+    nativeWatcher?.onChange(observedFile);
+
+    expect(reconciliationCalls).toHaveLength(0);
+
+    resolveInitialize?.();
+    await watcher.waitUntilReady();
+
+    expect(reconciliationCalls).toHaveLength(1);
+    expect(reconciliationCalls[0]).toEqual([{ path: observedFile, forceChange: true }]);
+  });
+
+  it("does not run a startup full reconcile when no buffered changes exist", async () => {
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
+    watcher.start(vi.fn());
+
+    resolveInitialize?.();
+    await watcher.waitUntilReady();
+
+    expect(reconciliationCalls).toHaveLength(0);
+  });
+
+  it("preserves .gitignore semantics with full-scope invalidation during startup", async () => {
+    const ignoredPath = path.join(projectRoot, ".gitignore");
+
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
+    watcher.start(vi.fn());
+
+    const nativeWatcher = nativeWatcherStates.at(-1);
+    expect(nativeWatcher).toBeDefined();
+    nativeWatcher?.onChange(ignoredPath);
+
+    resolveInitialize?.();
+    await watcher.waitUntilReady();
+
+    expect(reconciliationCalls).toHaveLength(1);
+    expect(reconciliationCalls[0]).toEqual([{ path: null, forceChange: false }]);
+  });
+});

--- a/tests/watcher-native-startup-race.test.ts
+++ b/tests/watcher-native-startup-race.test.ts
@@ -1,3 +1,4 @@
+import { FSWatcher } from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -106,6 +107,40 @@ describe("native FileWatcher startup buffering", () => {
     await watcher.waitUntilReady();
 
     expect(reconciliationCalls).toHaveLength(0);
+  });
+
+  it("waits for native initialization when its external config watcher recovers", async () => {
+    const externalConfigPath = path.join(path.dirname(projectRoot), "external-config.json");
+    const addSpy = vi.spyOn(FSWatcher.prototype, "add").mockImplementation(function (this: FSWatcher) {
+      return this;
+    });
+    vi.spyOn(FSWatcher.prototype, "close").mockResolvedValue(undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { configPath: externalConfigPath },
+    );
+    watcher.start(vi.fn());
+
+    const firstExternalWatcher = addSpy.mock.instances[0] as FSWatcher;
+    firstExternalWatcher.emit("ready");
+    firstExternalWatcher.emit("error", Object.assign(new Error("too many open files"), { code: "EMFILE" }));
+    const pollingExternalWatcher = addSpy.mock.instances[1] as FSWatcher;
+    pollingExternalWatcher.emit("ready");
+
+    let readySettled = false;
+    const readyPromise = watcher.waitUntilReady().then(() => {
+      readySettled = true;
+    });
+    await Promise.resolve();
+    expect(readySettled).toBe(false);
+
+    resolveInitialize?.();
+    await readyPromise;
+    expect(readySettled).toBe(true);
   });
 
   it("preserves .gitignore semantics with full-scope invalidation during startup", async () => {


### PR DESCRIPTION
## Summary
- remove the redundant full snapshot after native watcher startup
- keep native recursive project watching when configuration is inherited outside a worktree
- observe only the external configuration target with Chokidar
- cover hybrid watcher selection and inherited config refresh

## Evidence
- reproduced Chokidar descriptor exhaustion and polling fallback at 150,000 files across 10,000 directories: 424,293 ms
- native and hybrid watcher startup on the same workload: about 12,100 ms
- `npm run build:native && npm run build && npm run typecheck && npm run lint && npm run test:run` passed, 91 files and 1,438 tests

Fixes #276