### PR TITLE
fix: use adaptive compact Pi retrieval guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Pi now uses compact, adaptive repository-retrieval guidance: it recommends `codebase_context` for repository orientation rather than mechanically for every task, requests a small initial evidence pack, and avoids duplicate broad reads when that evidence is sufficient.
 - Retired the unavailable `github-copilot` embedding provider with an actionable migration error. GitHub Models retired its inference API.
 - Added Google `gemini-embedding-2` support with its recommended code-retrieval formatting.
 - Documented local Ollama model trade-offs and reproducible Nomic, EmbeddingGemma, and Qwen 0.6B comparison results.

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -310,9 +310,12 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   pi.on("before_agent_start", (event) => ({
     systemPrompt:
       `${event.systemPrompt}\n\n` +
-      "Check index_status first when index readiness is unknown. For repository questions, call codebase_context before search/grep/bash/read-style broad reads. " +
-      "Use implementation_lookup for known symbols and call_graph/call_graph_path after endpoints are identified for dependency flow. " +
-      "Avoid broad tool calls until semantic locations are known.",
+      "Check index_status first when index readiness is unknown. " +
+      "Use codebase_context only when repository orientation is needed (for layout, key symbols, or cross-file dependency intent), " +
+      "not mechanically for every task. " +
+      "When using codebase_context for orientation, request a compact first pass (for example: tokenBudget: 600, limit: 5) and inspect returned evidence before broad search/grep/bash/read-style reads. " +
+      "Avoid repeating broad reads when the compact evidence already answers the question. " +
+      "Use implementation_lookup for known symbols and call_graph/call_graph_path after endpoints are identified for dependency flow.",
   }));
 
   pi.on("session_shutdown", async (_event, ctx) => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -670,7 +670,7 @@ describe("Pi adapter conformance", () => {
     });
   });
 
-  it("injects client-neutral repository guidance on before_agent_start", async () => {
+  it("injects adaptive, compact Pi repository guidance on before_agent_start", async () => {
     const { beforeAgentStartHandlers } = await registerPiTools();
 
     const result = await beforeAgentStartHandlers[0]?.({ systemPrompt: "Base system prompt." });
@@ -678,7 +678,18 @@ describe("Pi adapter conformance", () => {
     expect(result).toMatchObject({
       systemPrompt: expect.stringContaining("Check index_status first"),
     });
-    expect((result as { systemPrompt?: string }).systemPrompt).toContain("codebase_context");
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain(
+      "Use codebase_context only when repository orientation is needed",
+    );
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain("tokenBudget: 600");
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain("limit: 5");
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain(
+      "inspect returned evidence before broad search/grep/bash/read-style reads",
+    );
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain(
+      "Avoid repeating broad reads when the compact evidence already answers the question",
+    );
+    expect((result as { systemPrompt?: string }).systemPrompt).toContain("not mechanically for every task");
     expect((result as { systemPrompt?: string }).systemPrompt).toContain("implementation_lookup");
     expect((result as { systemPrompt?: string }).systemPrompt).toContain("call_graph");
   });


### PR DESCRIPTION
## Summary
- make Pi repository retrieval guidance conditional on orientation needs
- recommend a compact initial codebase_context pass with tokenBudget 600 and limit 5
- advise against duplicate broad reads after sufficient evidence

## Validation
- npm run build
- npm run typecheck
- npm run lint
- npm run test:run (93 files, 1,447 tests)

This changes Pi-only startup guidance. Shared tool behavior and other host adapters are unchanged.
