### PR TITLE
fix benchmark query-weighted metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a `dryRun` option to `index_codebase` and an `index --dry-run` CLI flag: a read-only preflight that parses the real file set and reports the exact embedding token total (files, source chunks, tokens) without requesting embeddings or writing to the index. The total serves as a fixed, monotonic denominator for live indexing progress (a force index climbs to ~100%; an incremental index tops out below 100% because cached chunks are counted but not re-embedded) and as a cost preview before committing GPU or time.
+- Added query-weighted quality aggregates to cross-repository benchmark reports, alongside clearly labelled per-repository macro averages, so uneven cohort sizes cannot obscure the headline Hit@k, MRR, or nDCG results.
 
 ## [0.24.0] - 2026-08-18
 

--- a/docs/benchmarking-cross-repo.md
+++ b/docs/benchmarking-cross-repo.md
@@ -179,6 +179,21 @@ The report places results in a standalone **Fair codebase-memory-mcp Comparator*
 
 ## Output artifacts
 
+Reports expose two aggregate quality views:
+
+- **Macro average across repositories** gives every successful repository equal
+  weight. It retains latency rows, which are repository-level repeat summaries.
+- **Query-weighted quality** weights Hit@k, MRR@10, and nDCG@10 by the number
+  of queries evaluated by each comparator. Use this view as the headline when
+  cohorts contain different-sized repository datasets. It deliberately omits
+  latency, token, and cost rows because averaging their per-repository summary
+  values would not produce an exact per-query aggregate.
+
+The JSON report retains the compatibility `aggregate` object for macro metrics
+and adds `queryWeightedQuality` with each comparator's metric values and query
+denominator. Plugin uses the dataset query count, ripgrep its evaluated query
+count, and ast-grep its structural-query scope.
+
 Each run writes to:
 
 - `benchmarks/results/cross-repo/<timestamp>/report.md`

--- a/scripts/cross-repo-benchmark.ts
+++ b/scripts/cross-repo-benchmark.ts
@@ -1909,6 +1909,97 @@ function averageMetrics(metricsList: EvalMetrics[]): EvalMetrics {
   };
 }
 
+export interface QueryWeightedQualityInput {
+  metrics: EvalMetrics;
+  queryCount: number;
+}
+
+export interface QueryWeightedQuality {
+  queryCount: number;
+  hitAt1: number;
+  hitAt3: number;
+  hitAt5: number;
+  hitAt10: number;
+  mrrAt10: number;
+  ndcgAt10: number;
+}
+
+export interface QueryWeightedQualityAggregates {
+  plugin?: QueryWeightedQuality;
+  ripgrep?: QueryWeightedQuality;
+  sg?: QueryWeightedQuality;
+}
+
+function buildQueryWeightedQuality(values: QueryWeightedQualityInput[]): QueryWeightedQuality | undefined {
+  const weightedValues = values.filter((value) => value.queryCount > 0);
+  const denominator = weightedValues.reduce((sum, value) => sum + value.queryCount, 0);
+  if (denominator === 0) {
+    return undefined;
+  }
+
+  const totals = weightedValues.reduce((acc, value) => {
+    const weight = value.queryCount;
+    acc.hitAt1 += value.metrics.hitAt1 * weight;
+    acc.hitAt3 += value.metrics.hitAt3 * weight;
+    acc.hitAt5 += value.metrics.hitAt5 * weight;
+    acc.hitAt10 += value.metrics.hitAt10 * weight;
+    acc.mrrAt10 += value.metrics.mrrAt10 * weight;
+    acc.ndcgAt10 += value.metrics.ndcgAt10 * weight;
+    return acc;
+  }, {
+    hitAt1: 0,
+    hitAt3: 0,
+    hitAt5: 0,
+    hitAt10: 0,
+    mrrAt10: 0,
+    ndcgAt10: 0,
+  });
+
+  return {
+    queryCount: denominator,
+    hitAt1: totals.hitAt1 / denominator,
+    hitAt3: totals.hitAt3 / denominator,
+    hitAt5: totals.hitAt5 / denominator,
+    hitAt10: totals.hitAt10 / denominator,
+    mrrAt10: totals.mrrAt10 / denominator,
+    ndcgAt10: totals.ndcgAt10 / denominator,
+  };
+}
+
+export function buildQueryWeightedQualityAggregates(
+  repoResults: RepoBenchmarkResult[],
+): QueryWeightedQualityAggregates {
+  const successful = repoResults.filter((item) => !item.error);
+
+  return {
+    plugin: buildQueryWeightedQuality(
+      successful
+        .map((result) => ({ metrics: result.plugin.metrics, queryCount: result.datasetQueryCount }))
+        .filter((item): item is QueryWeightedQualityInput => item.queryCount > 0),
+    ),
+    ripgrep: buildQueryWeightedQuality(
+      successful
+        .map((result) => {
+          if (!result.ripgrep) {
+            return undefined;
+          }
+          return { metrics: result.ripgrep.metrics, queryCount: result.ripgrep.perQueryCount };
+        })
+        .filter((item): item is QueryWeightedQualityInput => item !== undefined && item.queryCount > 0),
+    ),
+    sg: buildQueryWeightedQuality(
+      successful
+        .map((result) => {
+          if (!result.sg) {
+            return undefined;
+          }
+          return { metrics: result.sg.metrics, queryCount: result.sg.scopedQueryCount };
+        })
+        .filter((item): item is QueryWeightedQualityInput => item !== undefined && item.queryCount > 0),
+    ),
+  };
+}
+
 function pct(value: number): string {
   return `${(value * 100).toFixed(2)}%`;
 }
@@ -1919,6 +2010,44 @@ function num(value: number): string {
 
 function ms(value: number): string {
   return value.toFixed(2);
+}
+
+function appendQueryWeightedQualityTable(
+  lines: string[],
+  aggregates: QueryWeightedQualityAggregates,
+): void {
+  const comparatorCount = [
+    aggregates.plugin,
+    aggregates.ripgrep,
+    aggregates.sg,
+  ].filter((item): item is QueryWeightedQuality => item !== undefined).length;
+
+  if (comparatorCount === 0) {
+    return;
+  }
+
+  lines.push("## Aggregate (Query-weighted quality)");
+  lines.push("");
+  lines.push("This section aggregates quality by evaluated query count for each comparator:");
+  lines.push("- Plugin: datasetQueryCount");
+  lines.push("- Ripgrep: perQueryCount");
+  lines.push("- ast-grep: scopedQueryCount");
+  lines.push("");
+  lines.push("| Comparator | Evaluated queries | Hit@1 | Hit@3 | Hit@5 | Hit@10 | MRR@10 | nDCG@10 |");
+  lines.push("|---|---:|---:|---:|---:|---:|---:|---:|");
+
+  const rows = [
+    { name: "Plugin", aggregate: aggregates.plugin },
+    { name: "Ripgrep", aggregate: aggregates.ripgrep },
+    { name: "ast-grep", aggregate: aggregates.sg },
+  ].filter((row): row is { name: string; aggregate: QueryWeightedQuality } => row.aggregate !== undefined);
+  for (const row of rows) {
+    const aggregate = row.aggregate;
+    lines.push(
+      `| ${row.name} | ${aggregate.queryCount} | ${pct(aggregate.hitAt1)} | ${pct(aggregate.hitAt3)} | ${pct(aggregate.hitAt5)} | ${pct(aggregate.hitAt10)} | ${num(aggregate.mrrAt10)} | ${num(aggregate.ndcgAt10)} |`,
+    );
+  }
+  lines.push("");
 }
 
 function appendCodeGraphMetricTable(
@@ -2049,7 +2178,7 @@ export function buildReportMarkdown(
   const sgSuccessful = successful.filter((item) => item.sg).map((item) => item.sg?.metrics).filter((item): item is EvalMetrics => item !== undefined);
   const sgAggregate = sgSuccessful.length > 0 ? averageMetrics(sgSuccessful) : undefined;
 
-  lines.push("## Aggregate (Median per repo, then average across repos)");
+  lines.push("## Aggregate quality (Macro average across repos)");
   lines.push("");
   lines.push(`| Metric | Plugin | Ripgrep | ${aggregateSgHeaderLabel} |`);
   lines.push("|---|---:|---:|---:|");
@@ -2063,6 +2192,8 @@ export function buildReportMarkdown(
   lines.push(`| Latency p95 (ms) | ${ms(pluginAggregate.latencyMs.p95)} | ${ripgrepAggregate ? ms(ripgrepAggregate.latencyMs.p95) : "N/A"} | ${sgAggregate ? ms(sgAggregate.latencyMs.p95) : "N/A"} |`);
   lines.push(`| Latency p99 (ms) | ${ms(pluginAggregate.latencyMs.p99)} | ${ripgrepAggregate ? ms(ripgrepAggregate.latencyMs.p99) : "N/A"} | ${sgAggregate ? ms(sgAggregate.latencyMs.p99) : "N/A"} |`);
   lines.push("");
+
+  appendQueryWeightedQualityTable(lines, buildQueryWeightedQualityAggregates(successful));
 
   if (options.codegraph) {
     lines.push("## Fair CodeGraph Comparator");
@@ -2525,9 +2656,17 @@ async function main(): Promise<void> {
             results
               .filter((item) => !item.error && item.sg)
               .map((item) => item.sg?.metrics)
-              .filter((item): item is EvalMetrics => item !== undefined)
+          .filter((item): item is EvalMetrics => item !== undefined)
           ),
     },
+    queryWeightedQuality: (() => {
+      const queryWeighted = buildQueryWeightedQualityAggregates(results);
+      return {
+        plugin: queryWeighted.plugin,
+        ripgrep: queryWeighted.ripgrep,
+        sg: queryWeighted.sg,
+      };
+    })(),
     codebaseMemoryMcpComparison: options.codebaseMemoryMcp ? (() => {
       const comparable = results
         .filter((item) => !item.error)

--- a/tests/cross-repo-query-weighted-metrics.test.ts
+++ b/tests/cross-repo-query-weighted-metrics.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import type { EvalMetrics } from "../src/eval/types.js";
+import {
+  buildQueryWeightedQualityAggregates,
+  buildReportMarkdown,
+  type CliOptions,
+  type RepoBenchmarkResult,
+} from "../scripts/cross-repo-benchmark.js";
+
+function metrics(hitAt5: number): EvalMetrics {
+  return {
+    hitAt1: hitAt5,
+    hitAt3: hitAt5,
+    hitAt5,
+    hitAt10: hitAt5,
+    mrrAt10: hitAt5,
+    ndcgAt10: hitAt5,
+    routeAccuracy: 1,
+    outcomeAccuracy: 1,
+    recoveryAccuracy: 1,
+    distinctTop3Ratio: 1,
+    rawDistinctTop3Ratio: 1,
+    latencyMs: { p50: 1, p95: 2, p99: 3 },
+    tokenEstimate: { queryTokens: 0, embeddingTokensUsed: 0 },
+    embedding: { callCount: 0, estimatedCostUsd: 0, costPer1MTokensUsd: 0 },
+    contextEfficiency: {
+      queryCount: 0,
+      responseTokens: { total: 0, average: 0, p95: 0, max: 0 },
+      duplicateCandidateRatio: 0,
+      selectedFileRatio: 0,
+      hitAt5Per1kResponseTokens: 0,
+      mrrAt10Per1kResponseTokens: 0,
+    },
+    failureBuckets: {
+      "wrong-file": 0,
+      "wrong-symbol": 0,
+      "docs-tests-outranking-source": 0,
+      "no-relevant-hit-top-k": 0,
+    },
+  };
+}
+
+function repo(name: string, queryCount: number, hitAt5: number): RepoBenchmarkResult {
+  return {
+    repoName: name,
+    repoPath: `/${name}`,
+    datasetPath: `${name}.json`,
+    datasetQueryCount: queryCount,
+    fileSampling: {
+      parsedFileCount: 1,
+      truncated: false,
+      maxParseFiles: 10,
+      fileSizeLimitBytes: 1_000_000,
+    },
+    plugin: {
+      outputDir: "plugin",
+      summaryPath: "summary.json",
+      perQueryPath: "per-query.json",
+      metrics: metrics(hitAt5),
+      repeatSummaries: [],
+    },
+  };
+}
+
+const options: CliOptions = {
+  repos: ["/small", "/large"],
+  outputRoot: "output",
+  reindex: false,
+  repeats: 1,
+  maxParseFiles: 10,
+  persistDatasets: false,
+  skipRipgrep: true,
+  skipSg: true,
+  codegraph: false,
+  codebaseMemoryMcp: false,
+  embeddingModel: "nomic-embed-text",
+};
+
+describe("cross-repo query-weighted quality reporting", () => {
+  it("distinguishes query-weighted quality from the macro average for uneven cohorts", () => {
+    const results = [repo("small", 1, 1), repo("large", 9, 0)];
+
+    expect(buildQueryWeightedQualityAggregates(results).plugin).toMatchObject({
+      queryCount: 10,
+      hitAt5: 0.1,
+    });
+
+    const report = buildReportMarkdown("2026-08-19T00:00:00.000Z", options, "run", results);
+    expect(report).toContain("## Aggregate quality (Macro average across repos)");
+    expect(report).toContain("| Hit@5 | 50.00% | N/A | N/A |");
+    expect(report).toContain("## Aggregate (Query-weighted quality)");
+    expect(report).toContain("| Plugin | 10 | 10.00% | 10.00% | 10.00% | 10.00% | 0.1000 | 0.1000 |");
+  });
+
+  it("uses comparator-specific query-count denominators for query-weighted aggregation", () => {
+    const weighted = buildQueryWeightedQualityAggregates([
+      {
+        ...repo("small", 1, 1),
+        ripgrep: {
+          metrics: metrics(0),
+          perQueryCount: 2,
+          repeatMetrics: [metrics(0)],
+        },
+        sg: {
+          metrics: metrics(1),
+          perQueryCount: 3,
+          repeatMetrics: [metrics(1)],
+          queryTypeScope: ["definition", "keyword-heavy"],
+          scopedQueryCount: 1,
+          totalQueryCount: 3,
+        },
+      },
+      {
+        ...repo("large", 9, 0),
+        ripgrep: {
+          metrics: metrics(1),
+          perQueryCount: 1,
+          repeatMetrics: [metrics(1)],
+        },
+        sg: {
+          metrics: metrics(0),
+          perQueryCount: 4,
+          repeatMetrics: [metrics(0)],
+          queryTypeScope: ["definition", "keyword-heavy"],
+          scopedQueryCount: 3,
+          totalQueryCount: 4,
+        },
+      },
+    ]);
+
+    expect(weighted.plugin).toMatchObject({ queryCount: 10, hitAt5: 0.1 });
+    expect(weighted.ripgrep).toMatchObject({ queryCount: 3, hitAt5: 1 / 3 });
+    expect(weighted.sg).toMatchObject({ queryCount: 4, hitAt5: 0.25 });
+
+    const report = buildReportMarkdown("2026-08-19T00:00:00.000Z", {
+      ...options,
+      skipRipgrep: false,
+      skipSg: false,
+    }, "run", [
+      {
+        ...repo("small", 1, 1),
+        ripgrep: {
+          metrics: metrics(0),
+          perQueryCount: 2,
+          repeatMetrics: [metrics(0)],
+        },
+        sg: {
+          metrics: metrics(1),
+          perQueryCount: 3,
+          repeatMetrics: [metrics(1)],
+          queryTypeScope: ["definition", "keyword-heavy"],
+          scopedQueryCount: 1,
+          totalQueryCount: 3,
+        },
+      },
+      {
+        ...repo("large", 9, 0),
+        ripgrep: {
+          metrics: metrics(1),
+          perQueryCount: 1,
+          repeatMetrics: [metrics(1)],
+        },
+        sg: {
+          metrics: metrics(0),
+          perQueryCount: 4,
+          repeatMetrics: [metrics(0)],
+          queryTypeScope: ["definition", "keyword-heavy"],
+          scopedQueryCount: 3,
+          totalQueryCount: 4,
+        },
+      },
+    ]);
+
+    expect(report).toContain("## Aggregate (Query-weighted quality)");
+    expect(report).toContain("| Plugin | 10 | 10.00% | 10.00% | 10.00% | 10.00% | 0.1000 | 0.1000 |");
+    expect(report).toContain("| Ripgrep | 3 | 33.33% | 33.33% | 33.33% | 33.33% | 0.3333 | 0.3333 |");
+    expect(report).toContain("| ast-grep | 4 | 25.00% | 25.00% | 25.00% | 25.00% | 0.2500 | 0.2500 |");
+  });
+});


### PR DESCRIPTION
## Summary
- label existing repository aggregate metrics as macro averages
- add query-weighted quality metrics and denominators to report Markdown and JSON
- document both views and cover uneven cohort sizes

## Validation
- npm run build && npm run typecheck && npm run lint && npm run test:run
- public benchmark CLI against pinned Axios and Newtonsoft.Json inputs, confirming both report sections and a 27-query weighted denominator