### PR TITLE
feat: add concise cbi human CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a `dryRun` option to `index_codebase` and an `index --dry-run` CLI flag: a read-only preflight that parses the real file set and reports the exact embedding token total (files, source chunks, tokens) without requesting embeddings or writing to the index. The total serves as a fixed, monotonic denominator for live indexing progress (a force index climbs to ~100%; an incremental index tops out below 100% because cached chunks are counted but not re-embedded) and as a cost preview before committing GPU or time.
 - Added query-weighted quality aggregates to cross-repository benchmark reports, alongside clearly labelled per-repository macro averages, so uneven cohort sizes cannot obscure the headline Hit@k, MRR, or nDCG results.
+- Added a concise `cbi` terminal command for status, indexing, search, definition lookup, and direct caller or callee inspection, while keeping the existing MCP binary unchanged.
 
 ## [0.24.0] - 2026-08-18
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -125,6 +125,23 @@ Claude uses:
 - global config: `~/.claude/codebase-index.json`
 - global index: `~/.claude/global-index/`
 
+## Human CLI
+
+The concise `cbi` command is for terminal use. It shares OCI's index and retrieval operations, while `open-codebase-index-mcp` remains the MCP-server binary.
+
+```bash
+# Inspect readiness, then create or refresh the index
+cbi status --project /path/to/repo --host jcode
+cbi index --project /path/to/repo --host jcode
+
+# Search and inspect code from the terminal
+cbi search "retry recovery" --project /path/to/repo --limit 5
+cbi definition Indexer --project /path/to/repo
+cbi graph callers Indexer --project /path/to/repo
+```
+
+Use `cbi index --dry-run` for a parse-only embedding-token total, `--estimate-only` for an estimate, and `cbi --help` for command usage.
+
 ## Generic MCP clients
 
 Run the published MCP server with `npx`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "zod": "^4.4.3"
       },
       "bin": {
-        "opencode-codebase-index-mcp": "dist/cli.js"
+        "opencode-codebase-index-mcp": "dist/cli.js",
+        "cbi": "dist/cbi.js"
       },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     }
   },
   "bin": {
-    "opencode-codebase-index-mcp": "dist/cli.js"
+    "opencode-codebase-index-mcp": "dist/cli.js",
+    "cbi": "dist/cbi.js"
   },
   "license": "MIT",
   "author": "Kenneth",

--- a/scripts/prepare-package-metadata.mjs
+++ b/scripts/prepare-package-metadata.mjs
@@ -96,8 +96,12 @@ if (!existsSync(packageLockPath)) fail(`Missing package-lock.json at ${packageLo
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 const packageLock = JSON.parse(readFileSync(packageLockPath, "utf-8"));
 const cliTarget = packageJson.bin?.[catalog.product.current.mcpBinary];
+const cbiTarget = packageJson.bin?.cbi;
 if (typeof cliTarget !== "string") {
   fail(`Missing current MCP binary entry: ${catalog.product.current.mcpBinary}`);
+}
+if (typeof cbiTarget !== "string") {
+  fail("Missing cbi binary entry");
 }
 
 function copyProject() {
@@ -225,10 +229,11 @@ function prepareClaudeMarketplace(manifestPath) {
 }
 
 const preparedBins = isCurrentIdentity()
-  ? { [catalog.product.current.mcpBinary]: cliTarget }
+  ? { [catalog.product.current.mcpBinary]: cliTarget, cbi: cbiTarget }
   : {
       [catalog.product.future.mcpBinary]: cliTarget,
       [catalog.product.current.mcpBinary]: cliTarget,
+      cbi: cbiTarget,
     };
 
 const targetPackageJsonPath = path.join(outputDir, "package.json");

--- a/scripts/smoke-test-built-cli.mjs
+++ b/scripts/smoke-test-built-cli.mjs
@@ -6,9 +6,15 @@ import * as path from "node:path";
 
 const require = createRequire(import.meta.url);
 
-function runCliCommand(args, { killAfterMs = null, action = null, actionDelayMs = 1_000 } = {}) {
+function runCliCommand(args, {
+  killAfterMs = null,
+  action = null,
+  actionDelayMs = 1_000,
+  cliPathOverride = null,
+} = {}) {
   return new Promise((resolve, reject) => {
-    const command = [cliPath, ...args];
+    const commandPath = cliPathOverride ?? cliPath;
+    const command = [commandPath, ...args];
     const child = spawn(process.execPath, command, {
       cwd: process.cwd(),
       stdio: ["pipe", "pipe", "pipe"],
@@ -60,6 +66,11 @@ try {
     JSON.stringify({ indexing: { autoIndex: false, watchFiles: true, requireProjectMarker: false } }),
   );
   const projectArgs = ["--host", "jcode", "--project", tempDir, "--config", configPath];
+
+  const cbiHelp = await runCliCommand(["--help"], { cliPathOverride: "dist/cbi.js" });
+  if (cbiHelp.code !== 0 || !cbiHelp.stdout.includes("Usage: cbi")) {
+    throw new Error(`Built CBI CLI failed on --help (code=${cbiHelp.code}):\nstdout=${cbiHelp.stdout}\nstderr=${cbiHelp.stderr}`);
+  }
 
   const mcpStartup = await runCliCommand(projectArgs, { killAfterMs: 2_000 });
   if (mcpStartup.signal === null && mcpStartup.code !== 0) {

--- a/scripts/smoke-test-packed-cli.mjs
+++ b/scripts/smoke-test-packed-cli.mjs
@@ -81,8 +81,8 @@ function smokeIdentity(identity, expectedBinaries) {
 }
 
 try {
-  smokeIdentity(catalog.product.current, [catalog.product.current.mcpBinary]);
-  smokeIdentity(catalog.product.future, [catalog.product.future.mcpBinary, catalog.product.current.mcpBinary]);
+  smokeIdentity(catalog.product.current, [catalog.product.current.mcpBinary, "cbi"]);
+  smokeIdentity(catalog.product.future, [catalog.product.future.mcpBinary, catalog.product.current.mcpBinary, "cbi"]);
 } finally {
   rmSync(scratchRoot, { recursive: true, force: true });
 }

--- a/src/adapters/cbi.ts
+++ b/src/adapters/cbi.ts
@@ -15,7 +15,7 @@ import {
 import { initializeTools } from "../tools/operation-runtime.js";
 import { searchCodebase } from "../tools/operations.js";
 import { formatSearchResults } from "../tools/utils.js";
-import { handleIndexCommand } from "./mcp/cli.js";
+import { handleIndexCommand, redactSensitiveText } from "./mcp/cli.js";
 
 type TextSink = (text: string) => void;
 type Result = { text: string; isError?: boolean };
@@ -159,7 +159,7 @@ function requirePositionals(args: CbiCommandArgs, command: string, count: number
 
 export async function runCbiCli(argv: string[], cwd: string, deps: CbiDeps = {}): Promise<number> {
   const stdout = deps.printStdout ?? ((text) => console.log(text));
-  const stderr = deps.printStderr ?? ((text) => console.error(text));
+  const stderr = deps.printStderr ?? ((text) => console.error(redactSensitiveText(text)));
   const command = argv[2];
 
   if (!command || command === "help" || command === "--help" || command === "-h") {

--- a/src/adapters/cbi.ts
+++ b/src/adapters/cbi.ts
@@ -1,0 +1,230 @@
+import { realpathSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { HostMode } from "../config/host.js";
+
+import { parseHostMode } from "../config/host.js";
+import { loadConfigFile } from "../config/merger.js";
+import { parseConfig } from "../config/schema.js";
+import {
+  executeCallGraph,
+  executeImplementationLookup,
+  executeIndexStatus,
+} from "../tools/execute-common.js";
+import { initializeTools } from "../tools/operation-runtime.js";
+import { searchCodebase } from "../tools/operations.js";
+import { formatSearchResults } from "../tools/utils.js";
+import { handleIndexCommand } from "./mcp/cli.js";
+
+type TextSink = (text: string) => void;
+type Result = { text: string; isError?: boolean };
+type GraphDirection = "callers" | "callees";
+
+export interface CbiDeps {
+  runIndex?: typeof handleIndexCommand;
+  runStatus?: (projectRoot: string | undefined, host: HostMode) => Promise<Result>;
+  runDefinition?: (projectRoot: string | undefined, host: HostMode, query: string) => Promise<Result>;
+  runSearch?: (projectRoot: string | undefined, host: HostMode, query: string, limit: number) => Promise<Result>;
+  runCallGraph?: (
+    projectRoot: string | undefined,
+    host: HostMode,
+    symbol: string,
+    direction: GraphDirection,
+    filePath?: string,
+  ) => Promise<Result>;
+  initializeRuntimeForConfig?: (projectRoot: string, config: ReturnType<typeof parseConfig>, host: HostMode) => void;
+  readConfigFile?: (filePath: string) => unknown;
+  printStdout?: TextSink;
+  printStderr?: TextSink;
+}
+
+export interface CbiCommandArgs {
+  project: string;
+  host: HostMode;
+  config?: string;
+  limit: number;
+  filePath?: string;
+  positionals: string[];
+}
+
+function printUsage(output: TextSink): void {
+  output(`Usage: cbi <command> [options]
+
+Commands:
+  status                          Show index status
+  index [options]                 Create or refresh the index
+  search <query> [--limit <n>]    Full-content semantic search
+  definition <symbol>             Find authoritative definitions
+  graph <callers|callees> <symbol> Inspect direct call-graph edges
+
+Global options:
+  --project <path>  Project root, default: current directory
+  --host <mode>     opencode, codex, claude, pi, or jcode
+  --config <path>   Explicit JSON config path
+  --help            Show this message
+`);
+}
+
+function printCommandUsage(output: TextSink, command: string): void {
+  const usage: Record<string, string> = {
+    status: "Usage: cbi status [--project <path>] [--host <mode>] [--config <path>]",
+    index: "Usage: cbi index [--project <path>] [--host <mode>] [--config <path>] [--force] [--estimate-only] [--dry-run] [--verbose]",
+    search: "Usage: cbi search <query> [--limit <n>] [--project <path>] [--host <mode>] [--config <path>]",
+    definition: "Usage: cbi definition <symbol> [--project <path>] [--host <mode>] [--config <path>]",
+    graph: "Usage: cbi graph <callers|callees> <symbol> [--file <path>] [--project <path>] [--host <mode>] [--config <path>]",
+  };
+  output(usage[command] ?? "Usage: cbi <command> [options]");
+}
+
+function optionValue(args: string[], index: number, name: string): { value: string; consumed: number } {
+  const arg = args[index];
+  const equalsPrefix = `--${name}=`;
+  if (arg.startsWith(equalsPrefix)) return { value: arg.slice(equalsPrefix.length), consumed: 0 };
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`--${name} requires a value.`);
+  return { value, consumed: 1 };
+}
+
+export function parseCbiCommandArgs(command: string, args: string[], cwd: string): CbiCommandArgs {
+  let project = cwd;
+  let host: HostMode = "opencode";
+  let config: string | undefined;
+  let limit = 5;
+  let filePath: string | undefined;
+  const positionals: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") throw new Error("help-requested");
+
+    if (arg === "--project" || arg.startsWith("--project=")) {
+      const parsed = optionValue(args, index, "project");
+      project = path.resolve(cwd, parsed.value);
+      index += parsed.consumed;
+      continue;
+    }
+    if (arg === "--host" || arg.startsWith("--host=")) {
+      const parsed = optionValue(args, index, "host");
+      host = parseHostMode(parsed.value);
+      index += parsed.consumed;
+      continue;
+    }
+    if (arg === "--config" || arg.startsWith("--config=")) {
+      const parsed = optionValue(args, index, "config");
+      config = path.resolve(cwd, parsed.value);
+      index += parsed.consumed;
+      continue;
+    }
+    if (command === "search" && (arg === "--limit" || arg.startsWith("--limit="))) {
+      const parsed = optionValue(args, index, "limit");
+      limit = Number(parsed.value);
+      if (!Number.isInteger(limit) || limit < 1) throw new Error("--limit must be a positive integer.");
+      index += parsed.consumed;
+      continue;
+    }
+    if (command === "graph" && (arg === "--file" || arg.startsWith("--file="))) {
+      const parsed = optionValue(args, index, "file");
+      filePath = path.resolve(cwd, parsed.value);
+      index += parsed.consumed;
+      continue;
+    }
+    if (arg.startsWith("--")) throw new Error(`Unknown option: ${arg}`);
+    positionals.push(arg);
+  }
+
+  return { project, host, config, limit, filePath, positionals };
+}
+
+async function initializeFromConfig(args: CbiCommandArgs, deps: CbiDeps): Promise<void> {
+  if (!args.config) return;
+  const rawConfig = (deps.readConfigFile ?? loadConfigFile)(args.config);
+  if (rawConfig === null) throw new Error(`Config file not found: ${args.config}`);
+  (deps.initializeRuntimeForConfig ?? initializeTools)(args.project, parseConfig(rawConfig), args.host);
+}
+
+const defaultSearch = async (projectRoot: string | undefined, host: HostMode, query: string, limit: number): Promise<Result> => {
+  const results = await searchCodebase(projectRoot, host, query, { limit });
+  return results.length === 0
+    ? { text: "No matching code found. Try a different query or run `cbi index` first." }
+    : { text: `Found ${results.length} results for "${query}":\n\n${formatSearchResults(results, "score")}` };
+};
+
+function requirePositionals(args: CbiCommandArgs, command: string, count: number): string[] {
+  if (args.positionals.length !== count) {
+    throw new Error(`${command} requires ${count === 1 ? "exactly one argument" : "a direction and a symbol"}.`);
+  }
+  return args.positionals;
+}
+
+export async function runCbiCli(argv: string[], cwd: string, deps: CbiDeps = {}): Promise<number> {
+  const stdout = deps.printStdout ?? ((text) => console.log(text));
+  const stderr = deps.printStderr ?? ((text) => console.error(text));
+  const command = argv[2];
+
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    printUsage(stdout);
+    return 0;
+  }
+
+  if (!["status", "index", "search", "definition", "graph"].includes(command)) {
+    stderr(`Unknown command: ${command}`);
+    printUsage(stderr);
+    return 1;
+  }
+
+  try {
+    if (command === "index") {
+      return await (deps.runIndex ?? handleIndexCommand)(argv.slice(3), cwd, {
+        printStdout: stdout,
+        printStderr: stderr,
+      });
+    }
+
+    const args = parseCbiCommandArgs(command, argv.slice(3), cwd);
+    await initializeFromConfig(args, deps);
+
+    if (command === "status") {
+      requirePositionals(args, command, 0);
+      const result = await (deps.runStatus ?? executeIndexStatus)(args.project, args.host);
+      if (result.isError) { stderr(result.text); return 1; }
+      stdout(result.text);
+      return 0;
+    }
+    if (command === "search") {
+      const [query] = requirePositionals(args, command, 1);
+      const result = await (deps.runSearch ?? defaultSearch)(args.project, args.host, query, args.limit);
+      if (result.isError) { stderr(result.text); return 1; }
+      stdout(result.text);
+      return 0;
+    }
+    if (command === "definition") {
+      const [query] = requirePositionals(args, command, 1);
+      const result = await (deps.runDefinition ?? ((root, hostMode, symbol) =>
+        executeImplementationLookup(root, hostMode, { query: symbol, limit: 5 })))(args.project, args.host, query);
+      if (result.isError) { stderr(result.text); return 1; }
+      stdout(result.text);
+      return 0;
+    }
+
+    const [direction, symbol] = requirePositionals(args, command, 2);
+    if (direction !== "callers" && direction !== "callees") throw new Error("graph direction must be callers or callees.");
+    const result = await (deps.runCallGraph ?? ((root, hostMode, name, graphDirection, file) =>
+      executeCallGraph(root, hostMode, { name, direction: graphDirection, filePath: file })))(args.project, args.host, symbol, direction, args.filePath);
+    if (result.isError) { stderr(result.text); return 1; }
+    stdout(result.text);
+    return 0;
+  } catch (error) {
+    if (error instanceof Error && error.message === "help-requested") {
+      printCommandUsage(stderr, command);
+      return 0;
+    }
+    stderr(error instanceof Error ? error.message : String(error));
+    printCommandUsage(stderr, command);
+    return 1;
+  }
+}
+
+export function isCbiEntrypoint(moduleUrl: string, argvPath: string | undefined): boolean {
+  return argvPath !== undefined && realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvPath);
+}

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -354,7 +354,7 @@ function isSensitiveKey(key: string): boolean {
   return /(?:api[-_]?key|token|password|secret|authorization)/i.test(key);
 }
 
-function redactSensitiveText(text: string): string {
+export function redactSensitiveText(text: string): string {
   return text.replace(
     /((?:api[-_]?key|token|password|secret|authorization)\s*[=:]\s*)([^\s,;]+)/gi,
     "$1[REDACTED]",

--- a/src/cbi.ts
+++ b/src/cbi.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+export { isCbiEntrypoint, runCbiCli } from "./adapters/cbi.js";
+
+import { isCbiEntrypoint, runCbiCli } from "./adapters/cbi.js";
+
+function handleCbiMainError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.startsWith("Invalid host mode")) {
+    console.error(message);
+    process.exit(1);
+  }
+
+  console.error("Failed to start CBI CLI. Check your command and configuration.");
+  if (message) {
+    console.error(message);
+  }
+  process.exit(1);
+}
+
+if (isCbiEntrypoint(import.meta.url, process.argv[1])) {
+  runCbiCli(process.argv, process.cwd()).then((exitCode) => {
+    process.exitCode = exitCode;
+  }).catch(handleCbiMainError);
+}

--- a/tests/cbi-cli.test.ts
+++ b/tests/cbi-cli.test.ts
@@ -45,4 +45,56 @@ describe("cbi CLI", () => {
 
     expect(calls).toEqual(["search:retry:2", "definition:Indexer", "graph:callees:Indexer:/tmp/src/index.ts"]);
   });
+
+  it("parses search options placed around the positional query without leaking values into positionals", () => {
+    const cwd = "/tmp";
+
+    const before = parseCbiCommandArgs("search", ["project-query", "--project", "repo", "--host", "jcode", "--config", "ci.json", "--limit", "3"], cwd);
+    expect(before).toMatchObject({
+      positionals: ["project-query"],
+      project: "/tmp/repo",
+      host: "jcode",
+      config: "/tmp/ci.json",
+      limit: 3,
+    });
+
+    const after = parseCbiCommandArgs("search", ["project-query", "--limit", "3", "--project", "repo", "--host", "jcode", "--config", "ci.json"], cwd);
+    expect(after).toMatchObject({
+      positionals: ["project-query"],
+      project: "/tmp/repo",
+      host: "jcode",
+      config: "/tmp/ci.json",
+      limit: 3,
+    });
+  });
+
+  it("parses definition options before and after the positional symbol without treating values as positionals", () => {
+    const before = parseCbiCommandArgs("definition", ["--project", "repo", "--host", "jcode", "--config", "ci.json", "CodebaseIndex"], "/tmp");
+    expect(before.positionals).toEqual(["CodebaseIndex"]);
+    expect(before.project).toBe("/tmp/repo");
+    expect(before.host).toBe("jcode");
+    expect(before.config).toBe("/tmp/ci.json");
+
+    const after = parseCbiCommandArgs("definition", ["CodebaseIndex", "--config", "ci.json", "--project", "repo", "--host", "jcode"], "/tmp");
+    expect(after.positionals).toEqual(["CodebaseIndex"]);
+    expect(after.project).toBe("/tmp/repo");
+    expect(after.host).toBe("jcode");
+    expect(after.config).toBe("/tmp/ci.json");
+  });
+
+  it("parses graph --file and shared global options before and after required args", () => {
+    const first = parseCbiCommandArgs("graph", ["callers", "codebaseContext", "--file", "src/index.ts", "--project", "repo", "--host", "jcode", "--config", "cli.json"], "/tmp");
+    expect(first.positionals).toEqual(["callers", "codebaseContext"]);
+    expect(first.filePath).toBe("/tmp/src/index.ts");
+    expect(first.project).toBe("/tmp/repo");
+    expect(first.host).toBe("jcode");
+    expect(first.config).toBe("/tmp/cli.json");
+
+    const second = parseCbiCommandArgs("graph", ["--file", "src/index.ts", "--project", "repo", "--host", "jcode", "callers", "codebaseContext", "--config", "cli.json"], "/tmp");
+    expect(second.positionals).toEqual(["callers", "codebaseContext"]);
+    expect(second.filePath).toBe("/tmp/src/index.ts");
+    expect(second.project).toBe("/tmp/repo");
+    expect(second.host).toBe("jcode");
+    expect(second.config).toBe("/tmp/cli.json");
+  });
 });

--- a/tests/cbi-cli.test.ts
+++ b/tests/cbi-cli.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCbiCommandArgs, runCbiCli } from "../src/adapters/cbi.js";
+
+describe("cbi CLI", () => {
+  it("parses search options without treating option values as positional arguments", () => {
+    expect(parseCbiCommandArgs("search", ["retry logic", "--limit", "3", "--project", "repo", "--host", "jcode"], "/tmp"))
+      .toMatchObject({ positionals: ["retry logic"], limit: 3, project: "/tmp/repo", host: "jcode" });
+  });
+
+  it("prints status through the shared status operation", async () => {
+    const stdout: string[] = [];
+    const exitCode = await runCbiCli(["node", "cbi", "status", "--project", "/repo", "--host", "jcode"], "/tmp", {
+      runStatus: async () => ({ text: "Indexed chunks: 10" }),
+      printStdout: (text) => stdout.push(text),
+      printStderr: () => undefined,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toEqual(["Indexed chunks: 10"]);
+  });
+
+  it("dispatches search, definition, and graph commands with parsed inputs", async () => {
+    const calls: string[] = [];
+    const deps = {
+      runSearch: async (_root: string | undefined, _host: string, query: string, limit: number) => {
+        calls.push(`search:${query}:${limit}`);
+        return { text: "search result" };
+      },
+      runDefinition: async (_root: string | undefined, _host: string, query: string) => {
+        calls.push(`definition:${query}`);
+        return { text: "definition result" };
+      },
+      runCallGraph: async (_root: string | undefined, _host: string, symbol: string, direction: "callers" | "callees", filePath?: string) => {
+        calls.push(`graph:${direction}:${symbol}:${filePath}`);
+        return { text: "graph result" };
+      },
+      printStdout: () => undefined,
+      printStderr: () => undefined,
+    };
+
+    await runCbiCli(["node", "cbi", "search", "retry", "--limit=2"], "/tmp", deps);
+    await runCbiCli(["node", "cbi", "definition", "Indexer"], "/tmp", deps);
+    await runCbiCli(["node", "cbi", "graph", "callees", "Indexer", "--file", "src/index.ts"], "/tmp", deps);
+
+    expect(calls).toEqual(["search:retry:2", "definition:Indexer", "graph:callees:Indexer:/tmp/src/index.ts"]);
+  });
+});

--- a/tests/cbi-cli.test.ts
+++ b/tests/cbi-cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { parseCbiCommandArgs, runCbiCli } from "../src/adapters/cbi.js";
 
@@ -96,5 +96,26 @@ describe("cbi CLI", () => {
     expect(second.project).toBe("/tmp/repo");
     expect(second.host).toBe("jcode");
     expect(second.config).toBe("/tmp/cli.json");
+  });
+
+  it("redacts apiKey-like values printed to the default stderr sink on CBI operation errors", async () => {
+    const stderr: string[] = [];
+    const originalConsoleError = console.error;
+    const spy = vi.spyOn(console, "error").mockImplementation((text) => {
+      stderr.push(String(text));
+    });
+
+    const exitCode = await runCbiCli(["node", "cbi", "status", "--project", "/repo", "--host", "jcode"], "/tmp", {
+      runStatus: async () => ({ text: "apiKey=top-secret-value", isError: true }),
+      printStdout: () => undefined,
+      printStderr: undefined,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr.join("\n")).toContain("apiKey=[REDACTED]");
+    expect(stderr.join("\n")).not.toContain("top-secret-value");
+
+    spy.mockRestore();
+    console.error = originalConsoleError;
   });
 });

--- a/tests/identity-phase0.test.ts
+++ b/tests/identity-phase0.test.ts
@@ -149,7 +149,7 @@ describe("Phase 1 product identity compatibility", () => {
     const claudeMarketplace = readJson<{ owner: { url: string } }>(".claude-plugin/marketplace.json");
     const codexManifest = readJson<CodexManifestMetadata>(".codex-plugin/plugin.json");
 
-    const expectedBin = { [current.mcpBinary]: "dist/cli.js" };
+    const expectedBin = { [current.mcpBinary]: "dist/cli.js", cbi: "dist/cbi.js" };
     expect(packageJson.name).toBe(current.packageName);
     expect(packageJson.bin).toEqual(expectedBin);
     expect(packageJson.repository.url).toBe(current.repository);
@@ -185,7 +185,7 @@ describe("Phase 1 product identity compatibility", () => {
       const packageLock = readJson<PackageLockMetadata>(path.join(tempDir, "package-lock.json"));
       const checkedInPackageJson = readJson<PackageMetadata>("package.json");
       const checkedInPackageLock = readJson<PackageLockMetadata>("package-lock.json");
-      const expectedBin = { [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js" };
+      const expectedBin = { [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js", cbi: "dist/cbi.js" };
 
       expect(packageJson.name).toBe(IDENTITY_CATALOG.product.current.packageName);
       expect(packageJson.bin).toEqual(expectedBin);
@@ -226,6 +226,7 @@ describe("Phase 1 product identity compatibility", () => {
       const expectedBin = {
         [IDENTITY_CATALOG.product.future.mcpBinary]: "dist/cli.js",
         [IDENTITY_CATALOG.product.current.mcpBinary]: "dist/cli.js",
+        cbi: "dist/cbi.js",
       };
       const expectedMcpArgs = [
         "-y",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts", "src/pi-extension.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/cbi.ts", "src/pi-extension.ts"],
   format: ["esm", "cjs"],
   dts: false,
   sourcemap: true,


### PR DESCRIPTION
## Summary
- add a concise `cbi` terminal binary for status, index, search, definition, and direct call-graph queries
- preserve the existing MCP CLI and route all human commands through shared operations
- ship `cbi` under both package identities, with installation guidance and built/package smoke coverage

## Validation
- `npm run build && npm run typecheck && npm run lint && npm run test:run`
- `npm run smoke:package`
- direct `cbi --help`, `cbi status`, and non-mutating `cbi index --dry-run` against this repository
