### PR TITLE
fix definition ranking for large symbols

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -4836,7 +4836,12 @@ export class Indexer {
     );
 
     const prePrimaryLane = mergeTieredResults(deterministicIdentifierLane, identifierLane, maxResults * 4);
-    const primaryLane = mergeTieredResults(prePrimaryLane, symbolLane, maxResults * 4);
+    // An explicit definition lookup can resolve to a symbol whose declaration
+    // spans more lines than any indexable chunk. Keep that exact symbol ahead
+    // of prefix and semantic matches so it is not pushed beyond maxResults.
+    const primaryLane = options?.definitionIntent === true
+      ? mergeTieredResults(symbolLane, prePrimaryLane, maxResults * 4)
+      : mergeTieredResults(prePrimaryLane, symbolLane, maxResults * 4);
     const tiered = mergeTieredResults(primaryLane, rescued, maxResults * 4);
     const hasCodeHints = extractCodeTermHints(query).length > 0 || identifierHints.length > 0;
 

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -232,6 +232,37 @@ export function rerankResults(query: string) { return rankHybridResults(query); 
     expect(results[0]?.endLine).toBeGreaterThanOrEqual(results[0]?.startLine ?? 0);
   });
 
+  it("keeps an exact large C# definition ahead of prefix matches", async () => {
+    const sourceFile = path.join(tempDir, "app", "indexer", "LargeDefinition.cs");
+    const noisyFile = path.join(tempDir, "app", "indexer", "LargeDefinitionProxy.cs");
+    fs.writeFileSync(
+      sourceFile,
+      `public class LargeDefinition {
+${Array.from({ length: 120 }, (_, index) => `  public int Value${index} { get; set; }`).join("\n")}
+}
+`,
+      "utf-8",
+    );
+    fs.writeFileSync(noisyFile, "public class LargeDefinitionProxy { }\n", "utf-8");
+
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: { baseUrl: "http://localhost:11434/v1", model: "mock-embedding-model", dimensions: 8 },
+      indexing: { watchFiles: false, maxChunksPerFile: 2, fallbackToTextOnMaxChunks: true },
+      search: { maxResults: 10, minScore: 0 },
+    });
+    const indexer = _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
+    await indexer.index();
+
+    const results = await indexer.search("LargeDefinition", 5, {
+      metadataOnly: true,
+      filterByBranch: false,
+      definitionIntent: true,
+    });
+
+    expect(results[0]).toMatchObject({ filePath: sourceFile, name: "LargeDefinition" });
+  });
+
   it("returns nested class methods that are not standalone semantic chunks", async () => {
     const classFile = path.join(tempDir, "app", "indexer", "service.ts");
     fs.writeFileSync(classFile, `export class Service {


### PR DESCRIPTION
## Summary\n- prioritize exact symbol-lane candidates for explicit definition lookups\n- preserve retrieval of declarations larger than the indexed chunk cap\n- add a C# regression with competing prefix matches\n\n## Validation\n- npm run build\n- npm run typecheck\n- npm run lint\n- npm run test:run\n- pinned public Newtonsoft.Json benchmark: Hit@5 77.78% -> 88.89%