### PR TITLE
docs: document cbi terminal command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 
 New installs should use `open-codebase-index` and `open-codebase-index-mcp`. The legacy package `opencode-codebase-index` and `opencode-codebase-index-mcp` remain supported aliases.
 
+For terminal use outside an MCP client, install the package globally and use the concise `cbi` command:
+
+```bash
+npm install -g open-codebase-index
+cbi status --project /path/to/repo --host jcode
+cbi search "retry recovery" --project /path/to/repo
+```
+
+`cbi` provides status, indexing, search, definition lookup, and direct caller or callee inspection. See [Installation and host setup](docs/installation.md#human-cli) for the full command reference.
+
 ## Highlights
 
 - **Semantic and hybrid retrieval** for questions where you do not know the identifier.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,7 +127,7 @@ Claude uses:
 
 ## Human CLI
 
-The concise `cbi` command is for terminal use. It shares OCI's index and retrieval operations, while `open-codebase-index-mcp` remains the MCP-server binary.
+The concise `cbi` command is for terminal use. It shares `open-codebase-index` index and retrieval operations, while `open-codebase-index-mcp` remains the MCP-server binary.
 
 ```bash
 # Inspect readiness, then create or refresh the index

--- a/docs/rename-to-open-codebase-index.md
+++ b/docs/rename-to-open-codebase-index.md
@@ -157,22 +157,24 @@ No neutral storage migration is required for the public rename.
 
 ## Package and binary compatibility design
 
-During the transition, the new `package.json` should expose both binary names to the same built CLI:
+During the transition, the new `package.json` should expose both MCP binary names to the same built CLI and the concise human CLI:
 
 ```json
 {
   "bin": {
     "open-codebase-index-mcp": "dist/cli.js",
-    "opencode-codebase-index-mcp": "dist/cli.js"
+    "opencode-codebase-index-mcp": "dist/cli.js",
+    "cbi": "dist/cbi.js"
   }
 }
 ```
 
-Keep `src/cli.ts` and `dist/cli.*` as stable executable facades. The MCP implementation remains under `src/adapters/mcp/`.
+Keep `src/cli.ts` and `dist/cli.*` as stable MCP executable facades. Keep `src/cbi.ts` and `dist/cbi.*` as the stable human CLI facade. The MCP implementation remains under `src/adapters/mcp/`.
 
 Before publishing, test:
 
 - direct npm execution of both binary names,
+- direct npm execution and global installation of `cbi`,
 - global and local installs,
 - symlink entrypoint detection,
 - ESM and CommonJS loading,


### PR DESCRIPTION
## Summary
- add a concise human CLI quick start to the README
- clarify the installation guide wording for CBI
- include CBI in package-transition binary compatibility guidance

## Validation
- `npm run build:ts`
- `npx vitest run tests/identity-phase0.test.ts`
