### PR TITLE
Improve conceptual context source ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Conceptual context retrieval**: Prefer implementation paths over tests and documentation for code-focused `codebase_context` searches, without applying a hard source-only filter or changing documentation and test queries.
 - **Scoped definition lookup**: Allow explicit definition searches constrained to a file type or directory to return matching declarations in fixtures and test paths without weakening source-first ranking for ordinary searches.
 
 ## [0.23.0] - 2026-08-11

--- a/src/eval/runner.ts
+++ b/src/eval/runner.ts
@@ -307,12 +307,13 @@ export async function runEvaluation(options: EvalRunOptions): Promise<EvalRunRes
             fileType: scope.fileType,
             directory: scope.directory,
           }),
-          search: (searchQuery, limit, scope) => indexer.search(searchQuery, limit, {
+          search: (searchQuery, limit, scope, _trace, searchOptions) => indexer.search(searchQuery, limit, {
             metadataOnly: true,
             filterByBranch: !!query.expected.branch,
             definitionIntent: false,
             fileType: scope.fileType,
             directory: scope.directory,
+            prioritizeSourcePaths: searchOptions?.prioritizeSourcePaths,
           }),
         })
         : undefined;

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -396,6 +396,8 @@ interface SearchOptions {
   filterByBranch?: boolean;
   metadataOnly?: boolean;
   definitionIntent?: boolean;
+  /** Soft ranking preference for context retrieval. Unlike definitionIntent, this never filters candidates. */
+  prioritizeSourcePaths?: boolean;
   blameAuthor?: string;
   blameSha?: string;
   blameSince?: string;
@@ -4699,8 +4701,9 @@ export class Indexer {
     const rerankTopN = this.config.search.rerankTopN;
     const filterByBranch = options?.filterByBranch ?? true;
     const sourceIntent = options?.definitionIntent === true || classifyQueryIntentRaw(query) === "source";
+    const prioritizeSourcePaths = sourceIntent || options?.prioritizeSourcePaths === true;
     const identifierHints = extractIdentifierHints(query);
-    const candidateLimit = maxResults * (sourceIntent ? 12 : 4);
+    const candidateLimit = maxResults * (prioritizeSourcePaths ? 12 : 4);
 
     this.logger.search("debug", "Starting search", {
       query,
@@ -4784,7 +4787,7 @@ export class Indexer {
       rerankTopN,
       limit: maxResults,
       hybridWeight: rankingHybridWeight,
-      prioritizeSourcePaths: sourceIntent,
+      prioritizeSourcePaths,
     });
     const rerankedCombined = await this.rerankCandidatesWithApi(query, combined, {
       definitionIntent: options?.definitionIntent === true,

--- a/src/indexer/intent-aware-ranking.ts
+++ b/src/indexer/intent-aware-ranking.ts
@@ -345,6 +345,10 @@ function scoreCandidate(query: string, intent: QueryIntentProfile, candidate: Ra
 
   if (intent.primary === "conceptual") {
     boost += Math.min(0.14, overlap * 0.14);
+    if (intent.preferSourcePaths) {
+      boost += implementationPath ? 0.32 : 0;
+      if (testPath || fixturePath || docsPath) boost -= 0.35;
+    }
     if (generatedOrVendor) boost -= 0.18;
     if (importChunk || weakContainer) boost -= 0.04;
   } else if (intent.primary === "test") {

--- a/src/tools/context-search.ts
+++ b/src/tools/context-search.ts
@@ -121,6 +121,9 @@ interface SearchContextOperations {
     limit: number,
     scope: SearchScope,
     trace?: (trace: SearchTrace) => void,
+    searchOptions?: {
+      prioritizeSourcePaths?: boolean;
+    },
   ): Promise<SearchResult[]>;
 }
 
@@ -407,13 +410,20 @@ export async function resolveSearchContext(
     searchQuery: string,
     scope: SearchScope,
     relaxedFieldsForAttempt: Array<"directory" | "fileType">,
+    prioritizeSourcePaths: boolean,
   ): Promise<SearchResult[]> => {
     return recordAttempt(
       "conceptual",
       searchQuery,
       scope,
       relaxedFieldsForAttempt,
-      (trace) => operations.search(searchQuery, MAX_CONTEXT_RESULT_LIMIT, scope, input.diagnostic ? trace : undefined),
+      (trace) => operations.search(
+        searchQuery,
+        MAX_CONTEXT_RESULT_LIMIT,
+        scope,
+        input.diagnostic ? trace : undefined,
+        { prioritizeSourcePaths },
+      ),
     );
   };
 
@@ -557,10 +567,12 @@ export async function resolveSearchContext(
   }
 
   for (const attempt of conceptualAttemptPlan) {
+    const attemptIntent = analyzeQueryIntent(attempt.queryText);
+    const prioritizeSourcePaths = attemptIntent.primary !== "docs" && attemptIntent.primary !== "test";
     if (inferredSymbol && attempt.queryText === inferredSymbol && attempt.queryText !== query) {
       decisions.fallbackFromOriginalConceptualToInferred = true;
     }
-    const results = await tryConceptualSearch(attempt.queryText, attempt.scope, attempt.relaxed);
+    const results = await tryConceptualSearch(attempt.queryText, attempt.scope, attempt.relaxed, prioritizeSourcePaths);
     if (results.length > 0) {
       const heading = buildPackHeading("conceptual", decisions);
       const intent = analyzeQueryIntent(attempt.queryText);

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -133,12 +133,13 @@ async function resolveCodebaseContextUnmeasured(
       directory: scope.directory,
       trace,
     }),
-    search: (queryText, retrievalLimit, scope, trace) => searchCodebase(projectRoot, host, queryText, {
+    search: (queryText, retrievalLimit, scope, trace, searchOptions) => searchCodebase(projectRoot, host, queryText, {
       limit: retrievalLimit,
       fileType: scope.fileType,
       directory: scope.directory,
       metadataOnly: true,
       trace,
+      prioritizeSourcePaths: searchOptions?.prioritizeSourcePaths,
     }),
   });
 }

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -229,6 +229,7 @@ export async function searchCodebase(
     contextLines?: number;
     metadataOnly?: boolean;
     definitionIntent?: boolean;
+    prioritizeSourcePaths?: boolean;
     blameAuthor?: string;
     blameSha?: string;
     blameSince?: string;
@@ -244,6 +245,7 @@ export async function searchCodebase(
     contextLines: options.contextLines,
     metadataOnly: options.metadataOnly,
     definitionIntent: options.definitionIntent,
+    prioritizeSourcePaths: options.prioritizeSourcePaths,
     blameAuthor: options.blameAuthor,
     blameSha: options.blameSha,
     blameSince: options.blameSince,

--- a/tests/intent-aware-source-paths.test.ts
+++ b/tests/intent-aware-source-paths.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import type { RankedCandidate } from "../src/indexer/intent-aware-ranking.js";
+import { rankIntentAwareCandidates } from "../src/indexer/intent-aware-ranking.js";
+
+function candidate(
+  id: string,
+  score: number,
+  filePath: string,
+  chunkType: string,
+): RankedCandidate {
+  return {
+    id,
+    score,
+    metadata: {
+      filePath,
+      startLine: 1,
+      endLine: 5,
+      chunkType,
+      language: "typescript",
+      hash: id,
+    },
+  };
+}
+
+describe("intent-aware source path preference", () => {
+  it("only promotes implementation evidence for an explicit source preference", () => {
+    const candidates = [
+      candidate("test", 0.82, "tests/search-ranking.test.ts", "function"),
+      candidate("source", 0.55, "src/indexer/search-ranking.ts", "function"),
+    ];
+    const query = "explain how semantic and keyword rankings are combined";
+
+    expect(rankIntentAwareCandidates(query, candidates, candidates.length).map(({ id }) => id))
+      .toEqual(["test", "source"]);
+    expect(rankIntentAwareCandidates(query, candidates, candidates.length, { prioritizeSourcePaths: true }).map(({ id }) => id))
+      .toEqual(["source", "test"]);
+  });
+});

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -595,6 +595,7 @@ describe("Pi adapter conformance", () => {
         fileType: undefined,
         directory: undefined,
         metadataOnly: true,
+        prioritizeSourcePaths: true,
       },
     );
     expect(result?.content[0]?.text).toContain("Codebase evidence");
@@ -630,6 +631,7 @@ describe("Pi adapter conformance", () => {
       fileType: "ts",
       directory: "src",
       metadataOnly: true,
+      prioritizeSourcePaths: true,
     });
     expect(result?.content[0]?.text).toContain("Codebase evidence");
     expect(result?.content[0]?.text).not.toContain("validation helper");
@@ -664,6 +666,7 @@ describe("Pi adapter conformance", () => {
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,
+      prioritizeSourcePaths: true,
     });
   });
 

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -248,6 +248,7 @@ describe("native OpenCode codebase_context", () => {
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,
+      prioritizeSourcePaths: expect.any(Boolean),
     });
     expect(result).toContain("Codebase evidence");
     expect(result).toContain("2 additional results excluded by result limit");
@@ -464,6 +465,7 @@ describe("native OpenCode codebase_context", () => {
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,
+      prioritizeSourcePaths: expect.any(Boolean),
     });
   });
 
@@ -501,6 +503,7 @@ describe("native OpenCode codebase_context", () => {
         fileType: "ts",
         directory: "src",
         metadataOnly: true,
+        prioritizeSourcePaths: expect.any(Boolean),
       });
     }
   });
@@ -531,6 +534,7 @@ describe("native OpenCode codebase_context", () => {
       fileType: undefined,
       directory: undefined,
       metadataOnly: true,
+      prioritizeSourcePaths: expect.any(Boolean),
     });
     expect(result).toContain("src/fallback.ts:1-4");
   });
@@ -566,8 +570,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "find request helpers", 100, { fileType: "ts", directory: "src" }, undefined);
-    expect(search).toHaveBeenNthCalledWith(2, "find request helpers", 100, { fileType: undefined, directory: undefined }, undefined);
+    expect(search).toHaveBeenNthCalledWith(1, "find request helpers", 100, { fileType: "ts", directory: "src" }, undefined, { prioritizeSourcePaths: true });
+    expect(search).toHaveBeenNthCalledWith(2, "find request helpers", 100, { fileType: undefined, directory: undefined }, undefined, { prioritizeSourcePaths: true });
     expect(result.details?.recovery?.attempts).toEqual([
       {
         kind: "conceptual",
@@ -619,8 +623,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "where is `getStatus` defined", 100, { fileType: undefined, directory: undefined }, undefined);
-    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined);
+    expect(search).toHaveBeenNthCalledWith(1, "where is `getStatus` defined", 100, { fileType: undefined, directory: undefined }, undefined, { prioritizeSourcePaths: true });
+    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined, { prioritizeSourcePaths: true });
     expect(result.text).toContain("src/auth.ts:1-8");
     expect(result.text).toContain("Recovery: inferred definition missed; inferred-symbol query tried.");
     expect(result.text.indexOf("Recovery:")).toBeLessThan(result.text.indexOf("[1]"));
@@ -683,8 +687,8 @@ describe("native OpenCode codebase_context", () => {
     );
 
     expect(search).toHaveBeenCalledTimes(2);
-    expect(search).toHaveBeenNthCalledWith(1, "getStatus", 100, { fileType: "ts", directory: "src" }, undefined);
-    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined);
+    expect(search).toHaveBeenNthCalledWith(1, "getStatus", 100, { fileType: "ts", directory: "src" }, undefined, { prioritizeSourcePaths: true });
+    expect(search).toHaveBeenNthCalledWith(2, "getStatus", 100, { fileType: undefined, directory: undefined }, undefined, { prioritizeSourcePaths: true });
     expect(result.details?.recovery?.attempts).toHaveLength(3);
     expect(new Set(result.details?.recovery?.attempts.map((attempt) => JSON.stringify(attempt))).size)
       .toBe(3);
@@ -782,10 +786,10 @@ describe("native OpenCode codebase_context", () => {
     });
 
     expect(search.mock.calls).toEqual([
-      ["where is `getStatus` defined", 100, { fileType: "ts", directory: "private/scope" }, undefined],
-      ["getStatus", 100, { fileType: "ts", directory: "private/scope" }, undefined],
-      ["where is `getStatus` defined", 100, {}, undefined],
-      ["getStatus", 100, {}, undefined],
+      ["where is `getStatus` defined", 100, { fileType: "ts", directory: "private/scope" }, undefined, { prioritizeSourcePaths: true }],
+      ["getStatus", 100, { fileType: "ts", directory: "private/scope" }, undefined, { prioritizeSourcePaths: true }],
+      ["where is `getStatus` defined", 100, {}, undefined, { prioritizeSourcePaths: true }],
+      ["getStatus", 100, {}, undefined, { prioritizeSourcePaths: true }],
     ]);
     const recoveryLine = result.text.split("\n").find((line) => line.startsWith("Recovery:"));
     expect(recoveryLine).toBe("Recovery: inferred definition missed; inferred-symbol query tried; directory filter removed; file-type filter removed.");
@@ -827,6 +831,47 @@ describe("native OpenCode codebase_context", () => {
     expect(countContextTokens(result.text)).toBeLessThanOrEqual(128);
   });
 
+  it("prefers source paths for conceptual code queries but not documentation queries", async () => {
+    const sourceSearch = vi.fn().mockResolvedValue([{
+      filePath: "src/index.ts",
+      startLine: 1,
+      endLine: 2,
+      chunkType: "function",
+      content: "export function search() {}",
+      score: 0.9,
+    }]);
+    const docsSearch = vi.fn().mockResolvedValue([{
+      filePath: "docs/search.md",
+      startLine: 1,
+      endLine: 2,
+      chunkType: "markdown",
+      content: "# Search",
+      score: 0.9,
+    }]);
+
+    await resolveSearchContext({
+      query: "find code that combines semantic and keyword rankings",
+    }, { lookup: vi.fn(), search: sourceSearch });
+    await resolveSearchContext({
+      query: "find documentation for configuring search",
+    }, { lookup: vi.fn(), search: docsSearch });
+
+    expect(sourceSearch).toHaveBeenCalledWith(
+      "find code that combines semantic and keyword rankings",
+      100,
+      {},
+      undefined,
+      { prioritizeSourcePaths: true },
+    );
+    expect(docsSearch).toHaveBeenCalledWith(
+      "find documentation for configuring search",
+      100,
+      {},
+      undefined,
+      { prioritizeSourcePaths: false },
+    );
+  });
+
   it("captures search and context-pack traces when diagnostic flag is set", async () => {
     const search = vi.fn().mockImplementation(async (_query: string, _limit: number, _scope: unknown, trace?: (trace: SearchTrace) => void) => {
       trace?.({
@@ -863,7 +908,13 @@ describe("native OpenCode codebase_context", () => {
       search,
     });
 
-    expect(search).toHaveBeenCalledWith("where is traceTarget defined", 100, {}, expect.any(Function));
+    expect(search).toHaveBeenCalledWith(
+      "where is traceTarget defined",
+      100,
+      {},
+      expect.any(Function),
+      { prioritizeSourcePaths: true },
+    );
     expect(result.details?.diagnostic).toMatchObject({
       route: "conceptual",
       searchQuery: expect.any(String),


### PR DESCRIPTION
## Summary
- give code-focused `codebase_context` searches a soft implementation-path preference
- retain documentation and test intent, without source-only filtering
- cover OpenCode, Pi, evaluation wiring, and ranking behavior

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (92 files, 1442 tests)
- `npm run eval:representative:ollama`

## Retrieval measurement
Representative Ollama run retained Hit@5 at 68.75% and improved MRR@10 from 0.5391 to 0.5818. The remaining strict misses are candidate-recall or label-granularity issues and were not relabeled.