### PR TITLE
test: harden frozen cross-repo benchmark cohort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Validate frozen cross-repo benchmark inputs and comparator contracts
         run: npm run benchmark:cross-repo:check
 
+      - name: Validate frozen cross-repo source evidence against pinned revisions
+        run: npm run benchmark:cross-repo:sources:check
+
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added an Ollama-only representative retrieval evaluation command with expanded coverage for embedding failure recovery, index-lock recovery, and duplicate-definition path disambiguation.
 - Added `--embedding-model` to the cross-repository benchmark runner, preserving `nomic-embed-text` as the default while recording the selected local Ollama model in its artifacts.
-- Expanded the frozen mixed-intent cross-repository cohort to 81 reviewed queries across JavaScript, Python, Go, Rust, Java, C#, PHP, and Ruby.
+- Expanded the frozen mixed-intent cross-repository cohort to 100 reviewed queries across JavaScript, Python, Go, Rust, Java, C#, PHP, and Ruby, with additional hard Ruby and C# cases.
+- Added a deterministic pull-request CI gate that clones each pinned cohort revision and validates every evidence path plus definition symbol without invoking embeddings.
 
 ### Changed
 

--- a/benchmarks/golden/expanded-cross-repo/cohort.json
+++ b/benchmarks/golden/expanded-cross-repo/cohort.json
@@ -1,8 +1,7 @@
 {
-  "version": "1.3.0",
-  "name": "expanded-cross-repo-mixed-intent-pilot-v3",
-  "description": "Reviewed definition, keyword-heavy, implementation-intent, and conceptual queries for a frozen, local-only cross-repository comparison cohort across JavaScript, Python, Go, Rust, Java, C#, PHP, and Ruby.",
-  "queryCountPerRepository": 9,
+  "version": "1.4.0",
+  "name": "expanded-cross-repo-mixed-intent-cohort-v4",
+  "description": "Reviewed definition, keyword-heavy, implementation-intent, and conceptual queries for a frozen, local-only cross-repository comparison cohort across JavaScript, Python, Go, Rust, Java, C#, PHP, and Ruby. The Ruby and C# datasets carry additional hard retrieval cases.",
   "repositories": [
     {
       "name": "axios",
@@ -67,5 +66,6 @@
       "language": "Ruby",
       "dataset": "sinatra.json"
     }
-  ]
+  ],
+  "queryCount": 100
 }

--- a/benchmarks/golden/expanded-cross-repo/newtonsoft-json.json
+++ b/benchmarks/golden/expanded-cross-repo/newtonsoft-json.json
@@ -175,6 +175,215 @@
           }
         ]
       }
+    },
+    {
+      "id": "newtonsoft-json-json-converter-definition",
+      "query": "where is JsonConverter defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "JsonConverter"
+      },
+      "expected": {
+        "filePath": "Src/Newtonsoft.Json/JsonConverter.cs",
+        "symbol": "JsonConverter",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "newtonsoft-json-json-exception-definition",
+      "query": "where is JsonException defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "JsonException"
+      },
+      "expected": {
+        "filePath": "Src/Newtonsoft.Json/JsonException.cs",
+        "symbol": "JsonException",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "newtonsoft-json-camel-case-naming-definition",
+      "query": "where is CamelCaseNamingStrategy defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "CamelCaseNamingStrategy"
+      },
+      "expected": {
+        "filePath": "Src/Newtonsoft.Json/Serialization/CamelCaseNamingStrategy.cs",
+        "symbol": "CamelCaseNamingStrategy",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "newtonsoft-json-json-contract-definition",
+      "query": "where is JsonContract defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "JsonContract"
+      },
+      "expected": {
+        "filePath": "Src/Newtonsoft.Json/Serialization/JsonContract.cs",
+        "symbol": "JsonContract",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "newtonsoft-json-converter-keywords",
+      "query": "CanConvert ReadJson WriteJson existingValue serializer converter",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "csharp",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "converter",
+        "serialization",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "Src/Newtonsoft.Json/JsonConverter.cs",
+            "relevance": 3
+          },
+          {
+            "path": "Src/Newtonsoft.Json/JsonConvert.cs",
+            "relevance": 2
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs",
+            "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "newtonsoft-json-contract-keywords",
+      "query": "JsonContract CreatedType Converter IsReference ItemContract UnderlyingType",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "csharp",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "contract",
+        "metadata",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/JsonContract.cs",
+            "relevance": 3
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "newtonsoft-json-converter-implementation",
+      "query": "implementation that selects a JsonConverter and uses it to read or write JSON values through the serializer pipeline",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "csharp",
+      "difficulty": "hard",
+      "tags": [
+        "implementation-intent",
+        "implementation",
+        "converter"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "Src/Newtonsoft.Json/JsonConverter.cs",
+            "relevance": 3
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs",
+            "relevance": 2
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/JsonSerializerInternalWriter.cs",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "newtonsoft-json-metadata-concept",
+      "query": "conceptual view of how contract resolution combines naming strategies, reflection metadata, and property serialization",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "csharp",
+      "difficulty": "hard",
+      "tags": [
+        "conceptual",
+        "conceptual",
+        "metadata"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/DefaultContractResolver.cs",
+            "relevance": 3
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/JsonContract.cs",
+            "relevance": 2
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/CamelCaseNamingStrategy.cs",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "newtonsoft-json-json-reader-concept",
+      "query": "conceptual view of how a JsonReader token stream is validated and mapped into serializer contracts",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "csharp",
+      "difficulty": "hard",
+      "tags": [
+        "conceptual",
+        "conceptual",
+        "reader"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "Src/Newtonsoft.Json/JsonTextReader.cs",
+            "relevance": 3
+          },
+          {
+            "path": "Src/Newtonsoft.Json/JsonValidatingReader.cs",
+            "relevance": 2
+          },
+          {
+            "path": "Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs",
+            "relevance": 2
+          }
+        ]
+      }
     }
   ]
 }

--- a/benchmarks/golden/expanded-cross-repo/sinatra.json
+++ b/benchmarks/golden/expanded-cross-repo/sinatra.json
@@ -195,6 +195,221 @@
           }
         ]
       }
+    },
+    {
+      "id": "sinatra-show-exceptions-definition",
+      "query": "where is ShowExceptions defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "ShowExceptions"
+      },
+      "expected": {
+        "filePath": "lib/sinatra/show_exceptions.rb",
+        "symbol": "ShowExceptions",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "sinatra-session-hijacking-definition",
+      "query": "where is SessionHijacking defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "SessionHijacking"
+      },
+      "expected": {
+        "filePath": "rack-protection/lib/rack/protection/session_hijacking.rb",
+        "symbol": "SessionHijacking",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "sinatra-content-security-policy-definition",
+      "query": "where is ContentSecurityPolicy defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "ContentSecurityPolicy"
+      },
+      "expected": {
+        "filePath": "rack-protection/lib/rack/protection/content_security_policy.rb",
+        "symbol": "ContentSecurityPolicy",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "sinatra-host-authorization-definition",
+      "query": "where is HostAuthorization defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "HostAuthorization"
+      },
+      "expected": {
+        "filePath": "rack-protection/lib/rack/protection/host_authorization.rb",
+        "symbol": "HostAuthorization",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "sinatra-reloader-watcher-definition",
+      "query": "where is Watcher defined",
+      "queryType": "definition",
+      "retrievalMode": "context",
+      "args": {
+        "symbol": "Watcher"
+      },
+      "expected": {
+        "filePath": "sinatra-contrib/lib/sinatra/reloader.rb",
+        "symbol": "Watcher",
+        "expectedRoute": "definition"
+      }
+    },
+    {
+      "id": "sinatra-reloader-keywords",
+      "query": "also_reload dont_reload watch reload! updated constant load dependency",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "ruby",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "reloader",
+        "development",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "sinatra-contrib/lib/sinatra/reloader.rb",
+            "relevance": 3
+          },
+          {
+            "path": "lib/sinatra/base.rb",
+            "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "sinatra-protection-headers-keywords",
+      "query": "content security policy nonce report only x frame options xss header referrer",
+      "queryType": "keyword-heavy",
+      "retrievalMode": "search",
+      "language": "ruby",
+      "difficulty": "hard",
+      "tags": [
+        "keyword",
+        "security",
+        "headers",
+        "multi-evidence"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "rack-protection/lib/rack/protection/content_security_policy.rb",
+            "relevance": 3
+          },
+          {
+            "path": "rack-protection/lib/rack/protection/xss_header.rb",
+            "relevance": 2
+          },
+          {
+            "path": "rack-protection/lib/rack/protection/frame_options.rb",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "sinatra-reloader-implementation",
+      "query": "implementation that watches source files, reloads changed constants, and reruns the application",
+      "queryType": "implementation-intent",
+      "retrievalMode": "context",
+      "language": "ruby",
+      "difficulty": "hard",
+      "tags": [
+        "implementation-intent",
+        "implementation",
+        "reloader"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "sinatra-contrib/lib/sinatra/reloader.rb",
+            "relevance": 3
+          },
+          {
+            "path": "lib/sinatra/base.rb",
+            "relevance": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "sinatra-session-security-concept",
+      "query": "how rack protection detects session hijacking, validates remote tokens, and protects request state",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "ruby",
+      "difficulty": "hard",
+      "tags": [
+        "conceptual",
+        "security",
+        "session"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "rack-protection/lib/rack/protection/session_hijacking.rb",
+            "relevance": 3
+          },
+          {
+            "path": "rack-protection/lib/rack/protection/remote_token.rb",
+            "relevance": 2
+          },
+          {
+            "path": "rack-protection/lib/rack/protection/authenticity_token.rb",
+            "relevance": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "sinatra-development-errors-concept",
+      "query": "how Sinatra wraps application failures to show exceptions, render stack traces, and negotiate error responses",
+      "queryType": "conceptual",
+      "retrievalMode": "context",
+      "language": "ruby",
+      "difficulty": "hard",
+      "tags": [
+        "conceptual",
+        "errors",
+        "development"
+      ],
+      "expected": {
+        "expectedRoute": "search",
+        "expectedOutcome": "results",
+        "gradedEvidence": [
+          {
+            "path": "lib/sinatra/show_exceptions.rb",
+            "relevance": 3
+          },
+          {
+            "path": "lib/sinatra/base.rb",
+            "relevance": 2
+          }
+        ]
+      }
     }
   ]
 }

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -86,9 +86,10 @@ describes the tested options and their trade-offs.
 
   The expanded frozen cohort currently covers Axios, Express, Click, Cobra,
   ripgrep, Gson, Newtonsoft.Json, Symfony Console, and Sinatra. It contains
-  nine mixed-intent queries per repository, 81 total, across JavaScript,
-  Python, Go, Rust, Java, C#, PHP, and Ruby. Exact revisions are recorded in
-  `benchmarks/golden/expanded-cross-repo/cohort.json`.
+  100 mixed-intent queries across JavaScript, Python, Go, Rust, Java, C#, PHP,
+  and Ruby. Sinatra carries 19 hard routing, reloading, and security queries;
+  Newtonsoft.Json carries 18 serializer, converter, and metadata queries. Exact
+  revisions are recorded in `benchmarks/golden/expanded-cross-repo/cohort.json`.
 
 ```bash
 npx tsx scripts/cross-repo-benchmark.ts \
@@ -108,10 +109,16 @@ npx tsx scripts/cross-repo-benchmark.ts --repos /path/to/repo1,/path/to/repo2 --
 
 ## Lightweight CI integrity gate
 
-The main CI workflow runs the following no-model check on every pull request. It validates frozen dataset shape, input loading, and the CodeGraph and codebase-memory-mcp comparator contracts without cloning external repositories, invoking Ollama, or running an expensive comparison.
+The main CI workflow first runs a no-model contract check on every pull request. It validates frozen dataset shape, input loading, and the CodeGraph and codebase-memory-mcp comparator contracts without cloning external repositories, invoking Ollama, or running an expensive comparison.
 
 ```bash
 npm run benchmark:cross-repo:check
+```
+
+It then runs a deterministic source-evidence gate that fetches and checks out each pinned cohort revision, checks every expected and graded-evidence path, and confirms every definition symbol is present in its target file. It does not execute checked-out code or invoke an embedding provider.
+
+```bash
+npm run benchmark:cross-repo:sources:check
 ```
 
 Run the full local benchmark manually or from a scheduled quality workflow when a retrieval change needs measured quality results.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "benchmark:indexing-memory": "npx tsx benchmarks/indexing-memory.ts",
     "benchmark:watcher": "npx tsx benchmarks/watcher.ts",
     "benchmark:cross-repo:check": "npx vitest run tests/cross-repo-benchmark-dataset-dir.test.ts tests/cross-repo-codegraph.test.ts tests/cross-repo-codebase-memory.test.ts",
+    "benchmark:cross-repo:sources:check": "npx tsx scripts/validate-cross-repo-cohort.ts --cohort-dir benchmarks/golden/expanded-cross-repo --work-dir ./.tmp/cross-repo-sources",
     "dev:link-mcp": "node scripts/link-local-mcp-bin.mjs",
     "test": "vitest",
     "pretest:run": "node scripts/run-build-native-with-rustflags.mjs && npm run build:ts",

--- a/scripts/validate-cross-repo-cohort.ts
+++ b/scripts/validate-cross-repo-cohort.ts
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+import { loadFixedDataset } from "./cross-repo-benchmark.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface CrossRepoCohortValidationOptions {
+  cohortDir: string;
+  workDir?: string;
+}
+
+interface CohortManifestRepository {
+  name: string;
+  url: string;
+  revision: string;
+  dataset: string;
+}
+
+interface CohortManifest {
+  repositories: CohortManifestRepository[];
+}
+
+interface RepoDefinitionMiss {
+  repository: string;
+  queryId: string;
+  symbol: string;
+  filePath: string;
+}
+
+interface RepoValidationResult {
+  repository: string;
+  dataset: string;
+  definitionQueriesChecked: number;
+  definitionQueriesWithMissingSymbols: number;
+  errors: string[];
+  missing: RepoDefinitionMiss[];
+}
+
+export interface CrossRepoCohortValidationSummary {
+  cohortDir: string;
+  workspaceDir: string;
+  repositoriesChecked: number;
+  repositoriesPassed: number;
+  repositoriesFailed: number;
+  repoResults: RepoValidationResult[];
+}
+
+const DEFAULT_COHORT_DIR = path.join(process.cwd(), "benchmarks", "golden", "expanded-cross-repo");
+
+function expandHome(input: string): string {
+  if (!input.startsWith("~")) {
+    return input;
+  }
+  const home = process.env.HOME;
+  if (!home) {
+    return input;
+  }
+
+  if (input === "~") {
+    return home;
+  }
+
+  return path.join(home, input.slice(2));
+}
+
+function normalizeLocalRepoSource(rawUrl: string, cohortRoot: string): string {
+  const value = expandHome(rawUrl);
+
+  if (value.startsWith("file://")) {
+    return fileURLToPath(value);
+  }
+
+  const looksLikeSshRemote = /^[^\s@:/]+@[^\s:/]+:/.test(value);
+
+  if (value.includes("://") || looksLikeSshRemote) {
+    return value;
+  }
+
+  if (path.isAbsolute(value)) {
+    return value;
+  }
+
+  return path.resolve(cohortRoot, value);
+}
+
+function isEmpty(value: unknown): value is null | undefined | "" {
+  return value === undefined || value === null || value === "";
+}
+
+function parseCohortManifest(manifestPath: string): CohortManifest {
+  const raw = fs.readFileSync(manifestPath, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Cannot parse cohort manifest ${manifestPath}: ${message}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Invalid cohort manifest ${manifestPath}: expected object`);
+  }
+
+  const candidate = parsed as {
+    repositories?: unknown;
+    [key: string]: unknown;
+  };
+  if (!Array.isArray(candidate.repositories)) {
+    throw new Error(`Invalid cohort manifest ${manifestPath}: repositories must be an array`);
+  }
+
+  const repositories = candidate.repositories.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`Invalid repository entry at index ${index}: expected object`);
+    }
+
+    const candidateRepo = entry as {
+      name?: unknown;
+      url?: unknown;
+      revision?: unknown;
+      dataset?: unknown;
+    };
+
+    if (typeof candidateRepo.name !== "string" || candidateRepo.name.trim().length === 0) {
+      throw new Error(`Invalid repository entry at index ${index}: name must be a non-empty string`);
+    }
+    if (typeof candidateRepo.url !== "string" || candidateRepo.url.trim().length === 0) {
+      throw new Error(`Invalid repository entry at index ${index}: url must be a non-empty string`);
+    }
+    if (typeof candidateRepo.revision !== "string" || candidateRepo.revision.trim().length === 0) {
+      throw new Error(`Invalid repository entry at index ${index}: revision must be a non-empty string`);
+    }
+    if (typeof candidateRepo.dataset !== "string" || candidateRepo.dataset.trim().length === 0) {
+      throw new Error(`Invalid repository entry at index ${index}: dataset must be a non-empty string`);
+    }
+
+    return {
+      name: candidateRepo.name,
+      url: candidateRepo.url,
+      revision: candidateRepo.revision,
+      dataset: candidateRepo.dataset,
+    } satisfies CohortManifestRepository;
+  });
+
+  return { repositories };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, {
+    cwd,
+    maxBuffer: 10 * 1024 * 1024,
+    encoding: "utf-8",
+  });
+}
+
+async function cloneRepository(source: string, revision: string, destination: string): Promise<void> {
+  if (fs.existsSync(destination)) {
+    fs.rmSync(destination, { recursive: true, force: true });
+  }
+
+  const cloneCommandSets: string[][] = [
+    ["clone", "--quiet", "--no-checkout", "--filter=blob:none", "--depth", "1", "--", source, destination],
+    ["clone", "--quiet", "--no-checkout", "--depth", "1", "--", source, destination],
+    ["clone", "--quiet", "--no-checkout", "--", source, destination],
+  ];
+
+  let cloneFailure: unknown = null;
+  for (const cloneArgs of cloneCommandSets) {
+    try {
+      await runGit(process.cwd(), cloneArgs);
+      cloneFailure = null;
+      break;
+    } catch (error: unknown) {
+      cloneFailure = error;
+      if (fs.existsSync(destination)) {
+        fs.rmSync(destination, { recursive: true, force: true });
+      }
+    }
+  }
+
+  if (cloneFailure) {
+    throw new Error(`Failed to clone repository ${source}: ${getErrorMessage(cloneFailure)}`);
+  }
+
+  try {
+    await runGit(destination, ["fetch", "--quiet", "--depth", "1", "origin", revision]);
+  } catch (error: unknown) {
+    if (!fs.existsSync(path.join(destination, ".git"))) {
+      throw new Error(`Failed to fetch ${revision} for ${source}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  try {
+    await runGit(destination, ["checkout", "--quiet", "--detach", revision]);
+  } catch (error: unknown) {
+    throw new Error(`Failed to checkout ${revision} for ${source}: ${getErrorMessage(error)}`);
+  }
+}
+
+function safeReadText(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+function sanitizeRepoDirName(name: string): string {
+  return name.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+async function validateRepo(
+  repo: CohortManifestRepository,
+  cohortDir: string,
+  workspace: string,
+  repoIndex: number,
+): Promise<RepoValidationResult> {
+  const repoDir = path.join(workspace, `${String(repoIndex).padStart(2, "0")}-${sanitizeRepoDirName(repo.name)}`);
+  const result: RepoValidationResult = {
+    repository: repo.name,
+    dataset: repo.dataset,
+    definitionQueriesChecked: 0,
+    definitionQueriesWithMissingSymbols: 0,
+    errors: [],
+    missing: [],
+  };
+
+  try {
+    const source = normalizeLocalRepoSource(repo.url, cohortDir);
+    await cloneRepository(source, repo.revision, repoDir);
+
+    const datasetPath = path.join(cohortDir, repo.dataset);
+    const dataset = loadFixedDataset(datasetPath, repoDir);
+    const definitionQueries = dataset.queries.filter((query) => query.queryType === "definition");
+
+    result.definitionQueriesChecked = definitionQueries.length;
+    for (const query of definitionQueries) {
+      const symbol = query.expected.symbol;
+      const filePath = query.expected.filePath;
+
+      if (isEmpty(symbol) || isEmpty(filePath)) {
+        result.errors.push(`Definition query ${query.id} is missing expected symbol or file path`);
+        result.definitionQueriesWithMissingSymbols += 1;
+        continue;
+      }
+
+      const absoluteFilePath = path.resolve(repoDir, filePath);
+      const sourceText = safeReadText(absoluteFilePath);
+
+      if (!sourceText.includes(symbol)) {
+        result.definitionQueriesWithMissingSymbols += 1;
+        result.missing.push({
+          repository: repo.name,
+          queryId: query.id,
+          symbol,
+          filePath,
+        });
+      }
+    }
+  } catch (error: unknown) {
+    result.errors.push(getErrorMessage(error));
+  } finally {
+    if (fs.existsSync(repoDir)) {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  }
+
+  return result;
+}
+
+export async function validateCrossRepoCohortSources(
+  options: CrossRepoCohortValidationOptions,
+): Promise<CrossRepoCohortValidationSummary> {
+  const resolvedCohortDir = path.resolve(options.cohortDir);
+  const manifestPath = path.join(resolvedCohortDir, "cohort.json");
+  const cohort = parseCohortManifest(manifestPath);
+
+  const baseWorkRoot = options.workDir
+    ? path.resolve(options.workDir)
+    : fs.mkdtempSync(path.join(os.tmpdir(), "cross-repo-source-validate-"));
+  if (!fs.existsSync(baseWorkRoot)) {
+    fs.mkdirSync(baseWorkRoot, { recursive: true });
+  }
+  const workspace = fs.mkdtempSync(path.join(baseWorkRoot, `run-${String(Date.now())}-`));
+
+  const repoResults: RepoValidationResult[] = [];
+  try {
+    for (let index = 0; index < cohort.repositories.length; index += 1) {
+      const repo = cohort.repositories[index];
+      const result = await validateRepo(repo, resolvedCohortDir, workspace, index + 1);
+      repoResults.push(result);
+    }
+  } finally {
+    if (fs.existsSync(workspace)) {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+
+    if (!options.workDir && fs.existsSync(baseWorkRoot)) {
+      fs.rmSync(baseWorkRoot, { recursive: true, force: true });
+    }
+  }
+
+  const failedResults = repoResults.filter(
+    (repo) => repo.errors.length > 0 || repo.definitionQueriesWithMissingSymbols > 0,
+  );
+
+  return {
+    cohortDir: resolvedCohortDir,
+    workspaceDir: workspace,
+    repositoriesChecked: repoResults.length,
+    repositoriesPassed: repoResults.length - failedResults.length,
+    repositoriesFailed: failedResults.length,
+    repoResults,
+  };
+}
+
+export function parseCliArgs(argv: string[]): CrossRepoCohortValidationOptions {
+  let cohortDir = DEFAULT_COHORT_DIR;
+  let workDir: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--cohort-dir") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--cohort-dir requires a path");
+      }
+      cohortDir = path.resolve(expandHome(value));
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--work-dir" || arg === "--cache-dir") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error("--work-dir requires a path");
+      }
+      workDir = path.resolve(expandHome(value));
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      console.log(`Usage:
+npx tsx scripts/validate-cross-repo-cohort.ts [--cohort-dir PATH] [--work-dir PATH]
+
+Defaults:
+  --cohort-dir: ${DEFAULT_COHORT_DIR}
+  --work-dir: a temporary directory created under os.tmpdir()
+
+Aliases:
+  --cache-dir can be used as a CI-friendly work directory alias for --work-dir
+`);
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { cohortDir, workDir };
+}
+
+function printFailureReport(summary: CrossRepoCohortValidationSummary): void {
+  console.error("Cross-repo source evidence validation failed");
+  console.error(`Cohort: ${summary.cohortDir}`);
+  console.error(`Checked repositories: ${summary.repositoriesChecked}`);
+
+  for (const repo of summary.repoResults) {
+    if (repo.errors.length === 0 && repo.definitionQueriesWithMissingSymbols === 0) {
+      console.log(`  [ok] ${repo.repository}`);
+      continue;
+    }
+
+    console.error(`  [fail] ${repo.repository}`);
+    if (repo.errors.length > 0) {
+      for (const error of repo.errors) {
+        console.error(`    - ${error}`);
+      }
+    }
+
+    for (const miss of repo.missing) {
+      console.error(
+        `    - ${miss.queryId}: expected symbol '${miss.symbol}' in ${miss.filePath}`,
+      );
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseCliArgs(process.argv.slice(2));
+  const summary = await validateCrossRepoCohortSources(options);
+  console.log(`Cross-repo source evidence validation complete: ${summary.repositoriesPassed}/${summary.repositoriesChecked} repositories passed.`);
+  if (summary.repositoriesFailed > 0) {
+    printFailureReport(summary);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("All repository definition symbol checks passed.");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  main().catch((error: unknown) => {
+    printFailureReport({
+      cohortDir: "",
+      workspaceDir: "",
+      repositoriesChecked: 0,
+      repositoriesPassed: 0,
+      repositoriesFailed: 1,
+      repoResults: [{
+        repository: "bootstrap",
+        dataset: "",
+        definitionQueriesChecked: 0,
+        definitionQueriesWithMissingSymbols: 0,
+        errors: [getErrorMessage(error)],
+        missing: [],
+      }],
+    });
+    process.exitCode = 1;
+  });
+}

--- a/tests/cross-repo-benchmark-dataset-dir.test.ts
+++ b/tests/cross-repo-benchmark-dataset-dir.test.ts
@@ -118,22 +118,23 @@ function withRunEvaluationMock(result: Awaited<ReturnType<typeof runner.runEvalu
 }
 
 describe("cross-repo benchmark dataset-dir flag", () => {
-  it("keeps the expanded frozen cohort balanced between definition and keyword-heavy retrieval", () => {
+  it("keeps the expanded frozen cohort balanced and source-evidenced across retrieval modes", () => {
     const cohortDir = path.join(process.cwd(), "benchmarks", "golden", "expanded-cross-repo");
     const cohort = JSON.parse(fs.readFileSync(path.join(cohortDir, "cohort.json"), "utf-8")) as {
       version: string;
       name: string;
-      queryCountPerRepository: number;
-      repositories: Array<{ dataset: string }>;
+      queryCount: number;
+      repositories: Array<{ name: string; dataset: string }>;
     };
 
     expect(cohort).toMatchObject({
-      version: "1.3.0",
-      name: "expanded-cross-repo-mixed-intent-pilot-v3",
-      queryCountPerRepository: 9,
+      version: "1.4.0",
+      name: "expanded-cross-repo-mixed-intent-cohort-v4",
+      queryCount: 100,
     });
     expect(cohort.repositories).toHaveLength(9);
 
+    let totalQueries = 0;
     for (const repository of cohort.repositories) {
       const dataset = JSON.parse(fs.readFileSync(path.join(cohortDir, repository.dataset), "utf-8")) as {
         version: string;
@@ -150,11 +151,18 @@ describe("cross-repo benchmark dataset-dir flag", () => {
       const conceptual = dataset.queries.filter((query) => query.queryType === "conceptual");
 
       expect(dataset.version).toBe("1.2.0");
-      expect(new Set(dataset.queries.map((query) => query.id)).size).toBe(9);
-      expect(definitions).toHaveLength(5);
-      expect(keywordHeavy).toHaveLength(2);
-      expect(implementation).toHaveLength(1);
-      expect(conceptual).toHaveLength(1);
+      expect(new Set(dataset.queries.map((query) => query.id)).size).toBe(dataset.queries.length);
+      totalQueries += dataset.queries.length;
+      const expectedCount = repository.name === "sinatra"
+        ? 19
+        : repository.name === "newtonsoft-json"
+          ? 18
+          : 9;
+      expect(dataset.queries).toHaveLength(expectedCount);
+      expect(definitions.length).toBeGreaterThanOrEqual(5);
+      expect(keywordHeavy.length).toBeGreaterThanOrEqual(2);
+      expect(implementation.length).toBeGreaterThanOrEqual(1);
+      expect(conceptual.length).toBeGreaterThanOrEqual(1);
       for (const query of keywordHeavy) {
         expect(query.retrievalMode).toBe("search");
         expect(query.expected.expectedRoute).toBe("search");
@@ -166,6 +174,8 @@ describe("cross-repo benchmark dataset-dir flag", () => {
         expect(query.expected.gradedEvidence?.length).toBeGreaterThan(0);
       }
     }
+
+    expect(totalQueries).toBe(cohort.queryCount);
   });
 
   it("parses --dataset-dir in CLI args", () => {

--- a/tests/validate-cross-repo-cohort.test.ts
+++ b/tests/validate-cross-repo-cohort.test.ts
@@ -1,0 +1,179 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  parseCliArgs,
+  validateCrossRepoCohortSources,
+} from "../scripts/validate-cross-repo-cohort.js";
+import { spawnSync } from "node:child_process";
+
+const tempDirs: string[] = [];
+
+function tempDir(prefix: string): string {
+  const directory = fs.mkdtempSync(path.join(process.cwd(), "tmp-") + prefix);
+  tempDirs.push(directory);
+  return directory;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function writeRepoFiles(repoPath: string, entries: Record<string, string>): void {
+  for (const [fileName, content] of Object.entries(entries)) {
+    const absolute = path.join(repoPath, fileName);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, content, "utf-8");
+  }
+}
+
+function runGit(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, {
+    cwd,
+    stdio: "ignore",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`git command failed: git ${args.join(" ")}`);
+  }
+}
+
+function createGitRepo(): { repoPath: string; rev1: string } {
+  const repoPath = tempDir("cross-repo-cohort-src-");
+  fs.mkdirSync(repoPath, { recursive: true });
+
+  runGit(repoPath, ["init"]);
+  runGit(repoPath, ["config", "user.name", "ci"]);
+  runGit(repoPath, ["config", "user.email", "ci@example.com"]);
+
+  writeRepoFiles(repoPath, {
+    "src/fixture.ts": "export function expectedSymbol() { return 1; }\n",
+  });
+  runGit(repoPath, ["add", "."]);
+  runGit(repoPath, ["commit", "-m", "initial"]); 
+  const rev1 = execSync("git rev-parse HEAD", { cwd: repoPath, encoding: "utf-8" }).trim();
+  return { repoPath, rev1 };
+}
+
+function createCohortFixture(options: { repoPath: string; revision: string; symbol: string }) {
+  const cohortDir = tempDir("cross-repo-cohort-manifest-");
+  const datasetName = "fixture.json";
+  const cohortName = "cohort-local";
+
+  writeJson(path.join(cohortDir, "cohort.json"), {
+    version: "1.3.0",
+    name: "cohort-local",
+    repositories: [{
+      name: "local-repo",
+      url: options.repoPath,
+      revision: options.revision,
+      dataset: datasetName,
+    }],
+  });
+
+  writeJson(path.join(cohortDir, datasetName), {
+    version: "1.2.0",
+    name: cohortName,
+    queries: [
+      {
+        id: "definition-1",
+        query: "where is expectedSymbol defined",
+        queryType: "definition",
+        retrievalMode: "context",
+        args: {
+          symbol: options.symbol,
+        },
+        expected: {
+          filePath: "src/fixture.ts",
+          symbol: options.symbol,
+          expectedRoute: "definition",
+        },
+      },
+    ],
+  });
+
+  return { cohortDir };
+}
+
+beforeEach(() => {
+  tempDirs.length = 0;
+});
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const directory = tempDirs.pop();
+    if (directory) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("cross-repo source validator", () => {
+  it("validates pinned revision definition symbol presence in local fixture repos", async () => {
+    const { repoPath, rev1 } = createGitRepo();
+    const { cohortDir } = createCohortFixture({
+      repoPath,
+      revision: rev1,
+      symbol: "expectedSymbol",
+    });
+    const workDir = tempDir("cross-repo-cohort-work-");
+
+    const summary = await validateCrossRepoCohortSources({
+      cohortDir,
+      workDir,
+    });
+
+    expect(summary.repositoriesChecked).toBe(1);
+    expect(summary.repositoriesPassed).toBe(1);
+    expect(summary.repositoriesFailed).toBe(0);
+    expect(summary.repoResults[0]).toMatchObject({
+      repository: "local-repo",
+      definitionQueriesChecked: 1,
+      definitionQueriesWithMissingSymbols: 0,
+    });
+    expect(fs.existsSync(summary.workspaceDir)).toBe(false);
+  });
+
+  it("fails when a definition symbol is not present in the expected file", async () => {
+    const { repoPath, rev1 } = createGitRepo();
+    const { cohortDir } = createCohortFixture({
+      repoPath,
+      revision: rev1,
+      symbol: "missingSymbol",
+    });
+
+    const result = await validateCrossRepoCohortSources({ cohortDir });
+
+    expect(result.repositoriesChecked).toBe(1);
+    expect(result.repositoriesPassed).toBe(0);
+    expect(result.repositoriesFailed).toBe(1);
+    expect(result.repoResults[0].definitionQueriesWithMissingSymbols).toBe(1);
+    expect(result.repoResults[0].missing).toHaveLength(1);
+    expect(result.repoResults[0].missing[0]!.queryId).toBe("definition-1");
+  });
+
+  it("supports --cohort-dir and --cache-dir CLI flags", () => {
+    const customCohortDir = path.join(process.cwd(), "tmp-fixture-cohort");
+    const customWorkDir = path.join(process.cwd(), "tmp-validator-work");
+    const parsed = parseCliArgs([
+      "--cohort-dir",
+      customCohortDir,
+      "--cache-dir",
+      customWorkDir,
+    ]);
+
+    expect(parsed).toEqual({
+      cohortDir: path.resolve(customCohortDir),
+      workDir: path.resolve(customWorkDir),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expands the frozen mixed-intent cohort to 100 reviewed queries, concentrating additional hard cases in Sinatra and Newtonsoft.Json
- adds a deterministic CI source-evidence gate that checks out every pinned revision, validates all evidence paths, and verifies definition symbols without executing source or invoking embeddings
- retains retrieval benchmarking as an opt-in/scheduled workflow

## Validation
- `npm run build && npm run test:run`
- `npm run benchmark:cross-repo:sources:check` completed 9/9 repositories
- exercised `scripts/cross-repo-benchmark.ts` with forced reindexing on the expanded Sinatra and Newtonsoft.Json datasets

## Public runner results
- Sinatra: 47.37% Hit@5 across 19 queries
- Newtonsoft.Json: 77.78% Hit@5 across 18 queries