### PR TITLE
feat(mcp): expose knowledge-base tools to all MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The index stores reusable content by hash and maintains branch catalogs for chun
 
 ## Knowledge bases and reranking
 
-OpenCode and Pi can index additional directories as knowledge bases. Configure them with `knowledgeBases` or use the host-native knowledge-base tools where available.
+OpenCode, Pi, and every MCP client can index additional directories as knowledge bases. Configure them with `knowledgeBases`, or use the knowledge-base tools: `add_knowledge_base`, `list_knowledge_bases`, and `remove_knowledge_base` for MCP clients and OpenCode, and `knowledge_base_add`, `knowledge_base_list`, and `knowledge_base_remove` for Pi.
 
 Optional external reranking supports Cohere, Jina, and custom compatible endpoints. Local filtering and evidence classes are applied before external candidates are submitted.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,15 +6,16 @@ Tool availability depends on the host mode.
 
 | Host / integration | Tool surface | Additional capabilities |
 |---|---|---|
-| `opencode` (plugin) | 17 tools in total (13 portable MCP tools + 4 OpenCode-native tools) | Slash commands and native knowledge-base management |
-| MCP clients, including `codex`, `claude`, and `jcode` | 13 tools + 5 prompts | No OpenCode slash commands |
-| `pi` (Pi extension) | 16 tools total (13 portable tools + 3 Pi knowledge-base tools) | Bundled `codebase-search` skill with host-specific knowledge-base names |
+| `opencode` (plugin) | 19 tools in total (15 portable tools + 3 knowledge-base tools + 1 OpenCode-native tool) | Slash commands and `index_visualize` |
+| MCP clients, including `codex`, `claude`, and `jcode` | 18 tools + 5 prompts (15 portable tools + 3 knowledge-base tools) | Knowledge-base management for every MCP client; no OpenCode slash commands |
+| `pi` (Pi extension) | 18 tools total (15 portable tools + 3 Pi knowledge-base tools) | Bundled `codebase-search` skill with host-specific knowledge-base names |
 
-### Portable MCP core (13 tools)
+### Portable MCP core (15 tools)
 
 These tools are available through the MCP server and the OpenCode plugin.
 
 - `codebase_context`
+- `codebase_edit_context`
 - `codebase_search`
 - `codebase_peek`
 - `index_codebase`
@@ -27,6 +28,7 @@ These tools are available through the MCP server and the OpenCode plugin.
 - `call_graph`
 - `call_graph_path`
 - `pr_impact`
+- `code_communities`
 
 The MCP server also exposes five prompts:
 
@@ -36,26 +38,41 @@ The MCP server also exposes five prompts:
 - `index`
 - `status`
 
-### OpenCode-only tools and commands
+### Knowledge-base tools
 
-OpenCode adds four extra tools beyond the core MCP set.
+The MCP server and the OpenCode plugin expose the same three knowledge-base tools. The index is the union of the project code and the configured knowledge-base folders.
 
 - `add_knowledge_base`
 - `list_knowledge_bases`
 - `remove_knowledge_base`
+
+Notes for MCP clients:
+
+- `add_knowledge_base` writes the path to the **project-local** host config of the MCP server (for example `<repo>/.claude/codebase-index.json` for the `claude` host, or `<repo>/.codebase-index/config.json` for `codex`, `jcode`, and `pi`), and refreshes the index. It is not a user-global change.
+- The MCP server runs at a fixed project root (`process.cwd()` or `--project`) for its lifetime. Knowledge-base tools operate on that root and the server host config; they are not per-call worktree-aware. For worktree-local knowledge-base management, use OpenCode or Pi.
+- Different MCP hosts pointed at the same repository keep separate knowledge-base lists in separate host config files.
+- `list_knowledge_bases` shows the union of project-local and user-global knowledge bases. `remove_knowledge_base` edits only the project-local config, so a knowledge base inherited from a user-global config is not removable by this tool.
+- Git blame metadata is collected only for files in the project git repository. Knowledge-base files outside the repository remain searchable by content but have no blame, so `blameAuthor`, `blameSha`, and `blameSince` filters match only in-repo files.
+
+### OpenCode-only tools and commands
+
+OpenCode adds one extra tool beyond the shared MCP and OpenCode set:
+
 - `index_visualize`
+
+`index_visualize` generates an interactive HTML view of recent code movement and the call graph.
 
 OpenCode also exposes slash commands (see [OpenCode slash commands](#opencode-slash-commands)).
 
 ### Pi naming notes
 
-Pi does not expose the OpenCode-native knowledge-base names. It registers equivalent tools with host-specific names:
+Pi does not expose the shared knowledge-base names. It registers equivalent tools with host-specific names:
 
 - `knowledge_base_list`
 - `knowledge_base_add`
 - `knowledge_base_remove`
 
-Pi exposes all 13 portable tools, including `call_graph` and `call_graph_path`, plus its three host-specific knowledge-base aliases.
+Pi exposes all 15 portable tools, including `call_graph` and `call_graph_path`, plus its three host-specific knowledge-base aliases.
 
 ## Recommended selection order
 
@@ -146,11 +163,8 @@ Analyzes changed files, affected symbols, transitive dependencies, graph communi
 
 ## OpenCode-native tools
 
-OpenCode registers the 13 portable tools above plus:
+OpenCode registers the 15 portable tools, the three shared knowledge-base tools, and one OpenCode-only tool:
 
-- `add_knowledge_base`
-- `list_knowledge_bases`
-- `remove_knowledge_base`
 - `index_visualize`
 
 `index_visualize` generates an interactive HTML view of recent code movement and the call graph.

--- a/src/adapters/mcp/register-tools.ts
+++ b/src/adapters/mcp/register-tools.ts
@@ -46,8 +46,11 @@ import {
 } from "../../tools/execute-common.js";
 import { formatPrImpact } from "../../tools/format-pr-impact.js";
 import {
+  addKnowledgeBase,
   findSimilarCode,
   getPrImpact,
+  listKnowledgeBases,
+  removeKnowledgeBase,
   searchCodebaseWithEffectiveness,
 } from "../../tools/operations.js";
 import type { McpServerRuntime } from "./shared.js";
@@ -55,6 +58,16 @@ import { TOOL_NAME } from "../../tools/tool-names.js";
 
 function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
   return z.preprocess((value) => (value === null ? undefined : value), schema) as unknown as T;
+}
+
+// Knowledge-base operations report failures as plain strings prefixed with "Error: " (for
+// example a missing directory or a blocked sensitive directory) instead of throwing. Surface
+// those to MCP clients as isError so they can distinguish a refusal from success. Informational
+// results such as "Knowledge base already configured" or "Knowledge base not found" do not use
+// the prefix and remain successful results.
+function knowledgeBaseResult(text: string): { content: Array<{ type: "text"; text: string }>; isError?: true } {
+  const content = [{ type: "text" as const, text }];
+  return text.startsWith("Error: ") ? { content, isError: true } : { content };
 }
 
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
@@ -367,6 +380,51 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     async (args) => {
       const result = await executeCodeCommunities(runtime.projectRoot, runtime.host, args);
       return { content: [{ type: "text", text: result.text }] };
+    },
+  );
+
+  server.tool(
+    TOOL_NAME.ADD_KNOWLEDGE_BASE,
+    "Add a folder as a knowledge base to the semantic search index. The folder is indexed "
+      + "alongside the project code on the next index run. Provide an absolute path or a path "
+      + "relative to the project root. The path is written to the project-local host config of "
+      + "this MCP server (under the server project root), not to a user-global config, and the "
+      + "index is refreshed. Git blame metadata is collected only for files in the project git "
+      + "repo; knowledge-base files outside the repo remain searchable by content but have no "
+      + "blame. A knowledge base that appears in list_knowledge_bases but was inherited from a "
+      + "global config cannot be removed by this tool.",
+    {
+      path: z.string().describe("Path to the folder to add as a knowledge base (absolute or relative to the project root)"),
+    },
+    async (args) => {
+      const result = addKnowledgeBase(runtime.projectRoot, runtime.host, args.path);
+      return knowledgeBaseResult(result);
+    },
+  );
+
+  server.tool(
+    TOOL_NAME.LIST_KNOWLEDGE_BASES,
+    "List the configured knowledge base folders that the index includes alongside the project "
+      + "code. The list is the union of project-local and user-global knowledge bases; each entry "
+      + "shows the resolved path and whether it exists.",
+    {},
+    async () => {
+      const result = listKnowledgeBases(runtime.projectRoot, runtime.host);
+      return knowledgeBaseResult(result);
+    },
+  );
+
+  server.tool(
+    TOOL_NAME.REMOVE_KNOWLEDGE_BASE,
+    "Remove a knowledge base folder from the semantic search index and refresh the index. The "
+      + "path must match a project-local configured path exactly. Knowledge bases inherited from "
+      + "a user-global config are not removable by this tool.",
+    {
+      path: z.string().describe("Path of the knowledge base to remove (must match a project-local configured path exactly)"),
+    },
+    async (args) => {
+      const result = removeKnowledgeBase(runtime.projectRoot, runtime.host, args.path.trim());
+      return knowledgeBaseResult(result);
     },
   );
 }

--- a/src/tools/tool-names.ts
+++ b/src/tools/tool-names.ts
@@ -86,4 +86,13 @@ export const PI_TOOL_NAMES = [
   TOOL_NAME.PI_KNOWLEDGE_BASE_REMOVE,
 ] as const;
 
-export const MCP_TOOL_NAMES = PORTABLE_TOOL_NAMES;
+// MCP clients expose the portable retrieval core plus the knowledge-base management tools.
+// Knowledge-base tools are intentionally NOT part of PORTABLE_TOOL_NAMES: that set is a Pi
+// contract (tests/pi-package.test.ts asserts Pi exposes every portable name), and Pi exposes
+// the knowledge-base tools under its own host-specific aliases (PI_KNOWLEDGE_BASE_*).
+export const MCP_TOOL_NAMES = [
+  ...PORTABLE_TOOL_NAMES,
+  TOOL_NAME.ADD_KNOWLEDGE_BASE,
+  TOOL_NAME.LIST_KNOWLEDGE_BASES,
+  TOOL_NAME.REMOVE_KNOWLEDGE_BASE,
+] as const;

--- a/tests/mcp-knowledge-bases.test.ts
+++ b/tests/mcp-knowledge-bases.test.ts
@@ -1,0 +1,234 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { parseConfig } from "../src/config/schema.js";
+import { getHostProjectConfigRelativePath } from "../src/config/paths.js";
+import type { HostMode } from "../src/config/host.js";
+import { createMcpServer } from "../src/mcp-server.js";
+
+const { indexerInstances, MockIndexer } = vi.hoisted(() => {
+  const indexerInstances: Array<{
+    projectRoot: string;
+    config: Record<string, unknown>;
+    getStatus: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  class MockIndexer {
+    public readonly projectRoot: string;
+    public readonly config: Record<string, unknown>;
+    public getStatus = vi.fn().mockResolvedValue({
+      indexed: true,
+      vectorCount: 0,
+      provider: "ollama",
+      model: "nomic-embed-text",
+      indexPath: "/tmp/index",
+      currentBranch: "main",
+      baseBranch: "main",
+    });
+
+    public constructor(projectRoot: string, config: Record<string, unknown>) {
+      this.projectRoot = projectRoot;
+      this.config = config;
+      indexerInstances.push({
+        projectRoot,
+        config,
+        getStatus: this.getStatus,
+      });
+    }
+  }
+
+  return { indexerInstances, MockIndexer };
+});
+
+vi.mock("../src/indexer/index.js", () => ({
+  Indexer: MockIndexer,
+}));
+
+interface Bootstrap {
+  client: Client;
+  close: () => Promise<void>;
+}
+
+function expectedConfigPath(projectRoot: string, host: HostMode): string {
+  return path.join(projectRoot, getHostProjectConfigRelativePath(host));
+}
+
+function readConfigKnowledgeBases(configPath: string): string[] {
+  if (!fs.existsSync(configPath)) {
+    return [];
+  }
+  const parsed = JSON.parse(fs.readFileSync(configPath, "utf-8")) as { knowledgeBases?: unknown };
+  return Array.isArray(parsed.knowledgeBases) ? (parsed.knowledgeBases as string[]) : [];
+}
+
+describe("MCP knowledge-base tools", () => {
+  let tempDir: string;
+  let kbDir: string;
+
+  beforeEach(() => {
+    indexerInstances.length = 0;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-kb-test-"));
+    kbDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-kb-source-"));
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("USERPROFILE", path.join(tempDir, "home"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(kbDir, { recursive: true, force: true });
+  });
+
+  async function bootstrap(host: HostMode): Promise<Bootstrap & { configPath: string }> {
+    const config = parseConfig({ indexing: { autoIndex: false, watchFiles: false } });
+    const server = createMcpServer(tempDir, config, host);
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+
+    return {
+      client,
+      configPath: expectedConfigPath(tempDir, host),
+      close: async () => {
+        await client.close();
+      },
+    };
+  }
+
+  it("writes the knowledge base to the project-local claude host config and refreshes the indexer", async () => {
+    const { client, configPath, close } = await bootstrap("claude");
+    try {
+      const baselineInstances = indexerInstances.length;
+
+      const result = await client.callTool({
+        name: "add_knowledge_base",
+        arguments: { path: kbDir },
+      });
+
+      const content = result.content as Array<{ type: string; text?: string }>;
+      expect(result.isError).not.toBe(true);
+      expect(content[0].text).toContain(path.normalize(kbDir));
+      expect(content[0].text).toContain("Total knowledge bases: 1");
+
+      // The local config file is created at the host-specific path and holds the KB path.
+      expect(configPath).toBe(path.join(tempDir, ".claude", "codebase-index.json"));
+      expect(fs.existsSync(configPath)).toBe(true);
+      const stored = readConfigKnowledgeBases(configPath);
+      expect(stored).toHaveLength(1);
+      expect(path.resolve(tempDir, stored[0])).toBe(path.resolve(kbDir));
+
+      // refreshIndexerForDirectory constructed a new indexer with the updated knowledgeBases.
+      expect(indexerInstances.length).toBe(baselineInstances + 1);
+      expect(indexerInstances.at(-1)?.projectRoot).toBe(tempDir);
+      expect(indexerInstances.at(-1)?.config.knowledgeBases).toEqual([path.normalize(kbDir)]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("writes the knowledge base to the project-local codebase-index host config for codex", async () => {
+    const { client, configPath, close } = await bootstrap("codex");
+    try {
+      const result = await client.callTool({
+        name: "add_knowledge_base",
+        arguments: { path: kbDir },
+      });
+
+      const content = result.content as Array<{ type: string; text?: string }>;
+      expect(result.isError).not.toBe(true);
+      expect(content[0].text).toContain(path.normalize(kbDir));
+
+      expect(configPath).toBe(path.join(tempDir, ".codebase-index", "config.json"));
+      expect(fs.existsSync(configPath)).toBe(true);
+      const stored = readConfigKnowledgeBases(configPath);
+      expect(stored).toHaveLength(1);
+      expect(path.resolve(tempDir, stored[0])).toBe(path.resolve(kbDir));
+    } finally {
+      await close();
+    }
+  });
+
+  it("lists, removes, and persists the empty knowledge base list back to the local config", async () => {
+    const { client, configPath, close } = await bootstrap("codex");
+    try {
+      await client.callTool({ name: "add_knowledge_base", arguments: { path: kbDir } });
+
+      const listed = await client.callTool({ name: "list_knowledge_bases", arguments: {} });
+      const listContent = listed.content as Array<{ type: string; text?: string }>;
+      expect(listed.isError).not.toBe(true);
+      expect(listContent[0].text).toContain(path.normalize(kbDir));
+      expect(listContent[0].text).toContain("Exists");
+
+      const removed = await client.callTool({
+        name: "remove_knowledge_base",
+        arguments: { path: kbDir },
+      });
+      const removeContent = removed.content as Array<{ type: string; text?: string }>;
+      expect(removed.isError).not.toBe(true);
+      expect(removeContent[0].text).toContain("Removed");
+      expect(readConfigKnowledgeBases(configPath)).toEqual([]);
+
+      const afterRemove = await client.callTool({ name: "list_knowledge_bases", arguments: {} });
+      const afterContent = afterRemove.content as Array<{ type: string; text?: string }>;
+      expect(afterContent[0].text).toContain("No knowledge bases configured");
+    } finally {
+      await close();
+    }
+  });
+
+  it("surfaces a missing path as isError with no config write and no indexer refresh", async () => {
+    const { client, configPath, close } = await bootstrap("claude");
+    try {
+      const baselineInstances = indexerInstances.length;
+      const missingPath = path.join(tempDir, "does-not-exist");
+
+      const result = await client.callTool({
+        name: "add_knowledge_base",
+        arguments: { path: missingPath },
+      });
+
+      const content = result.content as Array<{ type: string; text?: string }>;
+      expect(result.isError).toBe(true);
+      expect(content[0].text).toContain("Error: Directory does not exist");
+      expect(fs.existsSync(configPath)).toBe(false);
+      expect(indexerInstances.length).toBe(baselineInstances);
+    } finally {
+      await close();
+    }
+  });
+
+  it("treats a remove of an unconfigured knowledge base as a successful not-found result", async () => {
+    const { client, close } = await bootstrap("claude");
+    try {
+      const result = await client.callTool({
+        name: "remove_knowledge_base",
+        arguments: { path: path.join(tempDir, "never-configured") },
+      });
+
+      const content = result.content as Array<{ type: string; text?: string }>;
+      // "Knowledge base not found" is informational, not an "Error:"-prefixed failure.
+      expect(result.isError).not.toBe(true);
+      expect(content[0].text).toContain("Knowledge base not found");
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects add_knowledge_base when the required path argument is missing", async () => {
+    const { client, close } = await bootstrap("claude");
+    try {
+      const result = await client.callTool({ name: "add_knowledge_base", arguments: {} });
+      expect(result.isError).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -460,7 +460,7 @@ describe("MCP server tools and prompts", () => {
     fs.rmSync(testMainRepo, { recursive: true, force: true });
   });
 
-  it("should register all 14 tools", async () => {
+  it("should register all 18 tools", async () => {
     const tools = await client.listTools();
 
     expect(tools.tools).toHaveLength(MCP_TOOL_NAMES.length);


### PR DESCRIPTION
Summary

Registers add_knowledge_base, list_knowledge_bases, and remove_knowledge_base as MCP server tools so every MCP client (Codex, Claude Code, Jcode, and other MCP hosts) can manage knowledge bases.
Previously these operations were exposed only to the OpenCode plugin and the Pi extension (under host-native names); MCP clients had no way to add, list, or remove knowledge bases through the MCP
server.

Implements #298  

Background

The knowledge-base operations (addKnowledgeBase, listKnowledgeBase, removeKnowledgeBase in src/tools/operations.ts) were deliberately scoped to OpenCode and Pi, not overlooked: KB management
mutates persistent per-host config and rebuilds the shared indexer, and OpenCode/Pi pass a per-call worktree so KB edits land in worktree-local config. The MCP server, however, runs at a fixed
project root (process.cwd() / --project) for its lifetime, and all existing MCP tools already operate on that fixed root. Exposing KB tools on the startup root is therefore consistent with the
existing MCP model, not a new behavior.

Changes

- src/tools/tool-names.ts — MCP_TOOL_NAMES is no longer a bare alias of PORTABLE_TOOL_NAMES; it is now PORTABLE_TOOL_NAMES + the three KB tools. PORTABLE_TOOL_NAMES is left untouched because it
is a Pi contract (tests/pi-package.test.ts asserts Pi exposes every portable name, and Pi exposes KB tools only under its knowledge_base_* aliases).
- src/adapters/mcp/register-tools.ts — registers the three KB tools after code_communities, calling the existing operation functions with runtime.projectRoot + runtime.host. Returns are wrapped
so a response whose text starts with "Error: " is reported with MCP isError: true; informational returns ("already configured", "not found") are not flagged as errors.
- docs/tools.md — recomputes the host surface matrix (portable core 15; MCP 18 tools + 5 prompts; OpenCode 19; Pi 18), adds codebase_edit_context and code_communities to the portable list,
reclassifies the KB tools as shared by MCP + OpenCode, and documents the worktree, multi-host, config-layering, and repo-only-blame semantics.
- README.md — notes that MCP clients can add/list/remove knowledge bases via the exposed tools.
- tests/mcp-server.test.ts — updates the stale tool-count test name to 18.
- tests/mcp-knowledge-bases.test.ts (new) — MCP-to-operation integration tests: real temp project + MockIndexer + in-memory client; verifies add persists to the host-specific config path
(.claude/codebase-index.json for claude, .codebase-index/config.json for codex) and refreshes the indexer; list shows Exists; remove clears it; non-existent path returns isError: true with
"Error: Directory does not exist" and writes no config / triggers no refresh; remove of an unconfigured path returns "Knowledge base not found" without isError; missing required path is rejected
by Zod with isError: true.

Behavior notes

- add_knowledge_base writes the path to the project-local host config of the MCP server (e.g. <repo>/.claude/codebase-index.json for the claude host, <repo>/.codebase-index/config.json for
codex/jcode/pi) and refreshes the index. It is not a user-global change.
- The index is the union of the project code and the configured knowledge-base folders (getScopedRoots() = {projectRoot} ∪ knowledgeBases). Knowledge-base source/text files are searchable by all
retrieval tools.
- list_knowledge_bases shows the union of project-local and user-global knowledge bases. remove_knowledge_base edits only the project-local layer, so a knowledge base inherited from a user-global
config returns "Knowledge base not found" and is not removed.
- Git blame metadata is collected only for files in the project git repository. Knowledge-base files outside the repository remain searchable by content but have no blame, so
blameAuthor/blameSha/blameSince filters match only in-repo files.
- The MCP server runs at a fixed project root for its lifetime; KB tools are not per-call worktree-aware. For worktree-local KB management, use OpenCode or Pi.

Tests

- npx vitest run tests/mcp-server.test.ts tests/mcp-knowledge-bases.test.ts — green.
- npx vitest run tests/pi-package.test.ts tests/tools-knowledge-bases.test.ts — Pi contract and existing operation tests unaffected.
- Full npx vitest run — green (pre-existing failures on main unchanged; none caused by this change).

Manual verification

Installed and driven over stdio with raw JSON-RPC (--project <repo> --host claude, embeddings via OLLAMA_HOST → nomic-embed-text):

1. tools/list → 18 tools, KB trio present.
2. add_knowledge_base (sibling repo json-c) → Total knowledge bases: 1, wrote project-local .claude/codebase-index.json (only knowledgeBases; no inherited provider setting leaked).
3. list_knowledge_bases → Status: Exists.
4. index_codebase → 350 files processed, 6391 new chunks embedded (union of repo + json-c).
5. Retrieval after rebuild: codebase_search "json_object_from_file" → json-c definitions with full source (json_util.c:68-98, score 0.99); implementation_lookup → authoritative def in json-c;
codebase_peek → json-c lh_table_lookup/json_object_object_add alongside repo hits (union confirmed), with repo hits carrying git blame and json-c hits carrying none — matching the documented
blame semantics.
6. remove_knowledge_base → Removed; list_knowledge_bases → No knowledge bases configured.

Checklist

- [x] Exposes add_knowledge_base / list_knowledge_bases / remove_knowledge_base to all MCP clients
- [x] Preserves the PORTABLE_TOOL_NAMES Pi contract
- [x] Maps "Error:"-prefixed returns to MCP isError: true
- [x] Adds MCP integration unit tests
- [x] Updates docs and README
- [x] Verified end-to-end on the published package, including KB-content retrieval after rebuild

