### PR TITLE
chore(release): prepare v0.23.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.22.5"
+      "version": "0.23.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-08-11
+
 ### Added
 
 - **Low-descriptor native file watching**: On platforms that support it, file watching now uses one native recursive watcher and deterministic snapshot reconciliation for `add`, `change`, and `unlink` events, with automatic Chokidar fallback when native watching is unavailable.

--- a/benchmarks/baselines/eval-baseline-summary.json
+++ b/benchmarks/baselines/eval-baseline-summary.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-03-22T11:52:53.465Z",
+  "generatedAt": "2026-08-11T12:31:31.757Z",
   "projectRoot": ".",
   "datasetPath": "benchmarks/golden/small.json",
   "datasetName": "small",
   "datasetVersion": "1.0.0",
-  "datasetFingerprint": "054eccab2ca1480b532cbe5a87ad078a88597d8f832237719b3e07c65aeaf6e5",
+  "datasetFingerprint": "45db44e118b518ab5135d28d82b5abd8de0c8a8f257ac18193d42e01a2db2633",
   "queryCount": 4,
   "topK": 10,
   "searchConfig": {
@@ -14,32 +14,49 @@
     "rerankTopN": 20
   },
   "metrics": {
-    "hitAt1": 0.75,
-    "hitAt3": 1,
-    "hitAt5": 1,
+    "hitAt1": 0.5,
+    "hitAt3": 0.75,
+    "hitAt5": 0.75,
     "hitAt10": 1,
-    "mrrAt10": 0.875,
-    "ndcgAt10": 0.9127302324517832,
+    "mrrAt10": 0.6607142857142857,
+    "ndcgAt10": 0.7410657717261977,
+    "routeAccuracy": 0,
+    "outcomeAccuracy": 0,
+    "recoveryAccuracy": 0,
+    "graphNeighborRecall": 0,
     "distinctTop3Ratio": 1,
-    "rawDistinctTop3Ratio": 1,
+    "rawDistinctTop3Ratio": 0.8333333333333333,
     "latencyMs": {
-      "p50": 26.173166000000037,
-      "p95": 52.931082999999944,
-      "p99": 52.931082999999944
+      "p50": 7.0530834999954095,
+      "p95": 22.50668394999156,
+      "p99": 24.615703989990138
     },
     "tokenEstimate": {
       "queryTokens": 43,
-      "embeddingTokensUsed": 1760
+      "embeddingTokensUsed": 1020072
     },
     "embedding": {
-      "callCount": 5,
+      "callCount": 146,
       "estimatedCostUsd": 0,
       "costPer1MTokensUsd": 0
+    },
+    "contextEfficiency": {
+      "queryCount": 0,
+      "responseTokens": {
+        "total": 0,
+        "average": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "duplicateCandidateRatio": 0,
+      "selectedFileRatio": 0,
+      "hitAt5Per1kResponseTokens": 0,
+      "mrrAt10Per1kResponseTokens": 0
     },
     "failureBuckets": {
       "wrong-file": 1,
       "wrong-symbol": 0,
-      "docs-tests-outranking-source": 0,
+      "docs-tests-outranking-source": 1,
       "no-relevant-hit-top-k": 0
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.22.5",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.22.5",
+  "version": "0.23.0",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release candidate

Prepares **v0.23.0** from the full delta since `v0.22.5`.

### Included
- Native recursive watcher and large-worktree startup hardening.
- MCP watcher and shutdown lifecycle fixes.
- Mixed-intent cross-repository benchmark coverage.
- Version synchronization across package and Claude/Codex plugin metadata.
- Retrieval baseline realigned to a directly measured `v0.22.5` result with the current frozen dataset, enabling an actual no-regression gate.

### Validation
- `npm run build && npm run typecheck && npm run lint && npm run test:run` passed: 91 files, 1,439 tests.
- `npm run smoke:package` passed for both published package identities and MCP binary aliases.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` passed: 122 Rust tests.
- Production dependency audit found 0 vulnerabilities.
- Direct deterministic comparison to `v0.22.5`: Hit@5 improved 75% → 100%, MRR@10 improved 0.661 → 0.875, and p95 latency 22.5 ms → 28.6 ms, within the 1.35× budget.
- Pre-edit quality gate: Hit@5, MRR@10, route accuracy, outcome accuracy, and graph-neighbor recall all 1.0.

No publish, tag, or release creation is included in this PR.