### PR TITLE
fix: honor exclude globs so matched files are omitted from the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Config exclude**: `exclude` globs now omit matching files from indexing instead of recording them as skipped and still embedding them. Directory globs such as `**/common/**` skip the tree, and incremental `/index` plus `retryFailedBatches` drop stale failed-batch retries for newly excluded paths.
+
 ## [0.25.0] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Config exclude**: `exclude` globs now omit matching files from indexing instead of recording them as skipped and still embedding them. Directory globs such as `**/common/**` skip the tree, and incremental `/index` plus `retryFailedBatches` drop stale failed-batch retries for newly excluded paths.
+- **Failed-batch retries**: Project-owned stored paths are matched against `exclude` globs after normalizing to the project root, so a hidden parent directory (for example `~/.work/project`) no longer makes valid failed batches look excluded in global scope.
 
 ## [0.25.0] - 2026-08-19
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -385,10 +385,10 @@ Lower the minimum score:
 ```
 
 ### 5. Files Excluded
-Check if your files are being excluded by `.gitignore` or size limits:
+Check if your files are being excluded by `exclude` globs, `.gitignore`, or size limits:
 > "Run `/index` in verbose mode"
 
-This shows which files were skipped and why.
+This shows which files were skipped and why. `exclude` omits matching files from the index even when they also match `include`. After changing `exclude`, rerun `/index` (not force) so stale failed-batch retries for those paths are dropped. `.git/info/exclude` is not read.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,7 +275,9 @@ Example:
 - `include` replaces the default include patterns.
 - `additionalInclude` extends the defaults.
 - `exclude` replaces the default exclude patterns.
-- `.gitignore` is also respected.
+- Matching files are omitted from the index, including paths that also match `include`. Directory globs such as `**/generated/**` skip the whole tree.
+- Incremental `/index` and `retryFailedBatches` drop stale failed-batch retries for paths that are now excluded, so previously failed chunks are not re-embedded.
+- `.gitignore` is also respected. Tracked Git files can still be excluded from the index with `exclude`; `.git/info/exclude` is not read.
 
 ## Knowledge bases
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1265,21 +1265,19 @@ export class Indexer {
   }
 
   private isStoredPathExcluded(storedPath: string): boolean {
-    const posixStored = storedPath.split(path.sep).join("/");
-    if (isExcludedByPatterns(posixStored, this.config.exclude)) {
-      return true;
+    let matchPath = storedPath.split(path.sep).join("/");
+    if (path.isAbsolute(storedPath)) {
+      const relativePath = path.relative(this.projectRoot, storedPath).split(path.sep).join("/");
+      // Knowledge-base files live outside the project. A `../` prefix would
+      // false-match hidden-file globs such as **/.*/** because `..` starts with a dot.
+      // Glob-matching the raw absolute path has the same problem: default **/.*/**
+      // would treat a hidden parent such as /Users/me/.work/project as excluded.
+      if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+        return false;
+      }
+      matchPath = relativePath;
     }
-    if (!path.isAbsolute(storedPath)) {
-      return false;
-    }
-
-    const relativePath = path.relative(this.projectRoot, storedPath).split(path.sep).join("/");
-    // Knowledge-base files live outside the project. A `../` prefix would
-    // false-match hidden-file globs such as **/.*/** because `..` starts with a dot.
-    if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-      return false;
-    }
-    return isExcludedByPatterns(relativePath, this.config.exclude);
+    return isExcludedByPatterns(matchPath, this.config.exclude);
   }
 
   private resolveStoredFilePath(filePath: string, rootPath = this.projectRoot): string {

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -13,7 +13,7 @@ import {
   EmbeddingProviderInterface,
   CustomProviderNonRetryableError,
 } from "../embeddings/provider.js";
-import { collectFiles, SkippedFile } from "../utils/files.js";
+import { collectFiles, isExcludedByPatterns, type SkippedFile } from "../utils/files.js";
 import { createCostEstimate, CostEstimate, DryRunEstimate } from "../utils/cost.js";
 import { Logger, initializeLogger } from "../utils/logger.js";
 import {
@@ -1262,6 +1262,24 @@ export class Indexer {
     }
 
     return path.relative(this.projectRoot, canonicalFilePath).split(path.sep).join("/");
+  }
+
+  private isStoredPathExcluded(storedPath: string): boolean {
+    const posixStored = storedPath.split(path.sep).join("/");
+    if (isExcludedByPatterns(posixStored, this.config.exclude)) {
+      return true;
+    }
+    if (!path.isAbsolute(storedPath)) {
+      return false;
+    }
+
+    const relativePath = path.relative(this.projectRoot, storedPath).split(path.sep).join("/");
+    // Knowledge-base files live outside the project. A `../` prefix would
+    // false-match hidden-file globs such as **/.*/** because `..` starts with a dot.
+    if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+      return false;
+    }
+    return isExcludedByPatterns(relativePath, this.config.exclude);
   }
 
   private resolveStoredFilePath(filePath: string, rootPath = this.projectRoot): string {
@@ -4356,7 +4374,10 @@ export class Indexer {
     }
 
     const shouldRetryFailedPath = (filePath: string | null): boolean =>
-      filePath !== null && currentFileHashes.has(filePath) && unchangedFilePaths.has(filePath);
+      filePath !== null
+      && !this.isStoredPathExcluded(filePath)
+      && currentFileHashes.has(filePath)
+      && unchangedFilePaths.has(filePath);
     const failedProcessing = this.prepareFailedBatchProcessing(scopedRoots, shouldRetryFailedPath);
     const maxChunkTokens = getSafeEmbeddingChunkTokenLimit(configuredProviderInfo);
     const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
@@ -5957,7 +5978,9 @@ export class Indexer {
     const maxChunkTokens = getSafeEmbeddingChunkTokenLimit(configuredProviderInfo);
     const providerRateLimits = this.getProviderRateLimits(configuredProviderInfo.provider);
     const roots = this.config.scope === "global" ? this.getScopedRoots() : null;
-    const failedProcessing = this.prepareFailedBatchProcessing(roots, () => true);
+    const shouldProcessFailedPath = (filePath: string | null): boolean =>
+      filePath === null || !this.isStoredPathExcluded(filePath);
+    const failedProcessing = this.prepareFailedBatchProcessing(roots, shouldProcessFailedPath);
 
     if (failedProcessing.latestById.size === 0) {
       this.finalizeFailedBatchWriteState(failedProcessing.state);
@@ -5973,7 +5996,7 @@ export class Indexer {
       const retryableChunks = this.iterateLatestFailedChunks(
         failedProcessing.latestById,
         roots,
-        () => true,
+        shouldProcessFailedPath,
         maxChunkTokens,
       );
       for (const retryBatch of iterateOrderedFileBatches(

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -72,6 +72,39 @@ export function createIgnoreFilter(projectRoot: string): Ignore {
   return ig;
 }
 
+function toPosixRelativePath(relativePath: string): string {
+  return relativePath.split(path.sep).join("/");
+}
+
+function matchesAnyGlob(filePath: string, patterns: string[]): boolean {
+  const normalized = toPosixRelativePath(filePath);
+  return patterns.some((pattern) => matchGlob(normalized, pattern));
+}
+
+export function isExcludedByPatterns(relativePath: string, excludePatterns: string[]): boolean {
+  return matchesAnyGlob(relativePath, excludePatterns);
+}
+
+function isExcludedDirectory(relativePath: string, excludePatterns: string[]): boolean {
+  const normalized = toPosixRelativePath(relativePath);
+  if (matchesAnyGlob(normalized, excludePatterns)) {
+    return true;
+  }
+
+  for (const pattern of excludePatterns) {
+    const posixPattern = toPosixRelativePath(pattern).replace(/\/+$/, "");
+    if (!posixPattern.endsWith("/**")) {
+      continue;
+    }
+    const directoryPattern = posixPattern.slice(0, -3);
+    if (directoryPattern && matchesAnyGlob(normalized, [directoryPattern])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function shouldIncludeFile(
   filePath: string,
   projectRoot: string,
@@ -79,9 +112,9 @@ export function shouldIncludeFile(
   excludePatterns: string[],
   ignoreFilter: Ignore
 ): boolean {
-  const relativePath = path.relative(projectRoot, filePath);
+  const relativePath = toPosixRelativePath(path.relative(projectRoot, filePath));
 
-  if (hasFilteredPathSegment(relativePath, path.sep)) {
+  if (hasFilteredPathSegment(relativePath, "/")) {
     return false;
   }
 
@@ -89,19 +122,11 @@ export function shouldIncludeFile(
     return false;
   }
 
-  for (const pattern of excludePatterns) {
-    if (matchGlob(relativePath, pattern)) {
-      return false;
-    }
+  if (isExcludedByPatterns(relativePath, excludePatterns)) {
+    return false;
   }
 
-  for (const pattern of includePatterns) {
-    if (matchGlob(relativePath, pattern)) {
-      return true;
-    }
-  }
-
-  return false;
+  return matchesAnyGlob(relativePath, includePatterns);
 }
 
 function matchGlob(filePath: string, pattern: string): boolean {
@@ -153,7 +178,7 @@ export async function* walkDirectory(
 
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
-    const relativePath = path.relative(projectRoot, fullPath);
+    const relativePath = toPosixRelativePath(path.relative(projectRoot, fullPath));
 
     if (isHiddenPathSegment(entry.name)) {
       if (entry.isDirectory()) {
@@ -175,6 +200,10 @@ export async function* walkDirectory(
     }
 
     if (entry.isDirectory()) {
+      if (isExcludedDirectory(relativePath, excludePatterns)) {
+        skipped.push({ path: relativePath, reason: "excluded" });
+        continue;
+      }
       subdirs.push({ fullPath, relativePath });
     } else if (entry.isFile()) {
       const stat = await fsPromises.stat(fullPath);
@@ -184,22 +213,12 @@ export async function* walkDirectory(
         continue;
       }
 
-      for (const pattern of excludePatterns) {
-        if (matchGlob(relativePath, pattern)) {
-          skipped.push({ path: relativePath, reason: "excluded" });
-          continue;
-        }
+      if (isExcludedByPatterns(relativePath, excludePatterns)) {
+        skipped.push({ path: relativePath, reason: "excluded" });
+        continue;
       }
 
-      let matched = false;
-      for (const pattern of includePatterns) {
-        if (matchGlob(relativePath, pattern)) {
-          matched = true;
-          break;
-        }
-      }
-
-      if (matched) {
+      if (matchesAnyGlob(relativePath, includePatterns)) {
         filesInDir.push({ path: fullPath, size: stat.size });
       }
     }
@@ -211,7 +230,7 @@ export async function* walkDirectory(
     yield f;
   }
   for (let i = options.maxFilesPerDirectory; i < filesInDir.length; i++) {
-    skipped.push({ path: path.relative(projectRoot, filesInDir[i].path), reason: "excluded" });
+    skipped.push({ path: toPosixRelativePath(path.relative(projectRoot, filesInDir[i].path)), reason: "excluded" });
   }
 
   const canRecurse = options.maxDepth === -1 || currentDepth < options.maxDepth;

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -67,6 +67,20 @@ describe("files utilities", () => {
       ).toBe(false);
     });
 
+    it("should exclude files under a directory glob even when include matches", () => {
+      const filter = createIgnoreFilter(tempDir);
+
+      expect(
+        shouldIncludeFile(
+          path.join(tempDir, "toms_common", "huge.sql"),
+          tempDir,
+          ["**/*.sql"],
+          ["**/toms_common/**"],
+          filter
+        )
+      ).toBe(false);
+    });
+
     it("should respect gitignore", () => {
       fs.writeFileSync(path.join(tempDir, ".gitignore"), "ignored/\n");
       const filter = createIgnoreFilter(tempDir);
@@ -256,6 +270,85 @@ describe("files utilities", () => {
       expect(result.files.length).toBe(2);
       expect(result.files.some((f) => f.path.endsWith("root.js"))).toBe(true);
       expect(result.files.some((f) => f.path.endsWith("nested.js"))).toBe(true);
+    });
+
+    it("should omit files that match exclude even when they also match include", async () => {
+      fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+      fs.mkdirSync(path.join(tempDir, "toms_common"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, "src", "index.ts"), "export const x = 1;");
+      fs.writeFileSync(path.join(tempDir, "toms_common", "huge.sql"), "SELECT 1;");
+
+      const result = await collectFiles(
+        tempDir,
+        ["**/*.ts", "**/*.sql"],
+        ["**/toms_common/**"],
+        1048576
+      );
+
+      expect(result.files.map((file) => path.basename(file.path))).toEqual(["index.ts"]);
+      expect(result.files.some((file) => file.path.includes("toms_common"))).toBe(false);
+      expect(result.skipped.some((entry) => (
+        entry.reason === "excluded" && entry.path.replace(/\\/g, "/").includes("toms_common")
+      ))).toBe(true);
+    });
+
+    it("should omit exclude matches after a non-matching earlier exclude pattern", async () => {
+      fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+      fs.mkdirSync(path.join(tempDir, "common", "scripts"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, "src", "keep.ts"), "export const keep = true;");
+      fs.writeFileSync(path.join(tempDir, "common", "scripts", "bulk.sql"), "SELECT 1;");
+
+      const result = await collectFiles(
+        tempDir,
+        ["**/*.ts", "**/*.sql"],
+        ["**/generated/**", "**/common/scripts/**"],
+        1048576
+      );
+
+      expect(result.files.map((file) => path.basename(file.path))).toEqual(["keep.ts"]);
+      expect(result.files.some((file) => file.path.endsWith("bulk.sql"))).toBe(false);
+    });
+
+    it("should skip walking a directory covered by a /** exclude glob", async () => {
+      fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+      fs.mkdirSync(path.join(tempDir, "toms_common", "nested"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, "src", "index.ts"), "export const x = 1;");
+      fs.writeFileSync(path.join(tempDir, "toms_common", "nested", "deep.sql"), "SELECT 1;");
+
+      const result = await collectFiles(
+        tempDir,
+        ["**/*.ts", "**/*.sql"],
+        ["**/toms_common/**"],
+        1048576
+      );
+
+      expect(result.files.map((file) => path.basename(file.path))).toEqual(["index.ts"]);
+      expect(result.skipped).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "toms_common", reason: "excluded" }),
+        ])
+      );
+      expect(result.skipped.some((entry) => entry.path.includes("deep.sql"))).toBe(false);
+    });
+
+    it("should still walk directories when exclude matches only files", async () => {
+      fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, "src", "index.ts"), "export const x = 1;");
+      fs.writeFileSync(path.join(tempDir, "src", "seed.sql"), "SELECT 1;");
+
+      const result = await collectFiles(
+        tempDir,
+        ["**/*.ts", "**/*.sql"],
+        ["**/*.sql"],
+        1048576
+      );
+
+      expect(result.files.map((file) => path.basename(file.path))).toEqual(["index.ts"]);
+      expect(result.skipped).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: "src/seed.sql", reason: "excluded" }),
+        ])
+      );
     });
   });
 

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -1445,6 +1445,90 @@ describe("indexer failed batch recovery", () => {
     expect(foreignChunk?.texts).toBeUndefined();
   });
 
+  it("retries failed batches for a global-scope project beneath a hidden directory", async () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "failed-batches-hidden-parent-home-"));
+    _extraDirs.push(tempHome);
+    vi.stubEnv("HOME", tempHome);
+    vi.stubEnv("USERPROFILE", tempHome);
+
+    const projectRoot = path.join(tempDir, ".work", "project");
+    const projectFile = path.join(projectRoot, "src", "a.ts");
+    const excludedFile = path.join(projectRoot, ".hidden", "ignored.ts");
+    fs.mkdirSync(path.dirname(projectFile), { recursive: true });
+    fs.mkdirSync(path.dirname(excludedFile), { recursive: true });
+    fs.writeFileSync(projectFile, "export function alpha() { return 'a'; }\n", "utf-8");
+    fs.writeFileSync(excludedFile, "export function ignored() { return 'hidden'; }\n", "utf-8");
+
+    const globalFailedBatchesPath = path.join(tempHome, ".opencode", "global-index", "failed-batches.json");
+    fs.mkdirSync(path.dirname(globalFailedBatchesPath), { recursive: true });
+    fs.writeFileSync(
+      globalFailedBatchesPath,
+      JSON.stringify([
+        {
+          chunks: [
+            {
+              id: "hidden-parent-valid",
+              text: "export function alpha() { return 'a'; }",
+              content: "export function alpha() { return 'a'; }",
+              contentHash: "hidden-parent-valid-hash",
+              metadata: {
+                filePath: projectFile,
+                startLine: 1,
+                endLine: 1,
+                language: "typescript",
+                chunkType: "function",
+                hash: "hidden-parent-valid-hash",
+                name: "alpha",
+              },
+            },
+            {
+              id: "hidden-parent-excluded",
+              text: "export function ignored() { return 'hidden'; }",
+              content: "export function ignored() { return 'hidden'; }",
+              contentHash: "hidden-parent-excluded-hash",
+              metadata: {
+                filePath: excludedFile,
+                startLine: 1,
+                endLine: 1,
+                language: "typescript",
+                chunkType: "function",
+                hash: "hidden-parent-excluded-hash",
+                name: "ignored",
+              },
+            },
+          ],
+          error: "previous hidden-parent failure",
+          attemptCount: 1,
+          lastAttempt: new Date().toISOString(),
+        },
+      ], null, 2),
+      "utf-8"
+    );
+
+    const indexer = _indexers[_indexers.push(new Indexer(projectRoot, parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embedding-model",
+        dimensions: 8,
+      },
+      scope: "global",
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    }), "opencode")) - 1];
+
+    await indexer.initialize();
+    const retry = await indexer.retryFailedBatches();
+
+    expect(retry.succeeded).toBe(1);
+    expect(retry.failed).toBe(0);
+    expect(retry.remaining).toBe(0);
+    expect(fs.existsSync(globalFailedBatchesPath)).toBe(false);
+  });
+
   it("logs a warning when persisted failed batches are malformed", async () => {
     const failedBatchesPath = path.join(tempDir, ".opencode", "index", "failed-batches.json");
     fs.mkdirSync(path.dirname(failedBatchesPath), { recursive: true });

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -153,7 +153,7 @@ describe("indexer failed batch recovery", () => {
     _extraDirs = [];
   });
 
-  function createIndexer(): Indexer {
+  function createIndexer(overrides: Record<string, unknown> = {}): Indexer {
     const config = parseConfig({
       embeddingProvider: "custom",
       customProvider: {
@@ -176,6 +176,7 @@ describe("indexer failed batch recovery", () => {
         retries: 0,
         retryDelayMs: 1,
       },
+      ...overrides,
     });
 
     return _indexers[_indexers.push(new Indexer(tempDir, config, "opencode")) - 1];
@@ -255,6 +256,117 @@ describe("indexer failed batch recovery", () => {
     expect(recoveredStatus.indexed).toBe(true);
     expect(recoveredStatus.failedBatchesCount).toBe(0);
     expect(recoveredStatus.failedBatchesPath).toBeUndefined();
+  });
+
+  it("drops excluded files from incremental retries of stale failed batches", async () => {
+    fs.mkdirSync(path.join(tempDir, "toms_common"), { recursive: true });
+    const excludedSql = path.join(tempDir, "toms_common", "huge.sql");
+    fs.writeFileSync(excludedSql, "SELECT 1;\n".repeat(20), "utf-8");
+
+    failEmbeddings = true;
+    const firstIndexer = createIndexer();
+    const failedStats = await firstIndexer.index();
+    expect(failedStats.failedChunks).toBeGreaterThan(0);
+    expect((await firstIndexer.getStatus()).failedBatchesCount).toBeGreaterThan(0);
+    await firstIndexer.close();
+
+    const embedTexts: string[] = [];
+    fetchSpy.mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/tags")) {
+        return new Response(JSON.stringify({
+          models: [{ name: "nomic-embed-text" }],
+        }), { status: 200 });
+      }
+
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[]; prompt?: string };
+      const texts = Array.isArray(body.input) ? body.input : (body.prompt ? [body.prompt] : []);
+      embedTexts.push(...texts);
+
+      const data = texts.map((text) => {
+        let seed = 0;
+        for (const ch of text) {
+          seed = (seed * 31 + ch.charCodeAt(0)) % 1000;
+        }
+        const embedding = Array.from({ length: 8 }, (_, idx) => ((seed + idx * 17) % 997) / 997);
+        return { embedding };
+      });
+
+      return new Response(
+        JSON.stringify({
+          data,
+          usage: { total_tokens: Math.max(1, texts.length * 8) },
+        }),
+        { status: 200 }
+      );
+    });
+
+    const secondIndexer = createIndexer({
+      exclude: ["**/toms_common/**", "**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+    });
+    const recoveredStats = await secondIndexer.index();
+    expect(recoveredStats.failedChunks).toBe(0);
+    expect(recoveredStats.skippedFiles.some((entry) => (
+      entry.reason === "excluded" && entry.path.replace(/\\/g, "/").includes("toms_common")
+    ))).toBe(true);
+
+    const recoveredStatus = await secondIndexer.getStatus();
+    expect(recoveredStatus.failedBatchesCount).toBe(0);
+    expect(embedTexts.some((text) => text.includes("SELECT 1"))).toBe(false);
+
+    const retry = await secondIndexer.retryFailedBatches();
+    expect(retry.remaining).toBe(0);
+    expect(retry.failed).toBe(0);
+  });
+
+  it("retryFailedBatches discards chunks whose files are now excluded", async () => {
+    fs.mkdirSync(path.join(tempDir, "toms_common"), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, "toms_common", "huge.sql"), "SELECT 1;\n".repeat(20), "utf-8");
+
+    failEmbeddings = true;
+    const firstIndexer = createIndexer();
+    await firstIndexer.index();
+    expect((await firstIndexer.getStatus()).failedBatchesCount).toBeGreaterThan(0);
+    await firstIndexer.close();
+
+    const embedTexts: string[] = [];
+    failEmbeddings = false;
+    fetchSpy.mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/api/tags")) {
+        return new Response(JSON.stringify({
+          models: [{ name: "nomic-embed-text" }],
+        }), { status: 200 });
+      }
+
+      const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string[]; prompt?: string };
+      const texts = Array.isArray(body.input) ? body.input : (body.prompt ? [body.prompt] : []);
+      embedTexts.push(...texts);
+
+      const data = texts.map((text) => {
+        let seed = 0;
+        for (const ch of text) {
+          seed = (seed * 31 + ch.charCodeAt(0)) % 1000;
+        }
+        const embedding = Array.from({ length: 8 }, (_, idx) => ((seed + idx * 17) % 997) / 997);
+        return { embedding };
+      });
+
+      return new Response(
+        JSON.stringify({
+          data,
+          usage: { total_tokens: Math.max(1, texts.length * 8) },
+        }),
+        { status: 200 }
+      );
+    });
+
+    const secondIndexer = createIndexer({
+      exclude: ["**/toms_common/**", "**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+    });
+    const retry = await secondIndexer.retryFailedBatches();
+    expect(retry.failed).toBe(0);
+    expect(retry.remaining).toBe(0);
+    expect(embedTexts.some((text) => text.includes("SELECT 1"))).toBe(false);
+    expect((await secondIndexer.getStatus()).failedBatchesCount).toBe(0);
   });
 
   it("clears stale failed batch warnings after a clean no-op run", async () => {


### PR DESCRIPTION
## Summary

Config `exclude` globs were recorded as skipped but still indexed, because `walkDirectory` continued only the inner pattern loop. Matching files (and stale failed-batch retries for those paths) are now omitted from the index.

## Changes

- Skip files as soon as an `exclude` glob matches in `collectFiles` / `walkDirectory`, instead of falling through to include matching.
- Skip walking directories covered by `/**` exclude globs (for example `**/common/**`).
- Drop stale failed-batch retries for newly excluded paths on incremental `/index` and `retryFailedBatches`.
- Document the behavior and add unit/indexer coverage.

## Testing

How were these changes tested?

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`feature`, `bug`, `performance`, `documentation`, `dependencies`, `refactor`, `test`, `chore`, or `skip-changelog`)
- [x] Added at most one semver label (`semver:major`, `semver:minor`, or `semver:patch`) when needed

Labels: `bug`

## Related Issues

No tracked issue.