### PR TITLE
Add configurable cross-repo embedding models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an Ollama-only representative retrieval evaluation command with expanded coverage for embedding failure recovery, index-lock recovery, and duplicate-definition path disambiguation.
+- Added `--embedding-model` to the cross-repository benchmark runner, preserving `nomic-embed-text` as the default while recording the selected local Ollama model in its artifacts.
 
 ### Changed
 
 - Retired the unavailable `github-copilot` embedding provider with an actionable migration error. GitHub Models retired its inference API.
 - Added Google `gemini-embedding-2` support with its recommended code-retrieval formatting.
+- Documented local Ollama model trade-offs and reproducible Nomic, EmbeddingGemma, and Qwen 0.6B comparison results.
 
 ### Fixed
 

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -19,7 +19,8 @@ Metrics reported per repo and aggregated:
 
 - Built project dependencies (`npm install`)
 - Local Ollama daemon reachable at `OLLAMA_HOST` (default `http://localhost:11434`)
-- Installed Ollama embedding model `nomic-embed-text`
+- Installed Ollama embedding model `nomic-embed-text`, or the model passed to
+  `--embedding-model`
 - `rg` installed
 - `sg` installed (`brew install ast-grep` on macOS)
 - `npx` (for opt-in CodeGraph and `codebase-memory-mcp` execution)
@@ -58,6 +59,25 @@ npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --
 # Repeat runs for stable medians (recommended)
 npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --repeats 20
 ```
+
+## Embedding model selection
+
+The benchmark uses local Ollama and defaults to `nomic-embed-text`. Select a
+different installed model with `--embedding-model`. The selected name is saved
+in the controlled eval config and both report formats.
+
+```bash
+ollama pull embeddinggemma
+npx tsx scripts/cross-repo-benchmark.ts \
+  --repos /path/to/repo1,/path/to/repo2 \
+  --embedding-model embeddinggemma \
+  --reindex
+```
+
+Use `--reindex` whenever the model differs from the model used to create an
+existing index. This keeps the benchmark from measuring incompatible or stale
+vectors. The [local model comparison](benchmarks/2026-08-12-local-embedding-model-comparison.md)
+describes the tested options and their trade-offs.
 
 ## Sampling and mutability notes
 

--- a/docs/benchmarks/2026-08-12-local-embedding-model-comparison.md
+++ b/docs/benchmarks/2026-08-12-local-embedding-model-comparison.md
@@ -1,0 +1,72 @@
+# Local embedding model comparison
+
+This note records a local-only comparison of tested Ollama embedding models.
+It is guidance for choosing a model, not a claim of general retrieval
+superiority. Model quality, latency, memory use, and index size depend on the
+repository, hardware, and query mix.
+
+## Recommendation
+
+| Use case | Model | Why |
+|---|---|---|
+| Default and smallest tested download | `nomic-embed-text` | Fastest tested cross-repository latency and the project default |
+| Balanced local quality | `embeddinggemma` | Best representative MRR and a cross-repository MRR tie with Qwen 0.6B |
+| Maximum tested local quality | `qwen3-embedding:0.6b` | Best measured cross-repository nDCG |
+
+All three models achieved 100% Hit@5 in the frozen five-repository cohort, so
+the ranking differences below are small. Use Nomic when minimizing local model
+storage and latency matters more than those differences. Changing a model
+requires rebuilding the index.
+
+## Representative cohort
+
+- **Inputs:** 17 reviewed retrieval queries from the representative v2.2.0
+  dataset.
+- **Protocol:** local Ollama, RRF search configuration, forced reindex per
+  model, then warm query measurements.
+- **Environment:** local Apple silicon development machine on 2026-08-12.
+
+| Model | Download size | Hit@5 | MRR@10 | p95 query latency |
+|---|---:|---:|---:|---:|
+| `nomic-embed-text` | 274 MB | 68.75% | 0.5818 | 406 ms |
+| `embeddinggemma` | 621 MB | 81.25% | **0.6667** | 513 ms |
+| `mxbai-embed-large` | 669 MB | 81.25% | 0.5693 | 439 ms |
+| `bge-m3` | 1.2 GB | 81.25% | 0.5885 | 538 ms |
+| `qwen3-embedding:0.6b` | 639 MB | **87.50%** | 0.5703 | 532 ms |
+
+`qwen3-embedding:4b` was also downloaded, but the full representative run did
+not finish inside the 10-minute evaluation timeout. It is therefore excluded
+from comparisons and recommendations.
+
+## Frozen cross-repository cohort
+
+- **Inputs:** five pinned repositories, Axios, Express, Click, Cobra, and
+  ripgrep. The frozen cohort contains nine reviewed queries per repository, 45
+  total, across JavaScript, Python, Go, and Rust.
+- **Inputs and revisions:**
+  [`benchmarks/golden/expanded-cross-repo/`](../../benchmarks/golden/expanded-cross-repo/).
+- **Protocol:** one forced-reindex run per model, followed by warm retrieval
+  queries. Results are equal-repository averages, not a pooled query average.
+- **Comparability:** all three models had Hit@5 of 100%. The Qwen run was split
+  after the five-repository harness reached its 10-minute process timeout on
+  the final repository. Its first four repository artifacts and the separately
+  completed ripgrep run used the same frozen inputs and protocol.
+
+| Model | Hit@5 | MRR@10 | nDCG@10 | Per-repo p95 query latency |
+|---|---:|---:|---:|---:|
+| `nomic-embed-text` | 100.00% | 0.9222 | 0.9002 | 292 to 306 ms |
+| `embeddinggemma` | 100.00% | **0.9407** | 0.9038 | 382 to 398 ms |
+| `qwen3-embedding:0.6b` | 100.00% | **0.9407** | **0.9203** | 308 to 448 ms |
+
+The cohort is deliberately small and hand-reviewed. Treat it as a regression
+signal and a starting point for local selection, then reproduce it against
+your repositories with the cross-repository benchmark runner:
+
+```bash
+ollama pull qwen3-embedding:0.6b
+npx tsx scripts/cross-repo-benchmark.ts \
+  --repos /path/to/repo1,/path/to/repo2 \
+  --dataset-dir benchmarks/golden/expanded-cross-repo \
+  --embedding-model qwen3-embedding:0.6b \
+  --reindex --skip-ripgrep --skip-sg
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,44 @@ ollama pull nomic-embed-text
 }
 ```
 
+#### Choosing an Ollama embedding model
+
+`nomic-embed-text` remains the default local model. It is the smallest tested
+option and is a good starting point for most projects:
+
+```bash
+ollama pull nomic-embed-text
+```
+
+For a quality-focused local index, set `embeddingModel` explicitly. The
+following models were measured locally on the representative and frozen
+cross-repository cohorts:
+
+| Goal | Model | Trade-off |
+|---|---|---|
+| Small, fast default | `nomic-embed-text` | Lowest storage and latency among the tested models |
+| Balanced quality | `embeddinggemma` | Higher ranking quality with moderately higher latency and storage |
+| Maximum tested local quality | `qwen3-embedding:0.6b` | Best measured cross-repository nDCG, with higher latency and storage |
+
+For example, to use the balanced option:
+
+```bash
+ollama pull embeddinggemma
+```
+
+```json
+{
+  "embeddingProvider": "ollama",
+  "embeddingModel": "embeddinggemma"
+}
+```
+
+Changing an embedding model requires a force rebuild of its index. Check the
+current state with `index_status`, then run `index_codebase` with `force: true`.
+Keep the default when the additional local model download and query latency are
+not worthwhile for your project. See the [local model comparison](benchmarks/2026-08-12-local-embedding-model-comparison.md)
+for the methodology and measured results.
+
 ### OpenAI and Google
 
 Set the provider and corresponding environment credentials:

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -94,6 +94,7 @@ export interface CliOptions {
   skipSg: boolean;
   codegraph: boolean;
   codebaseMemoryMcp: boolean;
+  embeddingModel: string;
 }
 
 interface FileCollectionResult {
@@ -337,12 +338,13 @@ interface RipgrepJsonEvent {
 
 function printUsage(): void {
   console.log(`Usage:
-npx tsx scripts/cross-repo-benchmark.ts [--repos /path/a,/path/b] [--dataset-dir /path/to/golden] [--output benchmarks/results/cross-repo] [--reindex|--no-reindex] [--repeats N] [--max-parse-files N] [--persist-datasets] [--skip-ripgrep] [--skip-sg] [--codegraph] [--codebase-memory-mcp]
+npx tsx scripts/cross-repo-benchmark.ts [--repos /path/a,/path/b] [--dataset-dir /path/to/golden] [--embedding-model MODEL] [--output benchmarks/results/cross-repo] [--reindex|--no-reindex] [--repeats N] [--max-parse-files N] [--persist-datasets] [--skip-ripgrep] [--skip-sg] [--codegraph] [--codebase-memory-mcp]
 
 Defaults:
   repos: none (required via --repos or BENCHMARK_REPOS)
   output: benchmarks/results/cross-repo
   dataset-dir: none
+  embedding-model: ${CROSS_REPO_OLLAMA_MODEL}
   reindex: false
   repeats: 1
   max-parse-files: 2500
@@ -513,14 +515,17 @@ export function controlledEvalConfigPath(runDir: string, repoName: string): stri
   return path.join(runDir, "eval-configs", `${repoName}-benchmark.json`);
 }
 
-export function writeControlledEvalConfig(configPath: string): string {
+export function writeControlledEvalConfig(
+  configPath: string,
+  embeddingModel = CROSS_REPO_OLLAMA_MODEL,
+): string {
   const content = {
     indexing: {
       maxFileSize: MAX_FILE_SIZE_BYTES,
       maxChunksPerFile: MAX_CHUNKS_PER_FILE,
     },
     embeddingProvider: "ollama",
-    embeddingModel: CROSS_REPO_OLLAMA_MODEL,
+    embeddingModel,
   } satisfies ControlledEvalConfigArtifact;
 
   ensureDir(path.dirname(configPath));
@@ -581,6 +586,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
   let skipSg = false;
   let codegraph = false;
   let codebaseMemoryMcp = false;
+  let embeddingModel = CROSS_REPO_OLLAMA_MODEL;
 
   const envRepos = process.env.BENCHMARK_REPOS;
   if (envRepos && envRepos.trim().length > 0) {
@@ -685,6 +691,17 @@ export function parseCliArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (arg === "--embedding-model") {
+      const value = argv[i + 1];
+      const normalizedValue = value?.trim();
+      if (!normalizedValue) {
+        throw new Error("--embedding-model requires a model name");
+      }
+      embeddingModel = normalizedValue;
+      i += 1;
+      continue;
+    }
+
     if (arg === "--codegraph") {
       codegraph = true;
       continue;
@@ -714,6 +731,7 @@ export function parseCliArgs(argv: string[]): CliOptions {
     skipSg,
     codegraph,
     codebaseMemoryMcp,
+    embeddingModel,
   };
 }
 
@@ -1945,6 +1963,7 @@ export function buildReportMarkdown(
   lines.push("");
   lines.push(`- Generated at: ${runAt}`);
   lines.push(`- Output directory: ${runDir}`);
+  lines.push(`- Ollama embedding model: ${options.embeddingModel}`);
   lines.push(`- Reindex: ${options.reindex}`);
   lines.push(
     `- Reindex application in repeats: ${options.reindex ? "applied on repeat #1 only" : "disabled"}`
@@ -2224,7 +2243,8 @@ export async function runForRepo(
       reindexApplied: boolean;
     }> = [];
     const controlledEvalConfigArtifactPath = writeControlledEvalConfig(
-      controlledEvalConfigPath(runDir, repoName)
+      controlledEvalConfigPath(runDir, repoName),
+      options.embeddingModel,
     );
     let lastPluginResult: Awaited<ReturnType<typeof runEvaluation>> | null = null;
     let lastRipgrepQueryCount = 0;
@@ -2424,7 +2444,7 @@ async function main(): Promise<void> {
     }
   }
 
-  await ensureLocalOllamaForCrossRepoBenchmark();
+  await ensureLocalOllamaForCrossRepoBenchmark(options.embeddingModel);
 
   const runTimestamp = timestampForDir();
   const runDir = path.join(options.outputRoot, runTimestamp);
@@ -2475,6 +2495,7 @@ async function main(): Promise<void> {
     options: {
       repos: resolvedRepos,
       outputRoot: options.outputRoot,
+      embeddingModel: options.embeddingModel,
       reindex: options.reindex,
       repeats: options.repeats,
       maxParseFiles: options.maxParseFiles,

--- a/tests/cross-repo-benchmark-dataset-dir.test.ts
+++ b/tests/cross-repo-benchmark-dataset-dir.test.ts
@@ -178,6 +178,19 @@ describe("cross-repo benchmark dataset-dir flag", () => {
     expect(parseCliArgs(["--repos", repoPath]).datasetDir).toBeUndefined();
   });
 
+  it("parses a selected Ollama embedding model and retains the Nomic default", () => {
+    const repoPath = tempDir("cross-repo-benchmark-cli-model-");
+
+    expect(parseCliArgs(["--repos", repoPath]).embeddingModel).toBe("nomic-embed-text");
+    expect(
+      parseCliArgs(["--repos", repoPath, "--embedding-model", " embeddinggemma "])
+        .embeddingModel
+    ).toBe("embeddinggemma");
+    expect(() => parseCliArgs(["--repos", repoPath, "--embedding-model", " "])).toThrow(
+      "--embedding-model requires a model name"
+    );
+  });
+
   it("loads a fixed dataset with all supported evidence path fields", () => {
     const repoPath = tempDir("cross-repo-benchmark-fixed-load-repo-");
     const fixedDir = tempDir("cross-repo-benchmark-fixed-load-");
@@ -394,6 +407,7 @@ describe("cross-repo benchmark dataset-dir flag", () => {
       skipSg: true,
       codegraph: false,
       codebaseMemoryMcp: false,
+      embeddingModel: "embeddinggemma",
     };
 
     const result = await runForRepo(
@@ -411,6 +425,14 @@ describe("cross-repo benchmark dataset-dir flag", () => {
     const copied = JSON.parse(fs.readFileSync(result.datasetPath, "utf-8")) as { name: string; queries: unknown[] };
     expect(copied).toEqual(dataset);
     expect(vi.mocked(runner.runEvaluation).mock.calls[0]?.[0].datasetPath).toBe(result.datasetPath);
+    expect(
+      JSON.parse(
+        fs.readFileSync(path.join(runRoot, "eval-configs", `${repoName}-benchmark.json`), "utf-8")
+      )
+    ).toMatchObject({
+      embeddingProvider: "ollama",
+      embeddingModel: "embeddinggemma",
+    });
   });
 
   it("reports an error when a fixed dataset is absent for a repository", async () => {
@@ -445,6 +467,7 @@ describe("cross-repo benchmark dataset-dir flag", () => {
       skipSg: true,
       codegraph: false,
       codebaseMemoryMcp: false,
+      embeddingModel: "nomic-embed-text",
     };
 
     const expectedRunDatasetPath = path.join(runRoot, "datasets", `${path.basename(repoPath)}.json`);


### PR DESCRIPTION
## Summary
- add `--embedding-model` to the cross-repository benchmark runner, preserving Nomic as the default
- record the selected model in controlled configs and Markdown/JSON artifacts
- document local Ollama recommendations and reproducible comparison results

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run build && npm run test:run`
- `npx vitest run tests/cross-repo-benchmark-dataset-dir.test.ts tests/cross-repo-codegraph.test.ts tests/cross-repo-codebase-memory.test.ts`