### PR TITLE
docs: retire stale Copilot embedding guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,12 +168,11 @@ Abstracts different AI embedding APIs:
 
 | Provider | Implementation | Rate Limit Strategy |
 |----------|----------------|---------------------|
-| GitHub Copilot | OAuth + internal API | 1 concurrent, 4s delay |
 | OpenAI | Official API | 3 concurrent, 500ms delay |
 | Google | Gemini API | 5 concurrent, 200ms delay |
 | Ollama | Local REST | 5 concurrent, no delay |
 
-Detection order: Ollama → GitHub Copilot → OpenAI → Google
+Detection order: Ollama → OpenAI → Google
 
 ### Native Module (`native/src/`)
 
@@ -373,8 +372,7 @@ All processing happens locally. Nothing leaves your machine.
 
 ### Credential Handling
 
-- GitHub Copilot: Uses OpenCode's OAuth token
-- OpenAI/Google: Reads from environment variables
+- OpenAI/Google: Read credentials from OpenCode auth configuration
 - Ollama: Local REST, no credentials needed
 
 No credentials are stored by the plugin.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ New installs should use `open-codebase-index` and `open-codebase-index-mcp`. The
 - **Definition and graph navigation** through `implementation_lookup`, `call_graph`, and `call_graph_path`.
 - **Incremental, branch-aware indexing** with file watching and content-hash reuse.
 - **Local storage** backed by SQLite, usearch vectors, and a BM25 inverted index.
-- **Multiple embedding providers**: Ollama, GitHub Copilot, OpenAI, Google, or a custom OpenAI-compatible endpoint.
+- **Multiple embedding providers**: Ollama, OpenAI, Google, or a custom OpenAI-compatible endpoint.
 - **Native parsing** for TypeScript/TSX, JavaScript/JSX, Python, Rust, Swift, Go, Java, C#, Ruby, C/C++, Metal, PHP, Apex, Bash, Zig, GDScript, MATLAB, JSON, TOML, YAML, Markdown, and HTML, with text fallback.
 
 ## Quick start with OpenCode
@@ -176,7 +176,9 @@ The index stores reusable content by hash and maintains branch catalogs for chun
 
 ## Knowledge bases and reranking
 
-OpenCode, Pi, and every MCP client can index additional directories as knowledge bases. Configure them with `knowledgeBases`, or use the knowledge-base tools: `add_knowledge_base`, `list_knowledge_bases`, and `remove_knowledge_base` for MCP clients and OpenCode, and `knowledge_base_add`, `knowledge_base_list`, and `knowledge_base_remove` for Pi.
+OpenCode, Pi, and every MCP client can index additional directories as knowledge bases. Configure them with `knowledgeBases`, or use the knowledge-base tools:
+- MCP and OpenCode: `add_knowledge_base`, `list_knowledge_bases`, `remove_knowledge_base`
+- Pi: `knowledge_base_add`, `knowledge_base_list`, `knowledge_base_remove`
 
 Optional external reranking supports Cohere, Jina, and custom compatible endpoints. Local filtering and evidence classes are applied before external candidates are submitted.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ We will acknowledge receipt within 48 hours and provide a detailed response with
 
 This plugin:
 - Stores vector indices locally in your project directory
-- Sends code chunks to embedding APIs (GitHub Copilot, OpenAI, Google, or local Ollama)
+- Sends code chunks to embedding APIs (OpenAI, Google, Ollama, or a custom OpenAI-compatible endpoint)
 - Does not transmit data to any other third parties
 
 ### Data Privacy

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -79,29 +79,26 @@ Runtime state directories such as `.opencode` and `.codebase-index` are intentio
 
 **Error message:**
 ```
-No embedding provider available. Configure GitHub, OpenAI, Google, or Ollama.
+No embedding provider available. Configure OpenAI, Google, Ollama, or a custom OpenAI-compatible endpoint.
 ```
 
 **Cause:** The plugin cannot find any configured embedding provider credentials.
 
 **Solutions:**
 
-### Option 1: Use GitHub Copilot (if you have a subscription)
-No additional configuration needed. The plugin automatically detects Copilot credentials.
-
-### Option 2: Use OpenAI
+### Option 1: Use OpenAI
 ```bash
 export OPENAI_API_KEY=sk-...
 ```
 
 Or set in your shell profile (`~/.bashrc`, `~/.zshrc`).
 
-### Option 3: Use Google (Gemini)
+### Option 2: Use Google (Gemini)
 ```bash
 export GOOGLE_API_KEY=...
 ```
 
-### Option 4: Use Ollama (local, free)
+### Option 3: Use Ollama (local, free)
 ```bash
 # Install Ollama from https://ollama.ai
 # Then pull the embedding model:
@@ -120,9 +117,8 @@ Run `/status` in OpenCode to see which provider is detected.
 
 Auto-detect tries providers in this order:
 1. Ollama
-2. GitHub Copilot
-3. OpenAI
-4. Google (Gemini)
+2. OpenAI
+3. Google
 
 ---
 
@@ -139,11 +135,10 @@ Too many requests
 
 **Solutions:**
 
-### For GitHub Copilot
-GitHub Copilot has strict rate limits (~15 requests/minute). The plugin automatically:
-- Uses concurrency of 1
-- Adds 4-second delays between requests
-- Retries with exponential backoff
+### For OpenAI and Google
+These providers can enforce quota limits. The plugin automatically:
+- Uses provider defaults for concurrency and request timing
+- Retries with exponential backoff on transient rate-limit errors
 
 **If still hitting limits:**
 1. Wait 1-2 minutes and retry
@@ -153,18 +148,18 @@ GitHub Copilot has strict rate limits (~15 requests/minute). The plugin automati
    ```
 
 ### For OpenAI
-OpenAI has generous limits, but if you hit them:
 1. Check your OpenAI account tier (free tier has lower limits)
-2. Consider upgrading to a paid tier
-3. Use Ollama for initial indexing, then switch back
+2. Consider switching to a paid tier
+3. For OpenAI-heavy workloads, switch to Ollama for initial indexing, then switch back
 
 ### For Google
-Similar to OpenAI. Check your quota at [Google Cloud Console](https://console.cloud.google.com/).
+1. Check your quota at [Google Cloud Console](https://console.cloud.google.com/).
+2. Verify your API credentials can access Gemini embeddings.
 
 If you see provider/model errors, verify that your configured Google credentials have access to the Gemini embeddings API.
 
 ### For Large Codebases (1k+ files)
-Use Ollama locally - no rate limits:
+Use Ollama locally to avoid external rate limits:
 ```bash
 ollama pull nomic-embed-text
 ```
@@ -231,7 +226,7 @@ Index incompatible: <reason>. Run index with force=true to rebuild.
 **Cause:** The index was built with a different embedding provider or model than what's currently configured. Embeddings from different providers have different dimensions and are not compatible.
 
 **Common scenarios:**
-- Switched from GitHub Copilot to OpenAI
+- Switched from one embedding provider to another
 - Changed Ollama embedding model
 - Updated to a new version of the embedding model
 
@@ -250,7 +245,6 @@ Different embedding providers produce vectors with different dimensions:
 
 | Provider | Model | Dimensions |
 |----------|-------|------------|
-| GitHub Copilot | text-embedding-3-small | 1536 |
 | OpenAI | text-embedding-3-small | 1536 |
 | Google | text-embedding-004 | 768 |
 | Ollama | nomic-embed-text | 768 |
@@ -340,8 +334,8 @@ Files over 1MB are skipped by default, but many medium-sized files can still be 
 }
 ```
 
-### 3. GitHub Copilot Rate Limits
-Copilot has 4-second delays between requests.
+### 3. Provider Rate Limits
+Provider-specific settings vary by quota and account tier. See the earlier rate-limiting guidance for provider-specific behavior.
 
 **Solution:** For initial indexing, use a faster provider, then switch back:
 ```json

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -10,7 +10,7 @@ description: Semantic code and documentation search by meaning. Use codebase_pee
 The indexed codebase contains **two types of content**:
 
 1. **Project Source Code** — all code files in the current workspace
-2. **Knowledge Base Documentation** — external documentation, usage guides, API references, and example programs added via `add_knowledge_base`
+2. **Knowledge Base Documentation** — external documentation, usage guides, API references, and example programs added via `add_knowledge_base` (MCP/OpenCode) or `knowledge_base_add` (Pi).
 
 ## When to Use What
 
@@ -100,22 +100,17 @@ Manually trigger indexing. Required before first search.
 ### `index_status`
 Check if indexed and ready.
 
-### `add_knowledge_base`
-Add a folder as a knowledge base. The folder will be indexed alongside project code.
+### MCP/OpenCode knowledge-base tools
 
-```
-add_knowledge_base(path="/path/to/docs")
-```
+- `add_knowledge_base(path="/path/to/docs")`
+- `list_knowledge_bases`
+- `remove_knowledge_base(path="/path/to/docs")`
 
-### `list_knowledge_bases`
-List all configured knowledge base folders.
+### Pi knowledge-base tools
 
-### `remove_knowledge_base`
-Remove a knowledge base folder from the index.
-
-```
-remove_knowledge_base(path="/path/to/docs")
-```
+- `knowledge_base_add(path="/path/to/docs")`
+- `knowledge_base_list`
+- `knowledge_base_remove(path="/path/to/docs")`
 
 ## Query Tips
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -3313,7 +3313,7 @@ export class Indexer {
 
     if (!this.configuredProviderInfo) {
       throw new Error(
-        "No embedding provider available. Configure GitHub Copilot, OpenAI, Google, Ollama, or a custom OpenAI-compatible endpoint."
+        "No embedding provider available. Configure OpenAI, Google, Ollama, or a custom OpenAI-compatible endpoint."
       );
     }
 


### PR DESCRIPTION
## Summary
- remove retired GitHub Copilot embedding provider guidance from user-facing documentation and the no-provider error
- align architecture and security disclosures with supported providers
- clarify MCP/OpenCode versus Pi knowledge-base tool aliases in the bundled skill

## Validation
- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/config.test.ts tests/pi-conformance.test.ts tests/commands.test.ts`