### PR TITLE
fix: index Ruby module definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Forced re-embed migration safety**: While a project-scoped forced re-embed is pending, checkpoints no longer stamp new embedding metadata or a compatibility certificate, unchanged scope files are re-embedded instead of skipped, and `retryFailedBatches` only clears the pending migration after the main run has committed its new metadata. This prevents an interrupted migration from resuming into a silent mix of old and new vector spaces.
 - **Pi watcher startup**: Pi now starts the filesystem watcher after a successful index initialization, so codebase changes are observed rather than silently remaining stale.
 - **Indexer resilience**: Unreadable files no longer abort indexing, and invalid Pi indexing configuration is reported as a clear configuration error.
-- **Definition retrieval**: Large declarations and Ruby classes nested in modules are now indexed and ranked correctly for definition lookups.
+- **Definition retrieval**: Large declarations and Ruby classes or modules nested in modules are now indexed and ranked correctly for definition lookups.
 - **Conceptual context retrieval**: Prefer implementation paths over tests and documentation for code-focused `codebase_context` searches, without applying a hard source-only filter or changing documentation and test queries.
 - **Scoped definition lookup**: Allow explicit definition searches constrained to a file type or directory to return matching declarations in fixtures and test paths without weakening source-first ranking for ordinary searches.
 

--- a/src/indexer/call-graph-constants.ts
+++ b/src/indexer/call-graph-constants.ts
@@ -10,6 +10,9 @@ export const CALL_GRAPH_SYMBOL_CHUNK_TYPES = new Set([
   "enum_declaration",
   "function_definition",
   "class_definition",
+  // Ruby module/class symbols that are declaration-bearing and navigable.
+  "class",
+  "module",
   "class_specifier",
   "struct_specifier",
   "namespace_definition",

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -1756,6 +1756,61 @@ func caller() { helper(1) }
     });
   });
 
+  describe("ruby symbol persistence", () => {
+    it("persists class and module symbols in the branch symbol catalog", async () => {
+      const rubyFilePath = path.join(tempDir, "sinatra.rb");
+      const rubyContent = `module Sinatra
+  module NotFound
+    class Templates
+      def self.call
+        :ok
+      end
+    end
+  end
+end
+`;
+
+      fs.writeFileSync(rubyFilePath, rubyContent, "utf-8");
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string | string[] };
+        const texts = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        return new Response(
+          JSON.stringify({
+            data: texts.map(() => ({ embedding: Array.from({ length: 8 }, () => 0.125) })),
+            usage: { total_tokens: Math.max(1, texts.length) },
+          }),
+          { status: 200 },
+        );
+      });
+
+      const config = parseConfig({
+        embeddingProvider: "custom",
+        customProvider: {
+          baseUrl: "http://localhost:11434/v1",
+          model: "mock-model",
+          dimensions: 8,
+        },
+        indexing: { watchFiles: false },
+      });
+      const indexer = new Indexer(tempDir, config, "opencode");
+
+      try {
+        await indexer.index();
+
+        const symbols = await indexer.getSymbolsForBranch();
+        const rubySymbols = symbols.filter((symbol) => symbol.filePath === rubyFilePath);
+
+        expect(rubySymbols.some((symbol) => symbol.kind === "module" && symbol.name === "Sinatra")).toBe(true);
+        expect(rubySymbols.some((symbol) => symbol.kind === "module" && symbol.name === "NotFound")).toBe(true);
+        expect(rubySymbols.some((symbol) => symbol.kind === "class" && symbol.name === "Templates")).toBe(true);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
   describe("symbol enclosure", () => {
     it("should exclude a call at a Tree-sitter end-column boundary", () => {
       const filePath = path.join(tempDir, "Boundary.js");

--- a/tests/definition-ranking.test.ts
+++ b/tests/definition-ranking.test.ts
@@ -225,4 +225,68 @@ describe("definition ranking helpers", () => {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("finds a Ruby module definition when definitionIntent is requested", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "definition-ranking-ruby-"));
+    const rubyFilePath = path.join(tempDir, "sinatra.rb");
+    const rubyContent = `module Sinatra
+  module NotFound
+    module Templates
+      def self.call
+      end
+    end
+  end
+end
+`;
+    fs.writeFileSync(rubyFilePath, rubyContent, "utf-8");
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string | string[] };
+      const texts = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+      return new Response(
+        JSON.stringify({
+          data: texts.map(() => ({ embedding: Array.from({ length: 8 }, () => 0.125) })),
+          usage: { total_tokens: Math.max(1, texts.length) },
+        }),
+        { status: 200 },
+      );
+    });
+
+    const indexer = new Indexer(tempDir, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-model",
+        dimensions: 8,
+      },
+      indexing: {
+        watchFiles: false,
+      },
+      search: {
+        maxResults: 10,
+        minScore: 0,
+      },
+    }), "opencode");
+
+    try {
+      await indexer.index();
+
+      const results = await indexer.search("where is Templates definition", 10, {
+        definitionIntent: true,
+        fileType: "rb",
+        metadataOnly: true,
+        filterByBranch: false,
+      });
+
+      expect(results.some((result) =>
+        result.name === "Templates" &&
+        result.chunkType === "module" &&
+        result.filePath === rubyFilePath
+      )).toBe(true);
+    } finally {
+      await indexer.close();
+      fetchSpy.mockRestore();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- persist Ruby `class` and `module` symbols in the branch symbol catalog
- restore exact definition results for nested Ruby declarations
- add catalog and definition-ranking regressions

## Validation
- `npm run build && npm run typecheck && npm run lint && npm run test:run`
- Reindexed public Sinatra benchmark: Plugin Hit@5 improved from 84.21% to 94.74%; both `NotFound` and `Templates` definition queries now return `lib/sinatra/base.rb` at rank 1.

The remaining Sinatra route-dispatch keyword query is intentionally out of scope for this definition-catalog fix.