### PR TITLE
fix(pi): report index configuration errors

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -239,11 +239,16 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
       verbose: Type.Optional(Type.Boolean({ default: false })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const result = await runIndexCodebase(projectRoot(ctx), HOST, params);
-      if (result.kind === "estimate") return text(formatCostEstimate(result.estimate), result.estimate);
-      if (result.kind === "busy") return text(result.text, { code: "INDEX_BUSY" });
-      if (result.kind === "message") return text(result.text);
-      return text(formatIndexStats(result.stats, params.verbose ?? false), result.stats);
+      try {
+        const result = await runIndexCodebase(projectRoot(ctx), HOST, params);
+        if (result.kind === "estimate") return text(formatCostEstimate(result.estimate), result.estimate);
+        if (result.kind === "busy") return text(result.text, { code: "INDEX_BUSY" });
+        if (result.kind === "message") return text(result.text);
+        return text(formatIndexStats(result.stats, params.verbose ?? false), result.stats);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return text(`index_codebase failed: ${message}`);
+      }
     },
   });
 

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -7,6 +7,7 @@ const operationMocks = vi.hoisted(() => ({
   getCallGraphData: vi.fn(),
   getCallGraphPath: vi.fn(),
   getIndexHealthCheck: vi.fn(),
+  runIndexCodebase: vi.fn(),
   runIndexHealthCheck: vi.fn(),
   searchCodebase: vi.fn(),
   searchCodebaseWithEffectiveness: vi.fn(),
@@ -26,13 +27,13 @@ vi.mock("../src/tools/operations.js", () => ({
   getCallGraphData: operationMocks.getCallGraphData,
   getCallGraphPath: operationMocks.getCallGraphPath,
   getIndexHealthCheck: operationMocks.getIndexHealthCheck,
+  runIndexCodebase: operationMocks.runIndexCodebase,
   getIndexMetrics: operationMocks.getIndexMetrics,
   getIndexStatus: vi.fn(),
   getPrImpact: vi.fn(),
   implementationLookup: operationMocks.implementationLookup,
   listKnowledgeBases: vi.fn(() => "No knowledge bases configured."),
   removeKnowledgeBase: vi.fn(() => "Removed knowledge base"),
-  runIndexCodebase: vi.fn(),
   runIndexHealthCheck: operationMocks.runIndexHealthCheck,
   searchCodebase: operationMocks.searchCodebase,
   searchCodebaseWithEffectiveness: operationMocks.searchCodebaseWithEffectiveness,
@@ -99,6 +100,7 @@ async function registerPiTools(): Promise<RegisteredPiRuntime> {
 
 describe("Pi adapter conformance", () => {
   beforeEach(() => {
+    operationMocks.runIndexCodebase.mockReset();
     operationMocks.getCallGraphData.mockReset();
     operationMocks.getCallGraphPath.mockReset();
     operationMocks.getIndexHealthCheck.mockReset();
@@ -702,5 +704,25 @@ describe("Pi adapter conformance", () => {
     expect(result?.content[0]?.text).toContain("INDEX_BUSY");
     expect(result?.content[0]?.text).toContain("PID 4444");
     expect(result?.details).toEqual({ code: "INDEX_BUSY" });
+  });
+
+  it("returns a clear text failure when runIndexCodebase rejects with deprecated github-copilot config", async () => {
+    const errorMessage =
+      "`embeddingProvider: \"github-copilot\"` is deprecated and no longer available. " +
+      "Migrate existing configs to `embeddingProvider: \"google\"` and select an explicit Google model.";
+
+    operationMocks.runIndexCodebase.mockRejectedValue(new Error(errorMessage));
+    const { tools } = await registerPiTools();
+
+    const result = await tools.get("index_codebase")?.execute(
+      "tool-call",
+      { force: true },
+      new AbortController().signal,
+      () => {},
+      { cwd: "/repo" },
+    );
+
+    expect(result?.content[0]?.text).toContain("index_codebase failed:");
+    expect(result?.content[0]?.text).toContain(errorMessage);
   });
 });


### PR DESCRIPTION
## Summary
- return a completed Pi tool result when `index_codebase` rejects
- preserve the deprecated GitHub Copilot configuration migration message
- cover the rejected indexing path in Pi conformance tests

Fixes #291

## Validation
- `npx vitest run tests/pi-conformance.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (after `npm run build:native` because a fresh worktree lacks the required native artifact for the build:ts smoke test)
- `npm run test:run` (93 files, 1448 tests)