### PR TITLE
Release v0.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.24.0"
+      "version": "0.25.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-19
+
 ### Added
 
 - Added a `dryRun` option to `index_codebase` and an `index --dry-run` CLI flag: a read-only preflight that parses the real file set and reports the exact embedding token total (files, source chunks, tokens) without requesting embeddings or writing to the index. The total serves as a fixed, monotonic denominator for live indexing progress (a force index climbs to ~100%; an incremental index tops out below 100% because cached chunks are counted but not re-embedded) and as a cost preview before committing GPU or time.
 - Added query-weighted quality aggregates to cross-repository benchmark reports, alongside clearly labelled per-repository macro averages, so uneven cohort sizes cannot obscure the headline Hit@k, MRR, or nDCG results.
 - Added a concise `cbi` terminal command for status, indexing, search, definition lookup, and direct caller or callee inspection, while keeping the existing MCP binary unchanged.
+
+### Changed
+
+- Documented optional `codebase_edit_context` guidance for Pi, MCP, and OpenCode workflows, while leaving retrieval discretionary rather than mandatory.
+
+### Fixed
+
+- **Definition retrieval**: Ruby classes and modules are retained in the call-graph symbol catalog so nested Ruby declarations can be resolved by definition lookup.
 
 ## [0.24.0] - 2026-08-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -21,8 +21,8 @@
         "zod": "^4.4.3"
       },
       "bin": {
-        "opencode-codebase-index-mcp": "dist/cli.js",
-        "cbi": "dist/cbi.js"
+        "cbi": "dist/cbi.js",
+        "opencode-codebase-index-mcp": "dist/cli.js"
       },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release preparation

Prepares v0.25.0 for release.

### Included
- concise `cbi` terminal command, documented for installation and migration
- parse-only `index_codebase.dryRun` / `cbi index --dry-run` token preflight
- query-weighted cross-repository quality metrics
- Ruby nested class and module definition retrieval correction
- optional pre-edit context guidance

### Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (100 files, 1534 tests)
- `npm run smoke:package`
- `npm audit --omit=dev --audit-level=high` (0 production vulnerabilities)